### PR TITLE
Commands – Add CreateTableSql Command

### DIFF
--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -55,4 +55,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '1.8.2'
+__version__ = '1.8.3'


### PR DESCRIPTION
# Commands – Add CreateTableSql Command (#523)

**Closes #523**

## Overview
This PR adds the `CreateTableSql` command — a high-level helper that generates and executes safe `CREATE TABLE` statements with columns, constraints, and optional `IF NOT EXISTS` clause.

Key features:
- Two modes: raw script or structured (table_name + columns dict + constraints)
- Basic input validation & identifier sanitation
- Mandatory context-manager usage (`with self.sqlite_service as sql:`)
- Returns simple success dict
- Kept **internal** to `tiferet/commands/sqlite.py` (no top-level export)

This reduces boilerplate for schema creation in SQLite-backed apps, aligning with the existing command suite.

## Changes Summary

### Added / Modified Files
- `tiferet/commands/sqlite.py`  
  → New `CreateTableSql` class at end of file  
  → Supports script mode (raw SQL) and structured mode  
  → Validates table/column names, non-empty inputs  
  → Generates properly quoted SQL  
  → Executes via `sql.execute(...)` inside `with` block

- `tiferet/commands/tests/test_sqlite.py`  
  → 11 new tests:  
    - Basic creation  
    - With constraints  
    - Idempotency (`IF NOT EXISTS`)  
    - Validation failures (empty/invalid name, no columns)  
    - Execution errors

- `tiferet/__init__.py`  
  → Bumped `__version__` to `'1.8.3'` (patch release)

### Key Behaviors
- Script mode: passes raw script to `executescript` after validation
- Structured mode: generates safe SQL with quoted identifiers
- Validation: rejects empty/invalid table names, empty columns, etc.
- Idempotent: `if_not_exists=True` prevents duplicate table errors
- Errors: uses structured `TiferetError` for validation/execution issues

## Testing
- All 11 new tests pass
- Verified generated SQL is valid and properly quoted
- Round-trip: create → list → delete → confirm gone
- Manual checks: idempotency, invalid input rejection

## Deviations / Clarifications vs TRD
- **None**. Implementation follows TRD exactly: dual modes, basic sanitation, context-manager enforcement, success dict return.

## Next Steps (future PRs)
- `DropTableSql` (symmetric schema helper)
- v1.9 import pattern adoption (FACE modules)

Co-authored-by: Warp <agent@warp.dev>

Ready for review/merge — this is a clean, low-risk patch for v1.8.3.