### PR TITLE
Backport Documentation to v1.9.x-maintenance (#562)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,285 @@
+# AGENTS.md — Tiferet Framework (v1.9.x)
+
+## Project Overview
+
+**Tiferet** is a Python framework for Domain-Driven Design (DDD). It provides a layered architecture for building applications with domain events, service interfaces, configuration-driven feature workflows, and dependency injection. The framework uses YAML-based configuration files and `schematics` for model validation.
+
+- **Repository:** https://github.com/greatstrength/tiferet
+- **Branch:** `v1.9.x-maintenance`
+- **Python:** ≥ 3.10
+- **Version:** `1.9.x`
+
+## Architecture
+
+### Layer Overview
+
+The v1.9.x branch maintains a **dual-package structure**: legacy packages from v1.x coexist alongside forward-compatible packages that introduce the v2.0 naming and design. Both are fully supported; new code should prefer the forward-compatible packages.
+
+```
+tiferet/
+├── assets/               # Constants, exceptions (TiferetError), shared config
+├── commands/             # Legacy: Command base class
+├── contexts/             # Runtime orchestration (AppManager, Feature, Error, CLI, etc.)
+├── contracts/            # Legacy: Service/Repository contracts
+├── data/                 # Legacy: DataObject
+├── domain/               # Forward: DomainObject
+├── events/               # Forward: DomainEvent
+├── handlers/             # Handler implementations
+├── interfaces/           # Forward: Service ABC
+├── mappers/              # Forward: Aggregate + TransferObject
+├── middleware/           # File I/O middleware
+├── models/               # Legacy: ModelObject
+├── proxies/              # YAML/JSON/CSV proxies
+├── repos/                # Repository implementations
+└── tests_int/            # Integration tests
+```
+
+### Key Concepts
+
+**Legacy packages** (fully supported, carried from v1.x):
+
+- **ModelObject** (`models/settings.py`): Base domain model class extending `schematics.Model`. Instantiate via `ModelObject.new(Type, **kwargs)`.
+- **Command** (`commands/settings.py`): Base class for business operations with dependency injection and `execute(**kwargs)` entry point.
+- **DataObject** (`data/settings.py`): Combined data mapping/serialization class with `new()`, `map()`, `from_model()`, `from_data()`, `allow()`, `deny()`.
+- **Repository** / **Service** / **ModelContract** (`contracts/`): Abstract base classes for service and repository contracts.
+
+**Forward-compatible packages** (new in v1.9.x, aligned with v2.0 design):
+
+- **DomainObject** (`domain/settings.py`): Drop-in successor to `ModelObject`. Base class extending `schematics.Model`. Instantiate via `DomainObject.new(Type, **kwargs)`. Domain objects are read-only; mutation goes through Aggregates.
+- **DomainEvent** (`events/settings.py`): Successor to `Command`. Receives dependencies via constructor injection. Entry point is `execute(**kwargs)`. Use `@DomainEvent.parameters_required([...])` for declarative input validation. Use `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` for invocation in tests.
+- **Service** (`interfaces/settings.py`): Abstract base class (`ABC`) for service contracts. Successor to `contracts/` service interfaces. All vertical concerns (data access, config, middleware) are unified under Service.
+- **Aggregate** (`mappers/settings.py`): Mutable extension of domain objects. Successor to the mutation side of `DataObject`. Factory: `Aggregate.new(Type, **kwargs)`. Provides `set_attribute()` for validated mutation.
+- **TransferObject** (`mappers/settings.py`): Serialization layer with role-based field control (`allow()`, `deny()`). Successor to the serialization side of `DataObject`. Methods: `map()`, `from_model()`, `from_data()`.
+
+### Runtime Flow
+
+1. `App()` (alias for `AppManagerContext`) loads settings.
+2. `app.run(interface_id, feature_id, data={})` loads the interface via `AppInterfaceContext`.
+3. `FeatureContext.execute_feature()` loads the feature config, resolves commands from the container, and executes them sequentially.
+4. Each command is a `DomainEvent` (or legacy `Command`) subclass that receives injected services and performs domain logic.
+5. Results flow back through `RequestContext` and `handle_response()`.
+
+### Dependency Injection
+
+Tiferet uses the `dependencies` library for runtime DI. Injectors are created per app interface in `AppManagerContext.load_app_instance()`. Container attributes are defined in `app/configs/container.yml` and resolved via `ContainerContext`.
+
+## Structured Code Style
+
+All code follows a strict artifact comment hierarchy. **This is mandatory.**
+
+### Comment Levels
+
+- `# *** <section>` — Top-level: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `constants`, `classes`
+- `# ** <category>: <name>` — Mid-level: `core`, `infra`, `app` (for imports); `model: <name>`, `event: <name>`, `context: <name>`, etc.
+- `# * <component>` — Low-level: `attribute: <name>`, `init`, `method: <name>`, `method: <name> (static)`
+
+### Spacing Rules
+
+- One empty line between `# ***` and first `# **`.
+- One empty line between each `# *` section.
+- One empty line after docstrings and between code snippets within methods.
+
+### Import Organization
+
+```python
+# *** imports
+
+# ** core
+from typing import List, Any
+
+# ** infra
+from schematics import Model
+
+# ** app
+from ..domain import Feature
+from ..interfaces import FeatureService
+```
+
+### Docstrings
+
+Use RST format with `:param`, `:type`, `:return`, `:rtype` for all public methods.
+
+### Code Snippets
+
+Each logical step within a method is a separate snippet preceded by a 1–2 line comment:
+
+```python
+# Retrieve the feature from the service.
+feature = self.feature_service.get(id)
+
+# Verify the feature exists.
+self.verify(
+    expression=feature is not None,
+    error_code=a.const.FEATURE_NOT_FOUND_ID,
+    feature_id=id,
+)
+
+# Return the feature.
+return feature
+```
+
+## Domain Events
+
+Domain events are the primary operational units. Key patterns:
+
+- Extend `DomainEvent` from `tiferet/events/settings.py`.
+- Dependencies via constructor injection (usually a Service).
+- `execute(**kwargs)` is the entry point.
+- `@DomainEvent.parameters_required(['param1', 'param2'])` for declarative input validation (decorator on `execute`).
+- `self.verify(expression, error_code, message, **kwargs)` for domain rule enforcement.
+- `self.raise_error(error_code, message, **kwargs)` for direct error raising.
+- Return domain models or identifiers.
+
+### Static Events
+
+`ParseParameter`, `ImportDependency`, `RaiseError` in `events/static.py` are utility events called with static `.execute()` methods.
+
+### Testing Events
+
+Always use `DomainEvent.handle()` in tests:
+
+```python
+result = DomainEvent.handle(
+    GetFeature,
+    dependencies={'feature_service': mock_service},
+    id='group.feature_key',
+)
+```
+
+## Domain Objects
+
+- Extend `DomainObject` from `tiferet/domain/settings.py`.
+- Use Schematics types: `StringType`, `IntegerType`, `FloatType`, `BooleanType`, `ListType`, `DictType`, `ModelType`.
+- Instantiate via `DomainObject.new(Type, **kwargs)`.
+- Domain objects are **read-only**; place mutation logic in Aggregates (`mappers/`).
+
+### Domain Modules
+
+- `domain/app.py` — `AppInterface`, `AppAttribute`
+- `domain/cli.py` — `CliCommand`, `CliArgument`
+- `domain/container.py` — `ContainerAttribute`, `FlaggedDependency`
+- `domain/error.py` — `Error`, `ErrorMessage`
+- `domain/feature.py` — `Feature`, `FeatureCommand`
+- `domain/logging.py` — `Formatter`, `Handler`, `Logger`
+
+## Interfaces (Services)
+
+- Extend `Service` (ABC) from `tiferet/interfaces/settings.py`.
+- All methods marked `@abstractmethod`.
+- Artifact comments use `# *** interfaces` / `# ** interface: <name>`.
+- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
+
+## Mappers
+
+Split into two classes:
+
+- **Aggregate** — Extends domain object + `Aggregate`. Adds mutation methods (`rename()`, `add_command()`, `set_attribute()`).
+- **TransferObject** — Extends domain object + `TransferObject`. Adds serialization roles via inner `Options` class with `allow()`/`deny()`.
+
+### Naming Convention
+
+- `<Domain>Aggregate` (e.g., `FeatureAggregate`, `ErrorAggregate`)
+- `<Domain>YamlObject` (e.g., `FeatureYamlObject`, `ErrorYamlObject`)
+
+## Repositories
+
+Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backed:
+
+- `AppYamlRepository`, `CliYamlRepository`, `ContainerYamlRepository`
+- `ErrorYamlRepository`, `FeatureYamlRepository`, `LoggingYamlRepository`
+
+## Error Handling
+
+- `TiferetError` (`assets/exceptions.py`): Base exception with `error_code` and `kwargs`.
+- `TiferetAPIError`: Extends `TiferetError` with `name` and `message` for API responses.
+- Error constants defined in `assets/constants.py` (e.g., `FEATURE_NOT_FOUND_ID`, `COMMAND_PARAMETER_REQUIRED_ID`).
+- Default error definitions in `assets/constants.py::DEFAULT_ERRORS` dict.
+- Access constants via `from .. import assets as a` then `a.const.ERROR_CODE_ID`.
+
+## Configuration
+
+Applications are configured via YAML files in `app/configs/`:
+
+- `app.yml` — Interface definitions (name, module_path, class_name, attributes)
+- `container.yml` — Dependency injection container attributes (module_path, class_name, parameters)
+- `feature.yml` — Feature workflows (commands with attribute_id, parameters, data_key)
+- `error.yml` — Error definitions with multilingual messages
+- `cli.yml` — CLI command definitions with arguments
+- `logging.yml` — Logging formatters, handlers, loggers
+
+## Testing
+
+- **Framework:** `pytest` (with `pytest_env` for environment variables).
+- **Test location:** Co-located in `<package>/tests/` directories (e.g., `domain/tests/`, `events/tests/`, `mappers/tests/`).
+- **Integration tests:** `tiferet/tests_int/`.
+- **Run tests:** `pytest tiferet/` from project root (with venv activated).
+- **Test structure:** Uses artifact comments (`# *** fixtures`, `# ** fixture: <name>`, `# *** tests`, `# ** test: <name>`).
+- **Mocking:** Use `unittest.mock`. Mock injected services. Verify calls and return values.
+- **Event testing:** Always invoke via `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)`.
+
+## Utilities
+
+`tiferet/utils/` provides file I/O wrappers:
+
+- `FileLoader` / `File` — Base file operations (open, close, read, write) with context manager support.
+- `YamlLoader` / `Yaml` — YAML read/write via PyYAML.
+- `JsonLoader` / `Json` — JSON read/write.
+- `CsvLoader` / `Csv` — CSV read/write.
+- `CsvDictLoader` / `CsvDict` — CSV with dict reader/writer.
+- `SqliteClient` / `Sqlite` — SQLite connection management with context manager.
+
+## Package Exports
+
+The top-level `tiferet/__init__.py` exports:
+
+**Core:**
+- `App` (alias for `AppManagerContext`)
+- `TiferetError`, `TiferetAPIError`
+
+**Legacy:**
+- `ModelObject` and Schematics type wrappers (`StringType`, `IntegerType`, `BooleanType`, `FloatType`, `ListType`, `DictType`, `ModelType`)
+- `Command`, `ParseParameter` (from `commands/`)
+- `ModelContract`, `Repository`, `Service` (from `contracts/`)
+- `DataObject` (from `data/`)
+
+**Proxies and Middleware:**
+- `YamlFileProxy`, `JsonFileProxy`, `CsvFileProxy` (from `proxies/`)
+- `File`, `FileLoaderMiddleware`, `Yaml`, `YamlLoaderMiddleware`, `Json`, `JsonLoaderMiddleware`, `Csv`, `CsvLoaderMiddleware`, `CsvDict`, `CsvDictLoaderMiddleware` (from `middleware/`)
+
+**Forward-compatible** (available via their respective packages):
+- `DomainObject` (from `tiferet.domain`)
+- `DomainEvent`, `ParseParameter`, `ImportDependency`, `RaiseError` (from `tiferet.events`)
+- `Service` (from `tiferet.interfaces`)
+- `Aggregate`, `TransferObject` (from `tiferet.mappers`)
+
+## Forward-Compatible Packages
+
+The following packages are available on v1.9.x-maintenance as forward-compatible successors to legacy packages. New code should prefer these packages. Legacy packages remain fully supported.
+
+- **`tiferet/domain/`** → `DomainObject` — drop-in successor to `ModelObject` (`models/`). Same API, new name.
+- **`tiferet/events/`** → `DomainEvent` — successor to `Command` (`commands/`). Adds `@parameters_required` decorator and `DomainEvent.handle()` for testing.
+- **`tiferet/interfaces/`** → `Service` (ABC) — successor to `contracts/` service interfaces. Cleaner abstract base with `@abstractmethod`.
+- **`tiferet/mappers/`** → `Aggregate` + `TransferObject` — successor to `DataObject` (`data/`). Splits mutation (Aggregate) from serialization (TransferObject) for cleaner separation of concerns.
+
+## Key Files for Orientation
+
+- `tiferet/__init__.py` — Version and public exports
+- `tiferet/domain/settings.py` — `DomainObject` base class
+- `tiferet/events/settings.py` — `DomainEvent` base class (execute, verify, parameters_required, handle)
+- `tiferet/mappers/settings.py` — `Aggregate` and `TransferObject` base classes
+- `tiferet/interfaces/settings.py` — `Service` (ABC) base class
+- `tiferet/contexts/app.py` — `AppManagerContext` and `AppInterfaceContext`
+- `tiferet/contexts/feature.py` — `FeatureContext` (feature execution engine)
+- `tiferet/assets/constants.py` — Error codes and default configuration
+- `tiferet/assets/exceptions.py` — `TiferetError` and `TiferetAPIError`
+
+## Contributing
+
+See `CONTRIBUTING.md` for the full workflow:
+
+1. Tie work to a GitHub issue.
+2. Write a TRD (Technical Requirements Document) for non-trivial changes.
+3. Implement following structured code style and component-specific guides in `docs/core/`.
+4. Separate functional changes from docs/config in distinct commits.
+5. Include `Co-Authored-By:` lines when collaborating with AI agents.
+6. Publish a Collaboration Report on the issue upon completion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Tiferet
+
+Thank you for your interest in contributing to the Tiferet framework! This document outlines the process and expectations for contributing, whether you're fixing a bug, proposing a feature, or improving documentation.
+
+## Getting Started
+
+1. **Fork** the repository and clone your fork locally.
+2. Create a new branch from the appropriate base branch (e.g., `v1.x-proto` or `v2.0-proto`).
+3. Set up a virtual environment and install the package in development mode:
+   ```bash
+   python3.10 -m venv venv
+   source venv/bin/activate
+   pip install -e .
+   ```
+
+## Contribution Workflow
+
+### 1. Open or Claim an Issue
+
+All contributions should be tied to a GitHub issue. If one doesn't exist for the work you'd like to do, open an issue first to discuss the change with maintainers before starting.
+
+### 2. Write a Technical Requirements Document (TRD)
+
+For non-trivial changes (new features, refactors, architectural updates), a **Technical Requirements Document** is required before implementation begins. TRDs ensure clarity, alignment, and traceability across the project.
+
+See the full TRD authoring guide:
+**[docs/guides/tech_requirements.md](docs/guides/tech_requirements.md)**
+
+Key points:
+- Follow the standard structure (Overview, Scope, Components Affected, Detailed Requirements, Acceptance Criteria).
+- Include code signatures and behavior descriptions where applicable.
+- Reference the relevant [code style guides](docs/core/) for the components you're modifying.
+
+### 3. Implement
+
+- Follow the [Structured Code Style](docs/core/code_style.md) — artifact comments, spacing rules, RST docstrings, and snippet conventions are enforced across the codebase.
+- Consult the component-specific guides in `docs/core/` for the layers you're working in:
+  - [domain.md](docs/core/domain.md) — Domain objects
+  - [events.md](docs/core/events.md) — Domain events
+  - [mappers.md](docs/core/mappers.md) — Aggregates and transfer objects
+  - [interfaces.md](docs/core/interfaces.md) — Service interfaces
+  - [contexts.md](docs/core/contexts.md) — Application contexts
+- Write tests using `pytest`. Follow existing test structure (`# *** fixtures`, `# *** tests`).
+
+### 4. Commit Hygiene
+
+- Separate functional code changes from documentation, configuration, and packaging into distinct, atomic commits.
+- Title commits by scope (e.g., `Events – AddFeature event`, `Docs/Packaging – update guides`).
+- Include `Co-Authored-By: <name> <email>` in commit messages when collaborating with AI agents or other contributors.
+
+### 5. Open a Pull Request
+
+- Target the appropriate base branch.
+- Reference the GitHub issue in the PR description.
+- Ensure all tests pass and the code follows project conventions.
+- Keep PRs focused — one logical change per PR.
+
+### 6. Collaboration Report
+
+Upon completion of a story or issue, a **Collaboration Report** is published as a comment on the originating GitHub issue. This report documents the implementation, deviations from the TRD, git state, and a log of key decisions made during development.
+
+See the full report format guide:
+**[docs/guides/collab_report.md](docs/guides/collab_report.md)**
+
+## Code Style
+
+Tiferet enforces a structured code style across all modules. The essentials:
+
+- **Artifact comments** (`# ***`, `# **`, `# *`) organize code into predictable, machine-readable sections.
+- **RST docstrings** with `:param`, `:type`, `:return`, `:rtype` on all public methods.
+- **Commented code snippets** — each logical step is a separate snippet preceded by a descriptive comment.
+- **Consistent spacing** — one empty line between sections, comments, and code blocks.
+
+Full details: **[docs/core/code_style.md](docs/core/code_style.md)**
+
+## Reporting Issues
+
+When reporting bugs or requesting features:
+- Use the GitHub issue tracker.
+- Include a clear description, steps to reproduce (for bugs), and the expected vs. actual behavior.
+- Reference relevant files, configurations, or error messages where applicable.
+
+## License
+
+By contributing to Tiferet, you agree that your contributions will be licensed under the [BSD 3-Clause License](LICENSE) that covers the project.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Tiferet is a Python framework that elegantly distills Domain-Driven Design (DDD) into a practical, powerful tool. Drawing inspiration from the concept of beauty in balance as expressed in Kabbalah, Tiferet weaves purpose and functionality into software that not only performs but resonates deeply with its intended vision. As a cornerstone for crafting diverse applications, Tiferet empowers developers to build solutions with clarity, grace, and thoughtful design.
 
-Tiferet embraces the complexity of real-world processes through DDD, transforming intricate business logic and evolving requirements into clear, manageable models. Far from merely navigating this labyrinth, Tiferet provides a graceful path to craft software that reflects its intended purpose with wisdom and precision, embodying beauty and balance in form and function. This tutorial guides you through building a simple calculator application, demonstrating how Tiferet harmonizes code and concept. By defining commands and their configurations, you’ll create a robust and extensible calculator that resonates with Tiferet’s philosophy.
+Tiferet embraces the complexity of real-world processes through DDD, transforming intricate business logic and evolving requirements into clear, manageable models. Far from merely navigating this labyrinth, Tiferet provides a graceful path to craft software that reflects its intended purpose with wisdom and precision, embodying beauty and balance in form and function. This tutorial guides you through building a simple calculator application, demonstrating how Tiferet harmonizes code and concept. By defining domain events and their configurations, you'll create a robust and extensible calculator that resonates with Tiferet's philosophy.
 
 ## Getting Started with Tiferet
 Embark on your Tiferet journey with a few simple steps to set up your Python environment. Whether you're new to Python or a seasoned developer, these instructions will prepare you to craft a calculator application with grace and precision.
@@ -92,7 +92,7 @@ project_root/
 ├── basic_calc.py
 ├── calc_cli.py
 └── app/
-    ├── commands/
+    ├── events/
     │   ├── __init__.py
     │   ├── calc.py
     │   └── settings.py
@@ -106,31 +106,31 @@ project_root/
         └── logging.yml
 ```
 
-The `app/commands/` directory holds command classes for arithmetic operations (`calc.py`) and input validation (`settings.py`). The `app/configs/` directory contains configuration files for application settings (`app.yml`), CLI commands (`cli.yml`), dependency injection (`container.yml`), error handling (`error.yml`), feature workflows (`feature.yml`), and logging (`logging.yml`). The `basic_calc.py` script at the root initializes and runs the application. We recommend keeping the `app` directory name for internal projects to ensure consistency, though it can be customized for package releases. The `calc_cli.py` script provides a flexible command-line interface, easily integrated with shell scripts or external systems.
+The `app/events/` directory holds domain event classes for arithmetic operations (`calc.py`) and input validation (`settings.py`). The `app/configs/` directory contains configuration files for application settings (`app.yml`), CLI commands (`cli.yml`), dependency injection (`container.yml`), error handling (`error.yml`), feature workflows (`feature.yml`), and logging (`logging.yml`). The `basic_calc.py` script at the root initializes and runs the application. We recommend keeping the `app` directory name for internal projects to ensure consistency, though it can be customized for package releases. The `calc_cli.py` script provides a flexible command-line interface, easily integrated with shell scripts or external systems.
 
 ## Crafting the Calculator Application
-With Tiferet installed and your project structured, it’s time to build your calculator application. This section guides you through creating a base command for numeric validation, defining arithmetic commands, and setting up the application’s behavior with configurations. By weaving together commands and configurations, you’ll experience Tiferet’s elegant design, harmonizing functionality with clarity and precision.
+With Tiferet installed and your project structured, it's time to build your calculator application. This section guides you through creating a base domain event for numeric validation, defining arithmetic domain events, and setting up the application's behavior with configurations. By weaving together domain events and configurations, you'll experience Tiferet's elegant design, harmonizing functionality with clarity and precision.
 
-### Defining Base and Arithmetic Command Classes
-Start by creating command classes for numeric validation and arithmetic operations. The `BasicCalcCommand` in `app/commands/settings.py` provides validation logic, while arithmetic commands (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber`) in `app/commands/calc.py` perform calculations. All arithmetic commands inherit from `BasicCalcCommand`, which extends Tiferet’s `Command` class, ensuring robust numeric validation and core command functionality.
+### Defining Base and Arithmetic Domain Event Classes
+Start by creating domain event classes for numeric validation and arithmetic operations. The `BasicCalcEvent` in `app/events/settings.py` provides validation logic, while arithmetic domain events (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber`) in `app/events/calc.py` perform calculations. All arithmetic domain events inherit from `BasicCalcEvent`, which extends Tiferet's `DomainEvent` class, ensuring robust numeric validation and core event functionality.
 
-#### Base Command in commands/settings.py
-Numeric validation is critical to ensure the calculator handles inputs correctly, preventing errors from invalid data. The `BasicCalcCommand` class centralizes validation logic, making it reusable across all arithmetic commands by converting string inputs to integers or floats.
+#### Base Domain Event in events/settings.py
+Numeric validation is critical to ensure the calculator handles inputs correctly, preventing errors from invalid data. The `BasicCalcEvent` class centralizes validation logic, making it reusable across all arithmetic domain events by converting string inputs to integers or floats.
 
-Create `app/commands/settings.py` with the following contents:
+Create `app/events/settings.py` with the following contents:
 
 ```python
 # *** imports
 
 # ** infra
-from tiferet.commands import *
+from tiferet.events import *
 
-# *** commands
+# *** events
 
-# ** command: basic_calc_command
-class BasicCalcCommand(Command):
+# ** event: basic_calc_event
+class BasicCalcEvent(DomainEvent):
     '''
-    A command to validate that a value can be a Number object.
+    A domain event to validate that a value can be a Number object.
     '''
     
     # * method: verify_number
@@ -161,12 +161,12 @@ class BasicCalcCommand(Command):
         return int(value)
 ```
 
-The `BasicCalcCommand` extends Tiferet’s `Command` class, providing a `verify_number` method that validates string inputs and returns them as `int` or `float`. It raises an `INVALID_INPUT` error for invalid inputs, ensuring all arithmetic commands inherit robust validation.
+The `BasicCalcEvent` extends Tiferet's `DomainEvent` class, providing a `verify_number` method that validates string inputs and returns them as `int` or `float`. It raises an `INVALID_INPUT` error for invalid inputs, ensuring all arithmetic domain events inherit robust validation.
 
-#### Arithmetic Commands in commands/calc.py
-The arithmetic commands are the heart of the calculator, delivering core mathematical operations: addition, subtraction, multiplication, division, and exponentiation. These commands leverage Python’s numeric capabilities, processing validated inputs to produce precise results.
+#### Arithmetic Domain Events in events/calc.py
+The arithmetic domain events are the heart of the calculator, delivering core mathematical operations: addition, subtraction, multiplication, division, and exponentiation. These domain events leverage Python's numeric capabilities, processing validated inputs to produce precise results.
 
-Create `app/commands/calc.py` with the following content:
+Create `app/events/calc.py` with the following content:
 
 ```python
 # *** imports
@@ -175,21 +175,21 @@ Create `app/commands/calc.py` with the following content:
 from typing import Any
 
 # ** infra
-from tiferet.commands import *
+from tiferet.events import *
 
 # ** app
-from .settings import BasicCalcCommand
+from .settings import BasicCalcEvent
 
-# *** commands
+# *** events
 
-# ** command: add_number
-class AddNumber(BasicCalcCommand):
+# ** event: add_number
+class AddNumber(BasicCalcEvent):
     '''
-    A command to perform addition of two numbers.
+    A domain event to perform addition of two numbers.
     '''
     def execute(self, a: Any, b: Any, **kwargs) -> int | float:
         '''
-        Execute the addition command.
+        Execute the addition event.
 
         :param a: A number representing the first operand.
         :type a: Any
@@ -210,14 +210,14 @@ class AddNumber(BasicCalcCommand):
         # Return the result.
         return result
 
-# ** command: subtract_number
-class SubtractNumber(BasicCalcCommand):
+# ** event: subtract_number
+class SubtractNumber(BasicCalcEvent):
     '''
-    A command to perform subtraction of two numbers.
+    A domain event to perform subtraction of two numbers.
     '''
     def execute(self, a: Any, b: Any, **kwargs) -> int | float:
         '''
-        Execute the subtraction command.
+        Execute the subtraction event.
 
         :param a: A number representing the first operand.
         :type a: Any
@@ -238,14 +238,14 @@ class SubtractNumber(BasicCalcCommand):
         # Return the result.
         return result
 
-# ** command: multiply_number
-class MultiplyNumber(BasicCalcCommand):
+# ** event: multiply_number
+class MultiplyNumber(BasicCalcEvent):
     '''
-    A command to perform multiplication of two numbers.
+    A domain event to perform multiplication of two numbers.
     '''
     def execute(self, a: Any, b: Any, **kwargs) -> int | float:
         '''
-        Execute the multiplication command.
+        Execute the multiplication event.
 
         :param a: A number representing the first operand.
         :type a: Any
@@ -266,14 +266,14 @@ class MultiplyNumber(BasicCalcCommand):
         # Return the result.
         return result
 
-# ** command: divide_number
-class DivideNumber(BasicCalcCommand):
+# ** event: divide_number
+class DivideNumber(BasicCalcEvent):
     '''
-    A command to perform division of two numbers.
+    A domain event to perform division of two numbers.
     '''
     def execute(self, a: Any, b: Any, **kwargs) -> int | float:
         '''
-        Execute the division command.
+        Execute the division event.
 
         :param a: A number representing the numerator.
         :type a: Any
@@ -297,14 +297,14 @@ class DivideNumber(BasicCalcCommand):
         # Return the result.
         return result
 
-# ** command: exponentiate_number
-class ExponentiateNumber(BasicCalcCommand):
+# ** event: exponentiate_number
+class ExponentiateNumber(BasicCalcEvent):
     '''
-    A command to perform exponentiation of two numbers.
+    A domain event to perform exponentiation of two numbers.
     '''
     def execute(self, a: Any, b: Any, **kwargs) -> int | float:
         '''
-        Execute the exponentiation command.
+        Execute the exponentiation event.
 
         :param a: A number representing the base.
         :type a: Any
@@ -326,13 +326,13 @@ class ExponentiateNumber(BasicCalcCommand):
         return result
 ```
 
-These commands perform arithmetic operations on flexible input values, validated by `BasicCalcCommand.verify_number` to ensure they are valid integers or floats. The method converts string inputs to `int` or `float` before computation, returning the result as a numeric value. The `DivideNumber` command includes a check to prevent division by zero, raising a configured `DIVISION_BY_ZERO` error if needed.
+These domain events perform arithmetic operations on flexible input values, validated by `BasicCalcEvent.verify_number` to ensure they are valid integers or floats. The method converts string inputs to `int` or `float` before computation, returning the result as a numeric value. The `DivideNumber` event includes a check to prevent division by zero, raising a configured `DIVISION_BY_ZERO` error if needed.
 
 ### Configuring the Calculator Application
-With command classes defined, it’s time to configure the Tiferet application to recognize and orchestrate them, enabling seamless user interaction through features and interfaces. This section guides you through setting up the application interface (`app/configs/app.yml`), defining command classes as container attributes (`app/configs/container.yml`), specifying error messages (`app/configs/error.yml`), and organizing features (`app/configs/feature.yml`). These configurations weave together Tiferet’s dependency injection and feature-driven design, ensuring a robust and extensible calculator.
+With domain event classes defined, it's time to configure the Tiferet application to recognize and orchestrate them, enabling seamless user interaction through features and interfaces. This section guides you through setting up the application interface (`app/configs/app.yml`), defining domain event classes as container attributes (`app/configs/container.yml`), specifying error messages (`app/configs/error.yml`), and organizing features (`app/configs/feature.yml`). These configurations weave together Tiferet's dependency injection and feature-driven design, ensuring a robust and extensible calculator.
 
 #### Configuring the App Interface in `configs/app.yml`
-Define the calculator’s user interface in `app/configs/app.yml` to specify the interface type and its core attributes. This configuration enables Tiferet to initialize the application with default settings, supporting multiple interfaces for flexible command execution.
+Define the calculator's user interface in `app/configs/app.yml` to specify the interface type and its core attributes. This configuration enables Tiferet to initialize the application with default settings, supporting multiple interfaces for flexible feature execution.
 
 Create `app/configs/app.yml` with the following content:
 
@@ -343,33 +343,33 @@ interfaces:
     description: Perform basic calculator operations
 ```
 
-The `interfaces` section configures the `basic_calc` interface with a name and description, using Tiferet’s default settings to streamline application setup. This setup aligns with the project structure, preparing the calculator for command and feature integration.
+The `interfaces` section configures the `basic_calc` interface with a name and description, using Tiferet's default settings to streamline application setup. This setup aligns with the project structure, preparing the calculator for domain event and feature integration.
 
 #### Configuring the Container in `configs/container.yml`
-Expose command classes to Tiferet by defining them as container attributes in `app/configs/container.yml`. This configuration maps each command to its module and class, enabling dependency injection for seamless feature execution.
+Expose domain event classes to Tiferet by defining them as container attributes in `app/configs/container.yml`. This configuration maps each domain event to its module and class, enabling dependency injection for seamless feature execution.
 
 Create the `app/configs/container.yml` with the following content:
 
 ```yaml
 attrs:
-  add_number_cmd:
-    module_path: app.commands.calc
+  add_number_event:
+    module_path: app.events.calc
     class_name: AddNumber
-  subtract_number_cmd:
-    module_path: app.commands.calc
+  subtract_number_event:
+    module_path: app.events.calc
     class_name: SubtractNumber
-  multiply_number_cmd:
-    module_path: app.commands.calc
+  multiply_number_event:
+    module_path: app.events.calc
     class_name: MultiplyNumber
-  divide_number_cmd:
-    module_path: app.commands.calc
+  divide_number_event:
+    module_path: app.events.calc
     class_name: DivideNumber
-  exponentiate_number_cmd:
-    module_path: app.commands.calc
+  exponentiate_number_event:
+    module_path: app.events.calc
     class_name: ExponentiateNumber
 ```
 
-The `attrs` section lists each command with a unique identifier (ending in `_cmd`), specifying its module path and class name. This setup ensures Tiferet can instantiate and execute the calculator’s arithmetic commands efficiently.
+The `attrs` section lists each domain event with a unique identifier (ending in `_event`), specifying its module path and class name. This setup ensures Tiferet can instantiate and execute the calculator's arithmetic domain events efficiently.
 
 #### Configuring the Errors in `configs/error.yml`
 Handle errors gracefully by defining error messages in `app/configs/error.yml`. This configuration specifies error codes and multilingual messages, ensuring clear feedback for invalid inputs or operations.
@@ -397,7 +397,7 @@ errors:
 The `errors` section defines `invalid_input` for failed numeric validations and `division_by_zero` for division errors, supporting English (`en_US`) and Spanish (`es_ES`) messages. This configuration enhances user experience with localized, precise error handling.
 
 #### Configuring the Features in `configs/feature.yml`
-Orchestrate command execution by defining features in `app/configs/feature.yml`. This configuration organizes arithmetic operations into reusable workflows, mapping each feature to its corresponding command for streamlined execution.
+Orchestrate domain event execution by defining features in `app/configs/feature.yml`. This configuration organizes arithmetic operations into reusable workflows, mapping each feature to its corresponding domain event for streamlined execution.
 
 Create `app/configs/feature.yml` with the following content:
 
@@ -408,43 +408,43 @@ features:
       name: 'Add Number'
       description: 'Adds one number to another'
       commands:
-        - attribute_id: add_number_cmd
+        - attribute_id: add_number_event
           name: Add `a` and `b`
     subtract:
       name: 'Subtract Number'
       description: 'Subtracts one number from another'
       commands:
-        - attribute_id: subtract_number_cmd
+        - attribute_id: subtract_number_event
           name: Subtract `b` from `a`
     multiply:
       name: 'Multiply Number'
       description: 'Multiplies one number by another'
       commands:
-        - attribute_id: multiply_number_cmd
+        - attribute_id: multiply_number_event
           name: Multiply `a` and `b`
     divide:
       name: 'Divide Number'
       description: 'Divides one number by another'
       commands:
-        - attribute_id: divide_number_cmd
+        - attribute_id: divide_number_event
           name: Divide `a` by `b`
     exp:
       name: 'Exponentiate Number'
       description: 'Raises one number to the power of another'
       commands:
-        - attribute_id: exponentiate_number_cmd
+        - attribute_id: exponentiate_number_event
           name: Raise `a` to the power of `b`
     sqrt:
       name: 'Square Root'
       description: 'Calculates the square root of a number'
       commands:
-        - attribute_id: exponentiate_number_cmd
+        - attribute_id: exponentiate_number_event
           name: Calculate square root of `a`
           params:
             b: '0.5'  # Square root is equivalent to raising to the power of 0.5
 ```
 
-The `features` section maps each operation (e.g., `calc.add`, `calc.sqrt`) to its command via `attribute_id`, with descriptive names and parameters. The `calc.sqrt` feature reuses `exponentiate_number_cmd` with a fixed `b` value of `0.5`, showcasing Tiferet’s flexible workflow design.
+The `features` section maps each operation (e.g., `calc.add`, `calc.sqrt`) to its domain event via `attribute_id`, with descriptive names and parameters. The `calc.sqrt` feature reuses `exponentiate_number_event` with a fixed `b` value of `0.5`, showcasing Tiferet's flexible workflow design.
 
 ### Initializing and Demonstrating the Calculator in basic_calc.py
 Bring the Tiferet calculator to life with `basic_calc.py`, a script that initializes the application and demonstrates its arithmetic prowess. This script leverages Tiferet’s `App` class to load the `basic_calc` interface and execute features, showcasing robust calculations and error handling.
@@ -636,6 +636,6 @@ python calc_cli.py calc divide 5 0
 The `calc_cli.py` script offers a versatile, scriptable interface that integrates effortlessly with shell scripts or external systems, powered by `CliContext` for robust command execution. For quick testing or debugging, use `basic_calc.py` to run individual features with predefined values, while the CLI provides precise, argument-driven control.
 
 ## Conclusion
-Embark on a journey of elegance and precision with Tiferet’s Domain-Driven Design framework, as this tutorial has crafted a robust calculator application. You’ve defined arithmetic and validation commands in `app/commands/calc.py` and `app/commands/settings.py`, orchestrated them with configurations in `app/configs/app.yml`, `app/configs/feature.yml`, and `app/configs/cli.yml`, and brought them to life through `basic_calc.py` and the `CliContext`-powered `calc_cli.py`. This configuration-driven approach, enriched with dependency injection and multilingual error handling, reflects Tiferet’s harmonious balance of clarity and power, making development both functional and delightful.
+Embark on a journey of elegance and precision with Tiferet's Domain-Driven Design framework, as this tutorial has crafted a robust calculator application. You've defined arithmetic and validation domain events in `app/events/calc.py` and `app/events/settings.py`, orchestrated them with configurations in `app/configs/app.yml`, `app/configs/feature.yml`, and `app/configs/cli.yml`, and brought them to life through `basic_calc.py` and the `CliContext`-powered `calc_cli.py`. This configuration-driven approach, enriched with dependency injection and multilingual error handling, reflects Tiferet's harmonious balance of clarity and power, making development both functional and delightful.
 
-Extend your calculator’s potential with Tiferet’s modular design. Create a terminal user interface (TUI) in `calc_tui.py`, leveraging `CliContext` for interactive operation, or define a scientific calculator interface (`sci_calc`) in `app/configs/app.yml` with advanced features like trigonometric functions. Integrate the calculator into larger systems, such as financial modeling, by adding new commands and features in `app/configs/feature.yml`. Experiment with `calc_cli.py` to test additional operations, tweak configurations in `app/configs/`, or explore Tiferet’s documentation for advanced DDD techniques. Let Tiferet’s graceful framework guide you to solutions that resonate with purpose and precision, transforming complexity into clarity.
+Extend your calculator's potential with Tiferet's modular design. Create a terminal user interface (TUI) in `calc_tui.py`, leveraging `CliContext` for interactive operation, or define a scientific calculator interface (`sci_calc`) in `app/configs/app.yml` with advanced features like trigonometric functions. Integrate the calculator into larger systems, such as financial modeling, by adding new domain events and features in `app/configs/feature.yml`. Experiment with `calc_cli.py` to test additional operations, tweak configurations in `app/configs/`, or explore Tiferet's documentation for advanced DDD techniques. Let Tiferet's graceful framework guide you to solutions that resonate with purpose and precision, transforming complexity into clarity.

--- a/docs/guides/collab_report.md
+++ b/docs/guides/collab_report.md
@@ -1,0 +1,90 @@
+### Guide: How to Generate a Collaboration Summary Report (AI Agent Instructions)
+
+**Trigger Condition**  
+Generate this report **only** when the human explicitly confirms that the GitHub issue (story or subtask) is complete — for example, by stating “issue is completed”, “work is done”, “merged and ready”, or similar clear language. Do not generate it proactively.
+
+**Objective**  
+Produce a concise, professional, structured summary documenting:  
+- The original story/TRD goal  
+- Key code components modified (with important implementation highlights)  
+- Any intentional deviations or clarifications from the TRD  
+- Current Git/branch state  
+- Chronological record of significant AI ↔ Human decisions
+
+**Required Format**  
+Use **pure Markdown** and follow this exact structure and heading levels:
+
+```markdown
+# Collaboration Report: [Exact Story Title] (greatstrength/tiferet#[issue-number])
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** [Current date — e.g., February 23, 2026]  
+**Version:** [Milestone version — e.g., 1.9.0]
+
+## 1. Story / TRD Summary
+- **Issue:** `[exact title]` (greatstrength/tiferet#[issue-number])
+- **Goal:** One concise sentence summarizing the purpose, followed by a bullet list of the core requirements from the TRD.
+
+## 2. Code Components Touched
+### 2.1 [Component Name or Domain Area]
+**File:** `path/to/file.py`  
+**Class / Artifact:** `ClassName` (if applicable)  
+**Implements / Changes:**
+- Bullet list of the most important methods, attributes, or behavioral changes
+- Use **bold** for method names and file paths
+- Include short, relevant inline code snippets only for critical logic
+
+(Repeat 2.1, 2.2, … for each major area touched. Group logically — avoid listing every file.)
+
+## 3. Deviations / Clarifications vs TRD
+Numbered list of intentional differences (only include meaningful ones):
+
+1. **TRD expectation:** Brief quote or paraphrase from the TRD.
+   **Implemented behavior:** What was actually done.
+   **Rationale:** Why the change was made (e.g., better alignment with existing patterns, bug prevention, consistency, performance).
+
+(If no deviations occurred, state: “No deviations from the TRD were required.”)
+
+## 4. Git / Branch State
+- **Branch:** `feature/…` or `main` (include full name)
+- **Pull Request:** #NNN – [link to PR]
+- **Commits created in this work:**
+  1. `short commit message` (abcdef1) – [optional Co-Authored-By note]
+  2. …
+- **Current state:** pushed / merged / up-to-date with main / tagged, etc.
+
+## 5. Collaboration Log (AI ↔ Human)
+Chronological numbered list of key decision points:
+
+1. **AI** – [brief description of proposal, code suggestion, or question]
+2. **Human** – [brief summary of feedback, approval, or clarification]
+3. **AI** – [how the response was adjusted or implemented]
+
+End the log with:  
+“This log captures the essential iterative collaboration between AI and human that produced the final implementation.”
+
+**Tone & Style Rules**
+- Professional, concise, factual, neutral
+- Prefer bullet points and numbered lists for readability
+- Include only short, high-signal code snippets (with file path comment when helpful)
+- Never include full files or large blocks of code
+- The Collaboration Log section is **mandatory** — even if short
+
+**Length**  
+Target 1–2 pages when rendered. Be thorough yet avoid unnecessary detail.
+
+**Output**  
+Return **only** the final Markdown report. No additional commentary, explanations, or chat text.
+
+**Delivery Destination**
+- Post as a comment on the originating GitHub issue once triggered.
+- If the issue is locked or comments restricted → post to the associated PR and include a cross-link to the issue.
+- If neither channel is available → return the report in chat and ask the human for preferred delivery method.
+```
+
+### Process Conventions (for report generation)
+- Use exact calendar dates (e.g., February 23, 2026) — never relative terms like “today” or “yesterday”.
+- Include full PR link and short commit hashes (7 characters) in section 4.
+- When a release is part of the story, include links to the annotated tag and published GitHub release.
+- Keep the report focused on signal: prioritize decisions, changes, and rationale over exhaustive lists.

--- a/docs/guides/tech_requirements.md
+++ b/docs/guides/tech_requirements.md
@@ -1,0 +1,108 @@
+# Instructions for Creating Technical Requirements Documents in the Tiferet Framework Project
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+
+## Purpose
+These instructions ensure consistency, clarity, and completeness when drafting Technical Requirements Documents (TRDs) for stories, enhancements, refactors, and subtasks in the Tiferet project. TRDs serve as the primary specification for implementation and review.
+
+## General Guidelines
+- **Tone & Style**: Professional, precise, and concise. Use active voice where possible.
+- **Formatting**: Pure Markdown with proper headers, tables, code blocks, and lists.
+- **Date**: Use the current date (e.g., January 08, 2026).
+- **Version**: Use the current milestone version (e.g., 1.7.0). Increment only when instructed.
+- **Length**: Aim for completeness without unnecessary verbosity. Typical length: 1–3 pages when rendered.
+
+## Standard Structure
+Every TRD must follow this exact structure:
+
+```markdown
+# Technical Requirements Document: [Story Title]
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** [Current Date]  
+**Version:** [Current Milestone, e.g., 1.7.0]
+
+## 1. Overview
+[High-level summary of the change, purpose, and key outcomes.]
+
+## 2. Scope
+### In Scope
+- Bullet list of included work.
+### Out of Scope
+- Bullet list of excluded work.
+
+## 3. Components Affected
+| Component       | File/Path                          | Changes                                      |
+|-----------------|------------------------------------|----------------------------------------------|
+| ...             | ...                                | ...                                          |
+
+## 4. Detailed Requirements
+[Numbered subsections with code examples, signatures, behavior descriptions.]
+
+## 5. Acceptance Criteria
+1. Numbered list of verifiable outcomes.
+
+## 6. Non-Functional Requirements
+- Bullet list (performance, compatibility, style, etc.).
+
+[Optional additional sections: Subtasks, Tests, Verification, etc.]
+```
+
+## Specific Rules
+- **Title**: Use the exact story title prefixed with document type (e.g., "Commands – Feature: Add AddFeatureCommand Command").
+- **Overview**: 3–6 sentences. Include motivation and primary benefits.
+- **Scope**: Always include both "In Scope" and "Out of Scope" sections.
+- **Components Table**: Use proper Markdown table syntax. Include all directly modified files.
+- **Detailed Requirements**: 
+  - Use numbered subsections.
+  - Include code blocks with language hint and brief path comment when relevant.
+  - Describe behavior clearly, including validation, error cases, and return values.
+- **Acceptance Criteria**: Numbered, testable statements. Reference tests passing where appropriate.
+- **Non-Functional**: Always include consistency with patterns, backward compatibility, and maintainability notes.
+- **Subtasks**: For parent stories with subtasks, reference them or include separate linked documents.
+
+## Common Patterns
+- **Commands**: Include constructor, execute signature, validation, behavior, return value, and tests via `Command.handle`.
+- **Model Methods**: Include signature, behavior, and model tests.
+- **Refactors**: Highlight before/after, removed files, and migration steps.
+- **New Errors**: Add to constants with ID, name, and message.
+
+## Review Checklist
+Before finalizing:
+- [ ] All sections present.
+- [ ] Table formatted correctly.
+- [ ] Code blocks have language hint.
+- [ ] Acceptance criteria are verifiable.
+- [ ] No placeholder text or unresolved comments.
+
+These instructions ensure all TRDs remain uniform, readable, and actionable across the Tiferet codebase. Follow them strictly for every new document.
+
+## Related Code Style Documentation
+
+Every TRD must include a **"Related Code Style Documentation"** section at the end. This section provides targeted links to component-specific style guides based on the primary artifacts being modified in the story.
+
+**Rule for inclusion:**
+- Always include the general `code_style.md`.
+- Include a component-specific guide **only if the story directly adds, modifies, or refactors code in that component type**.
+- Do not include unrelated guides to avoid clutter.
+
+Current available guides (located in `docs/core/` on the `v1.9.x-maintenance` branch):
+- **[code_style.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/code_style.md)** – General structured code style (artifact comments, spacing, docstrings, snippets).
+- **[domain.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/domain.md)** – Domain model and aggregate conventions.
+- **[events.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/events.md)** – Domain event patterns and usage.
+- **[mappers.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/mappers.md)** – Data mapping, DTOs, and transformation conventions.
+- **[contexts.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/contexts.md)** – Context-specific conventions (injection patterns, lifecycle methods, execution flow).
+- **[interfaces.md](https://github.com/greatstrength/tiferet/blob/v1.9.x-maintenance/docs/core/interfaces.md)** – Interface / contract / service conventions.
+
+Additional component-specific style guides will be added as the framework evolves. Always consult the relevant documents when implementing or extending components.
+
+## Process Conventions (for TRD authors and executors)
+
+- Commit hygiene: separate functional code changes from documentation/config/packaging in distinct, atomic commits. Title commits by scope (e.g., "Interfaces – base class" vs "Docs/Packaging").
+- Versioning & tagging (when the story includes a release): specify the target version, branch, and bump type. Acceptance Criteria should include: (1) version bump commit, (2) annotated tag pushed, (3) published release with notes following the previous release style.
+- Source-of-truth references: when instructing to "retrofit from …", include the exact branch and path (and optionally the commit SHA) that contains the source document.
+- Reporting: upon completion, publish a Collaboration Report as a comment on the originating issue; include links to the PR, tag, and release.
+- Tooling fallback: if first-choice automation (e.g., MCP tools) is unavailable, specify the approved fallback (e.g., `gh` CLI) and prerequisites (authenticated session).
+- Cross-branch artifacts: if the referenced source does not exist locally on the working branch, it is acceptable to retrieve it via `git show <branch>:<path>` or include the minimal excerpts inline within the TRD.


### PR DESCRIPTION
## Summary

Backports key documentation artifacts to `v1.9.x-maintenance`, closing #562.

### Changes

- **`README.md`** — Updated with domain event terminology (cherry-picked from `v1.x-proto` commit `c6e5197`)
- **`CONTRIBUTING.md`** — Contribution guidelines (cherry-picked from `v1.x-proto` commit `0121e97`)
- **`AGENTS.md`** — AI/agent reference guide, newly adapted for the v1.9.x dual-package architecture (legacy + forward-compatible packages)
- **`docs/guides/collab_report.md`** — Collaboration report template (cherry-picked from `v1.x-proto` commit `0121e97`)
- **`docs/guides/tech_requirements.md`** — TRD authoring guide (cherry-picked from `v1.x-proto` commit `0121e97`)

### Deviation from TRD

- **Added `docs/guides/tech_requirements.md`**: Not listed in the original TRD scope, but included because `CONTRIBUTING.md` directly references it (`docs/guides/tech_requirements.md`). Without it, the contribution guide would contain a broken internal link.

### Notes

- No version bump, tag, or PyPI release — pure documentation change
- No Python code modified
- `AGENTS.md` contains no `v2.0-proto` references; accurately reflects the v1.9.x dual-package structure and current `__init__.py` exports

Co-Authored-By: Warp <agent@warp.dev>