### PR TITLE
Interfaces – File, Configuration, and SQLite Service Contracts (#568)

### DIFF
--- a/tiferet/interfaces/__init__.py
+++ b/tiferet/interfaces/__init__.py
@@ -4,3 +4,6 @@
 
 # ** app
 from .settings import Service
+from .file import FileService
+from .config import ConfigurationService
+from .sqlite import SqliteService

--- a/tiferet/interfaces/config.py
+++ b/tiferet/interfaces/config.py
@@ -1,0 +1,53 @@
+"""Tiferet Interfaces Configuration"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import Any, Callable
+
+# ** app
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: configuration_service
+class ConfigurationService(Service):
+    '''
+    Service contract for loading and persisting structured configuration data.
+    '''
+
+    # * method: load
+    @abstractmethod
+    def load(self,
+            start_node: Callable[[Any], Any] = lambda x: x,
+            data_factory: Callable[[Any], Any] = lambda x: x,
+            **kwargs) -> Any:
+        '''
+        Load structured configuration data, optionally transforming it.
+
+        :param start_node: Callable to select the starting node of the data.
+        :type start_node: Callable[[Any], Any]
+        :param data_factory: Callable to transform the loaded data.
+        :type data_factory: Callable[[Any], Any]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The loaded configuration data.
+        :rtype: Any
+        '''
+        raise NotImplementedError()
+
+    # * method: save
+    @abstractmethod
+    def save(self, data: Any, data_path: str | None = None, **kwargs) -> None:
+        '''
+        Persist structured configuration data.
+
+        :param data: The configuration data to persist.
+        :type data: Any
+        :param data_path: Optional path within the data structure.
+        :type data_path: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        '''
+        raise NotImplementedError()

--- a/tiferet/interfaces/file.py
+++ b/tiferet/interfaces/file.py
@@ -1,0 +1,48 @@
+"""Tiferet Interfaces File"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import IO, Any
+
+# ** app
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: file_service
+class FileService(Service):
+    '''
+    Service contract for low-level file stream operations.
+    '''
+
+    # * method: open_file
+    @abstractmethod
+    def open_file(self, path: str, mode: str = 'r', encoding: str | None = None, **kwargs) -> IO[Any]:
+        '''
+        Open a file stream.
+
+        :param path: File system path.
+        :type path: str
+        :param mode: File open mode (r, w, a, etc.).
+        :type mode: str
+        :param encoding: Text encoding (for text modes).
+        :type encoding: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: Open file object.
+        :rtype: IO[Any]
+        '''
+        raise NotImplementedError()
+
+    # * method: close_file
+    @abstractmethod
+    def close_file(self, file: IO[Any]) -> None:
+        '''
+        Safely close an open file stream.
+
+        :param file: The open file object to close.
+        :type file: IO[Any]
+        '''
+        raise NotImplementedError()

--- a/tiferet/interfaces/sqlite.py
+++ b/tiferet/interfaces/sqlite.py
@@ -1,0 +1,112 @@
+"""Tiferet Interfaces SQLite"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import Any, Iterable
+
+# ** app
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: sqlite_service
+class SqliteService(Service):
+    '''
+    Service contract for SQLite database operations.
+    '''
+
+    # * method: execute
+    @abstractmethod
+    def execute(self, sql: str, parameters: Iterable[Any] = ()) -> Any:
+        '''
+        Execute a single SQL statement.
+
+        :param sql: The SQL statement to execute.
+        :type sql: str
+        :param parameters: Parameters for the SQL statement.
+        :type parameters: Iterable[Any]
+        :return: The cursor result.
+        :rtype: Any
+        '''
+        raise NotImplementedError()
+
+    # * method: executemany
+    @abstractmethod
+    def executemany(self, sql: str, seq_of_parameters: Iterable[Iterable[Any]]) -> Any:
+        '''
+        Execute SQL repeatedly with parameter sequences.
+
+        :param sql: The SQL statement to execute.
+        :type sql: str
+        :param seq_of_parameters: Sequence of parameter sets.
+        :type seq_of_parameters: Iterable[Iterable[Any]]
+        :return: The cursor result.
+        :rtype: Any
+        '''
+        raise NotImplementedError()
+
+    # * method: executescript
+    @abstractmethod
+    def executescript(self, sql_script: str) -> Any:
+        '''
+        Execute multiple SQL statements from a script.
+
+        :param sql_script: The SQL script to execute.
+        :type sql_script: str
+        :return: The cursor result.
+        :rtype: Any
+        '''
+        raise NotImplementedError()
+
+    # * method: fetch_one
+    @abstractmethod
+    def fetch_one(self) -> tuple | None:
+        '''
+        Fetch the next row.
+
+        :return: The next row as a tuple, or None if no more rows.
+        :rtype: tuple | None
+        '''
+        raise NotImplementedError()
+
+    # * method: fetch_all
+    @abstractmethod
+    def fetch_all(self) -> list[tuple]:
+        '''
+        Fetch all remaining rows.
+
+        :return: All remaining rows as a list of tuples.
+        :rtype: list[tuple]
+        '''
+        raise NotImplementedError()
+
+    # * method: commit
+    @abstractmethod
+    def commit(self) -> None:
+        '''
+        Commit current transaction.
+        '''
+        raise NotImplementedError()
+
+    # * method: rollback
+    @abstractmethod
+    def rollback(self) -> None:
+        '''
+        Roll back current transaction.
+        '''
+        raise NotImplementedError()
+
+    # * method: backup
+    @abstractmethod
+    def backup(self, target: 'SqliteService', pages: int = -1) -> None:
+        '''
+        Backup database to another connection.
+
+        :param target: The target SQLite service to backup to.
+        :type target: SqliteService
+        :param pages: Number of pages to copy at a time (-1 for all).
+        :type pages: int
+        '''
+        raise NotImplementedError()


### PR DESCRIPTION
## Summary

Adds three foundational service contracts to `tiferet/interfaces/` as part of the v2.0 service-layer migration.

### New Files
- **`interfaces/file.py`** — `FileService` with `open_file` and `close_file` abstract methods
- **`interfaces/config.py`** — `ConfigurationService` with `load` and `save` abstract methods
- **`interfaces/sqlite.py`** — `SqliteService` with `execute`, `executemany`, `executescript`, `fetch_one`, `fetch_all`, `commit`, `rollback`, and `backup` abstract methods

### Updated Files
- **`interfaces/__init__.py`** — exports `FileService`, `ConfigurationService`, `SqliteService` alongside `Service`

All interfaces follow the structured code style with artifact comments, RST docstrings, and `@abstractmethod` decorators. No behavioral or signature changes — structural/package migration only.

Closes #568

Co-Authored-By: Oz <oz-agent@warp.dev>