### PR TITLE
Constants – Add utils error codes for file/format utilities (#570)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -223,6 +223,22 @@ SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
 # ** constant: SQLITE_CONN_NOT_INITIALIZED_id
 SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
 
+# ** constants: utils_errors
+
+YAML_FILE_NOT_FOUND_ID          = 'YAML_FILE_NOT_FOUND'
+YAML_FILE_LOAD_ERROR_ID         = 'YAML_FILE_LOAD_ERROR'
+YAML_FILE_SAVE_ERROR_ID         = 'YAML_FILE_SAVE_ERROR'
+
+JSON_FILE_LOAD_ERROR_ID         = 'JSON_FILE_LOAD_ERROR'
+JSON_FILE_SAVE_ERROR_ID         = 'JSON_FILE_SAVE_ERROR'
+
+CSV_INVALID_MODE_ID             = 'CSV_INVALID_MODE'
+CSV_HANDLE_NOT_INITIALIZED_ID   = 'CSV_HANDLE_NOT_INITIALIZED'
+CSV_INVALID_READ_MODE_ID        = 'CSV_INVALID_READ_MODE'
+CSV_INVALID_WRITE_MODE_ID       = 'CSV_INVALID_WRITE_MODE'
+CSV_FIELDNAMES_REQUIRED_ID      = 'CSV_FIELDNAMES_REQUIRED'
+CSV_DICT_NO_HEADER_ID           = 'CSV_DICT_NO_HEADER'
+
 # ** constant: default_errors
 DEFAULT_ERRORS = {
 
@@ -756,5 +772,104 @@ DEFAULT_ERRORS = {
                 'text': '{attribute} must be a non-empty string.',
             },
         ],
+    },
+
+    # * error: YAML_FILE_NOT_FOUND
+    YAML_FILE_NOT_FOUND_ID: {
+        'id': YAML_FILE_NOT_FOUND_ID,
+        'name': 'YAML File Not Found',
+        'message': [
+            {'lang': 'en_US', 'text': 'The specified YAML file could not be found at {path}.'}
+        ]
+    },
+
+    # * error: YAML_FILE_LOAD_ERROR
+    YAML_FILE_LOAD_ERROR_ID: {
+        'id': YAML_FILE_LOAD_ERROR_ID,
+        'name': 'YAML Load Failure',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to parse YAML file: {error}. Path: {path}.'}
+        ]
+    },
+
+    # * error: YAML_FILE_SAVE_ERROR
+    YAML_FILE_SAVE_ERROR_ID: {
+        'id': YAML_FILE_SAVE_ERROR_ID,
+        'name': 'YAML Save Failure',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to write YAML file: {error}. Path: {path}.'}
+        ]
+    },
+
+    # * error: JSON_FILE_LOAD_ERROR
+    JSON_FILE_LOAD_ERROR_ID: {
+        'id': JSON_FILE_LOAD_ERROR_ID,
+        'name': 'JSON Load Failure',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to parse JSON: {error}. Path: {path}.'}
+        ]
+    },
+
+    # * error: JSON_FILE_SAVE_ERROR
+    JSON_FILE_SAVE_ERROR_ID: {
+        'id': JSON_FILE_SAVE_ERROR_ID,
+        'name': 'JSON Save Failure',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to serialize/write JSON: {error}. Path: {path}.'}
+        ]
+    },
+
+    # * error: CSV_INVALID_MODE
+    CSV_INVALID_MODE_ID: {
+        'id': CSV_INVALID_MODE_ID,
+        'name': 'Invalid CSV Mode',
+        'message': [
+            {'lang': 'en_US', 'text': 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.'}
+        ]
+    },
+
+    # * error: CSV_HANDLE_NOT_INITIALIZED
+    CSV_HANDLE_NOT_INITIALIZED_ID: {
+        'id': CSV_HANDLE_NOT_INITIALIZED_ID,
+        'name': 'CSV Handle Not Initialized',
+        'message': [
+            {'lang': 'en_US', 'text': 'CSV file must be opened before reading/writing.'}
+        ]
+    },
+
+    # * error: CSV_INVALID_READ_MODE
+    CSV_INVALID_READ_MODE_ID: {
+        'id': CSV_INVALID_READ_MODE_ID,
+        'name': 'Invalid CSV Read Mode',
+        'message': [
+            {'lang': 'en_US', 'text': 'File not opened in readable mode for CSV reading.'}
+        ]
+    },
+
+    # * error: CSV_INVALID_WRITE_MODE
+    CSV_INVALID_WRITE_MODE_ID: {
+        'id': CSV_INVALID_WRITE_MODE_ID,
+        'name': 'Invalid CSV Write Mode',
+        'message': [
+            {'lang': 'en_US', 'text': 'File not opened in writable mode for CSV writing.'}
+        ]
+    },
+
+    # * error: CSV_FIELDNAMES_REQUIRED
+    CSV_FIELDNAMES_REQUIRED_ID: {
+        'id': CSV_FIELDNAMES_REQUIRED_ID,
+        'name': 'CSV Fieldnames Required',
+        'message': [
+            {'lang': 'en_US', 'text': 'Fieldnames must be provided when writing dict-based CSV rows.'}
+        ]
+    },
+
+    # * error: CSV_DICT_NO_HEADER
+    CSV_DICT_NO_HEADER_ID: {
+        'id': CSV_DICT_NO_HEADER_ID,
+        'name': 'CSV Dict Reader Without Header',
+        'message': [
+            {'lang': 'en_US', 'text': 'Dict reader expects header row; file appears to lack one or was not read correctly.'}
+        ]
     },
 }


### PR DESCRIPTION
## Summary

Adds 11 new error constants to `tiferet/assets/constants.py` for structured error handling in the `tiferet/utils/` package, covering YAML, JSON, and CSV file I/O operations.

### New Constants
- **YAML**: `YAML_FILE_NOT_FOUND_ID`, `YAML_FILE_LOAD_ERROR_ID`, `YAML_FILE_SAVE_ERROR_ID`
- **JSON**: `JSON_FILE_LOAD_ERROR_ID`, `JSON_FILE_SAVE_ERROR_ID`
- **CSV**: `CSV_INVALID_MODE_ID`, `CSV_HANDLE_NOT_INITIALIZED_ID`, `CSV_INVALID_READ_MODE_ID`, `CSV_INVALID_WRITE_MODE_ID`, `CSV_FIELDNAMES_REQUIRED_ID`, `CSV_DICT_NO_HEADER_ID`

All constants are registered in `DEFAULT_ERRORS` with `id`, `name`, and `en_US` message entries. No existing constants are modified or removed.

Resolves #570

Co-Authored-By: Oz <oz-agent@warp.dev>