### PR TITLE
Utils – SqliteClient Utility (#576)

### DIFF
--- a/docs/guides/utils/sqlite.md
+++ b/docs/guides/utils/sqlite.md
@@ -1,0 +1,151 @@
+# Utilities – SqliteClient (alias: Sqlite)
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** March 02, 2026  
+**Version:** 2.0.0a1
+
+## Overview
+
+`SqliteClient` is Tiferet’s friendly, safe way to work with SQLite databases.  
+It builds directly on top of `FileLoader` (so it gets all the path handling and context-manager goodness for free), then adds everything you need for real database work: connections, queries, transactions, backups, and clean error handling.
+
+What makes `SqliteClient` special compared to the other file utilities (`Yaml`, `Json`, `Csv`)?  
+It also implements the full `SqliteService` interface — which means you can inject it into domain events and repositories exactly the same way you inject other services.  
+At the same time, you can still use it directly (with or without the alias `Sqlite`) for quick scripts, tests, or simple one-off operations inside events.
+
+The context manager is especially helpful here:  
+- Everything inside the `with` block either succeeds completely (auto-commit)  
+- or fails safely (auto-rollback + connection closed)
+
+## When should you reach for SqliteClient?
+
+| Use case                                      | Best choice                                  | Why it fits                                                                 |
+|-----------------------------------------------|----------------------------------------------|-----------------------------------------------------------------------------|
+| Quick query or small script / test            | `with Sqlite(...) as db:`                    | Zero setup, immediate access                                                |
+| Need to mock or swap database backends later  | Inject `SqliteService`                       | Follows dependency injection; easy to test & replace                        |
+| Persistent domain objects (users, settings…)  | Use domain repository + injected service     | Keeps business logic clean and path-agnostic                                |
+| One-time database backup                      | `source.backup(target)`                      | Built-in, safe, with proper error wrapping                                  |
+| Enforce read-only access                      | `mode='ro'`                                  | SQLite itself prevents writes at connection level                           |
+
+## Quick examples to get you started
+
+```python
+from tiferet.utils import Sqlite
+
+# === In-memory database (great for tests and throwaway work) ===
+with Sqlite() as db:                        # defaults to :memory:
+    db.execute("CREATE TABLE pets (name TEXT, age INTEGER)")
+    db.execute("INSERT INTO pets VALUES (?, ?)", ("Luna", 3))
+    db.execute("SELECT * FROM pets WHERE age > 2")
+    print(db.fetch_all())                   # → [('Luna', 3)]
+
+# === Persistent file database – create if missing ===
+with Sqlite(path="data/myapp.db", mode="rwc") as db:
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS config (
+            key   TEXT PRIMARY KEY,
+            value TEXT
+        )
+    """)
+    db.execute("INSERT OR REPLACE INTO config VALUES (?, ?)", ("theme", "dark"))
+
+# === Read-only connection (safe for shared / production read paths) ===
+with Sqlite("data/myapp.db", mode="ro") as db:
+    db.execute("SELECT value FROM config WHERE key = 'theme'")
+    theme = db.fetch_one()[0]               # → 'dark'
+```
+
+## Constructor parameters (the ones you’ll use most)
+
+| Parameter         | Type                  | Default       | What it does                                                                 |
+|-------------------|-----------------------|---------------|------------------------------------------------------------------------------|
+| `path`            | `str \| Path`         | `':memory:'`  | File path or special `:memory:` for in-memory database                       |
+| `mode`            | `str`                 | `'rw'`        | `'ro'` = read-only, `'rw'` = read-write, `'rwc'` = read-write-create         |
+| `isolation_level` | `str \| None`         | `None`        | `None` → autocommit, or `'DEFERRED'`, `'IMMEDIATE'`, `'EXCLUSIVE'`           |
+| `timeout`         | `float`               | `5.0`         | How long to wait (seconds) when the database is locked by another connection |
+
+## Most commonly used methods
+
+- `execute(sql, parameters=())` → run one statement, get a cursor back  
+- `executemany(sql, sequence)` → bulk insert / update  
+- `executescript(sql_script)` → run several statements at once ( DDL + data usually)  
+- `fetch_one()` → get next row (or `None`)  
+- `fetch_all()` → get list of all remaining rows  
+- `commit()` / `rollback()` → manual transaction control (rarely needed with context manager)  
+- `backup(target_client)` → efficient page-by-page copy to another database
+
+The context manager handles commit / rollback / close for you automatically.
+
+## Typical domain-event usage (direct)
+
+```python
+from tiferet.events import DomainEvent, a
+from tiferet.utils import Sqlite
+
+class RecordVisit(DomainEvent):
+    '''
+    Log a page visit with timestamp.
+    '''
+
+    @DomainEvent.parameters_required(['db_path', 'page'])
+    def execute(self, db_path: str, page: str, **kwargs) -> int:
+        with Sqlite(path=db_path, mode='rwc') as db:
+            db.execute("""
+                CREATE TABLE IF NOT EXISTS visits (
+                    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                    page      TEXT NOT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            db.execute("INSERT INTO visits (page) VALUES (?)", (page,))
+            db.execute("SELECT COUNT(*) FROM visits")
+            return db.fetch_one()[0]
+```
+
+## Automatic rollback example (safety net)
+
+```python
+try:
+    with Sqlite("data/app.db", mode="rw") as db:
+        db.execute("UPDATE accounts SET balance = balance - 100 WHERE id = 1")
+        db.execute("INSERT INTO transactions VALUES (...)")
+        raise RuntimeError("payment gateway offline")   # simulate failure
+except RuntimeError:
+    pass  # ← nothing was committed – changes are gone
+```
+
+## Testing tip (very common pattern)
+
+```python
+def test_record_visit_creates_table_and_row(tmp_path):
+    db_path = tmp_path / "visits.db"
+
+    count = DomainEvent.handle(
+        RecordVisit,
+        db_path=str(db_path),
+        page="/home"
+    )
+
+    assert count == 1
+
+    with Sqlite(db_path, mode="ro") as db:
+        db.execute("SELECT page FROM visits")
+        assert db.fetch_one()[0] == "/home"
+```
+
+## Quick reminders – how SqliteClient is different
+
+- Returns `self` on `__enter__` (not a file object)  
+- Auto-commits on clean exit, auto-rolls back on exception  
+- Uses SQLite URI modes (`ro`/`rw`/`rwc`) instead of classic file modes  
+- Implements `SqliteService` — the only utility that does this  
+- No `encoding` or `newline` parameters (not meaningful for SQLite)
+
+## Related reading
+
+- [FileLoader guide](../file.md) – the parent class everyone inherits from  
+- [docs/core/utils.md](https://github.com/greatstrength/tiferet/blob/v2.0-proto/docs/core/utils.md) – full utilities architecture  
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/v2.0-proto/docs/core/interfaces.md) – `SqliteService` contract  
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/v2.0-proto/docs/core/events.md) – domain events & testing patterns  
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/v2.0-proto/docs/core/code_style.md) – formatting & artifact comments

--- a/tiferet/utils/__init__.py
+++ b/tiferet/utils/__init__.py
@@ -7,3 +7,4 @@ from .file import FileLoader, FileLoader as File
 from .json import JsonLoader, JsonLoader as Json
 from .yaml import YamlLoader, YamlLoader as Yaml
 from .csv import CsvLoader, CsvLoader as Csv, CsvDictLoader, CsvDictLoader as CsvDict
+from .sqlite import SqliteClient, SqliteClient as Sqlite

--- a/tiferet/utils/sqlite.py
+++ b/tiferet/utils/sqlite.py
@@ -1,0 +1,349 @@
+"""Tiferet Utils Sqlite"""
+
+# *** imports
+
+# ** core
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+import sqlite3
+
+# ** app
+from .file import FileLoader
+from ..interfaces.sqlite import SqliteService
+from ..events import RaiseError, a
+
+# *** utils
+
+# ** util: sqlite_client
+class SqliteClient(FileLoader, SqliteService):
+    '''
+    SQLite database client with connection management and structured error handling.
+    Extends FileLoader for file-based lifecycle and implements SqliteService.
+    '''
+
+    # * attribute: conn
+    conn: Optional[sqlite3.Connection]
+
+    # * attribute: cursor
+    cursor: Optional[sqlite3.Cursor]
+
+    # * attribute: isolation_level
+    isolation_level: Optional[str]
+
+    # * attribute: timeout
+    timeout: float
+
+    # * init
+    def __init__(self,
+            path: str | Path = ':memory:',
+            mode: str = 'rw',
+            isolation_level: Optional[str] = None,
+            timeout: float = 5.0,
+            **kwargs,
+        ):
+        '''
+        Initialize SqliteClient.
+
+        :param path: Database path or ':memory:' for in-memory database.
+        :type path: str | Path
+        :param mode: SQLite connection mode ('ro', 'rw', 'rwc').
+        :type mode: str
+        :param isolation_level: Transaction isolation level (None for autocommit, 'DEFERRED', etc.).
+        :type isolation_level: Optional[str]
+        :param timeout: Connection timeout in seconds.
+        :type timeout: float
+        :param kwargs: Additional parameters (ignored).
+        :type kwargs: dict
+        '''
+
+        # Initialize the parent FileLoader with path and mode.
+        super().__init__(path=path, mode=mode, **kwargs)
+
+        # Set the isolation level for transaction control.
+        self.isolation_level = isolation_level
+
+        # Set the connection timeout.
+        self.timeout = timeout
+
+        # Initialize the connection and cursor to None.
+        self.conn = None
+        self.cursor = None
+
+    # * method: verify_mode
+    def verify_mode(self):
+        '''
+        Validate the SQLite connection mode string.
+
+        :raises TiferetError: If the mode is not in the set of valid SQLite modes.
+        '''
+
+        # Define the set of valid SQLite modes.
+        valid_modes = {'ro', 'rw', 'rwc'}
+
+        # Raise an error if the mode is not valid.
+        if self.mode not in valid_modes:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_INVALID_MODE_ID,
+                mode=self.mode,
+            )
+
+    # * method: open_file
+    def open_file(self):
+        '''
+        Open the SQLite database connection and create a cursor.
+
+        :raises TiferetError: If the connection is already open, the mode is invalid,
+            or the connection fails.
+        '''
+
+        # Raise an error if the connection is already open.
+        if self.conn is not None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_ALREADY_OPEN_ID,
+                path=str(self.path),
+            )
+
+        # Validate the SQLite mode.
+        self.verify_mode()
+
+        # Build the URI for sqlite3.connect.
+        if str(self.path) == ':memory:':
+            uri = ':memory:'
+        else:
+            uri_mode = f'?mode={self.mode}'
+            uri = f'file:{self.path}{uri_mode}'
+
+        try:
+
+            # Open the SQLite connection with URI support.
+            self.conn = sqlite3.connect(
+                uri,
+                timeout=self.timeout,
+                isolation_level=self.isolation_level,
+                uri=str(self.path) != ':memory:',
+            )
+
+            # Create a cursor for query execution.
+            self.cursor = self.conn.cursor()
+
+        except sqlite3.OperationalError as e:
+
+            # Wrap connection failures as structured TiferetError.
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_FAILED_ID,
+                original_error=str(e),
+                path=str(self.path),
+            )
+
+    # * method: close_file
+    def close_file(self):
+        '''
+        Close the SQLite connection and reset state.
+        '''
+
+        # Close the connection if it is open and reset attributes.
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+            self.cursor = None
+
+    # * method: execute
+    def execute(self, sql: str, parameters: Iterable[Any] = ()) -> sqlite3.Cursor:
+        '''
+        Execute a single SQL statement.
+
+        :param sql: The SQL statement to execute.
+        :type sql: str
+        :param parameters: Parameters for the SQL statement.
+        :type parameters: Iterable[Any]
+        :return: The cursor after execution.
+        :rtype: sqlite3.Cursor
+        '''
+
+        # Guard against uninitialized connection.
+        if self.cursor is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Execute the SQL statement and return the cursor.
+        return self.cursor.execute(sql, parameters)
+
+    # * method: executemany
+    def executemany(self, sql: str, seq_of_parameters: Iterable[Iterable[Any]]) -> sqlite3.Cursor:
+        '''
+        Execute SQL repeatedly with parameter sequences.
+
+        :param sql: The SQL statement to execute.
+        :type sql: str
+        :param seq_of_parameters: Sequence of parameter sets.
+        :type seq_of_parameters: Iterable[Iterable[Any]]
+        :return: The cursor after execution.
+        :rtype: sqlite3.Cursor
+        '''
+
+        # Guard against uninitialized connection.
+        if self.cursor is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Execute the SQL with multiple parameter sets and return the cursor.
+        return self.cursor.executemany(sql, seq_of_parameters)
+
+    # * method: executescript
+    def executescript(self, sql_script: str) -> sqlite3.Cursor:
+        '''
+        Execute multiple SQL statements from a script.
+
+        :param sql_script: The SQL script to execute.
+        :type sql_script: str
+        :return: The cursor after execution.
+        :rtype: sqlite3.Cursor
+        '''
+
+        # Guard against uninitialized connection.
+        if self.cursor is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Execute the SQL script and return the cursor.
+        return self.cursor.executescript(sql_script)
+
+    # * method: fetch_one
+    def fetch_one(self) -> Optional[tuple]:
+        '''
+        Fetch the next row from the last executed query.
+
+        :return: The next row as a tuple, or None if no more rows.
+        :rtype: tuple | None
+        '''
+
+        # Guard against uninitialized connection.
+        if self.cursor is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Fetch and return the next row.
+        return self.cursor.fetchone()
+
+    # * method: fetch_all
+    def fetch_all(self) -> List[tuple]:
+        '''
+        Fetch all remaining rows from the last executed query.
+
+        :return: All remaining rows as a list of tuples.
+        :rtype: list[tuple]
+        '''
+
+        # Guard against uninitialized connection.
+        if self.cursor is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Fetch and return all remaining rows.
+        return self.cursor.fetchall()
+
+    # * method: commit
+    def commit(self) -> None:
+        '''
+        Commit the current transaction.
+        '''
+
+        # Guard against uninitialized connection.
+        if self.conn is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Commit the transaction.
+        self.conn.commit()
+
+    # * method: rollback
+    def rollback(self) -> None:
+        '''
+        Roll back the current transaction.
+        '''
+
+        # Guard against uninitialized connection.
+        if self.conn is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        # Roll back the transaction.
+        self.conn.rollback()
+
+    # * method: backup
+    def backup(self, target: 'SqliteClient', pages: int = -1) -> None:
+        '''
+        Backup database to another SqliteClient connection.
+
+        :param target: The target SqliteClient to backup to.
+        :type target: SqliteClient
+        :param pages: Number of pages to copy at a time (-1 for all).
+        :type pages: int
+        '''
+
+        # Guard against uninitialized source or target connection.
+        if self.conn is None or target.conn is None:
+            RaiseError.execute(
+                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
+            )
+
+        try:
+
+            # Perform the backup to the target connection.
+            self.conn.backup(target.conn, pages=pages)
+
+        except sqlite3.Error as e:
+
+            # Wrap backup failures as structured TiferetError.
+            RaiseError.execute(
+                error_code=a.const.SQLITE_BACKUP_FAILED_ID,
+                original_error=str(e),
+                target_path=str(target.path),
+            )
+
+    # * method: __enter__
+    def __enter__(self) -> 'SqliteClient':
+        '''
+        Enter the runtime context, opening the database connection.
+
+        :return: The SqliteClient instance with an active connection.
+        :rtype: SqliteClient
+        '''
+
+        # Open the database connection.
+        self.open_file()
+
+        # Return self for use within the with block.
+        return self
+
+    # * method: __exit__
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        '''
+        Exit the runtime context. Auto-commit on success, auto-rollback on exception.
+
+        :param exc_type: The exception type (if any).
+        :param exc_val: The exception value (if any).
+        :param exc_tb: The exception traceback (if any).
+        :return: False to propagate exceptions.
+        :rtype: bool
+        '''
+
+        # Auto-commit on success, auto-rollback on exception.
+        if exc_type is None:
+            self.commit()
+        else:
+            self.rollback()
+
+        # Close the connection.
+        self.close_file()
+
+        # Do not suppress exceptions.
+        return False

--- a/tiferet/utils/tests/test_sqlite.py
+++ b/tiferet/utils/tests/test_sqlite.py
@@ -1,0 +1,455 @@
+"""Tiferet Utils Sqlite Tests"""
+
+# *** imports
+
+# ** core
+from pathlib import Path
+
+import sqlite3
+
+# ** infra
+import pytest
+
+# ** app
+from ..sqlite import SqliteClient
+from ...events import a
+from ...events.settings import TiferetError
+
+# *** fixtures
+
+# ** fixture: memory_client
+@pytest.fixture
+def memory_client() -> SqliteClient:
+    '''
+    Fixture providing an in-memory SqliteClient (not yet opened).
+
+    :return: An in-memory SqliteClient instance.
+    :rtype: SqliteClient
+    '''
+
+    # Return an in-memory SqliteClient.
+    return SqliteClient(path=':memory:', mode='rw')
+
+# ** fixture: sample_table_sql
+@pytest.fixture
+def sample_table_sql() -> str:
+    '''
+    Fixture providing SQL to create a sample table.
+
+    :return: CREATE TABLE SQL statement.
+    :rtype: str
+    '''
+
+    # Return a CREATE TABLE statement.
+    return 'CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, value REAL)'
+
+# ** fixture: sample_insert_sql
+@pytest.fixture
+def sample_insert_sql() -> str:
+    '''
+    Fixture providing SQL to insert a sample row.
+
+    :return: INSERT SQL statement with placeholders.
+    :rtype: str
+    '''
+
+    # Return an INSERT statement with placeholders.
+    return 'INSERT INTO items (name, value) VALUES (?, ?)'
+
+# *** tests
+
+# ** test: sqlite_client_in_memory_open_close
+def test_sqlite_client_in_memory_open_close(memory_client: SqliteClient):
+    '''
+    Test opening and closing an in-memory SQLite connection.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Open the connection.
+    memory_client.open_file()
+
+    # Verify the connection and cursor are initialized.
+    assert memory_client.conn is not None
+    assert memory_client.cursor is not None
+
+    # Close the connection.
+    memory_client.close_file()
+
+    # Verify state is reset.
+    assert memory_client.conn is None
+    assert memory_client.cursor is None
+
+# ** test: sqlite_client_file_based_open_close
+def test_sqlite_client_file_based_open_close(tmp_path: Path):
+    '''
+    Test opening and closing a file-based SQLite database.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Create a client pointing to a file in the temp directory.
+    db_path = tmp_path / 'test.db'
+    client = SqliteClient(path=db_path, mode='rwc')
+
+    # Open, verify, and close.
+    with client as db:
+        assert db.conn is not None
+        assert db_path.exists()
+
+    # Verify state is reset after exit.
+    assert client.conn is None
+
+# ** test: sqlite_client_invalid_mode
+def test_sqlite_client_invalid_mode():
+    '''
+    Test that an invalid SQLite mode raises SQLITE_INVALID_MODE.
+    '''
+
+    # Create a client with an invalid mode.
+    client = SqliteClient(path=':memory:', mode='invalid')
+
+    # Attempt to open; expect SQLITE_INVALID_MODE error.
+    with pytest.raises(TiferetError) as exc_info:
+        client.open_file()
+
+    # Verify the error code.
+    assert exc_info.value.error_code == a.const.SQLITE_INVALID_MODE_ID
+
+# ** test: sqlite_client_already_open
+def test_sqlite_client_already_open(memory_client: SqliteClient):
+    '''
+    Test that opening an already-open connection raises SQLITE_CONN_ALREADY_OPEN.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Open the connection.
+    memory_client.open_file()
+
+    try:
+
+        # Attempt to open again; expect SQLITE_CONN_ALREADY_OPEN error.
+        with pytest.raises(TiferetError) as exc_info:
+            memory_client.open_file()
+
+        # Verify the error code.
+        assert exc_info.value.error_code == a.const.SQLITE_CONN_ALREADY_OPEN_ID
+
+    finally:
+
+        # Clean up.
+        memory_client.close_file()
+
+# ** test: sqlite_client_execute_success
+def test_sqlite_client_execute_success(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test executing SQL statements (CREATE TABLE and INSERT).
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert a sample row.
+    :type sample_insert_sql: str
+    '''
+
+    with memory_client as db:
+
+        # Create the table.
+        db.execute(sample_table_sql)
+
+        # Insert a row.
+        cursor = db.execute(sample_insert_sql, ('widget', 9.99))
+
+        # Verify the cursor is returned.
+        assert isinstance(cursor, sqlite3.Cursor)
+
+        # Verify the row was inserted.
+        db.execute('SELECT COUNT(*) FROM items')
+        count = db.fetch_one()[0]
+        assert count == 1
+
+# ** test: sqlite_client_executemany_success
+def test_sqlite_client_executemany_success(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test executemany with multiple parameter sets.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert rows.
+    :type sample_insert_sql: str
+    '''
+
+    with memory_client as db:
+
+        # Create the table.
+        db.execute(sample_table_sql)
+
+        # Insert multiple rows.
+        rows = [('alpha', 1.0), ('beta', 2.0), ('gamma', 3.0)]
+        db.executemany(sample_insert_sql, rows)
+
+        # Verify all rows were inserted.
+        db.execute('SELECT COUNT(*) FROM items')
+        count = db.fetch_one()[0]
+        assert count == 3
+
+# ** test: sqlite_client_executescript_success
+def test_sqlite_client_executescript_success(memory_client: SqliteClient):
+    '''
+    Test executescript with a multi-statement SQL script.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Define a multi-statement script.
+    script = '''
+        CREATE TABLE colors (id INTEGER PRIMARY KEY, name TEXT);
+        INSERT INTO colors (name) VALUES ('red');
+        INSERT INTO colors (name) VALUES ('blue');
+    '''
+
+    with memory_client as db:
+
+        # Execute the script.
+        db.executescript(script)
+
+        # Verify the rows were created.
+        db.execute('SELECT COUNT(*) FROM colors')
+        count = db.fetch_one()[0]
+        assert count == 2
+
+# ** test: sqlite_client_fetch_one
+def test_sqlite_client_fetch_one(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test fetch_one returns a single row as a tuple.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert a row.
+    :type sample_insert_sql: str
+    '''
+
+    with memory_client as db:
+
+        # Set up table and insert a row.
+        db.execute(sample_table_sql)
+        db.execute(sample_insert_sql, ('widget', 9.99))
+
+        # Fetch one row.
+        db.execute('SELECT name, value FROM items WHERE name = ?', ('widget',))
+        row = db.fetch_one()
+
+        # Verify the row is a tuple with expected values.
+        assert row == ('widget', 9.99)
+
+    # Verify fetch_one returns None when no more rows.
+    with SqliteClient(path=':memory:') as db:
+        db.execute('CREATE TABLE empty (id INTEGER)')
+        db.execute('SELECT * FROM empty')
+        assert db.fetch_one() is None
+
+# ** test: sqlite_client_fetch_all
+def test_sqlite_client_fetch_all(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test fetch_all returns all rows as a list of tuples.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert rows.
+    :type sample_insert_sql: str
+    '''
+
+    with memory_client as db:
+
+        # Set up table and insert rows.
+        db.execute(sample_table_sql)
+        db.executemany(sample_insert_sql, [('a', 1.0), ('b', 2.0)])
+
+        # Fetch all rows.
+        db.execute('SELECT name, value FROM items ORDER BY name')
+        rows = db.fetch_all()
+
+        # Verify all rows returned.
+        assert rows == [('a', 1.0), ('b', 2.0)]
+
+# ** test: sqlite_client_context_manager_commit_on_success
+def test_sqlite_client_context_manager_commit_on_success(tmp_path: Path):
+    '''
+    Test that the context manager auto-commits on successful exit.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Create and populate a file-based DB.
+    db_path = tmp_path / 'commit_test.db'
+    with SqliteClient(path=db_path, mode='rwc') as db:
+        db.execute('CREATE TABLE test (val TEXT)')
+        db.execute('INSERT INTO test (val) VALUES (?)', ('committed',))
+
+    # Reopen and verify the data persisted.
+    with SqliteClient(path=db_path, mode='ro') as db:
+        db.execute('SELECT val FROM test')
+        row = db.fetch_one()
+        assert row == ('committed',)
+
+# ** test: sqlite_client_context_manager_rollback_on_exception
+def test_sqlite_client_context_manager_rollback_on_exception(tmp_path: Path):
+    '''
+    Test that the context manager auto-rolls back on exception.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Create the DB and table first.
+    db_path = tmp_path / 'rollback_test.db'
+    with SqliteClient(path=db_path, mode='rwc', isolation_level='DEFERRED') as db:
+        db.execute('CREATE TABLE test (val TEXT)')
+
+    # Attempt to insert then raise — should rollback.
+    with pytest.raises(ValueError):
+        with SqliteClient(path=db_path, mode='rw', isolation_level='DEFERRED') as db:
+            db.execute('INSERT INTO test (val) VALUES (?)', ('rolled_back',))
+            raise ValueError('force rollback')
+
+    # Verify the insert was rolled back.
+    with SqliteClient(path=db_path, mode='ro') as db:
+        db.execute('SELECT COUNT(*) FROM test')
+        count = db.fetch_one()[0]
+        assert count == 0
+
+# ** test: sqlite_client_backup_success
+def test_sqlite_client_backup_success(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test successful database backup between two connections.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert a row.
+    :type sample_insert_sql: str
+    '''
+
+    # Set up source database.
+    memory_client.open_file()
+    memory_client.execute(sample_table_sql)
+    memory_client.execute(sample_insert_sql, ('backup_item', 42.0))
+    memory_client.commit()
+
+    # Create and open target database.
+    target = SqliteClient(path=':memory:')
+    target.open_file()
+
+    try:
+
+        # Perform backup.
+        memory_client.backup(target)
+
+        # Verify the target has the data.
+        target.execute('SELECT name, value FROM items')
+        row = target.fetch_one()
+        assert row == ('backup_item', 42.0)
+
+    finally:
+
+        # Clean up both connections.
+        target.close_file()
+        memory_client.close_file()
+
+# ** test: sqlite_client_backup_not_initialized
+def test_sqlite_client_backup_not_initialized(memory_client: SqliteClient):
+    '''
+    Test that backup raises SQLITE_CONN_NOT_INITIALIZED when connections are not open.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Create a target that is not opened.
+    target = SqliteClient(path=':memory:')
+
+    # Attempt backup with both closed; expect error.
+    with pytest.raises(TiferetError) as exc_info:
+        memory_client.backup(target)
+
+    # Verify the error code.
+    assert exc_info.value.error_code == a.const.SQLITE_CONN_NOT_INITIALIZED_ID
+
+# ** test: sqlite_client_execute_not_initialized
+def test_sqlite_client_execute_not_initialized(memory_client: SqliteClient):
+    '''
+    Test that execute raises SQLITE_CONN_NOT_INITIALIZED without an open connection.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Attempt to execute without opening; expect error.
+    with pytest.raises(TiferetError) as exc_info:
+        memory_client.execute('SELECT 1')
+
+    # Verify the error code.
+    assert exc_info.value.error_code == a.const.SQLITE_CONN_NOT_INITIALIZED_ID
+
+# ** test: sqlite_client_commit_not_initialized
+def test_sqlite_client_commit_not_initialized(memory_client: SqliteClient):
+    '''
+    Test that commit raises SQLITE_CONN_NOT_INITIALIZED without an open connection.
+
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    '''
+
+    # Attempt to commit without opening; expect error.
+    with pytest.raises(TiferetError) as exc_info:
+        memory_client.commit()
+
+    # Verify the error code.
+    assert exc_info.value.error_code == a.const.SQLITE_CONN_NOT_INITIALIZED_ID
+
+# ** test: sqlite_client_conn_failed
+def test_sqlite_client_conn_failed(tmp_path: Path):
+    '''
+    Test that connecting to a non-existent file in rw mode raises SQLITE_CONN_FAILED.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Point to a non-existent file with rw mode (not rwc, so it won't create).
+    client = SqliteClient(path=tmp_path / 'nonexistent.db', mode='rw')
+
+    # Attempt to open; expect SQLITE_CONN_FAILED error.
+    with pytest.raises(TiferetError) as exc_info:
+        client.open_file()
+
+    # Verify the error code.
+    assert exc_info.value.error_code == a.const.SQLITE_CONN_FAILED_ID
+
+# ** test: sqlite_client_isolation_level_propagation
+def test_sqlite_client_isolation_level_propagation():
+    '''
+    Test that isolation_level is propagated to the sqlite3 connection.
+    '''
+
+    # Create a client with explicit isolation level.
+    client = SqliteClient(path=':memory:', isolation_level='DEFERRED')
+
+    with client as db:
+
+        # Verify the isolation level was propagated.
+        assert db.conn.isolation_level == 'DEFERRED'


### PR DESCRIPTION
## Summary

Implements `SqliteClient` as the final format-specific utility in `tiferet/utils/`, extending `FileLoader` and implementing the `SqliteService` contract.

## Changes

- **`tiferet/utils/sqlite.py`** — `SqliteClient(FileLoader, SqliteService)` with:
  - SQLite URI mode support (`ro`, `rw`, `rwc`) and in-memory databases
  - Full `SqliteService` implementation: `execute`, `executemany`, `executescript`, `fetch_one`, `fetch_all`, `commit`, `rollback`, `backup`
  - Custom context manager: auto-commit on success, auto-rollback on exception
  - Structured error handling via `RaiseError.execute()` with pre-existing SQLite constants

- **`tiferet/utils/__init__.py`** — Added `SqliteClient` and `Sqlite` alias exports

- **`tiferet/utils/tests/test_sqlite.py`** — 17 tests covering:
  - In-memory and file-based connections
  - Mode validation, already-open guard, connection failure
  - Execute, executemany, executescript operations
  - Fetch_one, fetch_all results
  - Auto-commit on success, auto-rollback on exception
  - Backup success and not-initialized guard
  - Isolation level propagation

- **`docs/guides/utils/sqlite.md`** — Usage guide following existing guide patterns

Closes #576

Co-Authored-By: Oz <oz-agent@warp.dev>