### PR TITLE
Domain – App: Add AppServiceDependency and AppInterface Domain Objects

### DIFF
--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -1,0 +1,164 @@
+**This conversation is part of the Tiferet Framework project.**  
+**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
+
+```markdown
+# Domain – App: AppInterface and AppServiceDependency
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** March 06, 2026  
+**Version:** 2.0.0a2
+
+## Overview
+
+The App domain defines the structural foundation for application entry points in Tiferet. Every runnable interface — whether a REST API, CLI, background worker, or custom context — is described by an `AppInterface` domain object. Each interface declares its context implementation, logging configuration, dependency-resolution flags, static constants, and a list of injectable service dependency bindings (`AppServiceDependency`).
+
+These domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing services, updating constants, renaming) occur exclusively through Aggregates in the mappers layer.
+
+**Module:** `tiferet/domain/app.py`
+
+## Domain Objects
+
+### AppServiceDependency
+
+Represents a single injectable service dependency binding for an application interface.
+
+| Attribute      | Type                   | Required | Default | Description                                       |
+|----------------|------------------------|----------|---------|---------------------------------------------------|
+| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.            |
+| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.             |
+| `attribute_id` | `StringType`           | Yes      | —       | The attribute id for the application dependency.   |
+| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.     |
+
+No methods. Pure data structure.
+
+#### Rename Note: AppAttribute → AppServiceDependency
+
+In v1.x, service dependency bindings were called `AppAttribute`. In v2.0, the class is renamed to `AppServiceDependency` to better reflect its role as a service dependency binding rather than a generic attribute. The field set and semantics are unchanged.
+
+### AppInterface
+
+Represents the complete configuration of an application entry point.
+
+| Attribute      | Type                                | Required | Default       | Description                                           |
+|----------------|-------------------------------------|----------|---------------|-------------------------------------------------------|
+| `id`           | `StringType`                        | Yes      | —             | The unique identifier for the application interface.   |
+| `name`         | `StringType`                        | Yes      | —             | The name of the application interface.                 |
+| `description`  | `StringType`                        | No       | —             | The description of the application interface.          |
+| `module_path`  | `StringType`                        | Yes      | —             | The module path for the application instance context.  |
+| `class_name`   | `StringType`                        | Yes      | —             | The class name for the application instance context.   |
+| `logger_id`    | `StringType`                        | No       | `'default'`   | The logger ID for the application instance.            |
+| `flags`        | `ListType(StringType)`              | No       | `['default']` | The flags for the application interface.               |
+| `services`     | `ListType(ModelType(AppServiceDependency))` | Yes | `[]`        | The application instance service dependencies.         |
+| `constants`    | `DictType(StringType)`              | No       | `{}`          | The application dependency constants.                  |
+
+#### Methods
+
+**`get_service(attribute_id: str) -> AppServiceDependency`**
+
+Returns the `AppServiceDependency` whose `attribute_id` matches the given value, or `None` if no match is found.
+
+```python
+service = app_interface.get_service('cli_repo')
+if service:
+    print(service.module_path, service.class_name)
+```
+
+## Runtime Role
+
+The App domain objects participate in the application bootstrapping flow:
+
+1. **`AppManagerContext`** (alias `App`) loads application settings and interface configurations from `app/configs/app.yml`.
+2. **`app.load_interface(interface_id)`** retrieves the `AppInterface` domain object for the requested interface.
+3. **`load_app_instance()`** reads `AppInterface.module_path` and `AppInterface.class_name` to import and instantiate the context class.
+4. Each `AppServiceDependency` in `AppInterface.services` is resolved via the dependency injection container, wiring constructor parameters from `AppServiceDependency.parameters`.
+5. The instantiated context is ready to execute features, handle requests, or run CLI commands.
+
+## Configuration Mapping
+
+Application interfaces are defined in `app/configs/app.yml`. Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects:
+
+```yaml
+interfaces:
+  basic_calc:
+    name: Basic Calculator
+    description: Perform basic calculator operations
+  calc_cli:
+    name: Calculator CLI
+    description: Perform basic calculator operations via CLI
+    module_path: tiferet.contexts.cli
+    class_name: CliContext
+    attrs:
+      cli_repo:
+        module_path: tiferet.proxies.yaml.cli
+        class_name: CliYamlProxy
+        params:
+          cli_config_file: app/configs/cli.yml
+      cli_service:
+        module_path: tiferet.handlers.cli
+        class_name: CliHandler
+```
+
+## Domain Events
+
+The following domain events interact with `AppInterface` and `AppServiceDependency`:
+
+| Event                | Description                                       |
+|----------------------|---------------------------------------------------|
+| `GetAppInterface`    | Retrieves an `AppInterface` by ID.                |
+| `AddAppInterface`    | Creates and persists a new `AppInterface`.         |
+| `UpdateAppInterface` | Modifies an existing `AppInterface` via aggregate. |
+| `DeleteAppInterface` | Removes an `AppInterface` by ID.                   |
+
+These events depend on the `AppService` interface for persistence operations.
+
+## Service Interface
+
+**`AppService`** (`tiferet/interfaces/app.py`) defines the abstract contract for App domain persistence:
+
+- `exists(id: str) -> bool`
+- `get(id: str) -> AppInterface`
+- `list() -> List[AppInterface]`
+- `save(app_interface) -> None`
+- `delete(id: str) -> None`
+
+Concrete implementations (e.g., `AppYamlRepository`) satisfy this interface.
+
+## Relationships to Other Domains
+
+- **Dependency Injection (Container):** `AppServiceDependency` entries reference container attributes that are resolved at runtime via `ContainerContext`.
+- **Feature:** Once an interface is loaded and its context instantiated, features defined in `feature.yml` are executed through the `FeatureContext`.
+- **Logging:** `AppInterface.logger_id` references a logger configuration from the Logging domain (`logging.yml`).
+
+## Instantiation
+
+Both domain objects are instantiated via the standard `DomainObject.new()` factory:
+
+```python
+from tiferet.domain import DomainObject, AppServiceDependency, AppInterface
+
+dep = DomainObject.new(
+    AppServiceDependency,
+    attribute_id='cli_repo',
+    module_path='tiferet.proxies.yaml.cli',
+    class_name='CliYamlProxy',
+    parameters={'cli_config_file': 'app/configs/cli.yml'},
+)
+
+interface = DomainObject.new(
+    AppInterface,
+    id='calc_cli',
+    name='Calculator CLI',
+    module_path='tiferet.contexts.cli',
+    class_name='CliContext',
+    services=[dep],
+)
+```
+
+## Related Documentation
+
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+```

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -13,3 +13,7 @@ from .settings import (
     DictType,
     ModelType,
 )
+from .app import (
+    AppInterface,
+    AppServiceDependency,
+)

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -1,0 +1,149 @@
+"""Tiferet Domain App"""
+
+# *** imports
+
+# ** app
+from .settings import (
+    DomainObject,
+    StringType,
+    ListType,
+    DictType,
+    ModelType,
+)
+
+# *** models
+
+# ** model: app_service_dependency
+class AppServiceDependency(DomainObject):
+    '''
+    An app service dependency that defines the service configuration for an app interface.
+    '''
+
+    # * attribute: module_path
+    module_path = StringType(
+        required=True,
+        metadata=dict(
+            description='The module path for the app dependency.'
+        ),
+    )
+
+    # * attribute: class_name
+    class_name = StringType(
+        required=True,
+        metadata=dict(
+            description='The class name for the app dependency.'
+        ),
+    )
+
+    # * attribute: attribute_id
+    attribute_id = StringType(
+        required=True,
+        metadata=dict(
+            description='The attribute id for the application dependency.'
+        ),
+    )
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        metadata=dict(
+            description='The parameters for the application dependency.'
+        ),
+    )
+
+
+# ** model: app_interface
+class AppInterface(DomainObject):
+    '''
+    The base application interface object.
+    '''
+
+    # * attribute: id
+    id = StringType(
+        required=True,
+        metadata=dict(
+            description='The unique identifier for the application interface.'
+        ),
+    )
+
+    # * attribute: name
+    name = StringType(
+        required=True,
+        metadata=dict(
+            description='The name of the application interface.'
+        ),
+    )
+
+    # * attribute: description
+    description = StringType(
+        metadata=dict(
+            description='The description of the application interface.'
+        ),
+    )
+
+    # * attribute: module_path
+    module_path = StringType(
+        required=True,
+        metadata=dict(
+            description='The module path for the application instance context.'
+        ),
+    )
+
+    # * attribute: class_name
+    class_name = StringType(
+        required=True,
+        metadata=dict(
+            description='The class name for the application instance context.'
+        ),
+    )
+
+    # * attribute: logger_id
+    logger_id = StringType(
+        default='default',
+        metadata=dict(
+            description='The logger ID for the application instance.'
+        ),
+    )
+
+    # * attribute: flags
+    flags = ListType(
+        StringType(),
+        default=['default'],
+        metadata=dict(
+            description='The flags for the application interface.'
+        ),
+    )
+
+    # * attribute: services
+    services = ListType(
+        ModelType(AppServiceDependency),
+        required=True,
+        default=[],
+        metadata=dict(
+            description='The application instance service dependencies.'
+        ),
+    )
+
+    # * attribute: constants
+    constants = DictType(
+        StringType,
+        default={},
+        metadata=dict(
+            description='The application dependency constants.'
+        ),
+    )
+
+    # * method: get_service
+    def get_service(self, attribute_id: str) -> AppServiceDependency:
+        '''
+        Get the service dependency by attribute id.
+
+        :param attribute_id: The attribute id of the service dependency.
+        :type attribute_id: str
+        :return: The service dependency.
+        :rtype: AppServiceDependency
+        '''
+
+        # Get the service dependency by attribute id.
+        return next((dep for dep in self.services if dep.attribute_id == attribute_id), None)

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -1,0 +1,93 @@
+"""Tests for Tiferet Domain App"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import DomainObject
+from ..app import (
+    AppInterface,
+    AppServiceDependency,
+)
+
+# *** fixtures
+
+# ** fixture: app_dependency
+@pytest.fixture
+def app_dependency() -> AppServiceDependency:
+    '''
+    Fixture for an AppServiceDependency instance.
+
+    :return: The AppServiceDependency instance.
+    :rtype: AppServiceDependency
+    '''
+
+    # Create and return a new AppServiceDependency.
+    return DomainObject.new(
+        AppServiceDependency,
+        attribute_id='test_attribute',
+        module_path='test_module_path',
+        class_name='test_class_name',
+        parameters={'param1': 'value1', 'param2': 'value2'},
+    )
+
+# ** fixture: app_interface
+@pytest.fixture
+def app_interface(app_dependency: AppServiceDependency) -> AppInterface:
+    '''
+    Fixture for an AppInterface instance.
+
+    :param app_dependency: The AppServiceDependency fixture.
+    :type app_dependency: AppServiceDependency
+    :return: The AppInterface instance.
+    :rtype: AppInterface
+    '''
+
+    # Create and return a new AppInterface.
+    return DomainObject.new(
+        AppInterface,
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+        description='The test app.',
+        flags=['test'],
+        services=[app_dependency],
+    )
+
+# *** tests
+
+# ** test: app_interface_get_service
+def test_app_interface_get_service(app_interface: AppInterface) -> None:
+    '''
+    Test successful retrieval of a service dependency by attribute id.
+
+    :param app_interface: The AppInterface fixture.
+    :type app_interface: AppInterface
+    '''
+
+    # Retrieve the service dependency by attribute id.
+    service = app_interface.get_service('test_attribute')
+
+    # Assert the service dependency fields match.
+    assert service.module_path == 'test_module_path'
+    assert service.class_name == 'test_class_name'
+    assert service.attribute_id == 'test_attribute'
+    assert service.parameters == {'param1': 'value1', 'param2': 'value2'}
+
+# ** test: app_interface_get_service_invalid
+def test_app_interface_get_service_invalid(app_interface: AppInterface) -> None:
+    '''
+    Test that get_service returns None for an invalid attribute id.
+
+    :param app_interface: The AppInterface fixture.
+    :type app_interface: AppInterface
+    '''
+
+    # Attempt to retrieve a non-existent service dependency.
+    service = app_interface.get_service('invalid')
+
+    # Assert None is returned.
+    assert service is None


### PR DESCRIPTION
## Summary

Implements #565 — adds the foundational domain objects for application interfaces in the v2 domain model.

### Changes

- **`tiferet/domain/app.py`** — New file defining `AppServiceDependency` (immutable value object for service dependency bindings) and `AppInterface` (complete interface configuration with `get_service()` query method).
- **`tiferet/domain/__init__.py`** — Exports both new classes.
- **`tiferet/domain/tests/test_app.py`** — Two unit tests: successful `get_service` lookup and `None` return for invalid ID.
- **`docs/guides/domain/app.md`** — Narrative guide covering the App domain's role, runtime flow, configuration mapping, and relationships.

All domain tests pass with no regressions.

Closes #565

Co-Authored-By: Oz <oz-agent@warp.dev>