### PR TITLE
Domain – DI: Add FlaggedDependency and ServiceConfiguration Domain Objects

### DIFF
--- a/docs/guides/domain/di.md
+++ b/docs/guides/domain/di.md
@@ -1,0 +1,176 @@
+**This conversation is part of the Tiferet Framework project.**  
+**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
+
+```markdown
+# Domain – DI: ServiceConfiguration and FlaggedDependency
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** March 06, 2026  
+**Version:** 2.0.0a2
+
+## Overview
+
+The DI (Dependency Injection) domain defines the structural configuration for the Tiferet service container. Every injectable service entry is described by a `ServiceConfiguration` domain object, which holds a default implementation binding and zero or more `FlaggedDependency` overrides that are selected based on active runtime flags.
+
+These domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing dependencies, setting default types, updating parameters) occur exclusively through Aggregates in the mappers layer.
+
+**Module:** `tiferet/domain/di.py`
+
+### Rename Note: container.py → di.py, ContainerAttribute → ServiceConfiguration
+
+In v1.x, dependency injection configuration was defined in `container.py` with the `ContainerAttribute` domain object. In v2.0, the module is renamed to `di.py` and the class to `ServiceConfiguration` to better reflect its role in the DI infrastructure. `FlaggedDependency` retains its original name. The field set and semantics are unchanged.
+
+## Domain Objects
+
+### FlaggedDependency
+
+Represents one flag-qualified implementation override for a service.
+
+| Attribute      | Type                   | Required | Default | Description                                   |
+|----------------|------------------------|----------|---------|-----------------------------------------------|
+| `module_path`  | `StringType`           | Yes      | —       | The module path.                               |
+| `class_name`   | `StringType`           | Yes      | —       | The class name.                                |
+| `flag`         | `StringType`           | Yes      | —       | The flag for the container dependency.          |
+| `parameters`   | `DictType(StringType)` | No       | `{}`    | The container dependency parameters.            |
+
+No methods. Pure data structure.
+
+### ServiceConfiguration
+
+Represents a single injectable service entry in the DI registry.
+
+| Attribute       | Type                                  | Required | Default | Description                                       |
+|-----------------|---------------------------------------|----------|---------|---------------------------------------------------|
+| `id`            | `StringType`                          | Yes      | —       | The unique identifier for the service configuration. |
+| `name`          | `StringType`                          | No       | —       | The name of the service configuration.             |
+| `module_path`   | `StringType`                          | No       | —       | The default module path for the dependency class.  |
+| `class_name`    | `StringType`                          | No       | —       | The default class name for the dependency class.   |
+| `parameters`    | `DictType(StringType)`                | No       | `{}`    | The default configuration parameters.              |
+| `dependencies`  | `ListType(ModelType(FlaggedDependency))` | No    | `[]`    | The flag-specific implementation overrides.        |
+
+#### Methods
+
+**`get_dependency(*flags) -> FlaggedDependency`**
+
+Returns the first `FlaggedDependency` whose `flag` matches any of the provided flags. Flags are evaluated in argument order (ordinal priority), so the first match wins. Returns `None` if no dependency matches.
+
+```python
+# Single flag lookup
+dep = config.get_dependency('yaml')
+
+# Priority-ordered lookup: prefer 'sqlite' over 'yaml'
+dep = config.get_dependency('sqlite', 'yaml')
+```
+
+## Flag Resolution Flow
+
+Flags flow into the DI container from multiple sources:
+
+1. **`AppInterface.flags`** — interface-level flags set in `app/configs/app.yml` (e.g., `['yaml']`, `['sqlite', 'yaml']`).
+2. **`Feature.flags`** — feature-level flag overrides defined in `feature.yml`.
+3. **`FeatureEvent.flags`** — command-level flag overrides within a feature workflow.
+
+At resolution time, `ContainerContext` merges these flag sources and calls `ServiceConfiguration.get_dependency(*merged_flags)` to select the correct concrete implementation for each service.
+
+## Runtime Role
+
+The DI domain objects participate in the service resolution flow:
+
+1. **`ContainerContext`** loads all `ServiceConfiguration` entries from `app/configs/container.yml` via `ContainerService`.
+2. **`build_injector()`** iterates each `ServiceConfiguration`, resolving concrete types:
+   - If a matching `FlaggedDependency` is found via `get_dependency(*flags)`, its `module_path` and `class_name` are used.
+   - Otherwise, the default `module_path` and `class_name` on `ServiceConfiguration` are used.
+3. **`get_attribute_type()`** calls `ImportDependency.execute()` to dynamically import the resolved class.
+4. The resolved types and their parameters are wired into the dependency injection `Injector`.
+5. Domain events and contexts receive fully constructed service instances via constructor injection.
+
+## Configuration Mapping
+
+Service configurations are defined in `app/configs/container.yml`. Each top-level key under `attrs` maps to a `ServiceConfiguration`:
+
+```yaml
+attrs:
+  error_service:
+    module_path: tiferet.repos.error
+    class_name: ErrorYamlRepository
+    params:
+      error_config_file: app/configs/error.yml
+    dependencies:
+      - flag: sqlite
+        module_path: tiferet.repos.error_sqlite
+        class_name: ErrorSqliteRepository
+        params:
+          db_path: app/data/errors.db
+
+  feature_service:
+    module_path: tiferet.repos.feature
+    class_name: FeatureYamlRepository
+    params:
+      feature_config_file: app/configs/feature.yml
+```
+
+## Domain Events
+
+The following domain events interact with `ServiceConfiguration` and `FlaggedDependency`:
+
+| Event                       | Description                                              |
+|-----------------------------|----------------------------------------------------------|
+| `ListAllSettings`           | Lists all `ServiceConfiguration` entries.                |
+| `AddServiceConfiguration`   | Creates and persists a new `ServiceConfiguration`.        |
+| `UpdateServiceConfiguration`| Modifies an existing `ServiceConfiguration` via aggregate.|
+| `DeleteServiceConfiguration`| Removes a `ServiceConfiguration` by ID.                   |
+
+These events depend on the `ContainerService` interface for persistence operations.
+
+## Service Interface
+
+**`ContainerService`** (`tiferet/interfaces/container.py`) defines the abstract contract for DI configuration persistence:
+
+- `exists(id: str) -> bool`
+- `get(id: str) -> ServiceConfiguration`
+- `list() -> List[ServiceConfiguration]`
+- `save(service_configuration) -> None`
+- `delete(id: str) -> None`
+
+Concrete implementations (e.g., `ContainerYamlRepository`) satisfy this interface.
+
+## Relationships to Other Domains
+
+- **App:** `AppInterface.flags` provides the primary set of runtime flags used during dependency resolution.
+- **Feature:** `Feature.flags` and `FeatureEvent.flags` can override or extend the active flag set for specific workflows.
+- **Error:** Error service implementations are resolved through the DI container, making `ServiceConfiguration` entries for `error_service` a common pattern.
+
+## Instantiation
+
+Both domain objects are instantiated via the standard `DomainObject.new()` factory:
+
+```python
+from tiferet.domain import DomainObject, FlaggedDependency, ServiceConfiguration
+
+dep = DomainObject.new(
+    FlaggedDependency,
+    flag='sqlite',
+    module_path='tiferet.repos.error_sqlite',
+    class_name='ErrorSqliteRepository',
+    parameters={'db_path': 'app/data/errors.db'},
+)
+
+config = DomainObject.new(
+    ServiceConfiguration,
+    id='error_service',
+    module_path='tiferet.repos.error',
+    class_name='ErrorYamlRepository',
+    parameters={'error_config_file': 'app/configs/error.yml'},
+    dependencies=[dep],
+)
+```
+
+## Related Documentation
+
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
+- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (AppInterface, flags)
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+```

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -17,3 +17,7 @@ from .app import (
     AppInterface,
     AppServiceDependency,
 )
+from .di import (
+    FlaggedDependency,
+    ServiceConfiguration,
+)

--- a/tiferet/domain/di.py
+++ b/tiferet/domain/di.py
@@ -1,0 +1,131 @@
+"""Tiferet Domain DI"""
+
+# *** imports
+
+# ** app
+from .settings import (
+    DomainObject,
+    StringType,
+    ListType,
+    DictType,
+    ModelType,
+)
+
+# *** models
+
+# ** model: flagged_dependency
+class FlaggedDependency(DomainObject):
+    '''
+    A flagged container dependency object.
+    '''
+
+    # * attribute: module_path
+    module_path = StringType(
+        required=True,
+        metadata=dict(
+            description='The module path.'
+        ),
+    )
+
+    # * attribute: class_name
+    class_name = StringType(
+        required=True,
+        metadata=dict(
+            description='The class name.'
+        ),
+    )
+
+    # * attribute: flag
+    flag = StringType(
+        required=True,
+        metadata=dict(
+            description='The flag for the container dependency.'
+        ),
+    )
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        metadata=dict(
+            description='The container dependency parameters.'
+        ),
+    )
+
+
+# ** model: service_configuration
+class ServiceConfiguration(DomainObject):
+    '''
+    A service configuration that defines dependency injection behavior.
+    '''
+
+    # * attribute: id
+    id = StringType(
+        required=True,
+        metadata=dict(
+            description='The unique identifier for the service configuration.'
+        ),
+    )
+
+    # * attribute: name
+    name = StringType(
+        metadata=dict(
+            description='The name of the service configuration.'
+        ),
+    )
+
+    # * attribute: module_path
+    module_path = StringType(
+        metadata=dict(
+            description='The default module path for the dependency class.'
+        ),
+    )
+
+    # * attribute: class_name
+    class_name = StringType(
+        metadata=dict(
+            description='The default class name for the dependency class.'
+        ),
+    )
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        metadata=dict(
+            description='The default configuration parameters.'
+        ),
+    )
+
+    # * attribute: dependencies
+    dependencies = ListType(
+        ModelType(FlaggedDependency),
+        default=[],
+        metadata=dict(
+            description='The flag-specific implementation overrides.'
+        ),
+    )
+
+    # * method: get_dependency
+    def get_dependency(self, *flags) -> FlaggedDependency:
+        '''
+        Gets a flagged dependency by flag.
+
+        :param flags: The flags to match against flagged dependencies.
+        :type flags: Tuple[str, ...]
+        :return: The first flagged dependency matching any provided flag, or None.
+        :rtype: FlaggedDependency
+        '''
+
+        # Return the first dependency that matches any of the provided flags.
+        # Input flags are assumed ordinal in priority, so the first match is returned.
+        for flag in flags:
+            match = next(
+                (dependency for dependency in self.dependencies if dependency.flag == flag),
+                None
+            )
+            if match:
+                return match
+
+        # Return None if no dependency matches the flags.
+        return None

--- a/tiferet/domain/tests/test_di.py
+++ b/tiferet/domain/tests/test_di.py
@@ -1,0 +1,201 @@
+"""Tests for Tiferet Domain DI"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import DomainObject
+from ..di import (
+    FlaggedDependency,
+    ServiceConfiguration,
+)
+
+# *** classes
+
+# ** class: test_dependency
+class TestDependency:
+    '''
+    A stub dependency class for testing.
+    '''
+
+    pass
+
+# ** class: test_dependency_alpha
+class TestDependencyAlpha(TestDependency):
+    '''
+    A stub alpha dependency class for testing.
+    '''
+
+    pass
+
+# ** class: test_dependency_beta
+class TestDependencyBeta(TestDependency):
+    '''
+    A stub beta dependency class for testing.
+    '''
+
+    pass
+
+# *** fixtures
+
+# ** fixture: flagged_dependency
+@pytest.fixture
+def flagged_dependency() -> FlaggedDependency:
+    '''
+    Fixture for a FlaggedDependency instance with flag test_alpha.
+
+    :return: The FlaggedDependency instance.
+    :rtype: FlaggedDependency
+    '''
+
+    # Create and return a new FlaggedDependency.
+    return DomainObject.new(
+        FlaggedDependency,
+        flag='test_alpha',
+        module_path='tiferet.domain.tests.test_di',
+        class_name='TestDependencyAlpha',
+        parameters={'test_param': 'test_value', 'param': 'value1'},
+    )
+
+# ** fixture: flagged_dependency_to_add
+@pytest.fixture
+def flagged_dependency_to_add() -> FlaggedDependency:
+    '''
+    Fixture for a FlaggedDependency instance with flag test_beta.
+
+    :return: The FlaggedDependency instance.
+    :rtype: FlaggedDependency
+    '''
+
+    # Create and return a new FlaggedDependency.
+    return DomainObject.new(
+        FlaggedDependency,
+        flag='test_beta',
+        module_path='tiferet.domain.tests.test_di',
+        class_name='TestDependencyBeta',
+        parameters={'test_param': 'test_value', 'param': 'value2'},
+    )
+
+# ** fixture: service_configuration
+@pytest.fixture
+def service_configuration(flagged_dependency: FlaggedDependency) -> ServiceConfiguration:
+    '''
+    Fixture for a ServiceConfiguration with a default type and one flagged override.
+
+    :param flagged_dependency: The FlaggedDependency fixture.
+    :type flagged_dependency: FlaggedDependency
+    :return: The ServiceConfiguration instance.
+    :rtype: ServiceConfiguration
+    '''
+
+    # Create and return a new ServiceConfiguration.
+    return DomainObject.new(
+        ServiceConfiguration,
+        id='test_service',
+        module_path='tiferet.domain.tests.test_di',
+        class_name='TestDependency',
+        dependencies=[flagged_dependency],
+    )
+
+# ** fixture: service_configuration_no_default_type
+@pytest.fixture
+def service_configuration_no_default_type(flagged_dependency: FlaggedDependency) -> ServiceConfiguration:
+    '''
+    Fixture for a ServiceConfiguration with no default type, only flagged overrides.
+
+    :param flagged_dependency: The FlaggedDependency fixture.
+    :type flagged_dependency: FlaggedDependency
+    :return: The ServiceConfiguration instance.
+    :rtype: ServiceConfiguration
+    '''
+
+    # Create and return a new ServiceConfiguration without default type.
+    return DomainObject.new(
+        ServiceConfiguration,
+        id='test_service_no_default',
+        dependencies=[flagged_dependency],
+    )
+
+# ** fixture: service_configuration_multiple_deps
+@pytest.fixture
+def service_configuration_multiple_deps(
+        flagged_dependency: FlaggedDependency,
+        flagged_dependency_to_add: FlaggedDependency,
+    ) -> ServiceConfiguration:
+    '''
+    Fixture for a ServiceConfiguration with a default type and two flagged overrides.
+
+    :param flagged_dependency: The FlaggedDependency fixture (test_alpha).
+    :type flagged_dependency: FlaggedDependency
+    :param flagged_dependency_to_add: The FlaggedDependency fixture (test_beta).
+    :type flagged_dependency_to_add: FlaggedDependency
+    :return: The ServiceConfiguration instance.
+    :rtype: ServiceConfiguration
+    '''
+
+    # Create and return a new ServiceConfiguration with multiple dependencies.
+    return DomainObject.new(
+        ServiceConfiguration,
+        id='test_service_multi',
+        module_path='tiferet.domain.tests.test_di',
+        class_name='TestDependency',
+        dependencies=[flagged_dependency, flagged_dependency_to_add],
+    )
+
+# *** tests
+
+# ** test: service_configuration_get_dependency
+def test_service_configuration_get_dependency(service_configuration: ServiceConfiguration) -> None:
+    '''
+    Test successful retrieval of a flagged dependency by flag.
+
+    :param service_configuration: The ServiceConfiguration fixture.
+    :type service_configuration: ServiceConfiguration
+    '''
+
+    # Retrieve the flagged dependency by flag.
+    dep = service_configuration.get_dependency('test_alpha')
+
+    # Assert the flagged dependency fields match.
+    assert dep.flag == 'test_alpha'
+    assert dep.module_path == 'tiferet.domain.tests.test_di'
+    assert dep.class_name == 'TestDependencyAlpha'
+    assert dep.parameters == {'test_param': 'test_value', 'param': 'value1'}
+
+# ** test: service_configuration_get_dependency_invalid
+def test_service_configuration_get_dependency_invalid(service_configuration: ServiceConfiguration) -> None:
+    '''
+    Test that get_dependency returns None for an unknown flag.
+
+    :param service_configuration: The ServiceConfiguration fixture.
+    :type service_configuration: ServiceConfiguration
+    '''
+
+    # Attempt to retrieve a non-existent flagged dependency.
+    dep = service_configuration.get_dependency('invalid')
+
+    # Assert None is returned.
+    assert dep is None
+
+# ** test: service_configuration_get_dependency_multiple_flags
+def test_service_configuration_get_dependency_multiple_flags(
+        service_configuration_multiple_deps: ServiceConfiguration,
+    ) -> None:
+    '''
+    Test priority order: first matching flag in the argument tuple wins.
+
+    :param service_configuration_multiple_deps: The ServiceConfiguration fixture with multiple dependencies.
+    :type service_configuration_multiple_deps: ServiceConfiguration
+    '''
+
+    # Retrieve with test_alpha first — should return alpha.
+    dep_alpha_first = service_configuration_multiple_deps.get_dependency('test_alpha', 'test_beta')
+    assert dep_alpha_first.flag == 'test_alpha'
+    assert dep_alpha_first.class_name == 'TestDependencyAlpha'
+
+    # Retrieve with test_beta first — should return beta.
+    dep_beta_first = service_configuration_multiple_deps.get_dependency('test_beta', 'test_alpha')
+    assert dep_beta_first.flag == 'test_beta'
+    assert dep_beta_first.class_name == 'TestDependencyBeta'


### PR DESCRIPTION
## Summary

Implements #566 — adds the DI domain objects for dependency injection configuration in the v2 domain model.

### Changes

- **`tiferet/domain/di.py`** — New file defining `FlaggedDependency` (immutable value object for flag-qualified implementation overrides) and `ServiceConfiguration` (injectable service entry with `get_dependency(*flags)` query method).
- **`tiferet/domain/__init__.py`** — Exports both new classes.
- **`tiferet/domain/tests/test_di.py`** — Three unit tests: single-flag lookup, invalid flag returns `None`, and priority-ordered multi-flag resolution.
- **`docs/guides/domain/di.md`** — Narrative guide covering the DI domain's role, flag resolution flow, configuration mapping, and relationships.

All 6 domain tests pass with no regressions.

Closes #566

Co-Authored-By: Oz <oz-agent@warp.dev>