### PR TITLE
Domain – CLI: Add CliArgument and CliCommand Domain Objects

### DIFF
--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -1,0 +1,201 @@
+**This conversation is part of the Tiferet Framework project.**  
+**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
+
+```markdown
+# Domain – CLI: CliArgument and CliCommand
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** March 06, 2026  
+**Version:** 2.0.0a2
+
+## Overview
+
+The CLI domain defines the structural configuration for command-line interface commands in Tiferet. CLI commands serve as the **terminal-to-feature bridge**: each `CliCommand` has a composite identifier (`group_key.key`) that maps directly to a feature ID in `feature.yml`, enabling seamless execution of domain features via `argparse`-driven command-line input.
+
+- `CliArgument` — represents a single command-line argument or flag, mapping to `argparse.add_argument()` parameters.
+- `CliCommand` — represents a CLI command with a composite ID, a custom `new()` factory for ID derivation, and a `has_argument()` query method.
+
+Both domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing arguments, renaming commands) occur exclusively through Aggregates in the mappers layer.
+
+**Module:** `tiferet/domain/cli.py`
+
+## Domain Objects
+
+### CliArgument
+
+Represents a single command-line argument or flag.
+
+| Attribute       | Type                   | Required | Default | Description                                                                      |
+|-----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
+| `name_or_flags` | `ListType(StringType)` | Yes      | —       | The name or flags of the argument (e.g., `["-f", "--flag"]`).                     |
+| `description`   | `StringType`           | No       | —       | A brief description of the argument.                                              |
+| `type`          | `StringType`           | No       | `'str'` | The type: `"str"`, `"int"`, or `"float"`.                                         |
+| `required`      | `BooleanType`          | No       | —       | Whether the argument is required.                                                 |
+| `default`       | `StringType`           | No       | —       | The default value if not provided.                                                |
+| `choices`       | `ListType(StringType)` | No       | —       | Valid choices for the argument.                                                   |
+| `nargs`         | `StringType`           | No       | —       | Number of arguments: `"?"`, `"*"`, `"+"`, or an integer.                          |
+| `action`        | `StringType`           | No       | —       | The action: `store`, `store_true`, `store_false`, `append`, `count`, `help`, etc. |
+
+#### Methods
+
+**`get_type() -> str | int | float`**
+
+Maps the stored `type` string to a Python type object. Falls back to `str` if the type is `None` or unrecognized.
+
+```python
+arg = DomainObject.new(CliArgument, name_or_flags=['--count'], type='int')
+assert arg.get_type() is int
+```
+
+### CliCommand
+
+Represents a CLI command with a composite identifier.
+
+| Attribute    | Type                              | Required | Default | Description                                                  |
+|--------------|-----------------------------------|----------|---------|--------------------------------------------------------------|
+| `id`         | `StringType`                      | Yes      | —       | The unique identifier, formatted as `"group_key.key"`.        |
+| `name`       | `StringType`                      | Yes      | —       | The name of the command.                                      |
+| `description`| `StringType`                      | No       | —       | A brief description of the command.                           |
+| `key`        | `StringType`                      | Yes      | —       | The unique key for the command.                               |
+| `group_key`  | `StringType`                      | Yes      | —       | The group key the command belongs to.                         |
+| `arguments`  | `ListType(ModelType(CliArgument))`| No       | `[]`    | A list of arguments for the command.                          |
+
+#### Methods
+
+**`new(group_key, key, name, description=None, arguments=[]) -> CliCommand`** (static)
+
+Custom factory that derives the `id` by normalizing hyphens to underscores in both `group_key` and `key`, then joining with a dot:
+
+```python
+cmd = CliCommand.new(group_key='calc', key='add', name='Add Number')
+assert cmd.id == 'calc.add'
+
+cmd = CliCommand.new(group_key='my-group', key='my-cmd', name='My Command')
+assert cmd.id == 'my_group.my_cmd'
+```
+
+**`has_argument(flags: List[str]) -> bool`**
+
+Returns `True` if any of the provided flags match the `name_or_flags` of an existing argument in the command.
+
+```python
+cmd.has_argument(['-a', '--arg1'])  # True if arg1 exists
+cmd.has_argument(['-z'])            # False if no match
+```
+
+## The CLI-to-Feature Bridge
+
+The CLI domain's key design pattern is the **CLI-to-Feature bridge**: every `CliCommand.id` corresponds exactly to a feature ID in `feature.yml`. When a user runs a CLI command, the `CliContext` maps the parsed command to a feature and executes it via `FeatureContext`.
+
+For example:
+- CLI command `calc.add` → Feature `calc.add` (defined in `feature.yml`)
+- CLI command `calc.sqrt` → Feature `calc.sqrt`
+
+This 1:1 mapping ensures CLI commands are thin entry points that delegate all business logic to the feature layer.
+
+## Runtime Role
+
+The CLI domain objects participate in the command-line execution flow:
+
+1. **`CliContext.get_commands()`** loads all `CliCommand` entries from `app/configs/cli.yml` via `CliService`.
+2. **`parse_arguments()`** iterates each `CliCommand`, registering subparsers and arguments with `argparse` using `CliArgument` attributes (`name_or_flags`, `type`, `required`, `default`, `choices`, `nargs`, `action`).
+3. **`argparse`** parses the user's CLI input and returns the matched command group and key.
+4. **`parse_request()`** maps the parsed arguments to a feature ID (`group_key.key`) and data dictionary.
+5. **`FeatureContext`** executes the corresponding feature with the parsed data.
+
+## Configuration Mapping
+
+CLI commands are defined in `app/configs/cli.yml`. Each entry under `cli.cmds.<group>.<key>` maps to a `CliCommand`:
+
+```yaml
+cli:
+  cmds:
+    calc:
+      add:
+        group_key: calc
+        key: add
+        description: Adds two numbers.
+        args:
+          - name_or_flags:
+              - a
+            description: The first number to add.
+          - name_or_flags:
+              - b
+            description: The second number to add.
+        name: Add Number Command
+      sqrt:
+        group_key: calc
+        key: sqrt
+        description: Calculates the square root of a number.
+        args:
+          - name_or_flags:
+              - a
+            description: The number to square root.
+        name: Square Root Command
+```
+
+## Domain Events
+
+The following domain events interact with `CliCommand` and `CliArgument`:
+
+| Event                | Description                                              |
+|----------------------|----------------------------------------------------------|
+| `ListCliCommands`    | Lists all `CliCommand` entries.                          |
+| `GetParentArguments` | Retrieves shared arguments for a command group.          |
+| `AddCliCommand`      | Creates and persists a new `CliCommand`.                  |
+| `AddCliArgument`     | Adds an argument to an existing `CliCommand` via aggregate.|
+
+These events depend on the `CliService` interface for persistence operations.
+
+## Service Interface
+
+**`CliService`** (`tiferet/interfaces/cli.py`) defines the abstract contract for CLI configuration persistence:
+
+- `exists(id: str) -> bool`
+- `get(id: str) -> CliCommand`
+- `list() -> List[CliCommand]`
+- `save(cli_command) -> None`
+- `delete(id: str) -> None`
+
+Concrete implementations (e.g., `CliYamlRepository`) satisfy this interface.
+
+## Relationships to Other Domains
+
+- **Feature:** `CliCommand.id` maps 1:1 to feature IDs in `feature.yml`. CLI commands are thin entry points that delegate to the feature layer.
+- **App:** The `calc_cli` interface in `app.yml` specifies `CliContext` as its implementation, with `CliService` and `CliHandler` as service dependencies.
+- **Error:** CLI error responses are formatted via `ErrorContext`, providing user-friendly messages for validation failures and domain errors.
+
+## Instantiation
+
+```python
+from tiferet.domain import DomainObject, CliArgument, CliCommand
+
+# Create an argument directly
+arg = DomainObject.new(
+    CliArgument,
+    name_or_flags=['--count', '-c'],
+    description='Number of iterations.',
+    type='int',
+    required=True,
+)
+
+# Create a command via the custom factory
+cmd = CliCommand.new(
+    group_key='calc',
+    key='add',
+    name='Add Number',
+    description='Adds two numbers.',
+    arguments=[arg],
+)
+# cmd.id == 'calc.add'
+```
+
+## Related Documentation
+
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
+- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (interface configuration)
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+```

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -21,3 +21,7 @@ from .di import (
     FlaggedDependency,
     ServiceConfiguration,
 )
+from .cli import (
+    CliArgument,
+    CliCommand,
+)

--- a/tiferet/domain/cli.py
+++ b/tiferet/domain/cli.py
@@ -1,0 +1,219 @@
+"""Tiferet Domain CLI"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** app
+from .settings import (
+    DomainObject,
+    StringType,
+    BooleanType,
+    ListType,
+    ModelType,
+)
+
+# *** models
+
+# ** model: cli_argument
+class CliArgument(DomainObject):
+    '''
+    Represents a command line argument.
+    '''
+
+    # * attribute: name_or_flags
+    name_or_flags = ListType(
+        StringType,
+        required=True,
+        metadata=dict(
+            description='The name or flags of the argument. Can be a single name or multiple flags (e.g., ["-f", "--flag"])'
+        ),
+    )
+
+    # * attribute: description
+    description = StringType(
+        metadata=dict(
+            description='A brief description of the argument.'
+        ),
+    )
+
+    # * attribute: type
+    type = StringType(
+        choices=['str', 'int', 'float'],
+        default='str',
+        metadata=dict(
+            description='The type of the argument. Can be "str", "int", or "float". Defaults to "str".'
+        ),
+    )
+
+    # * attribute: required
+    required = BooleanType(
+        metadata=dict(
+            description='Whether the argument is required. Defaults to False.'
+        ),
+    )
+
+    # * attribute: default
+    default = StringType(
+        metadata=dict(
+            description='The default value of the argument if it is not provided. Only applicable if the argument is not required.'
+        ),
+    )
+
+    # * attribute: choices
+    choices = ListType(
+        StringType,
+        metadata=dict(
+            description='A list of valid choices for the argument. If provided, the argument must be one of these choices.'
+        ),
+    )
+
+    # * attribute: nargs
+    nargs = StringType(
+        metadata=dict(
+            description='The number of arguments that should be consumed. Can be an integer or "?" for optional, "*" for zero or more, or "+" for one or more.'
+        ),
+    )
+
+    # * attribute: action
+    action = StringType(
+        choices=['store', 'store_const', 'store_true', 'store_false', 'append', 'append_const', 'count', 'help', 'version'],
+        metadata=dict(
+            description='The action to be taken when the argument is encountered.'
+        ),
+    )
+
+    # * method: get_type
+    def get_type(self) -> str | int | float:
+        '''
+        Get the type of the argument.
+
+        :return: The type of the argument.
+        :rtype: str | int | float
+        '''
+
+        # Map the type string to a Python type.
+        if self.type == 'str':
+            return str
+        elif self.type == 'int':
+            return int
+        elif self.type == 'float':
+            return float
+
+        # If the type is not recognized, return str as a default.
+        else:
+            return str
+
+
+# ** model: cli_command
+class CliCommand(DomainObject):
+    '''
+    Represents a command line command.
+    '''
+
+    # * attribute: id
+    id = StringType(
+        required=True,
+        metadata=dict(
+            description='The unique identifier for the command, typically formatted as "group_key.key".'
+        ),
+    )
+
+    # * attribute: name
+    name = StringType(
+        required=True,
+        metadata=dict(
+            description='The name of the command.'
+        ),
+    )
+
+    # * attribute: description
+    description = StringType(
+        metadata=dict(
+            description='A brief description of the command.'
+        ),
+    )
+
+    # * attribute: key
+    key = StringType(
+        required=True,
+        metadata=dict(
+            description='A unique key for the command, typically used for identification in a configuration file.'
+        ),
+    )
+
+    # * attribute: group_key
+    group_key = StringType(
+        required=True,
+        metadata=dict(
+            description='A unique key for the group this command belongs to, typically used for modularly grouping commands by functional context in a configuration file.'
+        ),
+    )
+
+    # * attribute: arguments
+    arguments = ListType(
+        ModelType(CliArgument),
+        default=[],
+        metadata=dict(
+            description='A list of arguments for the command.'
+        ),
+    )
+
+    # * method: new
+    @staticmethod
+    def new(group_key: str,
+            key: str,
+            name: str,
+            description: str = None,
+            arguments: List[CliArgument] = [],
+        ) -> 'CliCommand':
+        '''
+        Create a new command.
+
+        :param group_key: The group key for the command.
+        :type group_key: str
+        :param key: The unique key for the command.
+        :type key: str
+        :param name: The name of the command.
+        :type name: str
+        :param description: A brief description of the command.
+        :type description: str
+        :param arguments: A list of arguments for the command.
+        :type arguments: List[CliArgument]
+        :return: The created command.
+        :rtype: CliCommand
+        '''
+
+        # Create the command id from the formatted group key and key.
+        id = '{}.{}'.format(group_key.replace('-', '_'), key.replace('-', '_'))
+
+        # Create and return the command object.
+        return DomainObject.new(
+            CliCommand,
+            id=id,
+            group_key=group_key,
+            key=key,
+            name=name,
+            description=description,
+            arguments=arguments,
+        )
+
+    # * method: has_argument
+    def has_argument(self, flags: List[str]) -> bool:
+        '''
+        Check if the command has an argument with the given flags.
+
+        :param flags: The flags to check for.
+        :type flags: List[str]
+        :return: True if the command has the argument, False otherwise.
+        :rtype: bool
+        '''
+
+        # Loop through the flags and check if any of them match the flags of an existing argument
+        for flag in flags:
+            if any([argument for argument in self.arguments if flag in argument.name_or_flags]):
+                return True
+
+        # Return False if no argument was found
+        return False

--- a/tiferet/domain/tests/test_cli.py
+++ b/tiferet/domain/tests/test_cli.py
@@ -1,0 +1,150 @@
+"""Tests for Tiferet Domain CLI"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import DomainObject
+from ..cli import (
+    CliArgument,
+    CliCommand,
+)
+
+# *** fixtures
+
+# ** fixture: cli_argument
+@pytest.fixture
+def cli_argument() -> CliArgument:
+    '''
+    Fixture for a CliArgument instance.
+
+    :return: The CliArgument instance.
+    :rtype: CliArgument
+    '''
+
+    # Create and return a new CliArgument.
+    return DomainObject.new(
+        CliArgument,
+        name_or_flags=['--test-arg', '-t'],
+        description='A test argument for CLI commands.',
+        required=True,
+        type='str',
+    )
+
+# ** fixture: cli_command
+@pytest.fixture
+def cli_command() -> CliCommand:
+    '''
+    Fixture for a CliCommand instance created via CliCommand.new().
+
+    :return: The CliCommand instance.
+    :rtype: CliCommand
+    '''
+
+    # Create an argument for the command.
+    arg = DomainObject.new(
+        CliArgument,
+        name_or_flags=['--arg1', '-a'],
+        description='First argument.',
+    )
+
+    # Create and return a new CliCommand via the custom factory.
+    return CliCommand.new(
+        group_key='test-group',
+        key='test-feature',
+        name='Test Feature Command',
+        description='A command for testing CLI features.',
+        arguments=[arg],
+    )
+
+# *** tests
+
+# ** test: cli_argument_get_type_str
+def test_cli_argument_get_type_str(cli_argument: CliArgument) -> None:
+    '''
+    Test that get_type returns str for the default type.
+
+    :param cli_argument: The CliArgument fixture.
+    :type cli_argument: CliArgument
+    '''
+
+    # Assert the type resolves to str.
+    assert cli_argument.get_type() is str
+
+# ** test: cli_argument_get_type_int
+def test_cli_argument_get_type_int(cli_argument: CliArgument) -> None:
+    '''
+    Test that get_type returns int when type is set to "int".
+
+    :param cli_argument: The CliArgument fixture.
+    :type cli_argument: CliArgument
+    '''
+
+    # Override the type to int.
+    cli_argument.type = 'int'
+
+    # Assert the type resolves to int.
+    assert cli_argument.get_type() is int
+
+# ** test: cli_argument_get_type_float
+def test_cli_argument_get_type_float(cli_argument: CliArgument) -> None:
+    '''
+    Test that get_type returns float when type is set to "float".
+
+    :param cli_argument: The CliArgument fixture.
+    :type cli_argument: CliArgument
+    '''
+
+    # Override the type to float.
+    cli_argument.type = 'float'
+
+    # Assert the type resolves to float.
+    assert cli_argument.get_type() is float
+
+# ** test: cli_argument_get_type_none
+def test_cli_argument_get_type_none(cli_argument: CliArgument) -> None:
+    '''
+    Test that get_type falls back to str when type is None.
+
+    :param cli_argument: The CliArgument fixture.
+    :type cli_argument: CliArgument
+    '''
+
+    # Set the type to None.
+    cli_argument.type = None
+
+    # Assert the type falls back to str.
+    assert cli_argument.get_type() is str
+
+# ** test: cli_command_new
+def test_cli_command_new(cli_command: CliCommand) -> None:
+    '''
+    Test that CliCommand.new() derives the id from hyphenated group key and key.
+
+    :param cli_command: The CliCommand fixture.
+    :type cli_command: CliCommand
+    '''
+
+    # Assert the id is derived correctly with hyphens replaced by underscores.
+    assert cli_command.id == 'test_group.test_feature'
+    assert cli_command.group_key == 'test-group'
+    assert cli_command.key == 'test-feature'
+    assert cli_command.name == 'Test Feature Command'
+    assert cli_command.description == 'A command for testing CLI features.'
+
+# ** test: cli_command_has_argument
+def test_cli_command_has_argument(cli_command: CliCommand) -> None:
+    '''
+    Test that has_argument returns True for matching flags and False otherwise.
+
+    :param cli_command: The CliCommand fixture.
+    :type cli_command: CliCommand
+    '''
+
+    # Assert existing argument flags return True.
+    assert cli_command.has_argument(['-a', '--arg1']) is True
+
+    # Assert non-existent argument flags return False.
+    assert cli_command.has_argument(['-b', '--arg2']) is False


### PR DESCRIPTION
## Summary

Implements #589 — adds the CLI domain objects for command-line interface configuration in the v2 domain model.

### Changes

- **`tiferet/domain/cli.py`** — New file defining `CliArgument` (immutable value object for CLI arguments with `get_type()` mapping) and `CliCommand` (CLI command with custom `new()` factory for composite ID derivation and `has_argument()` query method).
- **`tiferet/domain/__init__.py`** — Exports both new classes.
- **`tiferet/domain/tests/test_cli.py`** — Six unit tests: type resolution (str, int, float, None fallback), factory ID derivation, and argument flag lookup.
- **`docs/guides/domain/cli.md`** — Narrative guide covering the CLI domain's role as the terminal-to-feature bridge, runtime flow, configuration mapping, and relationships.

All 12 domain tests pass with no regressions.

Closes #589

Co-Authored-By: Oz <oz-agent@warp.dev>