### PR TITLE
Domain – Error: Add ErrorMessage and Error Domain Objects

### DIFF
--- a/docs/guides/domain/error.md
+++ b/docs/guides/domain/error.md
@@ -1,0 +1,179 @@
+**This conversation is part of the Tiferet Framework project.**  
+**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
+
+```markdown
+# Domain – Error: ErrorMessage and Error
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** March 06, 2026  
+**Version:** 2.0.0a2
+
+## Overview
+
+The Error domain defines the structural foundation for structured error handling in Tiferet. Every error definition is described by an `Error` domain object, which holds a unique identifier, error code, name, and one or more localized `ErrorMessage` translations. This enables consistent, multilingual error formatting across all application interfaces.
+
+Both domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries and formatting methods. All state changes (renaming, adding/removing messages) occur exclusively through Aggregates in the mappers layer.
+
+**Module:** `tiferet/domain/error.py`
+
+## Domain Objects
+
+### ErrorMessage
+
+Represents a single localized error message.
+
+| Attribute | Type         | Required | Default | Description                         |
+|-----------|--------------|----------|---------|-------------------------------------|
+| `lang`    | `StringType` | Yes      | —       | The language of the error message.   |
+| `text`    | `StringType` | Yes      | —       | The error message text (may contain format placeholders). |
+
+#### Methods
+
+**`format(**kwargs) -> str`**
+
+Returns the raw `text` when no kwargs are provided. When kwargs are given, performs Python string formatting:
+
+```python
+msg = DomainObject.new(ErrorMessage, lang='en_US', text='Value {value} is invalid')
+msg.format()                    # 'Value {value} is invalid'
+msg.format(value='abc')         # 'Value abc is invalid'
+```
+
+### Error
+
+Represents a named error definition with multilingual message support.
+
+| Attribute    | Type                              | Required | Default | Description                                   |
+|--------------|-----------------------------------|----------|---------|-----------------------------------------------|
+| `id`         | `StringType`                      | Yes      | —       | The unique identifier of the error.            |
+| `name`       | `StringType`                      | Yes      | —       | The name of the error.                         |
+| `description`| `StringType`                      | No       | —       | The description of the error.                  |
+| `error_code` | `StringType`                      | No       | —       | The unique code of the error (derived from id).|
+| `message`    | `ListType(ModelType(ErrorMessage))`| Yes     | —       | The error message translations.                |
+
+#### Methods
+
+**`new(name, id, message=[], **kwargs) -> Error`** (static)
+
+Custom factory that derives `error_code` by uppercasing `id` and replacing spaces with underscores:
+
+```python
+error = Error.new(id='invalid_input', name='Invalid Input', message=[...])
+assert error.error_code == 'INVALID_INPUT'
+```
+
+**`format_message(lang='en_US', **kwargs) -> str`**
+
+Finds the first `ErrorMessage` matching the given `lang` and formats it. Returns `None` if no message matches the language.
+
+**`format_response(lang='en_US', **kwargs) -> dict`**
+
+Returns a structured error response dict with `error_code`, `name`, `message`, and any additional kwargs. Returns `None` if the language is not supported.
+
+```python
+response = error.format_response('en_US', value='abc')
+# {'error_code': 'invalid_input', 'name': 'Invalid Input', 'message': 'Value abc is invalid', 'value': 'abc'}
+```
+
+## Error Formatting Flow
+
+The error formatting flow in Tiferet follows this path:
+
+1. A domain event calls `self.verify(expression, error_code, ...)` or `self.raise_error(error_code, ...)`.
+2. A `TiferetError` is raised with the `error_code` and contextual kwargs.
+3. The application context catches the error and delegates to `ErrorContext.handle_error()`.
+4. `ErrorContext` retrieves the `Error` domain object via `ErrorService.get(error_code)`.
+5. `Error.format_response(lang, **kwargs)` produces the structured error response.
+6. The response is returned to the caller (API response, CLI output, etc.).
+
+## Built-In Defaults
+
+Tiferet provides built-in error definitions in `assets/constants.py::DEFAULT_ERRORS`. These cover framework-level errors such as:
+
+- `COMMAND_PARAMETER_REQUIRED` — missing required parameters
+- `FEATURE_NOT_FOUND` — unknown feature ID
+- `INVALID_MODEL_ATTRIBUTE` — invalid attribute on a domain object
+
+Application-specific errors are defined in `app/configs/error.yml` and loaded via `ErrorService`.
+
+## Configuration Mapping
+
+Errors are defined in `app/configs/error.yml`. Each top-level key maps to an `Error`:
+
+```yaml
+errors:
+  invalid_input:
+    name: Invalid Numeric Input
+    message:
+      - lang: en_US
+        text: 'Value {value} must be a number'
+      - lang: es_ES
+        text: 'El valor {value} debe ser un número'
+  division_by_zero:
+    name: Division By Zero
+    message:
+      - lang: en_US
+        text: 'Cannot divide by zero'
+      - lang: es_ES
+        text: 'No se puede dividir por cero'
+```
+
+## Domain Events
+
+The following domain events interact with `Error` and `ErrorMessage`:
+
+| Event         | Description                                       |
+|---------------|---------------------------------------------------|
+| `GetError`    | Retrieves an `Error` by ID.                       |
+| `AddError`    | Creates and persists a new `Error`.                |
+| `RenameError` | Renames an existing `Error` via aggregate.         |
+| `SetErrorMessage` | Sets/updates a message translation via aggregate. |
+| `RemoveErrorMessage` | Removes a message translation via aggregate.  |
+
+These events depend on the `ErrorService` interface for persistence operations.
+
+## Service Interface
+
+**`ErrorService`** (`tiferet/interfaces/error.py`) defines the abstract contract for Error domain persistence:
+
+- `exists(id: str) -> bool`
+- `get(id: str) -> Error`
+- `list() -> List[Error]`
+- `save(error) -> None`
+- `delete(id: str) -> None`
+
+Concrete implementations (e.g., `ErrorYamlRepository`) satisfy this interface.
+
+## Relationships to Other Domains
+
+- **All Domains:** Every domain event uses `verify()` and `raise_error()` to raise `TiferetError`, which is resolved to an `Error` for formatting.
+- **App:** `ErrorContext` is loaded as part of the application interface bootstrap, receiving `ErrorService` via dependency injection.
+- **DI:** `ErrorService` is wired through the DI container (`ServiceConfiguration` entries in `container.yml`).
+
+## Instantiation
+
+```python
+from tiferet.domain import DomainObject, ErrorMessage, Error
+
+msg_en = DomainObject.new(ErrorMessage, lang='en_US', text='Value {value} is invalid')
+msg_es = DomainObject.new(ErrorMessage, lang='es_ES', text='El valor {value} no es válido')
+
+error = Error.new(
+    id='invalid_input',
+    name='Invalid Input',
+    message=[msg_en, msg_es],
+)
+# error.error_code == 'INVALID_INPUT'
+# error.format_message('es_ES', value='abc') == 'El valor abc no es válido'
+```
+
+## Related Documentation
+
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
+- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide
+- [docs/guides/domain/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/di.md) — DI domain guide
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+```

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -25,3 +25,7 @@ from .cli import (
     CliArgument,
     CliCommand,
 )
+from .error import (
+    Error,
+    ErrorMessage,
+)

--- a/tiferet/domain/error.py
+++ b/tiferet/domain/error.py
@@ -1,0 +1,184 @@
+"""Tiferet Domain Error"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict, List
+
+# ** app
+from .settings import (
+    DomainObject,
+    StringType,
+    ListType,
+    ModelType,
+)
+
+# *** models
+
+# ** model: error_message
+class ErrorMessage(DomainObject):
+    '''
+    An error message object.
+    '''
+
+    # * attribute: lang
+    lang = StringType(
+        required=True,
+        metadata=dict(
+            description='The language of the error message text.'
+        ),
+    )
+
+    # * attribute: text
+    text = StringType(
+        required=True,
+        metadata=dict(
+            description='The error message text.'
+        ),
+    )
+
+    # * method: format
+    def format(self, **kwargs) -> str:
+        '''
+        Formats the error message text.
+
+        :param kwargs: The format keyword arguments for the error message text.
+        :type kwargs: dict
+        :return: The formatted error message text.
+        :rtype: str
+        '''
+
+        # If there are no arguments, return the error message text.
+        if not kwargs:
+            return self.text
+
+        # Format the error message text and return it.
+        return self.text.format(**kwargs)
+
+
+# ** model: error
+class Error(DomainObject):
+    '''
+    An error object.
+    '''
+
+    # * attribute: id
+    id = StringType(
+        required=True,
+        metadata=dict(
+            description='The unique identifier of the error.'
+        ),
+    )
+
+    # * attribute: name
+    name = StringType(
+        required=True,
+        metadata=dict(
+            description='The name of the error.'
+        ),
+    )
+
+    # * attribute: description
+    description = StringType(
+        metadata=dict(
+            description='The description of the error.'
+        ),
+    )
+
+    # * attribute: error_code
+    error_code = StringType(
+        metadata=dict(
+            description='The unique code of the error.'
+        ),
+    )
+
+    # * attribute: message
+    message = ListType(
+        ModelType(ErrorMessage),
+        required=True,
+        metadata=dict(
+            description='The error message translations for the error.'
+        ),
+    )
+
+    # * method: new
+    @staticmethod
+    def new(name: str, id: str, message: List[Dict[str, str]] = [], **kwargs) -> 'Error':
+        '''
+        Initializes a new Error object.
+
+        :param name: The name of the error.
+        :type name: str
+        :param id: The unique identifier for the error.
+        :type id: str
+        :param message: The error message translations for the error.
+        :type message: list
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new Error object.
+        :rtype: Error
+        '''
+
+        # Set the error code as the id upper cased.
+        error_code = id.upper().replace(' ', '_')
+
+        # Create and return a new Error object.
+        return DomainObject.new(
+            Error,
+            id=id,
+            name=name,
+            error_code=error_code,
+            message=message,
+            **kwargs,
+        )
+
+    # * method: format_message
+    def format_message(self, lang: str = 'en_US', **kwargs) -> str:
+        '''
+        Formats the error message text for the specified language.
+
+        :param lang: The language of the error message text.
+        :type lang: str
+        :param kwargs: Additional format arguments for the error message text.
+        :type kwargs: dict
+        :return: The formatted error message text.
+        :rtype: str
+        '''
+
+        # Iterate through the error messages.
+        for msg in self.message:
+
+            # Skip if the language does not match.
+            if msg.lang != lang:
+                continue
+
+            # Format the error message text.
+            return msg.format(**kwargs)
+
+    # * method: format_response
+    def format_response(self, lang: str = 'en_US', **kwargs) -> Any:
+        '''
+        Formats the error response for the specified language.
+
+        :param lang: The language of the error message text.
+        :type lang: str
+        :param kwargs: Additional format arguments for the error message text.
+        :type kwargs: dict
+        :return: The formatted error response.
+        :rtype: dict
+        '''
+
+        # Format the error message text.
+        error_message = self.format_message(lang, **kwargs)
+
+        # If the error message is not found, return no response.
+        if not error_message:
+            return None
+
+        # Return the formatted error response.
+        return dict(
+            error_code=self.id,
+            name=self.name,
+            message=error_message,
+            **kwargs,
+        )

--- a/tiferet/domain/tests/test_error.py
+++ b/tiferet/domain/tests/test_error.py
@@ -1,0 +1,181 @@
+"""Tests for Tiferet Domain Error"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import DomainObject
+from ..error import (
+    Error,
+    ErrorMessage,
+)
+
+# *** fixtures
+
+# ** fixture: error_message
+@pytest.fixture
+def error_message() -> ErrorMessage:
+    '''
+    Fixture for a basic ErrorMessage instance.
+
+    :return: The ErrorMessage instance.
+    :rtype: ErrorMessage
+    '''
+
+    # Create and return a new ErrorMessage.
+    return DomainObject.new(
+        ErrorMessage,
+        lang='en_US',
+        text='An error occurred.',
+    )
+
+# ** fixture: formatted_error_message
+@pytest.fixture
+def formatted_error_message() -> ErrorMessage:
+    '''
+    Fixture for an ErrorMessage instance with a format placeholder.
+
+    :return: The ErrorMessage instance.
+    :rtype: ErrorMessage
+    '''
+
+    # Create and return a new ErrorMessage with a format placeholder.
+    return DomainObject.new(
+        ErrorMessage,
+        lang='en_US',
+        text='An error occurred: {error}',
+    )
+
+# ** fixture: error
+@pytest.fixture
+def error(error_message: ErrorMessage) -> Error:
+    '''
+    Fixture for an Error instance.
+
+    :param error_message: The ErrorMessage fixture.
+    :type error_message: ErrorMessage
+    :return: The Error instance.
+    :rtype: Error
+    '''
+
+    # Create and return a new Error via the custom factory.
+    return Error.new(
+        id='TEST_ERROR',
+        name='Test Error',
+        message=[error_message],
+    )
+
+# ** fixture: error_with_formatted_message
+@pytest.fixture
+def error_with_formatted_message(formatted_error_message: ErrorMessage) -> Error:
+    '''
+    Fixture for an Error instance with a formatted message.
+
+    :param formatted_error_message: The formatted ErrorMessage fixture.
+    :type formatted_error_message: ErrorMessage
+    :return: The Error instance.
+    :rtype: Error
+    '''
+
+    # Create and return a new Error with a formatted message.
+    return Error.new(
+        id='TEST_FORMATTED_ERROR',
+        name='Test Formatted Error',
+        message=[formatted_error_message],
+    )
+
+# *** tests
+
+# ** test: error_new
+def test_error_new(error: Error) -> None:
+    '''
+    Test that Error.new() sets id, name, error_code, and message correctly.
+
+    :param error: The Error fixture.
+    :type error: Error
+    '''
+
+    # Assert the error fields are set correctly.
+    assert error.id == 'TEST_ERROR'
+    assert error.name == 'Test Error'
+    assert error.error_code == 'TEST_ERROR'
+    assert len(error.message) == 1
+    assert error.message[0].lang == 'en_US'
+    assert error.message[0].text == 'An error occurred.'
+
+# ** test: error_message_format
+def test_error_message_format(error_message: ErrorMessage, formatted_error_message: ErrorMessage) -> None:
+    '''
+    Test that ErrorMessage.format() returns raw text with no args and formatted text with kwargs.
+
+    :param error_message: The basic ErrorMessage fixture.
+    :type error_message: ErrorMessage
+    :param formatted_error_message: The formatted ErrorMessage fixture.
+    :type formatted_error_message: ErrorMessage
+    '''
+
+    # Assert raw text is returned with no arguments.
+    assert error_message.format() == 'An error occurred.'
+
+    # Assert formatted text is returned with kwargs.
+    assert formatted_error_message.format(error='test failure') == 'An error occurred: test failure'
+
+# ** test: error_format_method
+def test_error_format_method(error: Error, error_with_formatted_message: Error) -> None:
+    '''
+    Test that Error.format_message() returns correct text with and without format arguments.
+
+    :param error: The Error fixture.
+    :type error: Error
+    :param error_with_formatted_message: The Error with formatted message fixture.
+    :type error_with_formatted_message: Error
+    '''
+
+    # Assert plain message formatting.
+    assert error.format_message('en_US') == 'An error occurred.'
+
+    # Assert formatted message with kwargs.
+    assert error_with_formatted_message.format_message('en_US', error='test failure') == 'An error occurred: test failure'
+
+# ** test: error_format_method_unsupported_lang
+def test_error_format_method_unsupported_lang(error: Error) -> None:
+    '''
+    Test that Error.format_message() returns None for an unsupported language.
+
+    :param error: The Error fixture.
+    :type error: Error
+    '''
+
+    # Assert None is returned for unsupported language.
+    assert error.format_message('fr_FR') is None
+
+# ** test: error_format_response
+def test_error_format_response(error: Error) -> None:
+    '''
+    Test that Error.format_response() returns a structured dict.
+
+    :param error: The Error fixture.
+    :type error: Error
+    '''
+
+    # Format the error response.
+    response = error.format_response('en_US')
+
+    # Assert the response structure.
+    assert response['error_code'] == 'TEST_ERROR'
+    assert response['name'] == 'Test Error'
+    assert response['message'] == 'An error occurred.'
+
+# ** test: error_format_response_unsupported_lang
+def test_error_format_response_unsupported_lang(error: Error) -> None:
+    '''
+    Test that Error.format_response() returns None for an unsupported language.
+
+    :param error: The Error fixture.
+    :type error: Error
+    '''
+
+    # Assert None is returned for unsupported language.
+    assert error.format_response('fr_FR') is None


### PR DESCRIPTION
## Summary

Implements #586 — adds the Error domain objects for structured error handling in the v2 domain model.

### Changes

- **`tiferet/domain/error.py`** — New file defining `ErrorMessage` (immutable value object for localized error messages with `format()`) and `Error` (error definition with custom `new()` factory for error_code derivation, `format_message()`, and `format_response()`).
- **`tiferet/domain/__init__.py`** — Exports both new classes.
- **`tiferet/domain/tests/test_error.py`** — Six unit tests: Error.new() validation, ErrorMessage.format() with/without args, format_message with supported/unsupported lang, format_response with supported/unsupported lang.
- **`docs/guides/domain/error.md`** — Narrative guide covering the Error domain's role, formatting flow, built-in defaults, configuration mapping, and relationships.

All 18 domain tests pass with no regressions.

Closes #586

Co-Authored-By: Oz <oz-agent@warp.dev>