### PR TITLE
Mappers – CLI: General Implementation & Refactor (#595)

### DIFF
--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -15,3 +15,8 @@ from .di import (
     ServiceConfigurationAggregate,
     ServiceConfigurationYamlObject,
 )
+from .cli import (
+    CliArgumentAggregate,
+    CliCommandAggregate,
+    CliCommandYamlObject,
+)

--- a/tiferet/mappers/cli.py
+++ b/tiferet/mappers/cli.py
@@ -1,0 +1,321 @@
+"""Tiferet CLI Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any, List
+
+# ** app
+from ..domain import (
+    CliCommand,
+    CliArgument,
+    DomainObject,
+    StringType,
+    ListType,
+    ModelType,
+)
+from ..events import RaiseError, a
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: cli_argument_aggregate
+class CliArgumentAggregate(CliArgument, Aggregate):
+    '''
+    An aggregate representation of a CLI argument.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'CliArgumentAggregate':
+        '''
+        Initializes a new CLI argument aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI argument aggregate.
+        :rtype: CliArgumentAggregate
+        '''
+
+        # Create a new CLI argument aggregate from the provided data.
+        return Aggregate.new(
+            CliArgumentAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Update a supported attribute on the CLI argument aggregate.
+
+        Supported attributes: description, type, required, default, choices, nargs, action.
+
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Define the set of supported attributes.
+        supported = {
+            'description',
+            'type',
+            'required',
+            'default',
+            'choices',
+            'nargs',
+            'action',
+        }
+
+        # Validate the attribute name.
+        if attribute not in supported:
+            RaiseError.execute(
+                error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+                message='Invalid attribute: {attribute}. Supported attributes are {supported}.',
+                attribute=attribute,
+                supported=', '.join(sorted(supported)),
+            )
+
+        # Apply the update to the attribute.
+        setattr(self, attribute, value)
+
+        # Perform final aggregate validation.
+        self.validate()
+
+
+# ** mapper: cli_command_aggregate
+class CliCommandAggregate(CliCommand, Aggregate):
+    '''
+    An aggregate representation of a CLI command.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'CliCommandAggregate':
+        '''
+        Initializes a new CLI command aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI command aggregate.
+        :rtype: CliCommandAggregate
+        '''
+
+        # Create a new CLI command aggregate from the provided CLI command data.
+        return Aggregate.new(
+            CliCommandAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: add_argument
+    def add_argument(self,
+            name_or_flags: list,
+            description: str = None,
+            type: str = None,
+            required: bool = None,
+            default: str = None,
+            choices: list = None,
+            nargs: str = None,
+            action: str = None
+        ) -> None:
+        '''
+        Add an argument to the command.
+
+        :param name_or_flags: The name or flags of the argument.
+        :type name_or_flags: list
+        :param description: A brief description of the argument.
+        :type description: str
+        :param type: The type of the argument (str, int, float).
+        :type type: str
+        :param required: Whether the argument is required.
+        :type required: bool
+        :param default: The default value of the argument.
+        :type default: str
+        :param choices: A list of valid choices for the argument.
+        :type choices: list
+        :param nargs: The number of arguments to consume.
+        :type nargs: str
+        :param action: The action to take when the argument is encountered.
+        :type action: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Create a new CliArgument instance using DomainObject.new.
+        argument = DomainObject.new(
+            CliArgument,
+            name_or_flags=name_or_flags,
+            description=description,
+            type=type,
+            required=required,
+            default=default,
+            choices=choices,
+            nargs=nargs,
+            action=action
+        )
+
+        # Append the argument to the command's arguments list.
+        self.arguments.append(argument)
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Update a supported scalar attribute on the CLI command aggregate.
+
+        Supported attributes: name, description, key, group_key.
+
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Define the set of supported attributes.
+        supported = {
+            'name',
+            'description',
+            'key',
+            'group_key',
+        }
+
+        # Validate the attribute name.
+        if attribute not in supported:
+            RaiseError.execute(
+                error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+                message='Invalid attribute: {attribute}. Supported attributes are {supported}.',
+                attribute=attribute,
+                supported=', '.join(sorted(supported)),
+            )
+
+        # Apply the update to the attribute.
+        setattr(self, attribute, value)
+
+        # Perform final aggregate validation.
+        self.validate()
+
+
+# ** mapper: cli_command_yaml_object
+class CliCommandYamlObject(CliCommand, TransferObject):
+    '''
+    A YAML data representation of a CLI command object.
+    '''
+
+    class Options():
+        '''
+        The options for the CLI command data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('arguments'),
+            'to_data.yaml': TransferObject.deny('id', 'arguments'),
+        }
+
+    # * attribute: arguments
+    arguments = ListType(
+        ModelType(CliArgument),
+        default=[],
+        deserialize_from=['args', 'arguments'],
+        serialized_name='args',
+        metadata={
+            'description': 'The list of arguments for the CLI command.'
+        },
+    )
+
+    # * method: to_primitive
+    def to_primitive(self, role='to_data.yaml', **kwargs) -> Dict[str, Any]:
+        '''
+        Converts the CLI command data to a primitive dictionary representation.
+
+        :param role: The role to use for the conversion.
+        :type role: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A primitive dictionary representation of the CLI command data.
+        :rtype: dict
+        '''
+
+        # Convert the CLI command data to a primitive dictionary, converting
+        # the arguments list into dictionaries as well.
+        return dict(
+            **super().to_primitive(role=role, **kwargs),
+            args=[
+                arg.to_primitive()
+                for arg in self.arguments
+            ]
+        )
+
+    # * method: map
+    def map(self, **kwargs) -> CliCommandAggregate:
+        '''
+        Maps the CLI command data to a CLI command aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI command aggregate.
+        :rtype: CliCommandAggregate
+        '''
+
+        # Map the CLI command data.
+        return super().map(
+            CliCommandAggregate,
+            arguments=[
+                arg.to_primitive()
+                for arg in self.arguments
+            ],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(cli_command: CliCommand, **kwargs) -> 'CliCommandYamlObject':
+        '''
+        Creates a CliCommandYamlObject from a CliCommand model.
+
+        :param cli_command: The CLI command model.
+        :type cli_command: CliCommand
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new CliCommandYamlObject.
+        :rtype: CliCommandYamlObject
+        '''
+
+        # Create a new CliCommandYamlObject from the model, converting
+        # the arguments list into primitive dictionaries.
+        return TransferObject.from_model(
+            CliCommandYamlObject,
+            cli_command,
+            arguments=[
+                arg.to_primitive()
+                for arg in cli_command.arguments
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/tests/test_cli.py
+++ b/tiferet/mappers/tests/test_cli.py
@@ -1,0 +1,302 @@
+"""Tiferet CLI Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...domain import CliArgument, CliCommand, DomainObject
+from ...assets import TiferetError
+from ..settings import TransferObject
+from ..cli import CliArgumentAggregate, CliCommandAggregate, CliCommandYamlObject
+
+# *** fixtures
+
+# ** fixture: cli_command_yaml_object
+@pytest.fixture
+def cli_command_yaml_object() -> CliCommandYamlObject:
+    '''
+    A fixture for a CLI command YAML data object with two arguments using the args alias.
+
+    :return: The CLI command YAML data object.
+    :rtype: CliCommandYamlObject
+    '''
+
+    # Create and return the CLI command YAML data object.
+    return TransferObject.from_data(
+        CliCommandYamlObject,
+        id='calc.add',
+        name='Add Number Command',
+        description='Adds two numbers.',
+        key='add',
+        group_key='calc',
+        args=[
+            dict(
+                name_or_flags=['a'],
+                description='The first number to add.',
+                type='str',
+            ),
+            dict(
+                name_or_flags=['b'],
+                description='The second number to add.',
+                type='str',
+            ),
+        ],
+    )
+
+# *** tests
+
+# ** test: cli_command_yaml_object_from_data
+def test_cli_command_yaml_object_from_data(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that the CliCommandYamlObject can be initialized from data with correct
+    attributes and two arguments using the args alias.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Assert the data is correctly initialized.
+    assert isinstance(cli_command_yaml_object, CliCommandYamlObject)
+    assert cli_command_yaml_object.id == 'calc.add'
+    assert cli_command_yaml_object.name == 'Add Number Command'
+    assert cli_command_yaml_object.description == 'Adds two numbers.'
+    assert cli_command_yaml_object.key == 'add'
+    assert cli_command_yaml_object.group_key == 'calc'
+
+    # Assert the arguments are correctly initialized.
+    assert len(cli_command_yaml_object.arguments) == 2
+    assert cli_command_yaml_object.arguments[0].name_or_flags == ['a']
+    assert cli_command_yaml_object.arguments[0].description == 'The first number to add.'
+    assert cli_command_yaml_object.arguments[1].name_or_flags == ['b']
+    assert cli_command_yaml_object.arguments[1].description == 'The second number to add.'
+
+
+# ** test: cli_command_yaml_object_map
+def test_cli_command_yaml_object_map(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that map() produces a CliCommandAggregate with correct arguments.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Map the CLI command YAML data to a CLI command aggregate.
+    aggregate = cli_command_yaml_object.map()
+
+    # Assert the mapped aggregate is valid.
+    assert isinstance(aggregate, CliCommandAggregate)
+    assert aggregate.id == 'calc.add'
+    assert aggregate.name == 'Add Number Command'
+    assert aggregate.key == 'add'
+    assert aggregate.group_key == 'calc'
+
+    # Assert the arguments are correctly mapped.
+    assert len(aggregate.arguments) == 2
+    assert aggregate.arguments[0].name_or_flags == ['a']
+    assert aggregate.arguments[1].name_or_flags == ['b']
+
+
+# ** test: cli_command_yaml_object_to_primitive
+def test_cli_command_yaml_object_to_primitive(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that custom to_primitive('to_data.yaml') serializes args correctly.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Serialize the data to primitive format for YAML.
+    primitive = cli_command_yaml_object.to_primitive('to_data.yaml')
+
+    # Assert the primitive data is a dict with the expected keys.
+    assert isinstance(primitive, dict)
+    assert 'id' not in primitive
+    assert 'args' in primitive
+    assert len(primitive['args']) == 2
+    assert primitive['args'][0]['name_or_flags'] == ['a']
+    assert primitive['args'][1]['name_or_flags'] == ['b']
+    assert primitive['name'] == 'Add Number Command'
+    assert primitive['key'] == 'add'
+    assert primitive['group_key'] == 'calc'
+
+
+# ** test: cli_command_yaml_object_from_model
+def test_cli_command_yaml_object_from_model():
+    '''
+    Test that from_model() from CliCommand.new() produces a valid YAML object.
+    '''
+
+    # Create a CliCommand domain object using the factory method.
+    cli_command = CliCommand.new(
+        group_key='calc',
+        key='subtract',
+        name='Subtract Number Command',
+        description='Subtracts one number from another.',
+        arguments=[
+            DomainObject.new(
+                CliArgument,
+                name_or_flags=['a'],
+                description='The number to subtract from.',
+            ),
+        ],
+    )
+
+    # Create a CliCommandYamlObject from the model.
+    yaml_obj = CliCommandYamlObject.from_model(cli_command)
+
+    # Assert the YAML object is valid.
+    assert isinstance(yaml_obj, CliCommandYamlObject)
+    assert yaml_obj.id == 'calc.subtract'
+    assert yaml_obj.name == 'Subtract Number Command'
+    assert yaml_obj.key == 'subtract'
+    assert yaml_obj.group_key == 'calc'
+    assert len(yaml_obj.arguments) == 1
+    assert yaml_obj.arguments[0].name_or_flags == ['a']
+
+
+# ** test: cli_command_aggregate_new
+def test_cli_command_aggregate_new():
+    '''
+    Test that CliCommandAggregate.new() creates an aggregate with correct fields.
+    '''
+
+    # Create a new CLI command aggregate.
+    aggregate = CliCommandAggregate.new(
+        id='calc.multiply',
+        name='Multiply Number Command',
+        description='Multiplies two numbers.',
+        key='multiply',
+        group_key='calc',
+        arguments=[],
+    )
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(aggregate, CliCommandAggregate)
+    assert aggregate.id == 'calc.multiply'
+    assert aggregate.name == 'Multiply Number Command'
+    assert aggregate.description == 'Multiplies two numbers.'
+    assert aggregate.key == 'multiply'
+    assert aggregate.group_key == 'calc'
+    assert aggregate.arguments == []
+
+
+# ** test: cli_command_aggregate_add_argument
+def test_cli_command_aggregate_add_argument():
+    '''
+    Test that add_argument() correctly adds a CliArgument to the aggregate.
+    '''
+
+    # Create a CLI command aggregate with no arguments.
+    aggregate = CliCommandAggregate.new(
+        id='calc.divide',
+        name='Divide Number Command',
+        key='divide',
+        group_key='calc',
+    )
+
+    # Add an argument to the command.
+    aggregate.add_argument(
+        name_or_flags=['a'],
+        description='The numerator.',
+        type='int',
+    )
+
+    # Assert the argument was added.
+    assert len(aggregate.arguments) == 1
+    assert isinstance(aggregate.arguments[0], CliArgument)
+    assert aggregate.arguments[0].name_or_flags == ['a']
+    assert aggregate.arguments[0].description == 'The numerator.'
+    assert aggregate.arguments[0].type == 'int'
+
+
+# ** test: cli_command_aggregate_set_attribute
+def test_cli_command_aggregate_set_attribute():
+    '''
+    Test that set_attribute() updates supported attributes on the CLI command aggregate.
+    '''
+
+    # Create a CLI command aggregate.
+    aggregate = CliCommandAggregate.new(
+        id='calc.exp',
+        name='Exponentiate Number Command',
+        key='exp',
+        group_key='calc',
+    )
+
+    # Update supported attributes.
+    aggregate.set_attribute('name', 'Updated Exp Command')
+    aggregate.set_attribute('description', 'Raises a number to a power.')
+
+    # Assert the attributes were updated.
+    assert aggregate.name == 'Updated Exp Command'
+    assert aggregate.description == 'Raises a number to a power.'
+
+
+# ** test: cli_argument_aggregate_new
+def test_cli_argument_aggregate_new():
+    '''
+    Test that CliArgumentAggregate.new() creates an aggregate with all supported fields.
+    '''
+
+    # Create a new CLI argument aggregate with all supported fields.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['-v', '--verbose'],
+        description='Enable verbose output.',
+        type='str',
+        required=False,
+        default='false',
+        action='store_true',
+    )
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(aggregate, CliArgumentAggregate)
+    assert aggregate.name_or_flags == ['-v', '--verbose']
+    assert aggregate.description == 'Enable verbose output.'
+    assert aggregate.type == 'str'
+    assert aggregate.required is False
+    assert aggregate.default == 'false'
+    assert aggregate.action == 'store_true'
+
+
+# ** test: cli_argument_aggregate_set_attribute
+def test_cli_argument_aggregate_set_attribute():
+    '''
+    Test that set_attribute() updates supported attributes on the CLI argument aggregate.
+    '''
+
+    # Create a CLI argument aggregate.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['a'],
+        description='Original description.',
+    )
+
+    # Update supported attributes.
+    aggregate.set_attribute('description', 'Updated description.')
+    aggregate.set_attribute('required', True)
+
+    # Assert the attributes were updated.
+    assert aggregate.description == 'Updated description.'
+    assert aggregate.required is True
+
+
+# ** test: cli_argument_aggregate_set_attribute_invalid
+def test_cli_argument_aggregate_set_attribute_invalid():
+    '''
+    Test that set_attribute() raises TiferetError for unsupported attributes (name_or_flags).
+    '''
+
+    # Create a CLI argument aggregate.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['a'],
+        description='Test argument.',
+    )
+
+    # Attempt to set an unsupported attribute and expect a TiferetError.
+    with pytest.raises(TiferetError) as exc_info:
+        aggregate.set_attribute('name_or_flags', ['b'])
+
+    # Verify that the correct error code is raised.
+    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
+    assert exc_info.value.kwargs.get('attribute') == 'name_or_flags'


### PR DESCRIPTION
## Summary

Implements the CLI mapper classes for the v2 mappers layer as specified in #595.

### New Files
- **`tiferet/mappers/cli.py`** — Defines `CliArgumentAggregate`, `CliCommandAggregate`, and `CliCommandYamlObject`
- **`tiferet/mappers/tests/test_cli.py`** — 10 unit tests covering all TRD-specified scenarios

### Modified Files
- **`tiferet/mappers/__init__.py`** — Added exports for all three new classes

### Key Design Decisions
- `CliArgumentAggregate` guards `set_attribute()` against identity field `name_or_flags`
- `CliCommandAggregate.add_argument()` creates `CliArgument` domain objects (not aggregates) per TRD
- `CliCommandYamlObject` uses `args` ↔ `arguments` aliasing with custom `to_primitive()` for inline argument serialization
- Guide document (`docs/guides/mappers/cli.md`) intentionally skipped — using the general mapper documentation instead

### Verification
- All 59 mapper tests pass (`pytest tiferet/mappers/tests/`)
- No regressions

Closes #595

Co-Authored-By: Oz <oz-agent@warp.dev>