### PR TITLE
Mappers – Error: General Implementation & Refactor (#591)

### DIFF
--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -20,3 +20,8 @@ from .cli import (
     CliCommandAggregate,
     CliCommandYamlObject,
 )
+from .error import (
+    ErrorAggregate,
+    ErrorYamlObject,
+    ErrorMessageYamlObject,
+)

--- a/tiferet/mappers/error.py
+++ b/tiferet/mappers/error.py
@@ -1,0 +1,244 @@
+"""Tiferet Error Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    Error,
+    ErrorMessage,
+    ListType,
+    ModelType,
+)
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: error_aggregate
+class ErrorAggregate(Error, Aggregate):
+    '''
+    An aggregate representation of an error.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'ErrorAggregate':
+        '''
+        Initializes a new error aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new error aggregate.
+        :rtype: ErrorAggregate
+        '''
+
+        # Create a new error aggregate from the provided data.
+        return Aggregate.new(
+            ErrorAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: rename
+    def rename(self, new_name: str) -> None:
+        '''
+        Renames the error.
+
+        :param new_name: The new name for the error.
+        :type new_name: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Update the name.
+        self.name = new_name
+
+        # Perform final aggregate validation.
+        self.validate()
+
+    # * method: set_message
+    def set_message(self, lang: str, text: str) -> None:
+        '''
+        Sets the error message text for the specified language.
+
+        :param lang: The language of the error message text.
+        :type lang: str
+        :param text: The error message text.
+        :type text: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Check if the message already exists for the language.
+        for msg in self.message:
+            if msg.lang == lang:
+                msg.text = text
+                return
+
+        # If not, create a new ErrorMessage object and add it to the message list.
+        from ..domain import DomainObject
+        self.message.append(
+            DomainObject.new(
+                ErrorMessage,
+                lang=lang,
+                text=text
+            )
+        )
+
+    # * method: remove_message
+    def remove_message(self, lang: str) -> None:
+        '''
+        Removes the error message for the specified language.
+
+        :param lang: The language of the error message to remove.
+        :type lang: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Filter out the message with the specified language.
+        self.message = [msg for msg in self.message if msg.lang != lang]
+
+# ** mapper: error_message_yaml_object
+class ErrorMessageYamlObject(ErrorMessage, TransferObject):
+    '''
+    A YAML data representation of an error message object.
+    '''
+
+    class Options():
+        '''
+        The options for the error message data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny(),
+            'to_data.yaml': TransferObject.deny(),
+            'to_data.json': TransferObject.deny(),
+        }
+
+    # * method: map
+    def map(self, **kwargs) -> ErrorMessage:
+        '''
+        Maps the error message data to an error message object.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new error message object.
+        :rtype: ErrorMessage
+        '''
+
+        # Map to the error message object.
+        return super().map(
+            ErrorMessage,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(error_message: ErrorMessage, **kwargs) -> 'ErrorMessageYamlObject':
+        '''
+        Creates an ErrorMessageYamlObject from an ErrorMessage model.
+
+        :param error_message: The error message model.
+        :type error_message: ErrorMessage
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new ErrorMessageYamlObject.
+        :rtype: ErrorMessageYamlObject
+        '''
+
+        # Create a new ErrorMessageYamlObject from the model.
+        return TransferObject.from_model(
+            ErrorMessageYamlObject,
+            error_message,
+            **kwargs,
+        )
+
+
+# ** mapper: error_yaml_object
+class ErrorYamlObject(Error, TransferObject):
+    '''
+    A YAML data representation of an error object.
+    '''
+
+    class Options():
+        '''
+        The options for the error data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('message'),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: message
+    message = ListType(
+        ModelType(ErrorMessageYamlObject),
+        required=True,
+        metadata=dict(
+            description='The error messages.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> ErrorAggregate:
+        '''
+        Maps the error data to an error aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new error aggregate.
+        :rtype: ErrorAggregate
+        '''
+
+        # Map the error data.
+        return super().map(
+            ErrorAggregate,
+            message=[msg.map() for msg in self.message],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(error: Error, **kwargs) -> 'ErrorYamlObject':
+        '''
+        Creates an ErrorYamlObject from an Error model.
+
+        :param error: The error model.
+        :type error: Error
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new ErrorYamlObject.
+        :rtype: ErrorYamlObject
+        '''
+
+        # Create a new ErrorYamlObject from the model, converting
+        # the message list into ErrorMessageYamlObject instances.
+        return TransferObject.from_model(
+            ErrorYamlObject,
+            error,
+            message=[
+                TransferObject.from_model(ErrorMessageYamlObject, msg)
+                for msg in error.message
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/tests/test_error.py
+++ b/tiferet/mappers/tests/test_error.py
@@ -1,0 +1,243 @@
+"""Tiferet Error Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..error import (
+    ErrorYamlObject,
+    ErrorAggregate,
+    ErrorMessageYamlObject,
+)
+from ...domain import (
+    Error,
+    ErrorMessage,
+)
+
+# *** fixtures
+
+# ** fixture: error_yaml_object
+@pytest.fixture
+def error_yaml_object() -> ErrorYamlObject:
+    '''
+    Provides an error YAML object fixture.
+
+    :return: The error YAML object instance.
+    :rtype: ErrorYamlObject
+    '''
+
+    # Create and return an error YAML object.
+    return TransferObject.from_data(
+        ErrorYamlObject,
+        id='TEST_ERROR',
+        name='TEST_ERROR',
+        error_code='TEST_ERROR',
+        message=[{
+            'lang': 'en',
+            'text': 'Test error message.'
+        }]
+    )
+
+# *** tests
+
+# ** test: error_data_from_data
+def test_error_data_from_data(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the creation of error data from a dictionary.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Assert the error data is an instance of ErrorYamlObject.
+    assert error_yaml_object.name == 'TEST_ERROR'
+    assert error_yaml_object.error_code == 'TEST_ERROR'
+    assert len(error_yaml_object.message) == 1
+    assert error_yaml_object.message[0].lang == 'en'
+    assert error_yaml_object.message[0].text == 'Test error message.'
+
+# ** test: error_data_to_primitive_to_data_yaml
+def test_error_data_to_primitive_to_data_yaml(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the conversion of error data to a primitive dictionary.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Convert the error data to a primitive.
+    primitive = error_yaml_object.to_primitive('to_data.yaml')
+
+    # Assert the primitive is a dictionary.
+    assert isinstance(primitive, dict)
+
+    # Assert the primitive values are correct.
+    assert primitive.pop('id', None) is None
+    assert primitive.get('name') == 'TEST_ERROR'
+    assert primitive.get('error_code') == 'TEST_ERROR'
+    assert len(primitive.get('message')) == 1
+    assert primitive.get('message')[0].get('lang') == 'en'
+    assert primitive.get('message')[0].get('text') == 'Test error message.'
+
+# ** test: error_data_map
+def test_error_data_map(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the mapping of error YAML object to an error aggregate.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Map the error data to an error aggregate.
+    error = error_yaml_object.map()
+
+    # Assert the error is an instance of ErrorAggregate.
+    assert isinstance(error, ErrorAggregate)
+    assert error.id == error_yaml_object.id
+    assert error.name == error_yaml_object.name
+    assert error.error_code == error_yaml_object.error_code
+    assert len(error.message) == 1
+    assert isinstance(error.message[0], ErrorMessage)
+
+    # Assert the error message attributes.
+    error_message = error.message[0]
+    assert error_message.lang == 'en'
+    assert error_message.text == 'Test error message.'
+
+
+# ** test: error_yaml_object_from_model
+def test_error_yaml_object_from_model():
+    '''
+    Test creating an ErrorYamlObject from an Error model.
+    '''
+
+    # Create an error model.
+    error = Error.new(
+        id='test_error',
+        name='Test Error',
+        message=[
+            {'lang': 'en', 'text': 'Test message'},
+            {'lang': 'es', 'text': 'Mensaje de prueba'}
+        ]
+    )
+
+    # Create YAML object from model.
+    yaml_object = ErrorYamlObject.from_model(error)
+
+    # Assert the YAML object is valid.
+    assert isinstance(yaml_object, ErrorYamlObject)
+    assert yaml_object.id == 'test_error'
+    assert yaml_object.name == 'Test Error'
+    assert len(yaml_object.message) == 2
+    assert all(isinstance(msg, ErrorMessageYamlObject) for msg in yaml_object.message)
+
+
+# ** test: error_aggregate_new
+def test_error_aggregate_new():
+    '''
+    Test creating a new ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'Test message'}
+        ]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Assert the aggregate is valid.
+    assert isinstance(aggregate, ErrorAggregate)
+    assert aggregate.id == 'test_error'
+    assert aggregate.name == 'Test Error'
+    assert len(aggregate.message) == 1
+
+
+# ** test: error_aggregate_rename
+def test_error_aggregate_rename():
+    '''
+    Test renaming an error via ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    aggregate = ErrorAggregate.new(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'Test message'}
+        ]
+    )
+
+    # Rename the error.
+    aggregate.rename('Renamed Error')
+
+    # Assert the name was updated.
+    assert aggregate.name == 'Renamed Error'
+
+# ** test: error_aggregate_set_message
+def test_error_aggregate_set_message():
+    '''
+    Test setting a message on an ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Set a message.
+    aggregate.set_message('en', 'New test message')
+
+    # Assert the message was set.
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].lang == 'en'
+    assert aggregate.message[0].text == 'New test message'
+
+    # Update the message.
+    aggregate.set_message('en', 'Updated message')
+
+    # Assert the message was updated (not added).
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].text == 'Updated message'
+
+
+# ** test: error_aggregate_remove_message
+def test_error_aggregate_remove_message():
+    '''
+    Test removing a message from an ErrorAggregate.
+    '''
+
+    # Create an error aggregate with messages.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'English message'},
+            {'lang': 'es', 'text': 'Spanish message'}
+        ]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Remove one message.
+    aggregate.remove_message('en')
+
+    # Assert only one message remains.
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].lang == 'es'


### PR DESCRIPTION
## Summary

Implements the Error mapper classes for the v2 mappers layer per #591.

### New Files
- **`tiferet/mappers/error.py`** — `ErrorAggregate`, `ErrorMessageYamlObject`, `ErrorYamlObject`
- **`tiferet/mappers/tests/test_error.py`** — 8 unit tests

### Modified Files
- **`tiferet/mappers/__init__.py`** — Added exports for all three new classes

### Key Details
- **ErrorAggregate**: Mutation methods `rename`, `set_message` (upsert), `remove_message`
- **ErrorMessageYamlObject**: Bidirectional YAML ↔ ErrorMessage mapping
- **ErrorYamlObject**: Role-based serialization (`to_model` denies `message`; `to_data.*` denies `id`) with nested message mapping
- All 67 mapper tests pass with no regressions

### Deviation from TRD
- Guide doc (`docs/guides/mappers/error.md`) intentionally omitted — preferring a general mappers document over individual context-group–based guides.

Closes #591

Co-Authored-By: Oz <oz-agent@warp.dev>