### PR TITLE
Mappers – Feature: General Implementation & Refactor (#593)

### DIFF
--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -25,3 +25,9 @@ from .error import (
     ErrorYamlObject,
     ErrorMessageYamlObject,
 )
+from .feature import (
+    FeatureAggregate,
+    FeatureYamlObject,
+    FeatureEventAggregate,
+    FeatureEventYamlObject,
+)

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -1,0 +1,478 @@
+"""Tiferet Feature Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any, List
+
+# ** app
+from ..domain import (
+    Feature,
+    FeatureStep,
+    FeatureEvent,
+    ListType,
+    ModelType,
+    DictType,
+    StringType,
+)
+from ..events import RaiseError, a
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: feature_event_aggregate
+class FeatureEventAggregate(FeatureEvent, Aggregate):
+    '''
+    An aggregate representation of a feature event.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'FeatureEventAggregate':
+        '''
+        Initializes a new feature event aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new feature event aggregate.
+        :rtype: FeatureEventAggregate
+        '''
+
+        # Create a new feature event aggregate from the provided data.
+        return Aggregate.new(
+            FeatureEventAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: set_pass_on_error
+    def set_pass_on_error(self, value: Any) -> None:
+        '''
+        Set the ``pass_on_error`` flag based on a provided value.
+
+        :param value: The value to interpret as a boolean.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Normalize the value, treating the string "false" (case-insensitive)
+        # as an explicit False value and using standard bool conversion otherwise.
+        if isinstance(value, str) and value.lower() == 'false':
+            self.pass_on_error = False
+        else:
+            self.pass_on_error = bool(value)
+
+    # * method: set_parameters
+    def set_parameters(self, parameters: Dict[str, Any] | None = None) -> None:
+        '''
+        Merge new parameters into the existing parameters, preferring new
+        values and removing keys with ``None`` values.
+
+        :param parameters: The new parameters to merge.
+        :type parameters: dict | None
+        :return: None
+        :rtype: None
+        '''
+
+        # Do nothing if no parameters were provided.
+        if parameters is None:
+            return
+
+        # Start from the existing parameters and update with new values.
+        merged = dict(self.parameters or {})
+        merged.update(parameters)
+
+        # Remove any keys whose value is None.
+        self.parameters = {k: v for k, v in merged.items() if v is not None}
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Set an attribute on the feature command, with special handling for
+        ``parameters`` and ``pass_on_error``.
+
+        :param attribute: The attribute name to set.
+        :type attribute: str
+        :param value: The value to apply to the attribute.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Delegate to specialized helpers for parameters and pass_on_error.
+        if attribute == 'parameters':
+            self.set_parameters(value)
+        elif attribute == 'pass_on_error':
+            self.set_pass_on_error(value)
+        else:
+            setattr(self, attribute, value)
+
+
+# ** mapper: feature_event_yaml_object
+class FeatureEventYamlObject(FeatureEvent, TransferObject):
+    '''
+    A YAML data representation of a feature event object.
+    '''
+
+    class Options():
+        '''
+        The options for the feature event data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('type'),
+            'to_data.yaml': TransferObject.deny('type'),
+            'to_data.json': TransferObject.deny('type')
+        }
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType(),
+        default={},
+        serialized_name='params',
+        deserialize_from=['params', 'parameters'],
+        metadata=dict(
+            description='The parameters for the feature event.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FeatureEvent:
+        '''
+        Maps the feature event data to a feature event object.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new feature event object.
+        :rtype: FeatureEvent
+        '''
+
+        # Map to the feature event aggregate.
+        return super().map(
+            FeatureEventAggregate,
+            parameters=self.parameters,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(feature_event: FeatureEvent, **kwargs) -> 'FeatureEventYamlObject':
+        '''
+        Creates a FeatureEventYamlObject from a FeatureEvent model.
+
+        :param feature_event: The feature event model.
+        :type feature_event: FeatureEvent
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FeatureEventYamlObject.
+        :rtype: FeatureEventYamlObject
+        '''
+
+        # Create a new FeatureEventYamlObject from the model.
+        return TransferObject.from_model(
+            FeatureEventYamlObject,
+            feature_event,
+            **kwargs,
+        )
+
+# ** mapper: feature_aggregate
+class FeatureAggregate(Feature, Aggregate):
+    '''
+    An aggregate representation of a feature.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        name: str = None,
+        group_id: str = None,
+        feature_key: str = None,
+        id: str = None,
+        description: str = None,
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'FeatureAggregate':
+        '''
+        Initializes a new feature aggregate.
+
+        :param name: The name of the feature.
+        :type name: str
+        :param group_id: The context group identifier of the feature.
+        :type group_id: str
+        :param feature_key: The key of the feature.
+        :type feature_key: str
+        :param id: The identifier of the feature.
+        :type id: str
+        :param description: The description of the feature.
+        :type description: str
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new feature aggregate.
+        :rtype: FeatureAggregate
+        '''
+
+        # Derive group_id and feature_key from id if provided.
+        if id and '.' in id and (not group_id or not feature_key):
+            group_id, feature_key = id.split('.', 1)
+
+        # Set the feature key as the snake case of the name if not provided.
+        if name and not feature_key:
+            feature_key = name.lower().replace(' ', '_')
+
+        # Feature ID is the group ID and feature key separated by a period.
+        if not id and group_id and feature_key:
+            id = f'{group_id}.{feature_key}'
+
+        # Set the description as the name if not provided.
+        if name and not description:
+            description = name
+
+        # Create a new feature aggregate from the provided data.
+        return Aggregate.new(
+            FeatureAggregate,
+            validate=validate,
+            strict=strict,
+            id=id,
+            name=name,
+            group_id=group_id,
+            feature_key=feature_key,
+            description=description,
+            **kwargs
+        )
+
+    # * method: add_step
+    def add_step(
+        self,
+        name: str,
+        attribute_id: str,
+        parameters: Dict[str, Any] | None = None,
+        data_key: str | None = None,
+        pass_on_error: bool = False,
+        position: int | None = None,
+    ) -> FeatureEvent:
+        '''
+        Add a feature event step using raw attributes.
+
+        :param name: Step name.
+        :type name: str
+        :param attribute_id: Container attribute ID.
+        :type attribute_id: str
+        :param parameters: Optional parameters dictionary.
+        :type parameters: dict | None
+        :param data_key: Optional result data key.
+        :type data_key: str | None
+        :param pass_on_error: Whether to pass on errors from this step.
+        :type pass_on_error: bool
+        :param position: Insertion position (None to append).
+        :type position: int | None
+        :return: Created FeatureEvent instance.
+        :rtype: FeatureEvent
+        '''
+
+        # Create the feature event from raw attributes.
+        step = FeatureEventAggregate.new(
+            name=name,
+            attribute_id=attribute_id,
+            parameters=parameters or {},
+            data_key=data_key,
+            pass_on_error=pass_on_error,
+        )
+
+        # Add the feature event step to the feature.
+        if position is not None:
+            self.steps.insert(position, step)
+        else:
+            self.steps.append(step)
+
+        return step
+
+    # * method: get_step
+    def get_step(self, position: int) -> FeatureStep | None:
+        '''
+        Get the feature step at the given position, or ``None`` if the
+        index is out of range or invalid.
+
+        :param position: The index of the step to retrieve.
+        :type position: int
+        :return: The FeatureStep at the position, or None.
+        :rtype: FeatureStep | None
+        '''
+
+        # Attempt to retrieve the step at the specified index.
+        try:
+            return self.steps[position]
+        except (IndexError, TypeError):
+            return None
+
+    # * method: remove_step
+    def remove_step(self, position: int) -> FeatureStep | None:
+        '''
+        Remove and return the feature step at the given position, or
+        return ``None`` if the index is out of range or invalid.
+
+        :param position: The index of the feature step to remove.
+        :type position: int
+        :return: The removed feature step or ``None``.
+        :rtype: FeatureStep | None
+        '''
+
+        # Validate the position argument.
+        if not isinstance(position, int) or position < 0:
+            return None
+
+        # Attempt to remove and return the step at the specified index.
+        try:
+            return self.steps.pop(position)
+        except IndexError:
+            return None
+
+    # * method: reorder_step
+    def reorder_step(self, current_position: int, new_position: int) -> FeatureStep | None:
+        '''
+        Move a feature step from its current position to a new position
+        within the ``steps`` list.
+
+        :param current_position: Current index of the step.
+        :type current_position: int
+        :param new_position: Desired new index.
+        :type new_position: int
+        :return: Moved step or ``None`` if ``current_position`` is invalid.
+        :rtype: FeatureStep | None
+        '''
+
+        # Attempt to remove the step at the current position.
+        try:
+            step = self.steps.pop(current_position)
+        except (IndexError, TypeError):
+            return None
+
+        # Clamp the new position index to the valid range.
+        if new_position < 0:
+            new_position = 0
+        if new_position > len(self.steps):
+            new_position = len(self.steps)
+
+        # Insert the step at the clamped position and return it.
+        self.steps.insert(new_position, step)
+
+        return step
+
+    # * method: rename
+    def rename(self, name: str) -> None:
+        '''
+        Update the display name of the feature.
+
+        :param name: The new name.
+        :type name: str
+        :return: None
+        :rtype: None
+        '''
+
+        self.name = name
+
+        # Perform final aggregate validation.
+        self.validate()
+
+    # * method: set_description
+    def set_description(self, description: str | None) -> None:
+        '''
+        Update the feature description.
+
+        :param description: The new description.
+        :type description: str | None
+        :return: None
+        :rtype: None
+        '''
+
+        self.description = description
+
+
+# ** mapper: feature_yaml_object
+class FeatureYamlObject(Feature, TransferObject):
+    '''
+    A YAML data representation of a feature object.
+    '''
+
+    class Options():
+        '''
+        The options for the feature data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('steps'),
+            'to_data.yaml': TransferObject.deny('feature_key', 'group_id', 'id'),
+            'to_data.json': TransferObject.deny('feature_key', 'group_id', 'id')
+        }
+
+    # * attribute: steps
+    steps = ListType(
+        ModelType(FeatureEventYamlObject),
+        deserialize_from=['handlers', 'functions', 'commands', 'steps'],
+        default=[],
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FeatureAggregate:
+        '''
+        Maps the feature data to a feature aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new feature aggregate.
+        :rtype: FeatureAggregate
+        '''
+
+        # Map the feature data.
+        return super().map(
+            FeatureAggregate,
+            steps=[step.map() for step in (self.steps or [])],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(feature: Feature, **kwargs) -> 'FeatureYamlObject':
+        '''
+        Creates a FeatureYamlObject from a Feature model.
+
+        :param feature: The feature model.
+        :type feature: Feature
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FeatureYamlObject.
+        :rtype: FeatureYamlObject
+        '''
+
+        # Create a new FeatureYamlObject from the model, converting
+        # the steps list into FeatureEventYamlObject instances.
+        return TransferObject.from_model(
+            FeatureYamlObject,
+            feature,
+            steps=[
+                TransferObject.from_model(FeatureEventYamlObject, step)
+                for step in feature.steps
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/tests/test_feature.py
+++ b/tiferet/mappers/tests/test_feature.py
@@ -1,0 +1,407 @@
+"""Tiferet Feature Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..feature import (
+    FeatureEventAggregate,
+    FeatureEventYamlObject,
+    FeatureAggregate,
+    FeatureYamlObject,
+)
+from ...domain import (
+    Feature,
+    FeatureEvent,
+)
+
+# *** fixtures
+
+# ** fixture: feature_event_yaml_object
+@pytest.fixture
+def feature_event_yaml_object() -> FeatureEventYamlObject:
+    '''
+    Provides a feature event YAML object fixture with pass_on_error,
+    data_key, and params alias.
+
+    :return: The feature event YAML object instance.
+    :rtype: FeatureEventYamlObject
+    '''
+
+    # Create and return a feature event YAML object.
+    return TransferObject.from_data(
+        FeatureEventYamlObject,
+        name='Test Event',
+        attribute_id='test_event_handler',
+        params={'key': 'value'},
+        data_key='result',
+        pass_on_error=True,
+    )
+
+
+# ** fixture: feature_yaml_object
+@pytest.fixture
+def feature_yaml_object() -> FeatureYamlObject:
+    '''
+    Provides a feature YAML object fixture with one step containing params.
+
+    :return: The feature YAML object instance.
+    :rtype: FeatureYamlObject
+    '''
+
+    # Create and return a feature YAML object.
+    return TransferObject.from_data(
+        FeatureYamlObject,
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        description='Adds one number to another',
+        steps=[{
+            'name': 'Add a and b',
+            'attribute_id': 'add_number_event',
+            'params': {'precision': '2'},
+        }],
+    )
+
+
+# *** tests
+
+# ** test: feature_event_data_init
+def test_feature_event_data_init(feature_event_yaml_object: FeatureEventYamlObject):
+    '''
+    Verifies from_data() initialization including params alias.
+
+    :param feature_event_yaml_object: The feature event YAML object.
+    :type feature_event_yaml_object: FeatureEventYamlObject
+    '''
+
+    # Assert basic attributes.
+    assert feature_event_yaml_object.name == 'Test Event'
+    assert feature_event_yaml_object.attribute_id == 'test_event_handler'
+    assert feature_event_yaml_object.data_key == 'result'
+    assert feature_event_yaml_object.pass_on_error is True
+
+    # Assert the params alias resolved correctly.
+    assert feature_event_yaml_object.parameters == {'key': 'value'}
+
+
+# ** test: feature_event_data_map
+def test_feature_event_data_map(feature_event_yaml_object: FeatureEventYamlObject):
+    '''
+    Verifies map() produces a FeatureEvent with correct fields.
+
+    :param feature_event_yaml_object: The feature event YAML object.
+    :type feature_event_yaml_object: FeatureEventYamlObject
+    '''
+
+    # Map the feature event data to a feature event aggregate.
+    event = feature_event_yaml_object.map()
+
+    # Assert the mapped object is a FeatureEventAggregate.
+    assert isinstance(event, FeatureEventAggregate)
+    assert event.name == 'Test Event'
+    assert event.attribute_id == 'test_event_handler'
+    assert event.parameters == {'key': 'value'}
+    assert event.data_key == 'result'
+    assert event.pass_on_error is True
+
+
+# ** test: feature_data_from_data
+def test_feature_data_from_data(feature_yaml_object: FeatureYamlObject):
+    '''
+    Verifies nested steps initialization.
+
+    :param feature_yaml_object: The feature YAML object.
+    :type feature_yaml_object: FeatureYamlObject
+    '''
+
+    # Assert basic attributes.
+    assert feature_yaml_object.id == 'calc.add'
+    assert feature_yaml_object.name == 'Add Number'
+    assert feature_yaml_object.group_id == 'calc'
+    assert feature_yaml_object.feature_key == 'add'
+    assert feature_yaml_object.description == 'Adds one number to another'
+
+    # Assert the steps were initialized as FeatureEventYamlObject instances.
+    assert len(feature_yaml_object.steps) == 1
+    step = feature_yaml_object.steps[0]
+    assert isinstance(step, FeatureEventYamlObject)
+    assert step.name == 'Add a and b'
+    assert step.attribute_id == 'add_number_event'
+    assert step.parameters == {'precision': '2'}
+
+
+# ** test: feature_data_map
+def test_feature_data_map(feature_yaml_object: FeatureYamlObject):
+    '''
+    Verifies map() produces a FeatureAggregate with nested steps.
+
+    :param feature_yaml_object: The feature YAML object.
+    :type feature_yaml_object: FeatureYamlObject
+    '''
+
+    # Map the feature data to a feature aggregate.
+    feature = feature_yaml_object.map()
+
+    # Assert the mapped object is a FeatureAggregate.
+    assert isinstance(feature, FeatureAggregate)
+    assert feature.id == 'calc.add'
+    assert feature.name == 'Add Number'
+    assert feature.group_id == 'calc'
+    assert feature.feature_key == 'add'
+
+    # Assert nested steps were mapped correctly.
+    assert len(feature.steps) == 1
+    step = feature.steps[0]
+    assert isinstance(step, FeatureEventAggregate)
+    assert step.name == 'Add a and b'
+    assert step.attribute_id == 'add_number_event'
+    assert step.parameters == {'precision': '2'}
+
+
+# ** test: feature_aggregate_new
+def test_feature_aggregate_new():
+    '''
+    Verifies smart derivation (name → feature_key → id).
+    '''
+
+    # Create a feature aggregate with only name and group_id.
+    feature = FeatureAggregate.new(
+        name='Add Number',
+        group_id='calc',
+    )
+
+    # Assert smart derivation of feature_key and id.
+    assert feature.feature_key == 'add_number'
+    assert feature.id == 'calc.add_number'
+    assert feature.description == 'Add Number'
+
+
+# ** test: feature_aggregate_add_step
+def test_feature_aggregate_add_step():
+    '''
+    Verifies step append.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+
+    # Add a step.
+    step = feature.add_step(
+        name='Step One',
+        attribute_id='step_one_event',
+    )
+
+    # Assert the step was appended.
+    assert len(feature.steps) == 1
+    assert feature.steps[0] is step
+    assert step.name == 'Step One'
+    assert step.attribute_id == 'step_one_event'
+
+
+# ** test: feature_aggregate_add_step_position
+def test_feature_aggregate_add_step_position():
+    '''
+    Verifies step insertion at position 0.
+    '''
+
+    # Create a feature aggregate with an existing step.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='Step One', attribute_id='step_one_event')
+
+    # Insert a new step at position 0.
+    inserted = feature.add_step(
+        name='Step Zero',
+        attribute_id='step_zero_event',
+        position=0,
+    )
+
+    # Assert the step was inserted at position 0.
+    assert len(feature.steps) == 2
+    assert feature.steps[0] is inserted
+    assert feature.steps[0].name == 'Step Zero'
+    assert feature.steps[1].name == 'Step One'
+
+
+# ** test: feature_aggregate_remove_step
+def test_feature_aggregate_remove_step():
+    '''
+    Verifies removal and invalid position handling.
+    '''
+
+    # Create a feature aggregate with steps.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='Step One', attribute_id='step_one_event')
+    feature.add_step(name='Step Two', attribute_id='step_two_event')
+
+    # Remove the first step.
+    removed = feature.remove_step(0)
+    assert removed is not None
+    assert removed.name == 'Step One'
+    assert len(feature.steps) == 1
+
+    # Attempt to remove at an invalid position.
+    assert feature.remove_step(-1) is None
+    assert feature.remove_step(99) is None
+
+
+# ** test: feature_aggregate_reorder_step
+def test_feature_aggregate_reorder_step():
+    '''
+    Verifies move with clamping.
+    '''
+
+    # Create a feature aggregate with steps.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='A', attribute_id='a_event')
+    feature.add_step(name='B', attribute_id='b_event')
+    feature.add_step(name='C', attribute_id='c_event')
+
+    # Move step A (position 0) to position 2.
+    moved = feature.reorder_step(0, 2)
+    assert moved is not None
+    assert moved.name == 'A'
+    assert feature.steps[0].name == 'B'
+    assert feature.steps[1].name == 'C'
+    assert feature.steps[2].name == 'A'
+
+
+# ** test: feature_aggregate_rename
+def test_feature_aggregate_rename():
+    '''
+    Verifies name update without id change.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Old Name',
+        group_id='test',
+    )
+    original_id = feature.id
+
+    # Rename the feature.
+    feature.rename('New Name')
+
+    # Assert the name was updated but the id was not.
+    assert feature.name == 'New Name'
+    assert feature.id == original_id
+
+
+# ** test: feature_aggregate_set_description
+def test_feature_aggregate_set_description():
+    '''
+    Verifies set and clear.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+
+    # Set a description.
+    feature.set_description('A custom description')
+    assert feature.description == 'A custom description'
+
+    # Clear the description.
+    feature.set_description(None)
+    assert feature.description is None
+
+
+# ** test: feature_event_aggregate_set_pass_on_error
+def test_feature_event_aggregate_set_pass_on_error():
+    '''
+    Verifies string normalization ("false", "False", truthy).
+    '''
+
+    # Create a feature event aggregate.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+    )
+
+    # String "false" should normalize to False.
+    event.set_pass_on_error('false')
+    assert event.pass_on_error is False
+
+    # String "False" should normalize to False.
+    event.set_pass_on_error('False')
+    assert event.pass_on_error is False
+
+    # Truthy string should normalize to True.
+    event.set_pass_on_error('true')
+    assert event.pass_on_error is True
+
+    # Boolean True should remain True.
+    event.set_pass_on_error(True)
+    assert event.pass_on_error is True
+
+
+# ** test: feature_event_aggregate_set_parameters
+def test_feature_event_aggregate_set_parameters():
+    '''
+    Verifies merge, None-prune, and no-op on None.
+    '''
+
+    # Create a feature event aggregate with initial parameters.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+        parameters={'a': '1', 'b': '2'},
+    )
+
+    # Merge new parameters (c added, a updated).
+    event.set_parameters({'a': '10', 'c': '3'})
+    assert event.parameters == {'a': '10', 'b': '2', 'c': '3'}
+
+    # Prune keys with None values.
+    event.set_parameters({'b': None})
+    assert event.parameters == {'a': '10', 'c': '3'}
+
+    # None input is a no-op.
+    event.set_parameters(None)
+    assert event.parameters == {'a': '10', 'c': '3'}
+
+
+# ** test: feature_event_aggregate_set_attribute
+def test_feature_event_aggregate_set_attribute():
+    '''
+    Verifies delegation to specialized helpers.
+    '''
+
+    # Create a feature event aggregate.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+        parameters={'x': '1'},
+    )
+
+    # set_attribute for parameters should delegate to set_parameters.
+    event.set_attribute('parameters', {'y': '2'})
+    assert event.parameters == {'x': '1', 'y': '2'}
+
+    # set_attribute for pass_on_error should delegate to set_pass_on_error.
+    event.set_attribute('pass_on_error', 'false')
+    assert event.pass_on_error is False
+
+    # set_attribute for other attributes should use setattr.
+    event.set_attribute('name', 'Renamed Event')
+    assert event.name == 'Renamed Event'


### PR DESCRIPTION
## Summary

Implements the Feature mapper classes for the v2 mappers layer, closing #593.

### New Classes (`tiferet/mappers/feature.py`)

- **FeatureEventAggregate** — mutable aggregate with `set_pass_on_error`, `set_parameters`, and delegating `set_attribute`
- **FeatureEventYamlObject** — transfer object with `params` ↔ `parameters` aliasing and `type` exclusion roles
- **FeatureAggregate** — mutable aggregate with smart `new()` derivation and step workflow methods (`add_step`, `get_step`, `remove_step`, `reorder_step`, `rename`, `set_description`)
- **FeatureYamlObject** — transfer object with backward-compatible deserialization aliases for steps

### Tests

14 unit tests in `tiferet/mappers/tests/test_feature.py` covering all mapper classes. Full mapper test suite (81 tests) passes with no regressions.

### Exports

All 4 classes exported from `tiferet/mappers/__init__.py`.

Closes #593

Co-Authored-By: Oz <oz-agent@warp.dev>