### PR TITLE
Mappers – Logging: General Implementation & Refactor (#592)

### DIFF
--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -31,3 +31,12 @@ from .feature import (
     FeatureEventAggregate,
     FeatureEventYamlObject,
 )
+from .logging import (
+    FormatterAggregate,
+    FormatterYamlObject,
+    HandlerAggregate,
+    HandlerYamlObject,
+    LoggerAggregate,
+    LoggerYamlObject,
+    LoggingSettingsYamlObject,
+)

--- a/tiferet/mappers/logging.py
+++ b/tiferet/mappers/logging.py
@@ -1,0 +1,407 @@
+"""Tiferet Logging Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    Formatter,
+    Handler,
+    Logger,
+    StringType,
+    DictType,
+    ModelType,
+)
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: formatter_aggregate
+class FormatterAggregate(Formatter, Aggregate):
+    '''
+    An aggregate for logging formatter configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'FormatterAggregate':
+        '''
+        Create a new FormatterAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FormatterAggregate.
+        :rtype: FormatterAggregate
+        '''
+
+        # Create a new formatter aggregate from the provided data.
+        return Aggregate.new(
+            FormatterAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: formatter_yaml_object
+class FormatterYamlObject(Formatter, TransferObject):
+    '''
+    A YAML data representation of a logging formatter configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the formatter data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the formatter.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FormatterAggregate:
+        '''
+        Maps the formatter data to a formatter aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new formatter aggregate.
+        :rtype: FormatterAggregate
+        '''
+
+        # Map to the formatter aggregate.
+        return super().map(
+            FormatterAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(formatter: Formatter, **kwargs) -> 'FormatterYamlObject':
+        '''
+        Creates a FormatterYamlObject from a Formatter model.
+
+        :param formatter: The formatter model.
+        :type formatter: Formatter
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FormatterYamlObject.
+        :rtype: FormatterYamlObject
+        '''
+
+        # Create a new FormatterYamlObject from the model.
+        return TransferObject.from_model(
+            FormatterYamlObject,
+            formatter,
+            **kwargs,
+        )
+
+
+# ** mapper: handler_aggregate
+class HandlerAggregate(Handler, Aggregate):
+    '''
+    An aggregate for logging handler configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'HandlerAggregate':
+        '''
+        Create a new HandlerAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new HandlerAggregate.
+        :rtype: HandlerAggregate
+        '''
+
+        # Create a new handler aggregate from the provided data.
+        return Aggregate.new(
+            HandlerAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: handler_yaml_object
+class HandlerYamlObject(Handler, TransferObject):
+    '''
+    A YAML data representation of a logging handler configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the handler data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the handler.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> HandlerAggregate:
+        '''
+        Maps the handler data to a handler aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new handler aggregate.
+        :rtype: HandlerAggregate
+        '''
+
+        # Map to the handler aggregate.
+        return super().map(
+            HandlerAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(handler: Handler, **kwargs) -> 'HandlerYamlObject':
+        '''
+        Creates a HandlerYamlObject from a Handler model.
+
+        :param handler: The handler model.
+        :type handler: Handler
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new HandlerYamlObject.
+        :rtype: HandlerYamlObject
+        '''
+
+        # Create a new HandlerYamlObject from the model.
+        return TransferObject.from_model(
+            HandlerYamlObject,
+            handler,
+            **kwargs,
+        )
+
+
+# ** mapper: logger_aggregate
+class LoggerAggregate(Logger, Aggregate):
+    '''
+    An aggregate for logger configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'LoggerAggregate':
+        '''
+        Create a new LoggerAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new LoggerAggregate.
+        :rtype: LoggerAggregate
+        '''
+
+        # Create a new logger aggregate from the provided data.
+        return Aggregate.new(
+            LoggerAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: logger_yaml_object
+class LoggerYamlObject(Logger, TransferObject):
+    '''
+    A YAML data representation of a logger configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the logger data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the logger.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> LoggerAggregate:
+        '''
+        Maps the logger data to a logger aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new logger aggregate.
+        :rtype: LoggerAggregate
+        '''
+
+        # Map to the logger aggregate.
+        return super().map(
+            LoggerAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(logger: Logger, **kwargs) -> 'LoggerYamlObject':
+        '''
+        Creates a LoggerYamlObject from a Logger model.
+
+        :param logger: The logger model.
+        :type logger: Logger
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new LoggerYamlObject.
+        :rtype: LoggerYamlObject
+        '''
+
+        # Create a new LoggerYamlObject from the model.
+        return TransferObject.from_model(
+            LoggerYamlObject,
+            logger,
+            **kwargs,
+        )
+
+
+# ** mapper: logging_settings_yaml_object
+class LoggingSettingsYamlObject(TransferObject):
+    '''
+    A YAML data representation of the overall logging configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the logging settings data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.allow(),
+            'to_data.json': TransferObject.allow(),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the logging settings.'
+        )
+    )
+
+    # * attribute: formatters
+    formatters = DictType(
+        ModelType(FormatterYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of formatter configurations, keyed by id.'
+        )
+    )
+
+    # * attribute: handlers
+    handlers = DictType(
+        ModelType(HandlerYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of handler configurations, keyed by id.'
+        )
+    )
+
+    # * attribute: loggers
+    loggers = DictType(
+        ModelType(LoggerYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of logger configurations, keyed by id.'
+        )
+    )
+
+    # * method: from_data
+    @staticmethod
+    def from_data(**data) -> 'LoggingSettingsYamlObject':
+        '''
+        Initializes a new LoggingSettingsYamlObject from a data representation.
+
+        :param data: The data to initialize the LoggingSettingsYamlObject.
+        :type data: dict
+        :return: A new LoggingSettingsYamlObject.
+        :rtype: LoggingSettingsYamlObject
+        '''
+
+        # Create a new LoggingSettingsYamlObject from the provided data,
+        # injecting dictionary keys as id attributes.
+        return TransferObject.from_data(
+            LoggingSettingsYamlObject,
+            formatters={id: TransferObject.from_data(
+                FormatterYamlObject,
+                **formatter_data,
+                id=id
+            ) for id, formatter_data in data.get('formatters', {}).items()},
+            handlers={id: TransferObject.from_data(
+                HandlerYamlObject,
+                **handler_data,
+                id=id
+            ) for id, handler_data in data.get('handlers', {}).items()},
+            loggers={id: TransferObject.from_data(
+                LoggerYamlObject,
+                **logger_data,
+                id=id
+            ) for id, logger_data in data.get('loggers', {}).items()},
+        )

--- a/tiferet/mappers/tests/test_logging.py
+++ b/tiferet/mappers/tests/test_logging.py
@@ -1,0 +1,429 @@
+"""Tiferet Logging Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..logging import (
+    FormatterAggregate,
+    FormatterYamlObject,
+    HandlerAggregate,
+    HandlerYamlObject,
+    LoggerAggregate,
+    LoggerYamlObject,
+    LoggingSettingsYamlObject,
+)
+from ...domain import (
+    Formatter,
+    Handler,
+    Logger,
+)
+
+# *** fixtures
+
+# ** fixture: formatter_config_data
+@pytest.fixture
+def formatter_config_data() -> FormatterYamlObject:
+    '''
+    Provides a formatter YAML object fixture.
+
+    :return: The formatter YAML object instance.
+    :rtype: FormatterYamlObject
+    '''
+
+    # Create and return a formatter YAML object.
+    return TransferObject.from_data(
+        FormatterYamlObject,
+        id='simple',
+        name='Simple Formatter',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+
+
+# ** fixture: handler_config_data
+@pytest.fixture
+def handler_config_data() -> HandlerYamlObject:
+    '''
+    Provides a handler YAML object fixture.
+
+    :return: The handler YAML object instance.
+    :rtype: HandlerYamlObject
+    '''
+
+    # Create and return a handler YAML object.
+    return TransferObject.from_data(
+        HandlerYamlObject,
+        id='console',
+        name='Console Handler',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='DEBUG',
+        formatter='simple',
+        stream='ext://sys.stdout',
+    )
+
+
+# ** fixture: logger_config_data
+@pytest.fixture
+def logger_config_data() -> LoggerYamlObject:
+    '''
+    Provides a logger YAML object fixture.
+
+    :return: The logger YAML object instance.
+    :rtype: LoggerYamlObject
+    '''
+
+    # Create and return a logger YAML object.
+    return TransferObject.from_data(
+        LoggerYamlObject,
+        id='app',
+        name='App Logger',
+        level='DEBUG',
+        handlers=['console'],
+    )
+
+
+# ** fixture: logging_settings_config_data
+@pytest.fixture
+def logging_settings_config_data(
+    formatter_config_data: FormatterYamlObject,
+    handler_config_data: HandlerYamlObject,
+    logger_config_data: LoggerYamlObject,
+) -> LoggingSettingsYamlObject:
+    '''
+    Provides a logging settings YAML object fixture assembled from
+    individual formatter, handler, and logger fixtures.
+
+    :param formatter_config_data: The formatter YAML object.
+    :type formatter_config_data: FormatterYamlObject
+    :param handler_config_data: The handler YAML object.
+    :type handler_config_data: HandlerYamlObject
+    :param logger_config_data: The logger YAML object.
+    :type logger_config_data: LoggerYamlObject
+    :return: The logging settings YAML object instance.
+    :rtype: LoggingSettingsYamlObject
+    '''
+
+    # Create and return a logging settings YAML object.
+    return LoggingSettingsYamlObject.from_data(
+        formatters={
+            'simple': {
+                'name': 'Simple Formatter',
+                'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                'datefmt': '%Y-%m-%d %H:%M:%S',
+            }
+        },
+        handlers={
+            'console': {
+                'name': 'Console Handler',
+                'module_path': 'logging',
+                'class_name': 'StreamHandler',
+                'level': 'DEBUG',
+                'formatter': 'simple',
+                'stream': 'ext://sys.stdout',
+            }
+        },
+        loggers={
+            'app': {
+                'name': 'App Logger',
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            }
+        },
+    )
+
+
+# *** tests
+
+# ** test: test_formatter_data_map_success
+def test_formatter_data_map_success(formatter_config_data: FormatterYamlObject):
+    '''
+    Test mapping a FormatterYamlObject to a Formatter and verifying format_config() output.
+
+    :param formatter_config_data: The formatter YAML object fixture.
+    :type formatter_config_data: FormatterYamlObject
+    '''
+
+    # Map the formatter data to a formatter aggregate.
+    formatter = formatter_config_data.map()
+
+    # Assert the formatter is mapped correctly.
+    assert isinstance(formatter, Formatter)
+    assert formatter.id == 'simple'
+    assert formatter.name == 'Simple Formatter'
+
+    # Verify format_config() output.
+    config = formatter.format_config()
+    assert config['format'] == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    assert config['datefmt'] == '%Y-%m-%d %H:%M:%S'
+
+
+# ** test: test_handler_data_map_success
+def test_handler_data_map_success(handler_config_data: HandlerYamlObject):
+    '''
+    Test mapping a HandlerYamlObject to a Handler and verifying format_config() with stream.
+
+    :param handler_config_data: The handler YAML object fixture.
+    :type handler_config_data: HandlerYamlObject
+    '''
+
+    # Map the handler data to a handler aggregate.
+    handler = handler_config_data.map()
+
+    # Assert the handler is mapped correctly.
+    assert isinstance(handler, Handler)
+    assert handler.id == 'console'
+    assert handler.name == 'Console Handler'
+
+    # Verify format_config() includes stream.
+    config = handler.format_config()
+    assert config['class'] == 'logging.StreamHandler'
+    assert config['level'] == 'DEBUG'
+    assert config['formatter'] == 'simple'
+    assert config['stream'] == 'ext://sys.stdout'
+
+
+# ** test: test_handler_data_map_no_optional
+def test_handler_data_map_no_optional():
+    '''
+    Test mapping a handler without stream/filename and verifying they are omitted from format_config().
+    '''
+
+    # Create a handler YAML object without optional stream/filename.
+    handler_yaml = TransferObject.from_data(
+        HandlerYamlObject,
+        id='file_handler',
+        name='File Handler',
+        module_path='logging',
+        class_name='FileHandler',
+        level='INFO',
+        formatter='simple',
+    )
+
+    # Map to handler aggregate.
+    handler = handler_yaml.map()
+
+    # Verify format_config() omits stream and filename.
+    config = handler.format_config()
+    assert 'stream' not in config
+    assert 'filename' not in config
+    assert config['class'] == 'logging.FileHandler'
+    assert config['level'] == 'INFO'
+
+
+# ** test: test_logger_data_map_success
+def test_logger_data_map_success(logger_config_data: LoggerYamlObject):
+    '''
+    Test mapping a LoggerYamlObject to a Logger and verifying format_config() output.
+
+    :param logger_config_data: The logger YAML object fixture.
+    :type logger_config_data: LoggerYamlObject
+    '''
+
+    # Map the logger data to a logger aggregate.
+    logger = logger_config_data.map()
+
+    # Assert the logger is mapped correctly.
+    assert isinstance(logger, Logger)
+    assert logger.id == 'app'
+    assert logger.name == 'App Logger'
+
+    # Verify format_config() output.
+    config = logger.format_config()
+    assert config['level'] == 'DEBUG'
+    assert config['handlers'] == ['console']
+    assert config['propagate'] is False
+
+
+# ** test: test_logger_data_map_empty_handlers
+def test_logger_data_map_empty_handlers():
+    '''
+    Test mapping a logger with empty handlers and is_root=True.
+    '''
+
+    # Create a logger YAML object with empty handlers and is_root=True.
+    logger_yaml = TransferObject.from_data(
+        LoggerYamlObject,
+        id='root',
+        name='Root Logger',
+        level='WARNING',
+        handlers=[],
+        is_root=True,
+    )
+
+    # Map to logger aggregate.
+    logger = logger_yaml.map()
+
+    # Verify the logger attributes.
+    assert logger.is_root is True
+    assert logger.handlers == []
+    assert logger.level == 'WARNING'
+
+
+# ** test: test_logging_settings_data_from_data_success
+def test_logging_settings_data_from_data_success(
+    logging_settings_config_data: LoggingSettingsYamlObject,
+):
+    '''
+    Test from_data() with full YAML data, verifying id injection.
+
+    :param logging_settings_config_data: The logging settings YAML object fixture.
+    :type logging_settings_config_data: LoggingSettingsYamlObject
+    '''
+
+    # Assert formatters were created with id injection.
+    assert 'simple' in logging_settings_config_data.formatters
+    formatter = logging_settings_config_data.formatters['simple']
+    assert isinstance(formatter, FormatterYamlObject)
+    assert formatter.id == 'simple'
+    assert formatter.name == 'Simple Formatter'
+
+    # Assert handlers were created with id injection.
+    assert 'console' in logging_settings_config_data.handlers
+    handler = logging_settings_config_data.handlers['console']
+    assert isinstance(handler, HandlerYamlObject)
+    assert handler.id == 'console'
+    assert handler.name == 'Console Handler'
+
+    # Assert loggers were created with id injection.
+    assert 'app' in logging_settings_config_data.loggers
+    logger = logging_settings_config_data.loggers['app']
+    assert isinstance(logger, LoggerYamlObject)
+    assert logger.id == 'app'
+    assert logger.name == 'App Logger'
+
+
+# ** test: test_logging_settings_data_from_data_empty
+def test_logging_settings_data_from_data_empty():
+    '''
+    Test from_data() with empty data returns empty dicts.
+    '''
+
+    # Create a logging settings YAML object with empty data.
+    settings = LoggingSettingsYamlObject.from_data(
+        formatters={},
+        handlers={},
+        loggers={},
+    )
+
+    # Assert all dictionaries are empty.
+    assert settings.formatters == {}
+    assert settings.handlers == {}
+    assert settings.loggers == {}
+
+
+# ** test: test_formatter_aggregate_new_success
+def test_formatter_aggregate_new_success():
+    '''
+    Test creating a FormatterAggregate via Aggregate.new().
+    '''
+
+    # Create a formatter aggregate.
+    formatter = FormatterAggregate.new(
+        id='detailed',
+        name='Detailed Formatter',
+        format='%(asctime)s %(levelname)s %(name)s %(message)s',
+        datefmt='%Y-%m-%d',
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(formatter, FormatterAggregate)
+    assert formatter.id == 'detailed'
+    assert formatter.name == 'Detailed Formatter'
+    assert formatter.format == '%(asctime)s %(levelname)s %(name)s %(message)s'
+
+
+# ** test: test_handler_aggregate_new_success
+def test_handler_aggregate_new_success():
+    '''
+    Test creating a HandlerAggregate via Aggregate.new().
+    '''
+
+    # Create a handler aggregate.
+    handler = HandlerAggregate.new(
+        id='file',
+        name='File Handler',
+        module_path='logging',
+        class_name='FileHandler',
+        level='ERROR',
+        formatter='detailed',
+        filename='error.log',
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(handler, HandlerAggregate)
+    assert handler.id == 'file'
+    assert handler.name == 'File Handler'
+    assert handler.filename == 'error.log'
+
+
+# ** test: test_logger_aggregate_new_success
+def test_logger_aggregate_new_success():
+    '''
+    Test creating a LoggerAggregate via Aggregate.new().
+    '''
+
+    # Create a logger aggregate.
+    logger = LoggerAggregate.new(
+        id='main',
+        name='Main Logger',
+        level='INFO',
+        handlers=['console', 'file'],
+        propagate=True,
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(logger, LoggerAggregate)
+    assert logger.id == 'main'
+    assert logger.name == 'Main Logger'
+    assert logger.level == 'INFO'
+    assert logger.handlers == ['console', 'file']
+    assert logger.propagate is True
+
+
+# ** test: test_formatter_yaml_object_map_returns_aggregate
+def test_formatter_yaml_object_map_returns_aggregate(formatter_config_data: FormatterYamlObject):
+    '''
+    Test that FormatterYamlObject.map() returns a FormatterAggregate instance.
+
+    :param formatter_config_data: The formatter YAML object fixture.
+    :type formatter_config_data: FormatterYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = formatter_config_data.map()
+    assert isinstance(result, FormatterAggregate)
+
+
+# ** test: test_handler_yaml_object_map_returns_aggregate
+def test_handler_yaml_object_map_returns_aggregate(handler_config_data: HandlerYamlObject):
+    '''
+    Test that HandlerYamlObject.map() returns a HandlerAggregate instance.
+
+    :param handler_config_data: The handler YAML object fixture.
+    :type handler_config_data: HandlerYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = handler_config_data.map()
+    assert isinstance(result, HandlerAggregate)
+
+
+# ** test: test_logger_yaml_object_map_returns_aggregate
+def test_logger_yaml_object_map_returns_aggregate(logger_config_data: LoggerYamlObject):
+    '''
+    Test that LoggerYamlObject.map() returns a LoggerAggregate instance.
+
+    :param logger_config_data: The logger YAML object fixture.
+    :type logger_config_data: LoggerYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = logger_config_data.map()
+    assert isinstance(result, LoggerAggregate)


### PR DESCRIPTION
## Summary

Implements the logging mapper layer for the v2 mappers package, delivering all 7 mapper classes specified in the TRD for issue #592.

### Changes

- **`tiferet/mappers/logging.py`** — New file with 7 mapper classes:
  - `FormatterAggregate`, `FormatterYamlObject` — formatter config pair
  - `HandlerAggregate`, `HandlerYamlObject` — handler config pair
  - `LoggerAggregate`, `LoggerYamlObject` — logger config pair
  - `LoggingSettingsYamlObject` — composite transfer object with `from_data()` id-injection
- **`tiferet/mappers/__init__.py`** — Exports all 7 new classes
- **`tiferet/mappers/tests/test_logging.py`** — 4 fixtures + 13 tests

### Design Notes

- All aggregate `new()` factories default to `strict=False` (flexible logging configs)
- Adapted from v2.0-proto reference to current `Aggregate.new()` API (no `data_dict` positional arg)

### Deviation from TRD

- Guide document (`docs/guides/mappers/logging.md`) was intentionally skipped; the general mappers document is preferred

### Testing

- All 13 new tests pass
- Full mapper test suite (94 tests) passes with no regressions

Closes #592

Co-Authored-By: Oz <oz-agent@warp.dev>