### PR TITLE
Rebase v2.0a3-release into main (#597)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a2`
+- **Version:** `2.0.0a3`
 
 ## Architecture
 
@@ -179,8 +179,8 @@ Split into two classes:
 
 ### Naming Convention
 
-- `<Domain>Aggregate` (e.g., `FeatureAggregate`, `ErrorAggregate`)
-- `<Domain>YamlObject` (e.g., `FeatureYamlObject`, `ErrorYamlObject`)
+- `<Domain>Aggregate` (e.g., `FeatureAggregate`, `ErrorAggregate`, `ServiceConfigurationAggregate`)
+- `<Domain>YamlObject` (e.g., `FeatureYamlObject`, `ErrorYamlObject`, `ServiceConfigurationYamlObject`)
 
 ## Repositories
 

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Architectural references for framework contributors and advanced users:
 
 ### Domain Guides
 
-Per-domain guides covering objects, runtime roles, configuration, and relationships:
+Practical guides for working with Tiferet's domain layers:
 
 - [App (Bootstrap & Assembly)](docs/guides/domain/app.md) — Application interfaces, service dependency bindings, runtime wiring
 - [CLI (Command-Line Interface)](docs/guides/domain/cli.md) — CLI commands, arguments, CLI-to-feature bridge
@@ -660,6 +660,7 @@ Per-domain guides covering objects, runtime roles, configuration, and relationsh
 - [Error (Structured Error Handling)](docs/guides/domain/error.md) — Error definitions, multilingual messages, formatting flow
 - [Feature (Workflow Orchestration)](docs/guides/domain/feature.md) — Features, steps, parameter resolution, execution flow
 - [Logging (Observability)](docs/guides/domain/logging.md) — Formatters, handlers, loggers, dictConfig assembly
+- [Mappers – Strategies and Patterns](docs/guides/mappers.md) — Aggregate and TransferObject design decisions, nested sub-objects, role strategies, and round-trip mapping
 
 ### Utility Guides
 

--- a/docs/guides/mappers.md
+++ b/docs/guides/mappers.md
@@ -1,0 +1,276 @@
+# Mappers – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/mappers/`  
+**Version:** 2.0.0a3
+
+## Overview
+
+The mappers layer bridges persistent configuration (YAML, JSON) and runtime domain objects. Every mapper module pairs two complementary classes:
+
+- **Aggregate** — extends a domain object with mutation logic.
+- **TransferObject** — extends a domain object with serialization roles and configuration mapping.
+
+This guide covers the cross-cutting strategies and design decisions that apply to all mapper modules, rather than any single domain.
+
+## When to Create an Aggregate
+
+An aggregate is warranted when the domain object needs **mutation methods** beyond simple attribute assignment — methods that enforce invariants, compose nested objects, or coordinate multi-field updates.
+
+If a domain object is only ever used as a **nested sub-object** inside a parent aggregate, and its fields map 1:1 with no special mutation logic, skip the aggregate. The parent aggregate owns the mutation responsibility, and the raw domain object is used directly.
+
+### Examples
+
+| Domain Object | Has Aggregate? | Reason |
+|---|---|---|
+| `AppInterface` | Yes (`AppInterfaceAggregate`) | Multi-field mutations (`set_service`, `set_constants`, gated `set_attribute`) |
+| `AppServiceDependency` | No | 1:1 field mapping; parent manages mutations |
+| `Feature` | Yes (`FeatureAggregate`) | Complex `new` factory with ID derivation; step ordering and insertion |
+| `FeatureEvent` | Yes (`FeatureEventAggregate`) | Specialized setters for `pass_on_error` and parameter merging |
+| `Error` | Yes (`ErrorAggregate`) | Message list management (`set_message`, `remove_message`) |
+| `ErrorMessage` | No | 1:1 mapping; parent manages the list |
+| `CliArgument` | Yes (`CliArgumentAggregate`) | Gated `set_attribute` for mutable fields; serves as return type for `CliService.get_parent_arguments()` |
+| `FlaggedDependency` | Yes (`FlaggedDependencyAggregate`) | Parameter merge-and-prune logic |
+| `Formatter`, `Handler`, `Logger` | Yes (thin aggregates) | Provide `new` factory for consistent instantiation |
+
+**Rule of thumb:** if you need `DomainObject.new(SubType, ...)` to create it and nothing else, you don't need an aggregate for it.
+
+## The `new` Factory Pattern
+
+Every aggregate provides a static `new` method. There are two common signatures:
+
+### Pass-through factory
+Delegates directly to `Aggregate.new` with no additional logic. Used when the domain object's fields are sufficient as-is.
+
+```python
+@staticmethod
+def new(validate=True, strict=True, **kwargs) -> 'ErrorAggregate':
+    return Aggregate.new(ErrorAggregate, validate=validate, strict=strict, **kwargs)
+```
+
+### Derivation factory
+Computes or derives fields before delegating. Used when the aggregate needs to normalize inputs, compute IDs, or provide defaults.
+
+```python
+@staticmethod
+def new(name=None, group_id=None, feature_key=None, id=None, ...) -> 'FeatureAggregate':
+    # Derive group_id and feature_key from id if provided.
+    if id and '.' in id and (not group_id or not feature_key):
+        group_id, feature_key = id.split('.', 1)
+    # ...
+    return Aggregate.new(FeatureAggregate, id=id, name=name, ...)
+```
+
+### Dict-wrapper factory
+Accepts a single data dict and unpacks it. Used when the caller already has a dict (e.g., from YAML loading).
+
+```python
+@staticmethod
+def new(app_interface_data: Dict[str, Any], validate=True, strict=True, **kwargs):
+    return Aggregate.new(AppInterfaceAggregate, **app_interface_data, **kwargs)
+```
+
+Choose the pattern that fits the domain. Derivation factories are useful when an ID is composed from multiple parts; dict-wrapper factories are useful when the aggregate is populated from configuration data.
+
+## Nested Sub-Objects Without Aggregates
+
+When a domain object has no aggregate, the parent aggregate creates instances via `DomainObject.new()` and mutates them directly. The parent transfer object handles all structural transformation.
+
+### Creation in the parent aggregate
+
+```python
+# AppInterfaceAggregate.add_service
+dependency = DomainObject.new(
+    AppServiceDependency,
+    module_path=module_path,
+    class_name=class_name,
+    attribute_id=attribute_id,
+    parameters=parameters,
+)
+self.services.append(dependency)
+```
+
+### Transformation in the parent transfer object
+
+The transfer object is responsible for any structural differences between the configuration format and the domain model. The most common pattern is **dict↔list conversion**, where YAML stores sub-objects as a dictionary keyed by an identifier, but the domain model stores them as a list with that identifier as a field.
+
+```python
+# AppInterfaceYamlObject.map — dict keys become attribute_id fields
+services=[dep.map(attribute_id=dep_id) for dep_id, dep in self.services.items()]
+
+# AppInterfaceYamlObject.from_model — list items become dict entries
+services={
+    dep.attribute_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
+    for dep in app_interface.services
+}
+```
+
+This pattern appears in every domain that nests sub-objects: services in app interfaces, dependencies in service configurations, messages in errors, steps in features.
+
+## Transfer Object Role Strategy
+
+Transfer objects use Schematics role-based serialization to control which fields appear in different contexts. Tiferet defines three standard roles:
+
+| Role | Purpose |
+|---|---|
+| `to_model` | Fields included when mapping to an aggregate or domain object |
+| `to_data.yaml` | Fields included when serializing to YAML configuration |
+| `to_data.json` | Fields included when serializing to JSON |
+
+### Deny vs Allow
+
+- **`deny`** (blacklist) is the default strategy. Start with all fields and exclude the ones that don't belong in the role.
+- **`allow`** (whitelist) is used when the domain object is simple enough that listing included fields is clearer, or when you want a full pass-through (`allow()` with no arguments).
+
+### Common deny patterns
+
+**Deny the ID on data roles.** The ID is typically derived from the YAML dictionary key, not stored as a field in the YAML value:
+
+```python
+roles = {
+    'to_data.yaml': TransferObject.deny('id'),
+    'to_data.json': TransferObject.deny('id'),
+}
+```
+
+**Deny nested collections on `to_model`.** Nested sub-objects need custom mapping (e.g., dict→list conversion), so they are excluded from the primitive and composed manually in `map()`:
+
+```python
+roles = {
+    'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
+}
+```
+
+The fields denied from `to_model` are then passed explicitly in `map()` with the correct transformation applied.
+
+### The map/deny handshake
+
+The `map()` method and `to_model` role work together. Whatever `to_model` denies, `map()` must supply:
+
+```python
+def map(self, **kwargs) -> ErrorAggregate:
+    return super().map(
+        ErrorAggregate,
+        message=[msg.map() for msg in self.message],   # denied from to_model
+        **self.to_primitive('to_model'),                # everything else
+        **kwargs
+    )
+```
+
+This pattern ensures the transfer object's role controls what gets auto-serialized, while `map()` handles custom transformations for the excluded fields.
+
+## Attribute Aliasing
+
+Transfer objects support `serialized_name` and `deserialize_from` for mapping between YAML/JSON field names and domain attribute names. Domain objects must **not** use aliasing — only transfer objects.
+
+Common aliases:
+
+| Domain field | YAML alias | `deserialize_from` |
+|---|---|---|
+| `parameters` | `params` | `['params', 'parameters']` |
+| `module_path` | `module` | `['module_path', 'module']` |
+| `class_name` | `class` | `['class_name', 'class']` |
+| `services` | `attrs` | `['attrs', 'services', 'dependencies', 'attributes']` |
+| `dependencies` | `deps` | `['deps', 'dependencies', 'flags']` |
+| `steps` | `commands` | `['handlers', 'functions', 'commands', 'steps']` |
+
+Broad `deserialize_from` lists provide backward compatibility with older configuration formats. The `serialized_name` controls the canonical output key.
+
+## Gated `set_attribute` Pattern
+
+Some aggregates override `set_attribute` with a gated version that restricts which attributes can be updated. This prevents accidental mutation of identity fields or fields that have dedicated mutation methods.
+
+```python
+def set_attribute(self, attribute: str, value: Any) -> None:
+    supported = {'name', 'description', 'module_path', 'class_name', 'logger_id', 'flags'}
+    if attribute not in supported:
+        RaiseError.execute(
+            error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+            attribute=attribute,
+            supported=', '.join(sorted(supported)),
+        )
+    setattr(self, attribute, value)
+    self.validate()
+```
+
+**When to gate:** when the aggregate has fields that should only change through dedicated methods (e.g., `services` via `add_service`/`remove_service`, `constants` via `set_constants`).
+
+**When to use the base `set_attribute`:** when any field on the model is fair game for direct update, or the aggregate is simple enough that gating adds no value.
+
+## Parameter Merge-and-Prune Pattern
+
+Several aggregates manage `parameters` dictionaries with merge semantics: new values override existing ones, and keys set to `None` are removed. This pattern appears in `set_constants`, `set_service`, `set_parameters`, and `set_default_type`.
+
+```python
+def set_constants(self, constants: Dict[str, Any] | None = None) -> None:
+    if constants is None:
+        self.constants = {}
+    else:
+        self.constants.update(constants)
+        self.constants = {k: v for k, v in self.constants.items() if v is not None}
+```
+
+The convention is:
+- `None` argument → clear all.
+- Dict argument → merge, then prune `None`-valued keys.
+
+## Round-Trip Mapping
+
+Every transfer object pair (`map` + `from_model`) should support lossless round-trip conversion:
+
+```
+Aggregate → from_model → YamlObject → map → Aggregate
+```
+
+Tests validate this by asserting field equality after a round trip:
+
+```python
+def test_round_trip(aggregate):
+    yaml_obj = YamlObject.from_model(aggregate)
+    round_tripped = yaml_obj.map()
+    assert round_tripped.id == aggregate.id
+    assert round_tripped.name == aggregate.name
+    # ...
+```
+
+When the transfer object performs structural transformations (dict↔list), both `map` and `from_model` must apply the inverse transformation so the round trip is complete.
+
+## Composite Transfer Objects
+
+Some transfer objects don't extend a domain object — they compose multiple domain objects into a single configuration structure. `LoggingSettingsYamlObject` is the canonical example: it holds dicts of `FormatterYamlObject`, `HandlerYamlObject`, and `LoggerYamlObject`, representing the entire `logging.yml` file.
+
+These composite transfer objects override `from_data` to handle sub-object hydration:
+
+```python
+@staticmethod
+def from_data(**data) -> 'LoggingSettingsYamlObject':
+    return TransferObject.from_data(
+        LoggingSettingsYamlObject,
+        formatters={id: TransferObject.from_data(FormatterYamlObject, **d, id=id)
+                    for id, d in data.get('formatters', {}).items()},
+        # ...
+    )
+```
+
+Use this pattern when a YAML file contains multiple related configuration sections that are loaded together.
+
+## Custom `to_primitive` Overrides
+
+When the standard role-based serialization isn't sufficient, transfer objects can override `to_primitive` to produce a custom dictionary. `CliCommandYamlObject` does this to handle argument serialization:
+
+```python
+def to_primitive(self, role='to_data.yaml', **kwargs) -> Dict[str, Any]:
+    return dict(
+        **super().to_primitive(role=role, **kwargs),
+        args=[arg.to_primitive() for arg in self.arguments]
+    )
+```
+
+Use sparingly — prefer role-based deny/allow when possible.
+
+## Related Documentation
+
+- [docs/core/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md) — Aggregate and TransferObject base class reference
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — DomainObject base class and conventions
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comments and formatting

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -69,4 +69,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a2'
+__version__ = '2.0.0a3'

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -20,3 +20,8 @@ from .cli import (
     CliCommandAggregate,
     CliCommandYamlObject,
 )
+from .error import (
+    ErrorAggregate,
+    ErrorYamlObject,
+    ErrorMessageYamlObject,
+)

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -31,3 +31,12 @@ from .feature import (
     FeatureEventAggregate,
     FeatureEventYamlObject,
 )
+from .logging import (
+    FormatterAggregate,
+    FormatterYamlObject,
+    HandlerAggregate,
+    HandlerYamlObject,
+    LoggerAggregate,
+    LoggerYamlObject,
+    LoggingSettingsYamlObject,
+)

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -11,3 +11,7 @@ from .app import (
     AppInterfaceAggregate,
     AppInterfaceYamlObject,
 )
+from .di import (
+    ServiceConfigurationAggregate,
+    ServiceConfigurationYamlObject,
+)

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -15,3 +15,8 @@ from .di import (
     ServiceConfigurationAggregate,
     ServiceConfigurationYamlObject,
 )
+from .cli import (
+    CliArgumentAggregate,
+    CliCommandAggregate,
+    CliCommandYamlObject,
+)

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -25,3 +25,9 @@ from .error import (
     ErrorYamlObject,
     ErrorMessageYamlObject,
 )
+from .feature import (
+    FeatureAggregate,
+    FeatureYamlObject,
+    FeatureEventAggregate,
+    FeatureEventYamlObject,
+)

--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -7,3 +7,7 @@ from .settings import (
     Aggregate,
     TransferObject,
 )
+from .app import (
+    AppInterfaceAggregate,
+    AppInterfaceYamlObject,
+)

--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -1,0 +1,419 @@
+"""Tiferet App Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    AppServiceDependency,
+    AppInterface,
+    DomainObject,
+    StringType,
+    DictType,
+    ModelType,
+)
+from ..events import RaiseError, a
+from .settings import (
+    Aggregate,
+    TransferObject,
+    DEFAULT_MODULE_PATH,
+    DEFAULT_CLASS_NAME,
+)
+
+# *** mappers
+
+# ** mapper: app_interface_aggregate
+class AppInterfaceAggregate(AppInterface, Aggregate):
+    '''
+    An aggregate representation of an app interface contract.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        app_interface_data: Dict[str, Any],
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'AppInterfaceAggregate':
+        '''
+        Initializes a new app interface aggregate.
+
+        :param app_interface_data: The data to create the app interface aggregate from.
+        :type app_interface_data: dict
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new app interface aggregate.
+        :rtype: AppInterfaceAggregate
+        '''
+
+        # Create a new app interface aggregate from the provided app interface data.
+        return Aggregate.new(
+            AppInterfaceAggregate,
+            validate=validate,
+            strict=strict,
+            **app_interface_data,
+            **kwargs
+        )
+
+    # * method: add_service
+    def add_service(self, module_path: str, class_name: str, attribute_id: str, parameters: Dict[str, str] = {}) -> None:
+        '''
+        Add a service dependency to the app interface.
+
+        :param module_path: The module path for the service dependency.
+        :type module_path: str
+        :param class_name: The class name for the service dependency.
+        :type class_name: str
+        :param attribute_id: The id for the service dependency.
+        :type attribute_id: str
+        :param parameters: Additional parameters for the service dependency.
+        :type parameters: dict
+        :return: None
+        :rtype: None
+        '''
+
+        # Create a new AppServiceDependency object.
+        dependency = DomainObject.new(
+            AppServiceDependency,
+            module_path=module_path,
+            class_name=class_name,
+            attribute_id=attribute_id,
+            parameters=parameters,
+        )
+
+        # Add the service dependency to the list of services.
+        self.services.append(dependency)
+
+    # * method: remove_service
+    def remove_service(self, attribute_id: str) -> AppServiceDependency:
+        '''
+        Remove and return a service dependency by its attribute_id (idempotent).
+
+        If a service dependency with the given attribute_id exists, it is removed.
+        If no matching service dependency exists, no action is taken (silent success).
+
+        :param attribute_id: The attribute_id of the service dependency to remove.
+        :type attribute_id: str
+        :return: The removed AppServiceDependency or None.
+        :rtype: AppServiceDependency
+        '''
+
+        # Iterate over services and remove the first match by attribute_id.
+        for index, dep in enumerate(self.services):
+            if dep.attribute_id == attribute_id:
+                return self.services.pop(index)
+
+        # If no service dependency matches, return None without modifying the list.
+        return None
+
+    # * method: set_service
+    def set_service(
+        self,
+        attribute_id: str,
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None,
+    ) -> None:
+        '''
+        Set or update a service dependency by attribute_id (PUT semantics).
+
+        If a service dependency with the given attribute_id exists:
+          - Update module_path and class_name.
+          - Merge parameters (favor new values; remove keys with None value).
+          - Clear parameters if parameters is None.
+
+        If no service dependency exists:
+          - Create new AppServiceDependency and append to services.
+
+        :param attribute_id: The service dependency identifier.
+        :type attribute_id: str
+        :param module_path: The module path.
+        :type module_path: str
+        :param class_name: The class name.
+        :type class_name: str
+        :param parameters: New parameters (None to clear).
+        :type parameters: Dict[str, Any]
+        :return: None
+        :rtype: None
+        '''
+
+        # Find the existing service dependency by attribute_id.
+        dep = self.get_service(attribute_id)
+
+        # If the service dependency exists, update its type fields and merge parameters.
+        if dep is not None:
+            dep.module_path = module_path
+            dep.class_name = class_name
+
+            # Clear parameters when parameters is None.
+            if parameters is None:
+                dep.parameters = {}
+
+            # Otherwise merge and then remove keys whose value is None.
+            else:
+                dep.parameters.update(parameters)
+                dep.parameters = {
+                    key: value
+                    for key, value in dep.parameters.items()
+                    if value is not None
+                }
+
+        # If the service dependency does not exist, create a new one and append.
+        else:
+            new_dep = DomainObject.new(
+                AppServiceDependency,
+                attribute_id=attribute_id,
+                module_path=module_path,
+                class_name=class_name,
+                parameters=parameters or {},
+            )
+            self.services.append(new_dep)
+
+    # * method: set_constants
+    def set_constants(self, constants: Dict[str, Any] | None = None) -> None:
+        '''
+        Update the constants dictionary.
+
+        :param constants: New constants to merge, or None to clear all. Keys with None value are removed.
+        :type constants: Dict[str, Any] | None
+        :return: None
+        :rtype: None
+        '''
+
+        # Clear all constants when None is provided.
+        if constants is None:
+            self.constants = {}
+
+        # Otherwise merge new constants and remove keys with None value.
+        else:
+            self.constants.update(constants)
+            self.constants = {
+                key: value
+                for key, value in self.constants.items()
+                if value is not None
+            }
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Update a supported scalar attribute on the app interface aggregate.
+
+        Supported attributes: name, description, module_path, class_name,
+        logger_id, flags.
+
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Define the set of supported attributes.
+        supported = {
+            'name',
+            'description',
+            'module_path',
+            'class_name',
+            'logger_id',
+            'flags',
+        }
+
+        # Validate the attribute name.
+        if attribute not in supported:
+            RaiseError.execute(
+                error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+                message='Invalid attribute: {attribute}. Supported attributes are {supported}.',
+                attribute=attribute,
+                supported=', '.join(sorted(supported)),
+            )
+
+        # Specific validation for module_path and class_name.
+        if attribute in {'module_path', 'class_name'}:
+            if not value or not str(value).strip():
+                RaiseError.execute(
+                    error_code=a.const.INVALID_APP_INTERFACE_TYPE_ID,
+                    message='{attribute} must be a non-empty string.',
+                    attribute=attribute,
+                )
+
+        # Apply the update to the attribute.
+        setattr(self, attribute, value)
+
+        # Perform final aggregate validation.
+        self.validate()
+
+
+# ** mapper: app_service_dependency_yaml_object
+class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
+    '''
+    A YAML data representation of an app service dependency object.
+    '''
+
+    # * attribute: attribute_id
+    attribute_id = StringType(
+        metadata=dict(
+            description='The attribute id for the application dependency that is not required for assembly.'
+        ),
+    )
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        serialized_name='params',
+        deserialize_from=['params', 'parameters'],
+        metadata=dict(
+            description='The parameters for the application dependency that are not required for assembly.'
+        ),
+    )
+
+    class Options():
+        '''
+        The options for the app dependency data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('parameters', 'attribute_id'),
+            'to_data.yaml': TransferObject.deny('attribute_id'),
+            'to_data.json': TransferObject.deny('attribute_id'),
+        }
+
+    # * method: map
+    def map(self, attribute_id: str, **kwargs) -> AppServiceDependency:
+        '''
+        Maps the app service dependency data to an app service dependency object.
+
+        :param attribute_id: The id for the app service dependency.
+        :type attribute_id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new app service dependency object.
+        :rtype: AppServiceDependency
+        '''
+
+        # Map to the app service dependency object.
+        return super().map(
+            AppServiceDependency,
+            attribute_id=attribute_id,
+            parameters=self.parameters,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+
+# ** mapper: app_interface_yaml_object
+class AppInterfaceYamlObject(AppInterface, TransferObject):
+    '''
+    A YAML data representation of an app interface settings object.
+    '''
+
+    class Options():
+        '''
+        The options for the app interface data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: module_path
+    module_path = StringType(
+        default=DEFAULT_MODULE_PATH,
+        serialized_name='module',
+        deserialize_from=['module_path', 'module'],
+        metadata=dict(
+            description='The app context module path for the app settings.'
+        ),
+    )
+
+    # * attribute: class_name
+    class_name = StringType(
+        default=DEFAULT_CLASS_NAME,
+        serialized_name='class',
+        deserialize_from=['class_name', 'class'],
+        metadata=dict(
+            description='The class name for the app context.'
+        ),
+    )
+
+    # * attribute: services
+    services = DictType(
+        ModelType(AppServiceDependencyYamlObject),
+        default={},
+        serialized_name='attrs',
+        deserialize_from=['attrs', 'services', 'dependencies', 'attributes'],
+        metadata=dict(
+            description='The app instance service dependencies.'
+        ),
+    )
+
+    # * attribute: constants
+    constants = DictType(
+        StringType,
+        default={},
+        serialized_name='const',
+        deserialize_from=['constants', 'const'],
+        metadata=dict(
+            description='The constants for the app settings.'
+        ),
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> AppInterfaceAggregate:
+        '''
+        Maps the app interface data to an app interface aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new app interface aggregate.
+        :rtype: AppInterfaceAggregate
+        '''
+
+        # Map the app interface data to an app interface aggregate.
+        return super().map(
+            AppInterfaceAggregate,
+            module_path=self.module_path,
+            class_name=self.class_name,
+            services=[dep.map(attribute_id=dep_id) for dep_id, dep in self.services.items()],
+            constants=self.constants,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(app_interface: AppInterfaceAggregate, **kwargs) -> 'AppInterfaceYamlObject':
+        '''
+        Creates an AppInterfaceYamlObject from an AppInterfaceAggregate model.
+
+        :param app_interface: The app interface model.
+        :type app_interface: AppInterfaceAggregate
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new AppInterfaceYamlObject.
+        :rtype: AppInterfaceYamlObject
+        '''
+
+        # Create a new AppInterfaceYamlObject from the model, converting
+        # the services list into a dictionary keyed by attribute_id.
+        return TransferObject.from_model(
+            AppInterfaceYamlObject,
+            app_interface,
+            services={
+                dep.attribute_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
+                for dep in app_interface.services
+            },
+            **kwargs,
+        )

--- a/tiferet/mappers/cli.py
+++ b/tiferet/mappers/cli.py
@@ -1,0 +1,321 @@
+"""Tiferet CLI Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any, List
+
+# ** app
+from ..domain import (
+    CliCommand,
+    CliArgument,
+    DomainObject,
+    StringType,
+    ListType,
+    ModelType,
+)
+from ..events import RaiseError, a
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: cli_argument_aggregate
+class CliArgumentAggregate(CliArgument, Aggregate):
+    '''
+    An aggregate representation of a CLI argument.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'CliArgumentAggregate':
+        '''
+        Initializes a new CLI argument aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI argument aggregate.
+        :rtype: CliArgumentAggregate
+        '''
+
+        # Create a new CLI argument aggregate from the provided data.
+        return Aggregate.new(
+            CliArgumentAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Update a supported attribute on the CLI argument aggregate.
+
+        Supported attributes: description, type, required, default, choices, nargs, action.
+
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Define the set of supported attributes.
+        supported = {
+            'description',
+            'type',
+            'required',
+            'default',
+            'choices',
+            'nargs',
+            'action',
+        }
+
+        # Validate the attribute name.
+        if attribute not in supported:
+            RaiseError.execute(
+                error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+                message='Invalid attribute: {attribute}. Supported attributes are {supported}.',
+                attribute=attribute,
+                supported=', '.join(sorted(supported)),
+            )
+
+        # Apply the update to the attribute.
+        setattr(self, attribute, value)
+
+        # Perform final aggregate validation.
+        self.validate()
+
+
+# ** mapper: cli_command_aggregate
+class CliCommandAggregate(CliCommand, Aggregate):
+    '''
+    An aggregate representation of a CLI command.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'CliCommandAggregate':
+        '''
+        Initializes a new CLI command aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI command aggregate.
+        :rtype: CliCommandAggregate
+        '''
+
+        # Create a new CLI command aggregate from the provided CLI command data.
+        return Aggregate.new(
+            CliCommandAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: add_argument
+    def add_argument(self,
+            name_or_flags: list,
+            description: str = None,
+            type: str = None,
+            required: bool = None,
+            default: str = None,
+            choices: list = None,
+            nargs: str = None,
+            action: str = None
+        ) -> None:
+        '''
+        Add an argument to the command.
+
+        :param name_or_flags: The name or flags of the argument.
+        :type name_or_flags: list
+        :param description: A brief description of the argument.
+        :type description: str
+        :param type: The type of the argument (str, int, float).
+        :type type: str
+        :param required: Whether the argument is required.
+        :type required: bool
+        :param default: The default value of the argument.
+        :type default: str
+        :param choices: A list of valid choices for the argument.
+        :type choices: list
+        :param nargs: The number of arguments to consume.
+        :type nargs: str
+        :param action: The action to take when the argument is encountered.
+        :type action: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Create a new CliArgument instance using DomainObject.new.
+        argument = DomainObject.new(
+            CliArgument,
+            name_or_flags=name_or_flags,
+            description=description,
+            type=type,
+            required=required,
+            default=default,
+            choices=choices,
+            nargs=nargs,
+            action=action
+        )
+
+        # Append the argument to the command's arguments list.
+        self.arguments.append(argument)
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Update a supported scalar attribute on the CLI command aggregate.
+
+        Supported attributes: name, description, key, group_key.
+
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Define the set of supported attributes.
+        supported = {
+            'name',
+            'description',
+            'key',
+            'group_key',
+        }
+
+        # Validate the attribute name.
+        if attribute not in supported:
+            RaiseError.execute(
+                error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
+                message='Invalid attribute: {attribute}. Supported attributes are {supported}.',
+                attribute=attribute,
+                supported=', '.join(sorted(supported)),
+            )
+
+        # Apply the update to the attribute.
+        setattr(self, attribute, value)
+
+        # Perform final aggregate validation.
+        self.validate()
+
+
+# ** mapper: cli_command_yaml_object
+class CliCommandYamlObject(CliCommand, TransferObject):
+    '''
+    A YAML data representation of a CLI command object.
+    '''
+
+    class Options():
+        '''
+        The options for the CLI command data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('arguments'),
+            'to_data.yaml': TransferObject.deny('id', 'arguments'),
+        }
+
+    # * attribute: arguments
+    arguments = ListType(
+        ModelType(CliArgument),
+        default=[],
+        deserialize_from=['args', 'arguments'],
+        serialized_name='args',
+        metadata={
+            'description': 'The list of arguments for the CLI command.'
+        },
+    )
+
+    # * method: to_primitive
+    def to_primitive(self, role='to_data.yaml', **kwargs) -> Dict[str, Any]:
+        '''
+        Converts the CLI command data to a primitive dictionary representation.
+
+        :param role: The role to use for the conversion.
+        :type role: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A primitive dictionary representation of the CLI command data.
+        :rtype: dict
+        '''
+
+        # Convert the CLI command data to a primitive dictionary, converting
+        # the arguments list into dictionaries as well.
+        return dict(
+            **super().to_primitive(role=role, **kwargs),
+            args=[
+                arg.to_primitive()
+                for arg in self.arguments
+            ]
+        )
+
+    # * method: map
+    def map(self, **kwargs) -> CliCommandAggregate:
+        '''
+        Maps the CLI command data to a CLI command aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new CLI command aggregate.
+        :rtype: CliCommandAggregate
+        '''
+
+        # Map the CLI command data.
+        return super().map(
+            CliCommandAggregate,
+            arguments=[
+                arg.to_primitive()
+                for arg in self.arguments
+            ],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(cli_command: CliCommand, **kwargs) -> 'CliCommandYamlObject':
+        '''
+        Creates a CliCommandYamlObject from a CliCommand model.
+
+        :param cli_command: The CLI command model.
+        :type cli_command: CliCommand
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new CliCommandYamlObject.
+        :rtype: CliCommandYamlObject
+        '''
+
+        # Create a new CliCommandYamlObject from the model, converting
+        # the arguments list into primitive dictionaries.
+        return TransferObject.from_model(
+            CliCommandYamlObject,
+            cli_command,
+            arguments=[
+                arg.to_primitive()
+                for arg in cli_command.arguments
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/di.py
+++ b/tiferet/mappers/di.py
@@ -1,0 +1,389 @@
+"""Tiferet DI Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    FlaggedDependency,
+    ServiceConfiguration,
+    DomainObject,
+    StringType,
+    DictType,
+    ModelType,
+)
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: flagged_dependency_aggregate
+class FlaggedDependencyAggregate(FlaggedDependency, Aggregate):
+    '''
+    An aggregate representation of a flagged dependency.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        flagged_dependency_data: Dict[str, Any],
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'FlaggedDependencyAggregate':
+        '''
+        Initializes a new flagged dependency aggregate.
+
+        :param flagged_dependency_data: The data to create the flagged dependency aggregate from.
+        :type flagged_dependency_data: dict
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new flagged dependency aggregate.
+        :rtype: FlaggedDependencyAggregate
+        '''
+
+        # Create a new flagged dependency aggregate from the provided data.
+        return Aggregate.new(
+            FlaggedDependencyAggregate,
+            validate=validate,
+            strict=strict,
+            **flagged_dependency_data,
+            **kwargs
+        )
+
+    # * method: set_parameters
+    def set_parameters(self, parameters: Dict[str, Any] | None = None) -> None:
+        '''
+        Update the parameters dictionary for this flagged dependency.
+
+        :param parameters: New parameters, or None to clear all.
+                           Keys with None values are removed.
+        :type parameters: Dict[str, Any] | None
+        :return: None
+        :rtype: None
+        '''
+
+        # If parameters is None, clear all.
+        if parameters is None:
+            self.parameters = {}
+
+        else:
+            # Merge existing parameters with new ones (new values win).
+            merged = dict(self.parameters or {})
+            merged.update(parameters)
+
+            # Filter out keys where the value is None.
+            self.parameters = {
+                k: v for k, v in merged.items() if v is not None
+            }
+
+
+# ** mapper: flagged_dependency_yaml_object
+class FlaggedDependencyYamlObject(FlaggedDependency, TransferObject):
+    '''
+    A YAML data representation of a flagged dependency object.
+    '''
+
+    class Options:
+        '''
+        The options for the flagged dependency data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny(),
+            'to_data.yaml': TransferObject.deny('flag'),
+            'to_data.json': TransferObject.deny('flag'),
+        }
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        serialized_name='params',
+        deserialize_from=['params', 'parameters'],
+        metadata=dict(
+            description='The parameters for the dependency.'
+        )
+    )
+
+    # * method: map
+    def map(self, flag: str = None, **kwargs) -> FlaggedDependency:
+        '''
+        Maps the flagged dependency data to a flagged dependency object.
+
+        :param flag: The flag for the dependency.
+        :type flag: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new flagged dependency object.
+        :rtype: FlaggedDependency
+        '''
+
+        # Map to the flagged dependency object.
+        # Note: parent map() already calls to_primitive, so we only pass overrides.
+        return super().map(
+            FlaggedDependency,
+            flag=flag or self.flag,
+            parameters=self.parameters,
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(flagged_dependency: FlaggedDependency, **kwargs) -> 'FlaggedDependencyYamlObject':
+        '''
+        Creates a FlaggedDependencyYamlObject from a FlaggedDependency model.
+
+        :param flagged_dependency: The flagged dependency model.
+        :type flagged_dependency: FlaggedDependency
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FlaggedDependencyYamlObject.
+        :rtype: FlaggedDependencyYamlObject
+        '''
+
+        # Create a new FlaggedDependencyYamlObject from the model.
+        return TransferObject.from_model(
+            FlaggedDependencyYamlObject,
+            flagged_dependency,
+            **kwargs,
+        )
+
+
+# ** mapper: service_configuration_aggregate
+class ServiceConfigurationAggregate(ServiceConfiguration, Aggregate):
+    '''
+    An aggregate representation of a service configuration.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        service_configuration_data: Dict[str, Any],
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'ServiceConfigurationAggregate':
+        '''
+        Initializes a new service configuration aggregate.
+
+        :param service_configuration_data: The data to create the service configuration aggregate from.
+        :type service_configuration_data: dict
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new service configuration aggregate.
+        :rtype: ServiceConfigurationAggregate
+        '''
+
+        # Create a new service configuration aggregate from the provided data.
+        return Aggregate.new(
+            ServiceConfigurationAggregate,
+            validate=validate,
+            strict=strict,
+            **service_configuration_data,
+            **kwargs
+        )
+
+    # * method: set_default_type
+    def set_default_type(
+        self,
+        module_path: str | None = None,
+        class_name: str | None = None,
+        parameters: Dict[str, Any] | None = None,
+    ) -> None:
+        '''
+        Update the default type and parameters for this service configuration.
+
+        :param module_path: New module path (or None to clear).
+        :type module_path: str | None
+        :param class_name: New class name (or None to clear).
+        :type class_name: str | None
+        :param parameters: New parameters dict (or None to clear all).
+        :type parameters: Dict[str, Any] | None
+        :return: None
+        :rtype: None
+        '''
+
+        # If both type fields are None, clear default type entirely.
+        if module_path is None and class_name is None:
+            self.module_path = None
+            self.class_name = None
+            self.parameters = {}
+
+        # Otherwise, set them to whatever is provided.
+        else:
+            self.module_path = module_path
+            self.class_name = class_name
+
+        # Update parameters: if parameters is None, clear all; otherwise replace with filtered dict.
+        if parameters is None:
+            self.parameters = {}
+        else:
+            self.parameters = {k: v for k, v in parameters.items() if v is not None}
+
+    # * method: set_dependency
+    def set_dependency(
+        self,
+        flag: str,
+        module_path: str | None = None,
+        class_name: str | None = None,
+        parameters: Dict[str, Any] | None = None,
+    ) -> None:
+        '''
+        Sets or updates a flagged dependency.
+
+        :param flag: The flag that identifies the dependency.
+        :type flag: str
+        :param module_path: The module path for the dependency.
+        :type module_path: str | None
+        :param class_name: The class name for the dependency.
+        :type class_name: str | None
+        :param parameters: The parameters for the dependency (empty dict by default).
+        :type parameters: Dict[str, Any] | None
+        :return: None
+        :rtype: None
+        '''
+
+        # Normalize parameters to a dict.
+        parameters = parameters or {}
+
+        # Replace the value of the dependency if a dependency with the same flag exists.
+        for dep in self.dependencies:
+            if dep.flag == flag:
+                dep.module_path = module_path
+                dep.class_name = class_name
+
+                # Inline set_parameters semantics — works on any FlaggedDependency instance.
+                merged = dict(dep.parameters or {})
+                merged.update(parameters)
+                dep.parameters = {k: v for k, v in merged.items() if v is not None}
+                return
+
+        # Create a new dependency if none exists with this flag.
+        dependency = DomainObject.new(
+            FlaggedDependency,
+            module_path=module_path,
+            class_name=class_name,
+            flag=flag,
+            parameters=parameters,
+        )
+
+        self.dependencies.append(dependency)
+
+    # * method: remove_dependency
+    def remove_dependency(self, flag: str) -> None:
+        '''
+        Remove a flagged dependency by its flag.
+
+        :param flag: The flag identifying the dependency to remove.
+        :type flag: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Filter out any dependency whose flag matches the provided flag.
+        self.dependencies = [
+            dependency
+            for dependency in self.dependencies
+            if dependency.flag != flag
+        ]
+
+
+# ** mapper: service_configuration_yaml_object
+class ServiceConfigurationYamlObject(ServiceConfiguration, TransferObject):
+    '''
+    A YAML data representation of a service configuration object.
+    '''
+
+    class Options:
+        '''
+        The options for the service configuration data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('dependencies', 'parameters'),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: dependencies
+    dependencies = DictType(
+        ModelType(FlaggedDependencyYamlObject),
+        default={},
+        serialized_name='deps',
+        deserialize_from=['deps', 'dependencies', 'flags'],
+        metadata=dict(
+            description='The dependencies as key-value pairs, keyed by flags.'
+        )
+    )
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType,
+        default={},
+        serialized_name='params',
+        deserialize_from=['params', 'parameters'],
+        metadata=dict(
+            description='The default parameters for the service configuration.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> ServiceConfigurationAggregate:
+        '''
+        Maps the service configuration data to a service configuration aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new service configuration aggregate.
+        :rtype: ServiceConfigurationAggregate
+        '''
+
+        # Map the service configuration data to a service configuration aggregate.
+        return super().map(
+            ServiceConfigurationAggregate,
+            dependencies=[dep.map(flag=flag) for flag, dep in self.dependencies.items()],
+            parameters=self.parameters,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(service_configuration: ServiceConfiguration, **kwargs) -> 'ServiceConfigurationYamlObject':
+        '''
+        Creates a ServiceConfigurationYamlObject from a ServiceConfiguration model.
+
+        :param service_configuration: The service configuration model.
+        :type service_configuration: ServiceConfiguration
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new ServiceConfigurationYamlObject.
+        :rtype: ServiceConfigurationYamlObject
+        '''
+
+        # Create a new ServiceConfigurationYamlObject from the model, converting
+        # the dependencies list into a dictionary keyed by flag.
+        return TransferObject.from_model(
+            ServiceConfigurationYamlObject,
+            service_configuration,
+            dependencies={
+                dep.flag: TransferObject.from_model(FlaggedDependencyYamlObject, dep)
+                for dep in service_configuration.dependencies
+            },
+            **kwargs,
+        )

--- a/tiferet/mappers/error.py
+++ b/tiferet/mappers/error.py
@@ -1,0 +1,244 @@
+"""Tiferet Error Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    Error,
+    ErrorMessage,
+    ListType,
+    ModelType,
+)
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: error_aggregate
+class ErrorAggregate(Error, Aggregate):
+    '''
+    An aggregate representation of an error.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'ErrorAggregate':
+        '''
+        Initializes a new error aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new error aggregate.
+        :rtype: ErrorAggregate
+        '''
+
+        # Create a new error aggregate from the provided data.
+        return Aggregate.new(
+            ErrorAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: rename
+    def rename(self, new_name: str) -> None:
+        '''
+        Renames the error.
+
+        :param new_name: The new name for the error.
+        :type new_name: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Update the name.
+        self.name = new_name
+
+        # Perform final aggregate validation.
+        self.validate()
+
+    # * method: set_message
+    def set_message(self, lang: str, text: str) -> None:
+        '''
+        Sets the error message text for the specified language.
+
+        :param lang: The language of the error message text.
+        :type lang: str
+        :param text: The error message text.
+        :type text: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Check if the message already exists for the language.
+        for msg in self.message:
+            if msg.lang == lang:
+                msg.text = text
+                return
+
+        # If not, create a new ErrorMessage object and add it to the message list.
+        from ..domain import DomainObject
+        self.message.append(
+            DomainObject.new(
+                ErrorMessage,
+                lang=lang,
+                text=text
+            )
+        )
+
+    # * method: remove_message
+    def remove_message(self, lang: str) -> None:
+        '''
+        Removes the error message for the specified language.
+
+        :param lang: The language of the error message to remove.
+        :type lang: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Filter out the message with the specified language.
+        self.message = [msg for msg in self.message if msg.lang != lang]
+
+# ** mapper: error_message_yaml_object
+class ErrorMessageYamlObject(ErrorMessage, TransferObject):
+    '''
+    A YAML data representation of an error message object.
+    '''
+
+    class Options():
+        '''
+        The options for the error message data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny(),
+            'to_data.yaml': TransferObject.deny(),
+            'to_data.json': TransferObject.deny(),
+        }
+
+    # * method: map
+    def map(self, **kwargs) -> ErrorMessage:
+        '''
+        Maps the error message data to an error message object.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new error message object.
+        :rtype: ErrorMessage
+        '''
+
+        # Map to the error message object.
+        return super().map(
+            ErrorMessage,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(error_message: ErrorMessage, **kwargs) -> 'ErrorMessageYamlObject':
+        '''
+        Creates an ErrorMessageYamlObject from an ErrorMessage model.
+
+        :param error_message: The error message model.
+        :type error_message: ErrorMessage
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new ErrorMessageYamlObject.
+        :rtype: ErrorMessageYamlObject
+        '''
+
+        # Create a new ErrorMessageYamlObject from the model.
+        return TransferObject.from_model(
+            ErrorMessageYamlObject,
+            error_message,
+            **kwargs,
+        )
+
+
+# ** mapper: error_yaml_object
+class ErrorYamlObject(Error, TransferObject):
+    '''
+    A YAML data representation of an error object.
+    '''
+
+    class Options():
+        '''
+        The options for the error data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('message'),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: message
+    message = ListType(
+        ModelType(ErrorMessageYamlObject),
+        required=True,
+        metadata=dict(
+            description='The error messages.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> ErrorAggregate:
+        '''
+        Maps the error data to an error aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new error aggregate.
+        :rtype: ErrorAggregate
+        '''
+
+        # Map the error data.
+        return super().map(
+            ErrorAggregate,
+            message=[msg.map() for msg in self.message],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(error: Error, **kwargs) -> 'ErrorYamlObject':
+        '''
+        Creates an ErrorYamlObject from an Error model.
+
+        :param error: The error model.
+        :type error: Error
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new ErrorYamlObject.
+        :rtype: ErrorYamlObject
+        '''
+
+        # Create a new ErrorYamlObject from the model, converting
+        # the message list into ErrorMessageYamlObject instances.
+        return TransferObject.from_model(
+            ErrorYamlObject,
+            error,
+            message=[
+                TransferObject.from_model(ErrorMessageYamlObject, msg)
+                for msg in error.message
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -1,0 +1,478 @@
+"""Tiferet Feature Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any, List
+
+# ** app
+from ..domain import (
+    Feature,
+    FeatureStep,
+    FeatureEvent,
+    ListType,
+    ModelType,
+    DictType,
+    StringType,
+)
+from ..events import RaiseError, a
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: feature_event_aggregate
+class FeatureEventAggregate(FeatureEvent, Aggregate):
+    '''
+    An aggregate representation of a feature event.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'FeatureEventAggregate':
+        '''
+        Initializes a new feature event aggregate.
+
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new feature event aggregate.
+        :rtype: FeatureEventAggregate
+        '''
+
+        # Create a new feature event aggregate from the provided data.
+        return Aggregate.new(
+            FeatureEventAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+    # * method: set_pass_on_error
+    def set_pass_on_error(self, value: Any) -> None:
+        '''
+        Set the ``pass_on_error`` flag based on a provided value.
+
+        :param value: The value to interpret as a boolean.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Normalize the value, treating the string "false" (case-insensitive)
+        # as an explicit False value and using standard bool conversion otherwise.
+        if isinstance(value, str) and value.lower() == 'false':
+            self.pass_on_error = False
+        else:
+            self.pass_on_error = bool(value)
+
+    # * method: set_parameters
+    def set_parameters(self, parameters: Dict[str, Any] | None = None) -> None:
+        '''
+        Merge new parameters into the existing parameters, preferring new
+        values and removing keys with ``None`` values.
+
+        :param parameters: The new parameters to merge.
+        :type parameters: dict | None
+        :return: None
+        :rtype: None
+        '''
+
+        # Do nothing if no parameters were provided.
+        if parameters is None:
+            return
+
+        # Start from the existing parameters and update with new values.
+        merged = dict(self.parameters or {})
+        merged.update(parameters)
+
+        # Remove any keys whose value is None.
+        self.parameters = {k: v for k, v in merged.items() if v is not None}
+
+    # * method: set_attribute
+    def set_attribute(self, attribute: str, value: Any) -> None:
+        '''
+        Set an attribute on the feature command, with special handling for
+        ``parameters`` and ``pass_on_error``.
+
+        :param attribute: The attribute name to set.
+        :type attribute: str
+        :param value: The value to apply to the attribute.
+        :type value: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Delegate to specialized helpers for parameters and pass_on_error.
+        if attribute == 'parameters':
+            self.set_parameters(value)
+        elif attribute == 'pass_on_error':
+            self.set_pass_on_error(value)
+        else:
+            setattr(self, attribute, value)
+
+
+# ** mapper: feature_event_yaml_object
+class FeatureEventYamlObject(FeatureEvent, TransferObject):
+    '''
+    A YAML data representation of a feature event object.
+    '''
+
+    class Options():
+        '''
+        The options for the feature event data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('type'),
+            'to_data.yaml': TransferObject.deny('type'),
+            'to_data.json': TransferObject.deny('type')
+        }
+
+    # * attribute: parameters
+    parameters = DictType(
+        StringType(),
+        default={},
+        serialized_name='params',
+        deserialize_from=['params', 'parameters'],
+        metadata=dict(
+            description='The parameters for the feature event.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FeatureEvent:
+        '''
+        Maps the feature event data to a feature event object.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new feature event object.
+        :rtype: FeatureEvent
+        '''
+
+        # Map to the feature event aggregate.
+        return super().map(
+            FeatureEventAggregate,
+            parameters=self.parameters,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(feature_event: FeatureEvent, **kwargs) -> 'FeatureEventYamlObject':
+        '''
+        Creates a FeatureEventYamlObject from a FeatureEvent model.
+
+        :param feature_event: The feature event model.
+        :type feature_event: FeatureEvent
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FeatureEventYamlObject.
+        :rtype: FeatureEventYamlObject
+        '''
+
+        # Create a new FeatureEventYamlObject from the model.
+        return TransferObject.from_model(
+            FeatureEventYamlObject,
+            feature_event,
+            **kwargs,
+        )
+
+# ** mapper: feature_aggregate
+class FeatureAggregate(Feature, Aggregate):
+    '''
+    An aggregate representation of a feature.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        name: str = None,
+        group_id: str = None,
+        feature_key: str = None,
+        id: str = None,
+        description: str = None,
+        validate: bool = True,
+        strict: bool = True,
+        **kwargs
+    ) -> 'FeatureAggregate':
+        '''
+        Initializes a new feature aggregate.
+
+        :param name: The name of the feature.
+        :type name: str
+        :param group_id: The context group identifier of the feature.
+        :type group_id: str
+        :param feature_key: The key of the feature.
+        :type feature_key: str
+        :param id: The identifier of the feature.
+        :type id: str
+        :param description: The description of the feature.
+        :type description: str
+        :param validate: True to validate the aggregate object.
+        :type validate: bool
+        :param strict: True to enforce strict mode for the aggregate object.
+        :type strict: bool
+        :param kwargs: Keyword arguments.
+        :type kwargs: dict
+        :return: A new feature aggregate.
+        :rtype: FeatureAggregate
+        '''
+
+        # Derive group_id and feature_key from id if provided.
+        if id and '.' in id and (not group_id or not feature_key):
+            group_id, feature_key = id.split('.', 1)
+
+        # Set the feature key as the snake case of the name if not provided.
+        if name and not feature_key:
+            feature_key = name.lower().replace(' ', '_')
+
+        # Feature ID is the group ID and feature key separated by a period.
+        if not id and group_id and feature_key:
+            id = f'{group_id}.{feature_key}'
+
+        # Set the description as the name if not provided.
+        if name and not description:
+            description = name
+
+        # Create a new feature aggregate from the provided data.
+        return Aggregate.new(
+            FeatureAggregate,
+            validate=validate,
+            strict=strict,
+            id=id,
+            name=name,
+            group_id=group_id,
+            feature_key=feature_key,
+            description=description,
+            **kwargs
+        )
+
+    # * method: add_step
+    def add_step(
+        self,
+        name: str,
+        attribute_id: str,
+        parameters: Dict[str, Any] | None = None,
+        data_key: str | None = None,
+        pass_on_error: bool = False,
+        position: int | None = None,
+    ) -> FeatureEvent:
+        '''
+        Add a feature event step using raw attributes.
+
+        :param name: Step name.
+        :type name: str
+        :param attribute_id: Container attribute ID.
+        :type attribute_id: str
+        :param parameters: Optional parameters dictionary.
+        :type parameters: dict | None
+        :param data_key: Optional result data key.
+        :type data_key: str | None
+        :param pass_on_error: Whether to pass on errors from this step.
+        :type pass_on_error: bool
+        :param position: Insertion position (None to append).
+        :type position: int | None
+        :return: Created FeatureEvent instance.
+        :rtype: FeatureEvent
+        '''
+
+        # Create the feature event from raw attributes.
+        step = FeatureEventAggregate.new(
+            name=name,
+            attribute_id=attribute_id,
+            parameters=parameters or {},
+            data_key=data_key,
+            pass_on_error=pass_on_error,
+        )
+
+        # Add the feature event step to the feature.
+        if position is not None:
+            self.steps.insert(position, step)
+        else:
+            self.steps.append(step)
+
+        return step
+
+    # * method: get_step
+    def get_step(self, position: int) -> FeatureStep | None:
+        '''
+        Get the feature step at the given position, or ``None`` if the
+        index is out of range or invalid.
+
+        :param position: The index of the step to retrieve.
+        :type position: int
+        :return: The FeatureStep at the position, or None.
+        :rtype: FeatureStep | None
+        '''
+
+        # Attempt to retrieve the step at the specified index.
+        try:
+            return self.steps[position]
+        except (IndexError, TypeError):
+            return None
+
+    # * method: remove_step
+    def remove_step(self, position: int) -> FeatureStep | None:
+        '''
+        Remove and return the feature step at the given position, or
+        return ``None`` if the index is out of range or invalid.
+
+        :param position: The index of the feature step to remove.
+        :type position: int
+        :return: The removed feature step or ``None``.
+        :rtype: FeatureStep | None
+        '''
+
+        # Validate the position argument.
+        if not isinstance(position, int) or position < 0:
+            return None
+
+        # Attempt to remove and return the step at the specified index.
+        try:
+            return self.steps.pop(position)
+        except IndexError:
+            return None
+
+    # * method: reorder_step
+    def reorder_step(self, current_position: int, new_position: int) -> FeatureStep | None:
+        '''
+        Move a feature step from its current position to a new position
+        within the ``steps`` list.
+
+        :param current_position: Current index of the step.
+        :type current_position: int
+        :param new_position: Desired new index.
+        :type new_position: int
+        :return: Moved step or ``None`` if ``current_position`` is invalid.
+        :rtype: FeatureStep | None
+        '''
+
+        # Attempt to remove the step at the current position.
+        try:
+            step = self.steps.pop(current_position)
+        except (IndexError, TypeError):
+            return None
+
+        # Clamp the new position index to the valid range.
+        if new_position < 0:
+            new_position = 0
+        if new_position > len(self.steps):
+            new_position = len(self.steps)
+
+        # Insert the step at the clamped position and return it.
+        self.steps.insert(new_position, step)
+
+        return step
+
+    # * method: rename
+    def rename(self, name: str) -> None:
+        '''
+        Update the display name of the feature.
+
+        :param name: The new name.
+        :type name: str
+        :return: None
+        :rtype: None
+        '''
+
+        self.name = name
+
+        # Perform final aggregate validation.
+        self.validate()
+
+    # * method: set_description
+    def set_description(self, description: str | None) -> None:
+        '''
+        Update the feature description.
+
+        :param description: The new description.
+        :type description: str | None
+        :return: None
+        :rtype: None
+        '''
+
+        self.description = description
+
+
+# ** mapper: feature_yaml_object
+class FeatureYamlObject(Feature, TransferObject):
+    '''
+    A YAML data representation of a feature object.
+    '''
+
+    class Options():
+        '''
+        The options for the feature data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.deny('steps'),
+            'to_data.yaml': TransferObject.deny('feature_key', 'group_id', 'id'),
+            'to_data.json': TransferObject.deny('feature_key', 'group_id', 'id')
+        }
+
+    # * attribute: steps
+    steps = ListType(
+        ModelType(FeatureEventYamlObject),
+        deserialize_from=['handlers', 'functions', 'commands', 'steps'],
+        default=[],
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FeatureAggregate:
+        '''
+        Maps the feature data to a feature aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new feature aggregate.
+        :rtype: FeatureAggregate
+        '''
+
+        # Map the feature data.
+        return super().map(
+            FeatureAggregate,
+            steps=[step.map() for step in (self.steps or [])],
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(feature: Feature, **kwargs) -> 'FeatureYamlObject':
+        '''
+        Creates a FeatureYamlObject from a Feature model.
+
+        :param feature: The feature model.
+        :type feature: Feature
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FeatureYamlObject.
+        :rtype: FeatureYamlObject
+        '''
+
+        # Create a new FeatureYamlObject from the model, converting
+        # the steps list into FeatureEventYamlObject instances.
+        return TransferObject.from_model(
+            FeatureYamlObject,
+            feature,
+            steps=[
+                TransferObject.from_model(FeatureEventYamlObject, step)
+                for step in feature.steps
+            ],
+            **kwargs,
+        )

--- a/tiferet/mappers/logging.py
+++ b/tiferet/mappers/logging.py
@@ -1,0 +1,407 @@
+"""Tiferet Logging Mappers"""
+
+# *** imports
+
+# ** core
+from typing import Dict, Any
+
+# ** app
+from ..domain import (
+    Formatter,
+    Handler,
+    Logger,
+    StringType,
+    DictType,
+    ModelType,
+)
+from .settings import (
+    Aggregate,
+    TransferObject,
+)
+
+# *** mappers
+
+# ** mapper: formatter_aggregate
+class FormatterAggregate(Formatter, Aggregate):
+    '''
+    An aggregate for logging formatter configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'FormatterAggregate':
+        '''
+        Create a new FormatterAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FormatterAggregate.
+        :rtype: FormatterAggregate
+        '''
+
+        # Create a new formatter aggregate from the provided data.
+        return Aggregate.new(
+            FormatterAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: formatter_yaml_object
+class FormatterYamlObject(Formatter, TransferObject):
+    '''
+    A YAML data representation of a logging formatter configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the formatter data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the formatter.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> FormatterAggregate:
+        '''
+        Maps the formatter data to a formatter aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new formatter aggregate.
+        :rtype: FormatterAggregate
+        '''
+
+        # Map to the formatter aggregate.
+        return super().map(
+            FormatterAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(formatter: Formatter, **kwargs) -> 'FormatterYamlObject':
+        '''
+        Creates a FormatterYamlObject from a Formatter model.
+
+        :param formatter: The formatter model.
+        :type formatter: Formatter
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new FormatterYamlObject.
+        :rtype: FormatterYamlObject
+        '''
+
+        # Create a new FormatterYamlObject from the model.
+        return TransferObject.from_model(
+            FormatterYamlObject,
+            formatter,
+            **kwargs,
+        )
+
+
+# ** mapper: handler_aggregate
+class HandlerAggregate(Handler, Aggregate):
+    '''
+    An aggregate for logging handler configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'HandlerAggregate':
+        '''
+        Create a new HandlerAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new HandlerAggregate.
+        :rtype: HandlerAggregate
+        '''
+
+        # Create a new handler aggregate from the provided data.
+        return Aggregate.new(
+            HandlerAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: handler_yaml_object
+class HandlerYamlObject(Handler, TransferObject):
+    '''
+    A YAML data representation of a logging handler configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the handler data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the handler.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> HandlerAggregate:
+        '''
+        Maps the handler data to a handler aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new handler aggregate.
+        :rtype: HandlerAggregate
+        '''
+
+        # Map to the handler aggregate.
+        return super().map(
+            HandlerAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(handler: Handler, **kwargs) -> 'HandlerYamlObject':
+        '''
+        Creates a HandlerYamlObject from a Handler model.
+
+        :param handler: The handler model.
+        :type handler: Handler
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new HandlerYamlObject.
+        :rtype: HandlerYamlObject
+        '''
+
+        # Create a new HandlerYamlObject from the model.
+        return TransferObject.from_model(
+            HandlerYamlObject,
+            handler,
+            **kwargs,
+        )
+
+
+# ** mapper: logger_aggregate
+class LoggerAggregate(Logger, Aggregate):
+    '''
+    An aggregate for logger configuration with domain logic.
+    '''
+
+    # * method: new
+    @staticmethod
+    def new(
+        validate: bool = True,
+        strict: bool = False,
+        **kwargs
+    ) -> 'LoggerAggregate':
+        '''
+        Create a new LoggerAggregate.
+
+        :param validate: Whether to validate the data.
+        :type validate: bool
+        :param strict: Whether to use strict validation.
+        :type strict: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new LoggerAggregate.
+        :rtype: LoggerAggregate
+        '''
+
+        # Create a new logger aggregate from the provided data.
+        return Aggregate.new(
+            LoggerAggregate,
+            validate=validate,
+            strict=strict,
+            **kwargs
+        )
+
+
+# ** mapper: logger_yaml_object
+class LoggerYamlObject(Logger, TransferObject):
+    '''
+    A YAML data representation of a logger configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the logger data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.deny('id'),
+            'to_data.json': TransferObject.deny('id'),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the logger.'
+        )
+    )
+
+    # * method: map
+    def map(self, **kwargs) -> LoggerAggregate:
+        '''
+        Maps the logger data to a logger aggregate.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new logger aggregate.
+        :rtype: LoggerAggregate
+        '''
+
+        # Map to the logger aggregate.
+        return super().map(
+            LoggerAggregate,
+            **self.to_primitive('to_model'),
+            **kwargs
+        )
+
+    # * method: from_model
+    @staticmethod
+    def from_model(logger: Logger, **kwargs) -> 'LoggerYamlObject':
+        '''
+        Creates a LoggerYamlObject from a Logger model.
+
+        :param logger: The logger model.
+        :type logger: Logger
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A new LoggerYamlObject.
+        :rtype: LoggerYamlObject
+        '''
+
+        # Create a new LoggerYamlObject from the model.
+        return TransferObject.from_model(
+            LoggerYamlObject,
+            logger,
+            **kwargs,
+        )
+
+
+# ** mapper: logging_settings_yaml_object
+class LoggingSettingsYamlObject(TransferObject):
+    '''
+    A YAML data representation of the overall logging configuration.
+    '''
+
+    class Options():
+        '''
+        The default options for the logging settings data.
+        '''
+
+        serialize_when_none = False
+        roles = {
+            'to_model': TransferObject.allow(),
+            'to_data.yaml': TransferObject.allow(),
+            'to_data.json': TransferObject.allow(),
+        }
+
+    # * attribute: id
+    id = StringType(
+        metadata=dict(
+            description='The unique identifier of the logging settings.'
+        )
+    )
+
+    # * attribute: formatters
+    formatters = DictType(
+        ModelType(FormatterYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of formatter configurations, keyed by id.'
+        )
+    )
+
+    # * attribute: handlers
+    handlers = DictType(
+        ModelType(HandlerYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of handler configurations, keyed by id.'
+        )
+    )
+
+    # * attribute: loggers
+    loggers = DictType(
+        ModelType(LoggerYamlObject),
+        required=True,
+        metadata=dict(
+            description='Dictionary of logger configurations, keyed by id.'
+        )
+    )
+
+    # * method: from_data
+    @staticmethod
+    def from_data(**data) -> 'LoggingSettingsYamlObject':
+        '''
+        Initializes a new LoggingSettingsYamlObject from a data representation.
+
+        :param data: The data to initialize the LoggingSettingsYamlObject.
+        :type data: dict
+        :return: A new LoggingSettingsYamlObject.
+        :rtype: LoggingSettingsYamlObject
+        '''
+
+        # Create a new LoggingSettingsYamlObject from the provided data,
+        # injecting dictionary keys as id attributes.
+        return TransferObject.from_data(
+            LoggingSettingsYamlObject,
+            formatters={id: TransferObject.from_data(
+                FormatterYamlObject,
+                **formatter_data,
+                id=id
+            ) for id, formatter_data in data.get('formatters', {}).items()},
+            handlers={id: TransferObject.from_data(
+                HandlerYamlObject,
+                **handler_data,
+                id=id
+            ) for id, handler_data in data.get('handlers', {}).items()},
+            loggers={id: TransferObject.from_data(
+                LoggerYamlObject,
+                **logger_data,
+                id=id
+            ) for id, logger_data in data.get('loggers', {}).items()},
+        )

--- a/tiferet/mappers/tests/test_app.py
+++ b/tiferet/mappers/tests/test_app.py
@@ -1,0 +1,616 @@
+"""Tiferet App Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...domain import AppServiceDependency, DomainObject
+from ...assets import TiferetError
+from ..settings import TransferObject, DEFAULT_MODULE_PATH, DEFAULT_CLASS_NAME
+from ..app import AppInterfaceAggregate, AppInterfaceYamlObject, AppServiceDependencyYamlObject
+
+# *** fixtures
+
+# ** fixture: app_interface_yaml_obj
+@pytest.fixture
+def app_interface_yaml_obj() -> AppInterfaceYamlObject:
+    '''
+    A fixture for an app interface yaml data object.
+
+    :return: The app interface yaml data object.
+    :rtype: AppInterfaceYamlObject
+    '''
+
+    # Create and return the app interface yaml data object.
+    return TransferObject.from_data(
+        AppInterfaceYamlObject,
+        id='app_yaml_data',
+        name='Test App YAML Data',
+        module_path=DEFAULT_MODULE_PATH,
+        class_name=DEFAULT_CLASS_NAME,
+        flags=['test_app_yaml_data'],
+        services=dict(
+            test_attribute=dict(
+                module_path='test_module_path',
+                class_name='test_class_name',
+                parameters=dict(
+                    test_param='test_value',
+                )
+            )
+        ),
+        constants=dict(
+            test_const='test_const_value',
+        )
+    )
+
+# ** fixture: app_interface_aggr
+@pytest.fixture
+def app_interface_aggr() -> AppInterfaceAggregate:
+    '''
+    Fixture to provide a sample AppInterface model for round-trip testing.
+
+    :return: A sample AppInterface instance.
+    :rtype: AppInterfaceAggregate
+    '''
+
+    # Create and return a sample AppInterfaceAggregate instance.
+    app_interface_data = {
+        'id': 'test.interface',
+        'name': 'Test Interface',
+        'description': 'The test app interface.',
+        'module_path': DEFAULT_MODULE_PATH,
+        'class_name': DEFAULT_CLASS_NAME,
+        'flags': ['test_feature', 'test_data'],
+        'services': [
+            {
+                'attribute_id': 'test_attribute',
+                'module_path': 'test_module_path',
+                'class_name': 'test_class_name',
+                'parameters': {
+                    'test_param': 'test_value',
+                },
+            }
+        ],
+        'constants': {
+            'TEST_CONST': 'test_const_value',
+        }
+    }
+
+    return AppInterfaceAggregate.new(app_interface_data=app_interface_data)
+
+# *** tests
+
+# ** test: app_interface_aggregate_new
+def test_app_interface_aggregate_new(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test creating an AppInterfaceAggregate.
+
+    :param app_interface_aggr: The app interface aggregate fixture.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(app_interface_aggr, AppInterfaceAggregate)
+    assert app_interface_aggr.id == 'test.interface'
+    assert app_interface_aggr.name == 'Test Interface'
+    assert app_interface_aggr.module_path == DEFAULT_MODULE_PATH
+    assert app_interface_aggr.class_name == DEFAULT_CLASS_NAME
+
+# ** test: app_interface_aggregate_set_attribute_valid_updates
+def test_app_interface_aggregate_set_attribute_valid_updates(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_attribute successfully updates supported attributes and validates the aggregate.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Update multiple supported attributes.
+    app_interface_aggr.set_attribute('name', 'Updated App')
+    app_interface_aggr.set_attribute('description', 'Updated description')
+    app_interface_aggr.set_attribute('logger_id', 'updated_logger')
+    app_interface_aggr.set_attribute('flags', ['updated_flag'])
+
+    # Assert that the attributes were updated.
+    assert app_interface_aggr.name == 'Updated App'
+    assert app_interface_aggr.description == 'Updated description'
+    assert app_interface_aggr.logger_id == 'updated_logger'
+    assert app_interface_aggr.flags == ['updated_flag']
+
+# ** test: app_interface_aggregate_set_attribute_invalid_name
+def test_app_interface_aggregate_set_attribute_invalid_name(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_attribute rejects an unsupported attribute name.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Attempt to update an unsupported attribute and expect a TiferetError.
+    with pytest.raises(TiferetError) as exc_info:
+        app_interface_aggr.set_attribute('invalid_attribute', 'value')
+
+    # Verify that the correct error code is raised.
+    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
+    assert exc_info.value.kwargs.get('attribute') == 'invalid_attribute'
+
+# ** test: app_interface_aggregate_set_attribute_invalid_module_path
+def test_app_interface_aggregate_set_attribute_invalid_module_path(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_attribute enforces non-empty string for module_path.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Attempt to set an empty module_path and expect a TiferetError.
+    with pytest.raises(TiferetError) as exc_info:
+        app_interface_aggr.set_attribute('module_path', '')
+
+    # Verify that the correct error code is raised.
+    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
+    assert exc_info.value.kwargs.get('attribute') == 'module_path'
+
+# ** test: app_interface_aggregate_set_attribute_invalid_class_name
+def test_app_interface_aggregate_set_attribute_invalid_class_name(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_attribute enforces non-empty string for class_name.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Attempt to set a blank class_name and expect a TiferetError.
+    with pytest.raises(TiferetError) as exc_info:
+        app_interface_aggr.set_attribute('class_name', '   ')
+
+    # Verify that the correct error code is raised.
+    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
+    assert exc_info.value.kwargs.get('attribute') == 'class_name'
+
+# ** test: app_interface_aggregate_set_constants_clears_when_none
+def test_app_interface_aggregate_set_constants_clears_when_none(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_constants clears all constants when called with None.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed existing constants on the aggregate.
+    app_interface_aggr.constants = {
+        'existing': 'value',
+        'another': 'value',
+    }
+
+    # Call set_constants with None to clear all constants.
+    app_interface_aggr.set_constants(None)
+
+    # All constants should be cleared.
+    assert app_interface_aggr.constants == {}
+
+# ** test: app_interface_aggregate_set_constants_merges_and_overrides
+def test_app_interface_aggregate_set_constants_merges_and_overrides(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_constants merges new constants and overrides existing keys.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed existing constants on the aggregate.
+    app_interface_aggr.constants = {
+        'keep': 'original',
+        'override': 'old',
+    }
+
+    # Merge new constants, overriding existing keys and adding new ones.
+    app_interface_aggr.set_constants(
+        {
+            'override': 'new',
+            'add': 'added',
+        },
+    )
+
+    # Existing keys should be preserved or overridden as appropriate.
+    assert app_interface_aggr.constants == {
+        'keep': 'original',
+        'override': 'new',
+        'add': 'added',
+    }
+
+# ** test: app_interface_aggregate_set_constants_removes_none_valued_keys
+def test_app_interface_aggregate_set_constants_removes_none_valued_keys(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_constants removes keys whose new value is None.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed existing constants on the aggregate.
+    app_interface_aggr.constants = {
+        'keep': 'value',
+        'remove': 'value',
+    }
+
+    # Provide an update that sets one key to None.
+    app_interface_aggr.set_constants(
+        {
+            'remove': None,
+        },
+    )
+
+    # The key set to None should be removed, and others preserved.
+    assert app_interface_aggr.constants == {
+        'keep': 'value',
+    }
+
+# ** test: app_interface_aggregate_set_constants_mixed_operations
+def test_app_interface_aggregate_set_constants_mixed_operations(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test that set_constants supports mixed operations of clearing, overriding,
+    adding, and preserving keys in a single call.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed existing constants on the aggregate.
+    app_interface_aggr.constants = {
+        'remove': 'value',
+        'override': 'old',
+        'preserve': 'present',
+    }
+
+    # Perform a mixed update.
+    app_interface_aggr.set_constants(
+        {
+            'remove': None,
+            'override': 'new',
+            'add': 'added',
+        },
+    )
+
+    # Verify mixed behavior across keys.
+    assert app_interface_aggr.constants == {
+        'override': 'new',
+        'preserve': 'present',
+        'add': 'added',
+    }
+
+# ** test: app_interface_aggregate_remove_service_removes_matching_from_middle_start_end
+def test_app_interface_aggregate_remove_service_removes_matching_from_middle_start_end() -> None:
+    '''
+    Test that remove_service removes and returns services when attribute_id
+    matches for items in the middle, start, and end positions.
+    '''
+
+    # Create three service dependencies with distinct attribute_ids.
+    first = DomainObject.new(
+        AppServiceDependency,
+        attribute_id='first',
+        module_path='module.first',
+        class_name='FirstClass',
+    )
+    middle = DomainObject.new(
+        AppServiceDependency,
+        attribute_id='middle',
+        module_path='module.middle',
+        class_name='MiddleClass',
+    )
+    last = DomainObject.new(
+        AppServiceDependency,
+        attribute_id='last',
+        module_path='module.last',
+        class_name='LastClass',
+    )
+
+    # Create an app interface aggregate seeded with the three services.
+    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+        services=[first, middle, last],
+    ))
+
+    # Remove the middle service and verify it is returned and removed.
+    removed_middle = app_interface.remove_service('middle')
+    assert removed_middle is not None
+    assert removed_middle.attribute_id == 'middle'
+    assert [svc.attribute_id for svc in app_interface.services] == ['first', 'last']
+
+    # Remove the first service and verify it is returned and removed.
+    removed_first = app_interface.remove_service('first')
+    assert removed_first is not None
+    assert removed_first.attribute_id == 'first'
+    assert [svc.attribute_id for svc in app_interface.services] == ['last']
+
+    # Remove the last remaining service and verify it is returned and removed.
+    removed_last = app_interface.remove_service('last')
+    assert removed_last is not None
+    assert removed_last.attribute_id == 'last'
+    assert app_interface.services == []
+
+# ** test: app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify
+def test_app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify() -> None:
+    '''
+    Test that remove_service returns None and leaves the services list
+    unchanged when no service with the given attribute_id exists.
+    '''
+
+    # Create two service dependencies and an app interface aggregate seeded with them.
+    first = DomainObject.new(
+        AppServiceDependency,
+        attribute_id='first',
+        module_path='module.first',
+        class_name='FirstClass',
+    )
+    second = DomainObject.new(
+        AppServiceDependency,
+        attribute_id='second',
+        module_path='module.second',
+        class_name='SecondClass',
+    )
+    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+        services=[first, second],
+    ))
+
+    # Capture the original list of services for comparison.
+    original_services = list(app_interface.services)
+
+    # Attempt to remove a non-existent service.
+    result = app_interface.remove_service('missing')
+
+    # Verify the method returns None and the list is unchanged.
+    assert result is None
+    assert app_interface.services == original_services
+
+# ** test: app_interface_aggregate_remove_service_on_empty_services_returns_none
+def test_app_interface_aggregate_remove_service_on_empty_services_returns_none() -> None:
+    '''
+    Test that remove_service returns None when called on an app interface aggregate with
+    an empty services list.
+    '''
+
+    # Create an app interface aggregate with no services.
+    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+        services=[],
+    ))
+
+    # Attempt to remove any service and verify None is returned.
+    result = app_interface.remove_service('anything')
+    assert result is None
+
+# ** test: app_interface_aggregate_set_service_updates_existing_and_merges_parameters
+def test_app_interface_aggregate_set_service_updates_existing_and_merges_parameters(
+    app_interface_aggr: AppInterfaceAggregate,
+) -> None:
+    '''
+    Test that set_service updates an existing dependency and merges parameters,
+    removing keys whose values are None.
+
+    :param app_interface_aggr: The app interface aggregate to test.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed existing parameters on the dependency.
+    dependency = app_interface_aggr.get_service('test_attribute')
+    dependency.parameters = {
+        'keep': 'original',
+        'override': 'old',
+        'remove': 'value',
+    }
+
+    # Perform an update with new type information and parameter overrides.
+    app_interface_aggr.set_service(
+        attribute_id='test_attribute',
+        module_path='updated.module',
+        class_name='UpdatedClass',
+        parameters={
+            'override': 'new',
+            'remove': None,
+            'add': 'added',
+        },
+    )
+
+    # Reload the dependency and assert type fields were updated.
+    updated = app_interface_aggr.get_service('test_attribute')
+    assert updated.module_path == 'updated.module'
+    assert updated.class_name == 'UpdatedClass'
+
+    # Existing parameters should be merged, with None-valued keys removed.
+    assert updated.parameters == {
+        'keep': 'original',
+        'override': 'new',
+        'add': 'added',
+    }
+
+# ** test: app_interface_aggregate_set_service_clears_parameters_when_none
+def test_app_interface_aggregate_set_service_clears_parameters_when_none(
+    app_interface_aggr: AppInterfaceAggregate,
+) -> None:
+    '''
+    Test that set_service clears parameters when parameters is None.
+
+    :param app_interface_aggr: The app interface aggregate to test.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Seed parameters on the dependency.
+    dependency = app_interface_aggr.get_service('test_attribute')
+    dependency.parameters = {
+        'existing': 'value',
+    }
+
+    # Call set_service with parameters=None.
+    app_interface_aggr.set_service(
+        attribute_id='test_attribute',
+        module_path='cleared.module',
+        class_name='ClearedClass',
+        parameters=None,
+    )
+
+    # Parameters should be cleared while type fields are updated.
+    updated = app_interface_aggr.get_service('test_attribute')
+    assert updated.module_path == 'cleared.module'
+    assert updated.class_name == 'ClearedClass'
+    assert updated.parameters == {}
+
+# ** test: app_interface_aggregate_set_service_creates_new
+def test_app_interface_aggregate_set_service_creates_new(
+    app_interface_aggr: AppInterfaceAggregate,
+) -> None:
+    '''
+    Test that set_service creates a new dependency when none exists.
+
+    :param app_interface_aggr: The app interface aggregate to test.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Ensure that no dependency exists with the new attribute_id.
+    assert app_interface_aggr.get_service('new_attribute') is None
+
+    # Create a new dependency via set_service.
+    app_interface_aggr.set_service(
+        attribute_id='new_attribute',
+        module_path='new.module',
+        class_name='NewClass',
+        parameters={
+            'param': 'value',
+        },
+    )
+
+    # Verify that the dependency was created with the correct values.
+    new_svc = app_interface_aggr.get_service('new_attribute')
+    assert new_svc is not None
+    assert new_svc.module_path == 'new.module'
+    assert new_svc.class_name == 'NewClass'
+    assert new_svc.parameters == {'param': 'value'}
+
+# ** test: app_attribute_yaml_object_map
+def test_app_attribute_yaml_object_map():
+    '''
+    Test mapping an AppServiceDependencyYamlObject to an AppServiceDependency entity.
+    '''
+
+    # Create an AppServiceDependencyYamlObject.
+    yaml_obj = TransferObject.from_data(
+        AppServiceDependencyYamlObject,
+        module_path='test.module',
+        class_name='TestClass',
+        parameters={'key': 'value'},
+    )
+
+    # Map to entity.
+    entity = yaml_obj.map(attribute_id='test_attr')
+
+    # Assert the mapping is correct.
+    assert isinstance(entity, AppServiceDependency)
+    assert entity.attribute_id == 'test_attr'
+    assert entity.module_path == 'test.module'
+    assert entity.class_name == 'TestClass'
+    assert entity.parameters == {'key': 'value'}
+
+# ** test: app_interface_yaml_object_from_model
+def test_app_interface_yaml_object_from_model(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test creating an AppInterfaceYamlObject from an AppInterfaceAggregate.
+
+    :param app_interface_aggr: The app interface aggregate.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Create YamlObject from aggregate using the custom from_model method.
+    yaml_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
+
+    # Assert the conversion is correct.
+    assert isinstance(yaml_obj, AppInterfaceYamlObject)
+    assert yaml_obj.id == app_interface_aggr.id
+    assert yaml_obj.name == app_interface_aggr.name
+    assert yaml_obj.module_path == app_interface_aggr.module_path
+    assert yaml_obj.class_name == app_interface_aggr.class_name
+    assert 'test_attribute' in yaml_obj.services
+    assert yaml_obj.constants == app_interface_aggr.constants
+
+# ** test: app_settings_yaml_data_map
+def test_app_settings_yaml_data_map(app_interface_yaml_obj: AppInterfaceYamlObject):
+    '''
+    Tests the mapping of an app interface yaml data object to an app interface object.
+
+    :param app_interface_yaml_obj: The app interface yaml data object.
+    :type app_interface_yaml_obj: AppInterfaceYamlObject
+    '''
+
+    # Map the app interface yaml data to an app interface object.
+    app_settings = app_interface_yaml_obj.map()
+
+    # Assert the mapped app interface is valid.
+    assert isinstance(app_settings, AppInterfaceAggregate)
+    assert app_settings.id == app_interface_yaml_obj.id
+    assert app_settings.name == app_interface_yaml_obj.name
+    assert app_settings.flags == app_interface_yaml_obj.flags
+
+    # Assert that the module path and class name are correctly set.
+    assert app_settings.module_path == DEFAULT_MODULE_PATH
+    assert app_settings.class_name == DEFAULT_CLASS_NAME
+
+    # Assert that the mapped service contains the correct data.
+    svc = next(
+        svc for svc in app_settings.services if svc.attribute_id == 'test_attribute')
+    assert svc is not None
+    assert isinstance(svc, AppServiceDependency)
+    assert svc.module_path == 'test_module_path'
+    assert svc.class_name == 'test_class_name'
+
+    # Assert that the parameters are correctly set.
+    param = next(
+        (p for p in svc.parameters if p == 'test_param'), None)
+    assert param is not None
+    assert param == 'test_param'
+    assert svc.parameters['test_param'] == 'test_value'
+
+    # Assert that the constants are correctly set.
+    assert app_settings.constants
+    assert app_settings.constants['test_const'] == 'test_const_value'
+
+# ** test: app_interface_config_data_round_trip
+def test_app_interface_config_data_round_trip(app_interface_aggr: AppInterfaceAggregate):
+    '''
+    Test round-trip mapping: app interface aggregate -> app interface yaml object -> app interface aggregate.
+
+    :param app_interface_aggr: The app interface aggregate fixture.
+    :type app_interface_aggr: AppInterfaceAggregate
+    '''
+
+    # Convert aggregate to yaml object and back to aggregate.
+    data_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
+    round_tripped = data_obj.map()
+
+    # Assert core fields match.
+    assert round_tripped.id == app_interface_aggr.id
+    assert round_tripped.name == app_interface_aggr.name
+    assert round_tripped.module_path == app_interface_aggr.module_path
+    assert round_tripped.class_name == app_interface_aggr.class_name
+
+    # Assert services match field-by-field.
+    assert len(round_tripped.services) == len(app_interface_aggr.services)
+    for orig_svc, rt_svc in zip(app_interface_aggr.services, round_tripped.services):
+        assert rt_svc.attribute_id == orig_svc.attribute_id
+        assert rt_svc.module_path == orig_svc.module_path
+        assert rt_svc.class_name == orig_svc.class_name
+        assert rt_svc.parameters == orig_svc.parameters
+
+    # Assert constants match.
+    assert round_tripped.constants == app_interface_aggr.constants

--- a/tiferet/mappers/tests/test_cli.py
+++ b/tiferet/mappers/tests/test_cli.py
@@ -1,0 +1,302 @@
+"""Tiferet CLI Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...domain import CliArgument, CliCommand, DomainObject
+from ...assets import TiferetError
+from ..settings import TransferObject
+from ..cli import CliArgumentAggregate, CliCommandAggregate, CliCommandYamlObject
+
+# *** fixtures
+
+# ** fixture: cli_command_yaml_object
+@pytest.fixture
+def cli_command_yaml_object() -> CliCommandYamlObject:
+    '''
+    A fixture for a CLI command YAML data object with two arguments using the args alias.
+
+    :return: The CLI command YAML data object.
+    :rtype: CliCommandYamlObject
+    '''
+
+    # Create and return the CLI command YAML data object.
+    return TransferObject.from_data(
+        CliCommandYamlObject,
+        id='calc.add',
+        name='Add Number Command',
+        description='Adds two numbers.',
+        key='add',
+        group_key='calc',
+        args=[
+            dict(
+                name_or_flags=['a'],
+                description='The first number to add.',
+                type='str',
+            ),
+            dict(
+                name_or_flags=['b'],
+                description='The second number to add.',
+                type='str',
+            ),
+        ],
+    )
+
+# *** tests
+
+# ** test: cli_command_yaml_object_from_data
+def test_cli_command_yaml_object_from_data(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that the CliCommandYamlObject can be initialized from data with correct
+    attributes and two arguments using the args alias.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Assert the data is correctly initialized.
+    assert isinstance(cli_command_yaml_object, CliCommandYamlObject)
+    assert cli_command_yaml_object.id == 'calc.add'
+    assert cli_command_yaml_object.name == 'Add Number Command'
+    assert cli_command_yaml_object.description == 'Adds two numbers.'
+    assert cli_command_yaml_object.key == 'add'
+    assert cli_command_yaml_object.group_key == 'calc'
+
+    # Assert the arguments are correctly initialized.
+    assert len(cli_command_yaml_object.arguments) == 2
+    assert cli_command_yaml_object.arguments[0].name_or_flags == ['a']
+    assert cli_command_yaml_object.arguments[0].description == 'The first number to add.'
+    assert cli_command_yaml_object.arguments[1].name_or_flags == ['b']
+    assert cli_command_yaml_object.arguments[1].description == 'The second number to add.'
+
+
+# ** test: cli_command_yaml_object_map
+def test_cli_command_yaml_object_map(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that map() produces a CliCommandAggregate with correct arguments.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Map the CLI command YAML data to a CLI command aggregate.
+    aggregate = cli_command_yaml_object.map()
+
+    # Assert the mapped aggregate is valid.
+    assert isinstance(aggregate, CliCommandAggregate)
+    assert aggregate.id == 'calc.add'
+    assert aggregate.name == 'Add Number Command'
+    assert aggregate.key == 'add'
+    assert aggregate.group_key == 'calc'
+
+    # Assert the arguments are correctly mapped.
+    assert len(aggregate.arguments) == 2
+    assert aggregate.arguments[0].name_or_flags == ['a']
+    assert aggregate.arguments[1].name_or_flags == ['b']
+
+
+# ** test: cli_command_yaml_object_to_primitive
+def test_cli_command_yaml_object_to_primitive(cli_command_yaml_object: CliCommandYamlObject):
+    '''
+    Test that custom to_primitive('to_data.yaml') serializes args correctly.
+
+    :param cli_command_yaml_object: The CLI command YAML data object.
+    :type cli_command_yaml_object: CliCommandYamlObject
+    '''
+
+    # Serialize the data to primitive format for YAML.
+    primitive = cli_command_yaml_object.to_primitive('to_data.yaml')
+
+    # Assert the primitive data is a dict with the expected keys.
+    assert isinstance(primitive, dict)
+    assert 'id' not in primitive
+    assert 'args' in primitive
+    assert len(primitive['args']) == 2
+    assert primitive['args'][0]['name_or_flags'] == ['a']
+    assert primitive['args'][1]['name_or_flags'] == ['b']
+    assert primitive['name'] == 'Add Number Command'
+    assert primitive['key'] == 'add'
+    assert primitive['group_key'] == 'calc'
+
+
+# ** test: cli_command_yaml_object_from_model
+def test_cli_command_yaml_object_from_model():
+    '''
+    Test that from_model() from CliCommand.new() produces a valid YAML object.
+    '''
+
+    # Create a CliCommand domain object using the factory method.
+    cli_command = CliCommand.new(
+        group_key='calc',
+        key='subtract',
+        name='Subtract Number Command',
+        description='Subtracts one number from another.',
+        arguments=[
+            DomainObject.new(
+                CliArgument,
+                name_or_flags=['a'],
+                description='The number to subtract from.',
+            ),
+        ],
+    )
+
+    # Create a CliCommandYamlObject from the model.
+    yaml_obj = CliCommandYamlObject.from_model(cli_command)
+
+    # Assert the YAML object is valid.
+    assert isinstance(yaml_obj, CliCommandYamlObject)
+    assert yaml_obj.id == 'calc.subtract'
+    assert yaml_obj.name == 'Subtract Number Command'
+    assert yaml_obj.key == 'subtract'
+    assert yaml_obj.group_key == 'calc'
+    assert len(yaml_obj.arguments) == 1
+    assert yaml_obj.arguments[0].name_or_flags == ['a']
+
+
+# ** test: cli_command_aggregate_new
+def test_cli_command_aggregate_new():
+    '''
+    Test that CliCommandAggregate.new() creates an aggregate with correct fields.
+    '''
+
+    # Create a new CLI command aggregate.
+    aggregate = CliCommandAggregate.new(
+        id='calc.multiply',
+        name='Multiply Number Command',
+        description='Multiplies two numbers.',
+        key='multiply',
+        group_key='calc',
+        arguments=[],
+    )
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(aggregate, CliCommandAggregate)
+    assert aggregate.id == 'calc.multiply'
+    assert aggregate.name == 'Multiply Number Command'
+    assert aggregate.description == 'Multiplies two numbers.'
+    assert aggregate.key == 'multiply'
+    assert aggregate.group_key == 'calc'
+    assert aggregate.arguments == []
+
+
+# ** test: cli_command_aggregate_add_argument
+def test_cli_command_aggregate_add_argument():
+    '''
+    Test that add_argument() correctly adds a CliArgument to the aggregate.
+    '''
+
+    # Create a CLI command aggregate with no arguments.
+    aggregate = CliCommandAggregate.new(
+        id='calc.divide',
+        name='Divide Number Command',
+        key='divide',
+        group_key='calc',
+    )
+
+    # Add an argument to the command.
+    aggregate.add_argument(
+        name_or_flags=['a'],
+        description='The numerator.',
+        type='int',
+    )
+
+    # Assert the argument was added.
+    assert len(aggregate.arguments) == 1
+    assert isinstance(aggregate.arguments[0], CliArgument)
+    assert aggregate.arguments[0].name_or_flags == ['a']
+    assert aggregate.arguments[0].description == 'The numerator.'
+    assert aggregate.arguments[0].type == 'int'
+
+
+# ** test: cli_command_aggregate_set_attribute
+def test_cli_command_aggregate_set_attribute():
+    '''
+    Test that set_attribute() updates supported attributes on the CLI command aggregate.
+    '''
+
+    # Create a CLI command aggregate.
+    aggregate = CliCommandAggregate.new(
+        id='calc.exp',
+        name='Exponentiate Number Command',
+        key='exp',
+        group_key='calc',
+    )
+
+    # Update supported attributes.
+    aggregate.set_attribute('name', 'Updated Exp Command')
+    aggregate.set_attribute('description', 'Raises a number to a power.')
+
+    # Assert the attributes were updated.
+    assert aggregate.name == 'Updated Exp Command'
+    assert aggregate.description == 'Raises a number to a power.'
+
+
+# ** test: cli_argument_aggregate_new
+def test_cli_argument_aggregate_new():
+    '''
+    Test that CliArgumentAggregate.new() creates an aggregate with all supported fields.
+    '''
+
+    # Create a new CLI argument aggregate with all supported fields.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['-v', '--verbose'],
+        description='Enable verbose output.',
+        type='str',
+        required=False,
+        default='false',
+        action='store_true',
+    )
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(aggregate, CliArgumentAggregate)
+    assert aggregate.name_or_flags == ['-v', '--verbose']
+    assert aggregate.description == 'Enable verbose output.'
+    assert aggregate.type == 'str'
+    assert aggregate.required is False
+    assert aggregate.default == 'false'
+    assert aggregate.action == 'store_true'
+
+
+# ** test: cli_argument_aggregate_set_attribute
+def test_cli_argument_aggregate_set_attribute():
+    '''
+    Test that set_attribute() updates supported attributes on the CLI argument aggregate.
+    '''
+
+    # Create a CLI argument aggregate.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['a'],
+        description='Original description.',
+    )
+
+    # Update supported attributes.
+    aggregate.set_attribute('description', 'Updated description.')
+    aggregate.set_attribute('required', True)
+
+    # Assert the attributes were updated.
+    assert aggregate.description == 'Updated description.'
+    assert aggregate.required is True
+
+
+# ** test: cli_argument_aggregate_set_attribute_invalid
+def test_cli_argument_aggregate_set_attribute_invalid():
+    '''
+    Test that set_attribute() raises TiferetError for unsupported attributes (name_or_flags).
+    '''
+
+    # Create a CLI argument aggregate.
+    aggregate = CliArgumentAggregate.new(
+        name_or_flags=['a'],
+        description='Test argument.',
+    )
+
+    # Attempt to set an unsupported attribute and expect a TiferetError.
+    with pytest.raises(TiferetError) as exc_info:
+        aggregate.set_attribute('name_or_flags', ['b'])
+
+    # Verify that the correct error code is raised.
+    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
+    assert exc_info.value.kwargs.get('attribute') == 'name_or_flags'

--- a/tiferet/mappers/tests/test_di.py
+++ b/tiferet/mappers/tests/test_di.py
@@ -1,0 +1,561 @@
+"""Tiferet DI Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..di import (
+    FlaggedDependencyAggregate,
+    FlaggedDependencyYamlObject,
+    ServiceConfigurationAggregate,
+    ServiceConfigurationYamlObject,
+)
+from ...domain import (
+    DomainObject,
+    FlaggedDependency,
+)
+
+# *** fixtures
+
+# ** fixture: flagged_dependency_aggregate
+@pytest.fixture
+def flagged_dependency_aggregate() -> FlaggedDependencyAggregate:
+    '''
+    Provides a fixture for a FlaggedDependencyAggregate instance.
+
+    :return: The FlaggedDependencyAggregate instance.
+    :rtype: FlaggedDependencyAggregate
+    '''
+
+    # Create and return a FlaggedDependencyAggregate.
+    return FlaggedDependencyAggregate.new(
+        flagged_dependency_data=dict(
+            module_path='tests.repos.test',
+            class_name='TestRepoProxy',
+            flag='test',
+            parameters={'keep': 'original', 'override': 'old'},
+        )
+    )
+
+# ** fixture: service_configuration_aggregate
+@pytest.fixture
+def service_configuration_aggregate() -> ServiceConfigurationAggregate:
+    '''
+    Provides a fixture for a ServiceConfigurationAggregate instance.
+
+    :return: The ServiceConfigurationAggregate instance.
+    :rtype: ServiceConfigurationAggregate
+    '''
+
+    # Create and return a ServiceConfigurationAggregate with one seeded dependency.
+    return ServiceConfigurationAggregate.new(
+        service_configuration_data=dict(
+            id='test_repo',
+            module_path='tests.repos.test',
+            class_name='DefaultTestRepoProxy',
+            parameters={'default_param': 'default_value'},
+            dependencies=[
+                DomainObject.new(
+                    FlaggedDependency,
+                    module_path='tests.repos.test',
+                    class_name='TestRepoProxy',
+                    flag='existing',
+                    parameters={'param1': 'value1'},
+                )
+            ],
+        )
+    )
+
+# ** fixture: flagged_dependency_yaml_object
+@pytest.fixture
+def flagged_dependency_yaml_object() -> FlaggedDependencyYamlObject:
+    '''
+    Provides a fixture for FlaggedDependency YAML object.
+
+    :return: The FlaggedDependencyYamlObject instance.
+    :rtype: FlaggedDependencyYamlObject
+    '''
+
+    # Create and return a FlaggedDependencyYamlObject.
+    return TransferObject.from_data(
+        FlaggedDependencyYamlObject,
+        module_path='tests.repos.test',
+        class_name='TestRepoProxy',
+        flag='test',
+        params=dict(
+            test_param='test_value'
+        )
+    )
+
+# ** fixture: service_configuration_yaml_object
+@pytest.fixture
+def service_configuration_yaml_object() -> ServiceConfigurationYamlObject:
+    '''
+    Provides a fixture for ServiceConfiguration YAML object.
+
+    :return: The ServiceConfigurationYamlObject instance.
+    :rtype: ServiceConfigurationYamlObject
+    '''
+
+    # Create and return a ServiceConfigurationYamlObject.
+    return TransferObject.from_data(
+        ServiceConfigurationYamlObject,
+        id='test_repo',
+        module_path='tests.repos.test',
+        class_name='DefaultTestRepoProxy',
+        deps=dict(
+            test=dict(
+                module_path='tests.repos.test',
+                class_name='TestRepoProxy',
+                params={'test_param': 'test_value'}
+            ),
+            test2=dict(
+                module_path='tests.repos.test',
+                class_name='TestRepoProxy2',
+                params={'param2': 'value2'}
+            )
+        ),
+        params=dict(
+            test_param='test_value',
+            param0='value0'
+        )
+    )
+
+# ** fixture: flagged_dependency_model
+@pytest.fixture
+def flagged_dependency_model(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
+    '''
+    Fixture to create a FlaggedDependency model instance for testing.
+
+    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
+    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
+    :return: The FlaggedDependency model instance.
+    :rtype: FlaggedDependency
+    '''
+
+    # Map the YAML object to a FlaggedDependency model.
+    model = flagged_dependency_yaml_object.map()
+    model.class_name = 'TestRepoProxy2'
+    model.parameters = {'test_param2': 'test_value2'}
+
+    # Return the model object.
+    return model
+
+# *** tests
+
+# ** test: service_configuration_yaml_object_to_primitive_to_data_yaml
+def test_service_configuration_yaml_object_to_primitive_to_data_yaml(service_configuration_yaml_object: ServiceConfigurationYamlObject):
+    '''
+    Test that the ServiceConfigurationYamlObject can be serialized to primitive data for YAML.
+
+    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
+    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
+    '''
+
+    # Serialize the data to primitive format for YAML.
+    primitive_data = service_configuration_yaml_object.to_primitive(role='to_data.yaml')
+
+    # Check if the primitive data is correct.
+    assert isinstance(primitive_data, dict)
+    assert primitive_data == {
+        'module_path': 'tests.repos.test',
+        'class_name': 'DefaultTestRepoProxy',
+        'deps': {
+            'test': {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy',
+                'params': {'test_param': 'test_value'}
+            },
+            'test2': {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy2',
+                'params': {'param2': 'value2'}
+            },
+        },
+        'params': {
+            'test_param': 'test_value',
+            'param0': 'value0'
+        }
+    }
+
+# ** test: flagged_dependency_yaml_data_from_data
+def test_flagged_dependency_yaml_data_from_data(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
+    '''
+    Test that the FlaggedDependencyYamlObject can be initialized from data.
+
+    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
+    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
+    '''
+
+    # Check if the data is correctly initialized.
+    assert flagged_dependency_yaml_object.module_path == 'tests.repos.test'
+    assert flagged_dependency_yaml_object.class_name == 'TestRepoProxy'
+    assert flagged_dependency_yaml_object.flag == 'test'
+    assert flagged_dependency_yaml_object.parameters == {'test_param': 'test_value'}
+
+# ** test: flagged_dependency_yaml_data_map
+def test_flagged_dependency_yaml_data_map(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
+    '''
+    Test that the FlaggedDependencyYamlObject can be mapped to a FlaggedDependency object.
+
+    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
+    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
+    '''
+
+    # Map the data to a flagged dependency object.
+    mapped_dep = flagged_dependency_yaml_object.map()
+
+    # Check if the mapped object is of the correct type.
+    assert isinstance(mapped_dep, FlaggedDependency)
+    assert mapped_dep.module_path == 'tests.repos.test'
+    assert mapped_dep.class_name == 'TestRepoProxy'
+    assert mapped_dep.flag == 'test'
+    assert mapped_dep.parameters == {'test_param': 'test_value'}
+
+# ** test: flagged_dependency_yaml_data_from_model
+def test_flagged_dependency_yaml_data_from_model(flagged_dependency_model: FlaggedDependency):
+    '''
+    Test that the FlaggedDependencyYamlObject can be created from a model object.
+
+    :param flagged_dependency_model: The FlaggedDependency model instance.
+    :type flagged_dependency_model: FlaggedDependency
+    '''
+
+    # Create a new data object from the model object.
+    data_from_model = FlaggedDependencyYamlObject.from_model(flagged_dependency_model)
+
+    # Assert the data object is valid.
+    assert isinstance(data_from_model, FlaggedDependencyYamlObject)
+    assert data_from_model.module_path == flagged_dependency_model.module_path
+    assert data_from_model.class_name == flagged_dependency_model.class_name
+    assert data_from_model.flag == flagged_dependency_model.flag
+    assert data_from_model.parameters == flagged_dependency_model.parameters
+
+# ** test: service_configuration_yaml_data_from_data
+def test_service_configuration_yaml_data_from_data(service_configuration_yaml_object: ServiceConfigurationYamlObject):
+    '''
+    Test that the ServiceConfigurationYamlObject can be initialized from data.
+
+    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
+    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
+    '''
+
+    # Check if the data is correctly initialized.
+    assert service_configuration_yaml_object.id == 'test_repo'
+    assert len(service_configuration_yaml_object.dependencies) == 2
+
+    # Check if dependencies are correctly initialized.
+    for flag, dep in service_configuration_yaml_object.dependencies.items():
+        assert flag in ['test', 'test2']
+        assert dep.module_path == 'tests.repos.test'
+        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
+        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+
+# ** test: service_configuration_yaml_data_map
+def test_service_configuration_yaml_data_map(service_configuration_yaml_object: ServiceConfigurationYamlObject):
+    '''
+    Test that the ServiceConfigurationYamlObject can be mapped to a ServiceConfiguration aggregate.
+
+    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
+    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
+    '''
+
+    # Map the data to a service configuration aggregate.
+    mapped_attr = service_configuration_yaml_object.map()
+
+    # Assert the mapped object is valid.
+    assert isinstance(mapped_attr, ServiceConfigurationAggregate)
+    assert mapped_attr.id == 'test_repo'
+    assert mapped_attr.module_path == 'tests.repos.test'
+    assert mapped_attr.class_name == 'DefaultTestRepoProxy'
+    assert mapped_attr.parameters == {'test_param': 'test_value', 'param0': 'value0'}
+    assert len(mapped_attr.dependencies) == 2
+
+    # Assert the dependencies are correctly mapped.
+    for dep in mapped_attr.dependencies:
+        assert isinstance(dep, FlaggedDependency)
+        assert dep.module_path == 'tests.repos.test'
+        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
+        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+
+# ** test: service_configuration_yaml_data_from_model
+def test_service_configuration_yaml_data_from_model(service_configuration_yaml_object: ServiceConfigurationYamlObject):
+    '''
+    Test that the ServiceConfigurationYamlObject can be created from a model object.
+
+    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
+    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
+    '''
+
+    # Create a new model object from the fixture.
+    model_object = service_configuration_yaml_object.map()
+
+    # Add another dependency to the model object.
+    model_object.set_dependency(
+        flag='test3',
+        module_path='tests.repos.test',
+        class_name='TestRepoProxy3',
+        parameters={'param3': 'value3'}
+    )
+
+    # Create a new data object from the model object.
+    data_object = ServiceConfigurationYamlObject.from_model(model_object)
+
+    # Assert the data object is valid.
+    assert isinstance(data_object, ServiceConfigurationYamlObject)
+    assert data_object.id == 'test_repo'
+    assert len(data_object.dependencies) == 3
+
+    # Check if all dependencies are of type FlaggedDependencyYamlObject.
+    for dep in data_object.dependencies.values():
+        assert isinstance(dep, FlaggedDependencyYamlObject)
+        assert dep.module_path == 'tests.repos.test'
+        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2', 'TestRepoProxy3']
+        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}, {'param3': 'value3'}]
+
+# ** test: service_configuration_yaml_data_flags_alias_round_trip
+def test_service_configuration_yaml_data_flags_alias_round_trip() -> None:
+    '''
+    Test that the ``flags`` alias for dependencies is accepted on input and
+    that dependencies are still serialized under ``deps``.
+    '''
+
+    # Create a ServiceConfigurationYamlObject using the legacy 'flags' alias.
+    data_object = TransferObject.from_data(
+        ServiceConfigurationYamlObject,
+        id='test_repo_flags',
+        module_path='tests.repos.test',
+        class_name='DefaultTestRepoProxy',
+        flags=dict(
+            flag1=dict(
+                module_path='tests.repos.test',
+                class_name='TestRepoProxy',
+                params={'test_param': 'test_value'},
+            ),
+        ),
+        params=dict(
+            test_param='test_value',
+        ),
+    )
+
+    # The alias should populate the dependencies mapping keyed by flag.
+    assert isinstance(data_object, ServiceConfigurationYamlObject)
+    assert 'flag1' in data_object.dependencies
+    assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyYamlObject)
+
+    # When serializing to data, dependencies should still be emitted as 'deps'.
+    primitive = data_object.to_primitive(role='to_data.yaml')
+    assert 'flags' not in primitive
+    assert 'deps' in primitive
+    assert 'flag1' in primitive['deps']
+
+# ** test: flagged_dependency_aggregate_new
+def test_flagged_dependency_aggregate_new(flagged_dependency_aggregate: FlaggedDependencyAggregate):
+    '''
+    Test that FlaggedDependencyAggregate.new() creates a valid aggregate.
+
+    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
+    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
+    '''
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(flagged_dependency_aggregate, FlaggedDependencyAggregate)
+    assert flagged_dependency_aggregate.module_path == 'tests.repos.test'
+    assert flagged_dependency_aggregate.class_name == 'TestRepoProxy'
+    assert flagged_dependency_aggregate.flag == 'test'
+    assert flagged_dependency_aggregate.parameters == {'keep': 'original', 'override': 'old'}
+
+# ** test: flagged_dependency_aggregate_set_parameters_clears_when_none
+def test_flagged_dependency_aggregate_set_parameters_clears_when_none(
+    flagged_dependency_aggregate: FlaggedDependencyAggregate,
+):
+    '''
+    Test that set_parameters clears all parameters when called with None.
+
+    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
+    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
+    '''
+
+    # Call set_parameters with None to clear all parameters.
+    flagged_dependency_aggregate.set_parameters(None)
+
+    # All parameters should be cleared.
+    assert flagged_dependency_aggregate.parameters == {}
+
+# ** test: flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values
+def test_flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values(
+    flagged_dependency_aggregate: FlaggedDependencyAggregate,
+):
+    '''
+    Test that set_parameters merges new values and removes keys whose value is None.
+
+    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
+    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
+    '''
+
+    # Merge: override existing, add new, remove by setting to None.
+    flagged_dependency_aggregate.set_parameters({
+        'override': 'new',
+        'remove': None,
+        'add': 'added',
+    })
+
+    # 'keep' preserved, 'override' updated, 'remove' pruned, 'add' added.
+    assert flagged_dependency_aggregate.parameters == {
+        'keep': 'original',
+        'override': 'new',
+        'add': 'added',
+    }
+
+# ** test: service_configuration_aggregate_new
+def test_service_configuration_aggregate_new(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that ServiceConfigurationAggregate.new() creates a valid aggregate.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Assert the aggregate is correctly instantiated.
+    assert isinstance(service_configuration_aggregate, ServiceConfigurationAggregate)
+    assert service_configuration_aggregate.id == 'test_repo'
+    assert service_configuration_aggregate.module_path == 'tests.repos.test'
+    assert service_configuration_aggregate.class_name == 'DefaultTestRepoProxy'
+    assert service_configuration_aggregate.parameters == {'default_param': 'default_value'}
+    assert len(service_configuration_aggregate.dependencies) == 1
+
+# ** test: service_configuration_aggregate_set_default_type_updates
+def test_service_configuration_aggregate_set_default_type_updates(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that set_default_type updates module_path, class_name, and parameters.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Update the default type with new values.
+    service_configuration_aggregate.set_default_type(
+        module_path='updated.module',
+        class_name='UpdatedClass',
+        parameters={'new_param': 'new_value'},
+    )
+
+    # Assert the fields were updated correctly.
+    assert service_configuration_aggregate.module_path == 'updated.module'
+    assert service_configuration_aggregate.class_name == 'UpdatedClass'
+    assert service_configuration_aggregate.parameters == {'new_param': 'new_value'}
+
+# ** test: service_configuration_aggregate_set_default_type_clears_when_both_none
+def test_service_configuration_aggregate_set_default_type_clears_when_both_none(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that set_default_type clears module_path, class_name, and parameters
+    when both type fields are None.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Call with both type fields as None to clear the default type.
+    service_configuration_aggregate.set_default_type(
+        module_path=None,
+        class_name=None,
+    )
+
+    # Both type fields and parameters should be cleared.
+    assert service_configuration_aggregate.module_path is None
+    assert service_configuration_aggregate.class_name is None
+    assert service_configuration_aggregate.parameters == {}
+
+# ** test: service_configuration_aggregate_set_dependency_creates_new
+def test_service_configuration_aggregate_set_dependency_creates_new(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that set_dependency appends a new FlaggedDependency when the flag is not found.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Confirm the flag does not already exist.
+    assert service_configuration_aggregate.get_dependency('new_flag') is None
+
+    # Add a new dependency via set_dependency.
+    service_configuration_aggregate.set_dependency(
+        flag='new_flag',
+        module_path='tests.repos.test',
+        class_name='NewTestRepoProxy',
+        parameters={'new_param': 'new_value'},
+    )
+
+    # Verify the dependency was created with the correct values.
+    dep = service_configuration_aggregate.get_dependency('new_flag')
+    assert dep is not None
+    assert isinstance(dep, FlaggedDependency)
+    assert dep.module_path == 'tests.repos.test'
+    assert dep.class_name == 'NewTestRepoProxy'
+    assert dep.parameters == {'new_param': 'new_value'}
+    assert len(service_configuration_aggregate.dependencies) == 2
+
+# ** test: service_configuration_aggregate_set_dependency_updates_existing
+def test_service_configuration_aggregate_set_dependency_updates_existing(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that set_dependency updates an existing dependency in place, merging
+    parameters and pruning None-valued keys.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Update the existing 'existing' dependency.
+    service_configuration_aggregate.set_dependency(
+        flag='existing',
+        module_path='tests.repos.updated',
+        class_name='UpdatedRepoProxy',
+        parameters={'param1': None, 'param2': 'value2'},
+    )
+
+    # Verify module_path and class_name were updated.
+    dep = service_configuration_aggregate.get_dependency('existing')
+    assert dep.module_path == 'tests.repos.updated'
+    assert dep.class_name == 'UpdatedRepoProxy'
+
+    # 'param1' had None value so it should be removed; 'param2' should be added.
+    assert dep.parameters == {'param2': 'value2'}
+
+    # The list should still have only one dependency.
+    assert len(service_configuration_aggregate.dependencies) == 1
+
+# ** test: service_configuration_aggregate_remove_dependency
+def test_service_configuration_aggregate_remove_dependency(
+    service_configuration_aggregate: ServiceConfigurationAggregate,
+):
+    '''
+    Test that remove_dependency filters out the dependency matching the given flag.
+
+    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
+    :type service_configuration_aggregate: ServiceConfigurationAggregate
+    '''
+
+    # Confirm the dependency exists before removal.
+    assert service_configuration_aggregate.get_dependency('existing') is not None
+
+    # Remove the dependency.
+    service_configuration_aggregate.remove_dependency('existing')
+
+    # Verify it is gone and the list is empty.
+    assert service_configuration_aggregate.get_dependency('existing') is None
+    assert service_configuration_aggregate.dependencies == []

--- a/tiferet/mappers/tests/test_error.py
+++ b/tiferet/mappers/tests/test_error.py
@@ -1,0 +1,243 @@
+"""Tiferet Error Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..error import (
+    ErrorYamlObject,
+    ErrorAggregate,
+    ErrorMessageYamlObject,
+)
+from ...domain import (
+    Error,
+    ErrorMessage,
+)
+
+# *** fixtures
+
+# ** fixture: error_yaml_object
+@pytest.fixture
+def error_yaml_object() -> ErrorYamlObject:
+    '''
+    Provides an error YAML object fixture.
+
+    :return: The error YAML object instance.
+    :rtype: ErrorYamlObject
+    '''
+
+    # Create and return an error YAML object.
+    return TransferObject.from_data(
+        ErrorYamlObject,
+        id='TEST_ERROR',
+        name='TEST_ERROR',
+        error_code='TEST_ERROR',
+        message=[{
+            'lang': 'en',
+            'text': 'Test error message.'
+        }]
+    )
+
+# *** tests
+
+# ** test: error_data_from_data
+def test_error_data_from_data(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the creation of error data from a dictionary.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Assert the error data is an instance of ErrorYamlObject.
+    assert error_yaml_object.name == 'TEST_ERROR'
+    assert error_yaml_object.error_code == 'TEST_ERROR'
+    assert len(error_yaml_object.message) == 1
+    assert error_yaml_object.message[0].lang == 'en'
+    assert error_yaml_object.message[0].text == 'Test error message.'
+
+# ** test: error_data_to_primitive_to_data_yaml
+def test_error_data_to_primitive_to_data_yaml(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the conversion of error data to a primitive dictionary.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Convert the error data to a primitive.
+    primitive = error_yaml_object.to_primitive('to_data.yaml')
+
+    # Assert the primitive is a dictionary.
+    assert isinstance(primitive, dict)
+
+    # Assert the primitive values are correct.
+    assert primitive.pop('id', None) is None
+    assert primitive.get('name') == 'TEST_ERROR'
+    assert primitive.get('error_code') == 'TEST_ERROR'
+    assert len(primitive.get('message')) == 1
+    assert primitive.get('message')[0].get('lang') == 'en'
+    assert primitive.get('message')[0].get('text') == 'Test error message.'
+
+# ** test: error_data_map
+def test_error_data_map(error_yaml_object: ErrorYamlObject):
+    '''
+    Test the mapping of error YAML object to an error aggregate.
+
+    :param error_yaml_object: The error YAML object.
+    :type error_yaml_object: ErrorYamlObject
+    '''
+
+    # Map the error data to an error aggregate.
+    error = error_yaml_object.map()
+
+    # Assert the error is an instance of ErrorAggregate.
+    assert isinstance(error, ErrorAggregate)
+    assert error.id == error_yaml_object.id
+    assert error.name == error_yaml_object.name
+    assert error.error_code == error_yaml_object.error_code
+    assert len(error.message) == 1
+    assert isinstance(error.message[0], ErrorMessage)
+
+    # Assert the error message attributes.
+    error_message = error.message[0]
+    assert error_message.lang == 'en'
+    assert error_message.text == 'Test error message.'
+
+
+# ** test: error_yaml_object_from_model
+def test_error_yaml_object_from_model():
+    '''
+    Test creating an ErrorYamlObject from an Error model.
+    '''
+
+    # Create an error model.
+    error = Error.new(
+        id='test_error',
+        name='Test Error',
+        message=[
+            {'lang': 'en', 'text': 'Test message'},
+            {'lang': 'es', 'text': 'Mensaje de prueba'}
+        ]
+    )
+
+    # Create YAML object from model.
+    yaml_object = ErrorYamlObject.from_model(error)
+
+    # Assert the YAML object is valid.
+    assert isinstance(yaml_object, ErrorYamlObject)
+    assert yaml_object.id == 'test_error'
+    assert yaml_object.name == 'Test Error'
+    assert len(yaml_object.message) == 2
+    assert all(isinstance(msg, ErrorMessageYamlObject) for msg in yaml_object.message)
+
+
+# ** test: error_aggregate_new
+def test_error_aggregate_new():
+    '''
+    Test creating a new ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'Test message'}
+        ]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Assert the aggregate is valid.
+    assert isinstance(aggregate, ErrorAggregate)
+    assert aggregate.id == 'test_error'
+    assert aggregate.name == 'Test Error'
+    assert len(aggregate.message) == 1
+
+
+# ** test: error_aggregate_rename
+def test_error_aggregate_rename():
+    '''
+    Test renaming an error via ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    aggregate = ErrorAggregate.new(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'Test message'}
+        ]
+    )
+
+    # Rename the error.
+    aggregate.rename('Renamed Error')
+
+    # Assert the name was updated.
+    assert aggregate.name == 'Renamed Error'
+
+# ** test: error_aggregate_set_message
+def test_error_aggregate_set_message():
+    '''
+    Test setting a message on an ErrorAggregate.
+    '''
+
+    # Create an error aggregate.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Set a message.
+    aggregate.set_message('en', 'New test message')
+
+    # Assert the message was set.
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].lang == 'en'
+    assert aggregate.message[0].text == 'New test message'
+
+    # Update the message.
+    aggregate.set_message('en', 'Updated message')
+
+    # Assert the message was updated (not added).
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].text == 'Updated message'
+
+
+# ** test: error_aggregate_remove_message
+def test_error_aggregate_remove_message():
+    '''
+    Test removing a message from an ErrorAggregate.
+    '''
+
+    # Create an error aggregate with messages.
+    error_data = dict(
+        id='test_error',
+        name='Test Error',
+        error_code='TEST_ERROR',
+        message=[
+            {'lang': 'en', 'text': 'English message'},
+            {'lang': 'es', 'text': 'Spanish message'}
+        ]
+    )
+
+    aggregate = ErrorAggregate.new(**error_data)
+
+    # Remove one message.
+    aggregate.remove_message('en')
+
+    # Assert only one message remains.
+    assert len(aggregate.message) == 1
+    assert aggregate.message[0].lang == 'es'

--- a/tiferet/mappers/tests/test_feature.py
+++ b/tiferet/mappers/tests/test_feature.py
@@ -1,0 +1,407 @@
+"""Tiferet Feature Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..feature import (
+    FeatureEventAggregate,
+    FeatureEventYamlObject,
+    FeatureAggregate,
+    FeatureYamlObject,
+)
+from ...domain import (
+    Feature,
+    FeatureEvent,
+)
+
+# *** fixtures
+
+# ** fixture: feature_event_yaml_object
+@pytest.fixture
+def feature_event_yaml_object() -> FeatureEventYamlObject:
+    '''
+    Provides a feature event YAML object fixture with pass_on_error,
+    data_key, and params alias.
+
+    :return: The feature event YAML object instance.
+    :rtype: FeatureEventYamlObject
+    '''
+
+    # Create and return a feature event YAML object.
+    return TransferObject.from_data(
+        FeatureEventYamlObject,
+        name='Test Event',
+        attribute_id='test_event_handler',
+        params={'key': 'value'},
+        data_key='result',
+        pass_on_error=True,
+    )
+
+
+# ** fixture: feature_yaml_object
+@pytest.fixture
+def feature_yaml_object() -> FeatureYamlObject:
+    '''
+    Provides a feature YAML object fixture with one step containing params.
+
+    :return: The feature YAML object instance.
+    :rtype: FeatureYamlObject
+    '''
+
+    # Create and return a feature YAML object.
+    return TransferObject.from_data(
+        FeatureYamlObject,
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        description='Adds one number to another',
+        steps=[{
+            'name': 'Add a and b',
+            'attribute_id': 'add_number_event',
+            'params': {'precision': '2'},
+        }],
+    )
+
+
+# *** tests
+
+# ** test: feature_event_data_init
+def test_feature_event_data_init(feature_event_yaml_object: FeatureEventYamlObject):
+    '''
+    Verifies from_data() initialization including params alias.
+
+    :param feature_event_yaml_object: The feature event YAML object.
+    :type feature_event_yaml_object: FeatureEventYamlObject
+    '''
+
+    # Assert basic attributes.
+    assert feature_event_yaml_object.name == 'Test Event'
+    assert feature_event_yaml_object.attribute_id == 'test_event_handler'
+    assert feature_event_yaml_object.data_key == 'result'
+    assert feature_event_yaml_object.pass_on_error is True
+
+    # Assert the params alias resolved correctly.
+    assert feature_event_yaml_object.parameters == {'key': 'value'}
+
+
+# ** test: feature_event_data_map
+def test_feature_event_data_map(feature_event_yaml_object: FeatureEventYamlObject):
+    '''
+    Verifies map() produces a FeatureEvent with correct fields.
+
+    :param feature_event_yaml_object: The feature event YAML object.
+    :type feature_event_yaml_object: FeatureEventYamlObject
+    '''
+
+    # Map the feature event data to a feature event aggregate.
+    event = feature_event_yaml_object.map()
+
+    # Assert the mapped object is a FeatureEventAggregate.
+    assert isinstance(event, FeatureEventAggregate)
+    assert event.name == 'Test Event'
+    assert event.attribute_id == 'test_event_handler'
+    assert event.parameters == {'key': 'value'}
+    assert event.data_key == 'result'
+    assert event.pass_on_error is True
+
+
+# ** test: feature_data_from_data
+def test_feature_data_from_data(feature_yaml_object: FeatureYamlObject):
+    '''
+    Verifies nested steps initialization.
+
+    :param feature_yaml_object: The feature YAML object.
+    :type feature_yaml_object: FeatureYamlObject
+    '''
+
+    # Assert basic attributes.
+    assert feature_yaml_object.id == 'calc.add'
+    assert feature_yaml_object.name == 'Add Number'
+    assert feature_yaml_object.group_id == 'calc'
+    assert feature_yaml_object.feature_key == 'add'
+    assert feature_yaml_object.description == 'Adds one number to another'
+
+    # Assert the steps were initialized as FeatureEventYamlObject instances.
+    assert len(feature_yaml_object.steps) == 1
+    step = feature_yaml_object.steps[0]
+    assert isinstance(step, FeatureEventYamlObject)
+    assert step.name == 'Add a and b'
+    assert step.attribute_id == 'add_number_event'
+    assert step.parameters == {'precision': '2'}
+
+
+# ** test: feature_data_map
+def test_feature_data_map(feature_yaml_object: FeatureYamlObject):
+    '''
+    Verifies map() produces a FeatureAggregate with nested steps.
+
+    :param feature_yaml_object: The feature YAML object.
+    :type feature_yaml_object: FeatureYamlObject
+    '''
+
+    # Map the feature data to a feature aggregate.
+    feature = feature_yaml_object.map()
+
+    # Assert the mapped object is a FeatureAggregate.
+    assert isinstance(feature, FeatureAggregate)
+    assert feature.id == 'calc.add'
+    assert feature.name == 'Add Number'
+    assert feature.group_id == 'calc'
+    assert feature.feature_key == 'add'
+
+    # Assert nested steps were mapped correctly.
+    assert len(feature.steps) == 1
+    step = feature.steps[0]
+    assert isinstance(step, FeatureEventAggregate)
+    assert step.name == 'Add a and b'
+    assert step.attribute_id == 'add_number_event'
+    assert step.parameters == {'precision': '2'}
+
+
+# ** test: feature_aggregate_new
+def test_feature_aggregate_new():
+    '''
+    Verifies smart derivation (name → feature_key → id).
+    '''
+
+    # Create a feature aggregate with only name and group_id.
+    feature = FeatureAggregate.new(
+        name='Add Number',
+        group_id='calc',
+    )
+
+    # Assert smart derivation of feature_key and id.
+    assert feature.feature_key == 'add_number'
+    assert feature.id == 'calc.add_number'
+    assert feature.description == 'Add Number'
+
+
+# ** test: feature_aggregate_add_step
+def test_feature_aggregate_add_step():
+    '''
+    Verifies step append.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+
+    # Add a step.
+    step = feature.add_step(
+        name='Step One',
+        attribute_id='step_one_event',
+    )
+
+    # Assert the step was appended.
+    assert len(feature.steps) == 1
+    assert feature.steps[0] is step
+    assert step.name == 'Step One'
+    assert step.attribute_id == 'step_one_event'
+
+
+# ** test: feature_aggregate_add_step_position
+def test_feature_aggregate_add_step_position():
+    '''
+    Verifies step insertion at position 0.
+    '''
+
+    # Create a feature aggregate with an existing step.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='Step One', attribute_id='step_one_event')
+
+    # Insert a new step at position 0.
+    inserted = feature.add_step(
+        name='Step Zero',
+        attribute_id='step_zero_event',
+        position=0,
+    )
+
+    # Assert the step was inserted at position 0.
+    assert len(feature.steps) == 2
+    assert feature.steps[0] is inserted
+    assert feature.steps[0].name == 'Step Zero'
+    assert feature.steps[1].name == 'Step One'
+
+
+# ** test: feature_aggregate_remove_step
+def test_feature_aggregate_remove_step():
+    '''
+    Verifies removal and invalid position handling.
+    '''
+
+    # Create a feature aggregate with steps.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='Step One', attribute_id='step_one_event')
+    feature.add_step(name='Step Two', attribute_id='step_two_event')
+
+    # Remove the first step.
+    removed = feature.remove_step(0)
+    assert removed is not None
+    assert removed.name == 'Step One'
+    assert len(feature.steps) == 1
+
+    # Attempt to remove at an invalid position.
+    assert feature.remove_step(-1) is None
+    assert feature.remove_step(99) is None
+
+
+# ** test: feature_aggregate_reorder_step
+def test_feature_aggregate_reorder_step():
+    '''
+    Verifies move with clamping.
+    '''
+
+    # Create a feature aggregate with steps.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+    feature.add_step(name='A', attribute_id='a_event')
+    feature.add_step(name='B', attribute_id='b_event')
+    feature.add_step(name='C', attribute_id='c_event')
+
+    # Move step A (position 0) to position 2.
+    moved = feature.reorder_step(0, 2)
+    assert moved is not None
+    assert moved.name == 'A'
+    assert feature.steps[0].name == 'B'
+    assert feature.steps[1].name == 'C'
+    assert feature.steps[2].name == 'A'
+
+
+# ** test: feature_aggregate_rename
+def test_feature_aggregate_rename():
+    '''
+    Verifies name update without id change.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Old Name',
+        group_id='test',
+    )
+    original_id = feature.id
+
+    # Rename the feature.
+    feature.rename('New Name')
+
+    # Assert the name was updated but the id was not.
+    assert feature.name == 'New Name'
+    assert feature.id == original_id
+
+
+# ** test: feature_aggregate_set_description
+def test_feature_aggregate_set_description():
+    '''
+    Verifies set and clear.
+    '''
+
+    # Create a feature aggregate.
+    feature = FeatureAggregate.new(
+        name='Test Feature',
+        group_id='test',
+    )
+
+    # Set a description.
+    feature.set_description('A custom description')
+    assert feature.description == 'A custom description'
+
+    # Clear the description.
+    feature.set_description(None)
+    assert feature.description is None
+
+
+# ** test: feature_event_aggregate_set_pass_on_error
+def test_feature_event_aggregate_set_pass_on_error():
+    '''
+    Verifies string normalization ("false", "False", truthy).
+    '''
+
+    # Create a feature event aggregate.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+    )
+
+    # String "false" should normalize to False.
+    event.set_pass_on_error('false')
+    assert event.pass_on_error is False
+
+    # String "False" should normalize to False.
+    event.set_pass_on_error('False')
+    assert event.pass_on_error is False
+
+    # Truthy string should normalize to True.
+    event.set_pass_on_error('true')
+    assert event.pass_on_error is True
+
+    # Boolean True should remain True.
+    event.set_pass_on_error(True)
+    assert event.pass_on_error is True
+
+
+# ** test: feature_event_aggregate_set_parameters
+def test_feature_event_aggregate_set_parameters():
+    '''
+    Verifies merge, None-prune, and no-op on None.
+    '''
+
+    # Create a feature event aggregate with initial parameters.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+        parameters={'a': '1', 'b': '2'},
+    )
+
+    # Merge new parameters (c added, a updated).
+    event.set_parameters({'a': '10', 'c': '3'})
+    assert event.parameters == {'a': '10', 'b': '2', 'c': '3'}
+
+    # Prune keys with None values.
+    event.set_parameters({'b': None})
+    assert event.parameters == {'a': '10', 'c': '3'}
+
+    # None input is a no-op.
+    event.set_parameters(None)
+    assert event.parameters == {'a': '10', 'c': '3'}
+
+
+# ** test: feature_event_aggregate_set_attribute
+def test_feature_event_aggregate_set_attribute():
+    '''
+    Verifies delegation to specialized helpers.
+    '''
+
+    # Create a feature event aggregate.
+    event = FeatureEventAggregate.new(
+        name='Test Event',
+        attribute_id='test_handler',
+        parameters={'x': '1'},
+    )
+
+    # set_attribute for parameters should delegate to set_parameters.
+    event.set_attribute('parameters', {'y': '2'})
+    assert event.parameters == {'x': '1', 'y': '2'}
+
+    # set_attribute for pass_on_error should delegate to set_pass_on_error.
+    event.set_attribute('pass_on_error', 'false')
+    assert event.pass_on_error is False
+
+    # set_attribute for other attributes should use setattr.
+    event.set_attribute('name', 'Renamed Event')
+    assert event.name == 'Renamed Event'

--- a/tiferet/mappers/tests/test_logging.py
+++ b/tiferet/mappers/tests/test_logging.py
@@ -1,0 +1,429 @@
+"""Tiferet Logging Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import (
+    TransferObject,
+)
+from ..logging import (
+    FormatterAggregate,
+    FormatterYamlObject,
+    HandlerAggregate,
+    HandlerYamlObject,
+    LoggerAggregate,
+    LoggerYamlObject,
+    LoggingSettingsYamlObject,
+)
+from ...domain import (
+    Formatter,
+    Handler,
+    Logger,
+)
+
+# *** fixtures
+
+# ** fixture: formatter_config_data
+@pytest.fixture
+def formatter_config_data() -> FormatterYamlObject:
+    '''
+    Provides a formatter YAML object fixture.
+
+    :return: The formatter YAML object instance.
+    :rtype: FormatterYamlObject
+    '''
+
+    # Create and return a formatter YAML object.
+    return TransferObject.from_data(
+        FormatterYamlObject,
+        id='simple',
+        name='Simple Formatter',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+
+
+# ** fixture: handler_config_data
+@pytest.fixture
+def handler_config_data() -> HandlerYamlObject:
+    '''
+    Provides a handler YAML object fixture.
+
+    :return: The handler YAML object instance.
+    :rtype: HandlerYamlObject
+    '''
+
+    # Create and return a handler YAML object.
+    return TransferObject.from_data(
+        HandlerYamlObject,
+        id='console',
+        name='Console Handler',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='DEBUG',
+        formatter='simple',
+        stream='ext://sys.stdout',
+    )
+
+
+# ** fixture: logger_config_data
+@pytest.fixture
+def logger_config_data() -> LoggerYamlObject:
+    '''
+    Provides a logger YAML object fixture.
+
+    :return: The logger YAML object instance.
+    :rtype: LoggerYamlObject
+    '''
+
+    # Create and return a logger YAML object.
+    return TransferObject.from_data(
+        LoggerYamlObject,
+        id='app',
+        name='App Logger',
+        level='DEBUG',
+        handlers=['console'],
+    )
+
+
+# ** fixture: logging_settings_config_data
+@pytest.fixture
+def logging_settings_config_data(
+    formatter_config_data: FormatterYamlObject,
+    handler_config_data: HandlerYamlObject,
+    logger_config_data: LoggerYamlObject,
+) -> LoggingSettingsYamlObject:
+    '''
+    Provides a logging settings YAML object fixture assembled from
+    individual formatter, handler, and logger fixtures.
+
+    :param formatter_config_data: The formatter YAML object.
+    :type formatter_config_data: FormatterYamlObject
+    :param handler_config_data: The handler YAML object.
+    :type handler_config_data: HandlerYamlObject
+    :param logger_config_data: The logger YAML object.
+    :type logger_config_data: LoggerYamlObject
+    :return: The logging settings YAML object instance.
+    :rtype: LoggingSettingsYamlObject
+    '''
+
+    # Create and return a logging settings YAML object.
+    return LoggingSettingsYamlObject.from_data(
+        formatters={
+            'simple': {
+                'name': 'Simple Formatter',
+                'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                'datefmt': '%Y-%m-%d %H:%M:%S',
+            }
+        },
+        handlers={
+            'console': {
+                'name': 'Console Handler',
+                'module_path': 'logging',
+                'class_name': 'StreamHandler',
+                'level': 'DEBUG',
+                'formatter': 'simple',
+                'stream': 'ext://sys.stdout',
+            }
+        },
+        loggers={
+            'app': {
+                'name': 'App Logger',
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            }
+        },
+    )
+
+
+# *** tests
+
+# ** test: test_formatter_data_map_success
+def test_formatter_data_map_success(formatter_config_data: FormatterYamlObject):
+    '''
+    Test mapping a FormatterYamlObject to a Formatter and verifying format_config() output.
+
+    :param formatter_config_data: The formatter YAML object fixture.
+    :type formatter_config_data: FormatterYamlObject
+    '''
+
+    # Map the formatter data to a formatter aggregate.
+    formatter = formatter_config_data.map()
+
+    # Assert the formatter is mapped correctly.
+    assert isinstance(formatter, Formatter)
+    assert formatter.id == 'simple'
+    assert formatter.name == 'Simple Formatter'
+
+    # Verify format_config() output.
+    config = formatter.format_config()
+    assert config['format'] == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    assert config['datefmt'] == '%Y-%m-%d %H:%M:%S'
+
+
+# ** test: test_handler_data_map_success
+def test_handler_data_map_success(handler_config_data: HandlerYamlObject):
+    '''
+    Test mapping a HandlerYamlObject to a Handler and verifying format_config() with stream.
+
+    :param handler_config_data: The handler YAML object fixture.
+    :type handler_config_data: HandlerYamlObject
+    '''
+
+    # Map the handler data to a handler aggregate.
+    handler = handler_config_data.map()
+
+    # Assert the handler is mapped correctly.
+    assert isinstance(handler, Handler)
+    assert handler.id == 'console'
+    assert handler.name == 'Console Handler'
+
+    # Verify format_config() includes stream.
+    config = handler.format_config()
+    assert config['class'] == 'logging.StreamHandler'
+    assert config['level'] == 'DEBUG'
+    assert config['formatter'] == 'simple'
+    assert config['stream'] == 'ext://sys.stdout'
+
+
+# ** test: test_handler_data_map_no_optional
+def test_handler_data_map_no_optional():
+    '''
+    Test mapping a handler without stream/filename and verifying they are omitted from format_config().
+    '''
+
+    # Create a handler YAML object without optional stream/filename.
+    handler_yaml = TransferObject.from_data(
+        HandlerYamlObject,
+        id='file_handler',
+        name='File Handler',
+        module_path='logging',
+        class_name='FileHandler',
+        level='INFO',
+        formatter='simple',
+    )
+
+    # Map to handler aggregate.
+    handler = handler_yaml.map()
+
+    # Verify format_config() omits stream and filename.
+    config = handler.format_config()
+    assert 'stream' not in config
+    assert 'filename' not in config
+    assert config['class'] == 'logging.FileHandler'
+    assert config['level'] == 'INFO'
+
+
+# ** test: test_logger_data_map_success
+def test_logger_data_map_success(logger_config_data: LoggerYamlObject):
+    '''
+    Test mapping a LoggerYamlObject to a Logger and verifying format_config() output.
+
+    :param logger_config_data: The logger YAML object fixture.
+    :type logger_config_data: LoggerYamlObject
+    '''
+
+    # Map the logger data to a logger aggregate.
+    logger = logger_config_data.map()
+
+    # Assert the logger is mapped correctly.
+    assert isinstance(logger, Logger)
+    assert logger.id == 'app'
+    assert logger.name == 'App Logger'
+
+    # Verify format_config() output.
+    config = logger.format_config()
+    assert config['level'] == 'DEBUG'
+    assert config['handlers'] == ['console']
+    assert config['propagate'] is False
+
+
+# ** test: test_logger_data_map_empty_handlers
+def test_logger_data_map_empty_handlers():
+    '''
+    Test mapping a logger with empty handlers and is_root=True.
+    '''
+
+    # Create a logger YAML object with empty handlers and is_root=True.
+    logger_yaml = TransferObject.from_data(
+        LoggerYamlObject,
+        id='root',
+        name='Root Logger',
+        level='WARNING',
+        handlers=[],
+        is_root=True,
+    )
+
+    # Map to logger aggregate.
+    logger = logger_yaml.map()
+
+    # Verify the logger attributes.
+    assert logger.is_root is True
+    assert logger.handlers == []
+    assert logger.level == 'WARNING'
+
+
+# ** test: test_logging_settings_data_from_data_success
+def test_logging_settings_data_from_data_success(
+    logging_settings_config_data: LoggingSettingsYamlObject,
+):
+    '''
+    Test from_data() with full YAML data, verifying id injection.
+
+    :param logging_settings_config_data: The logging settings YAML object fixture.
+    :type logging_settings_config_data: LoggingSettingsYamlObject
+    '''
+
+    # Assert formatters were created with id injection.
+    assert 'simple' in logging_settings_config_data.formatters
+    formatter = logging_settings_config_data.formatters['simple']
+    assert isinstance(formatter, FormatterYamlObject)
+    assert formatter.id == 'simple'
+    assert formatter.name == 'Simple Formatter'
+
+    # Assert handlers were created with id injection.
+    assert 'console' in logging_settings_config_data.handlers
+    handler = logging_settings_config_data.handlers['console']
+    assert isinstance(handler, HandlerYamlObject)
+    assert handler.id == 'console'
+    assert handler.name == 'Console Handler'
+
+    # Assert loggers were created with id injection.
+    assert 'app' in logging_settings_config_data.loggers
+    logger = logging_settings_config_data.loggers['app']
+    assert isinstance(logger, LoggerYamlObject)
+    assert logger.id == 'app'
+    assert logger.name == 'App Logger'
+
+
+# ** test: test_logging_settings_data_from_data_empty
+def test_logging_settings_data_from_data_empty():
+    '''
+    Test from_data() with empty data returns empty dicts.
+    '''
+
+    # Create a logging settings YAML object with empty data.
+    settings = LoggingSettingsYamlObject.from_data(
+        formatters={},
+        handlers={},
+        loggers={},
+    )
+
+    # Assert all dictionaries are empty.
+    assert settings.formatters == {}
+    assert settings.handlers == {}
+    assert settings.loggers == {}
+
+
+# ** test: test_formatter_aggregate_new_success
+def test_formatter_aggregate_new_success():
+    '''
+    Test creating a FormatterAggregate via Aggregate.new().
+    '''
+
+    # Create a formatter aggregate.
+    formatter = FormatterAggregate.new(
+        id='detailed',
+        name='Detailed Formatter',
+        format='%(asctime)s %(levelname)s %(name)s %(message)s',
+        datefmt='%Y-%m-%d',
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(formatter, FormatterAggregate)
+    assert formatter.id == 'detailed'
+    assert formatter.name == 'Detailed Formatter'
+    assert formatter.format == '%(asctime)s %(levelname)s %(name)s %(message)s'
+
+
+# ** test: test_handler_aggregate_new_success
+def test_handler_aggregate_new_success():
+    '''
+    Test creating a HandlerAggregate via Aggregate.new().
+    '''
+
+    # Create a handler aggregate.
+    handler = HandlerAggregate.new(
+        id='file',
+        name='File Handler',
+        module_path='logging',
+        class_name='FileHandler',
+        level='ERROR',
+        formatter='detailed',
+        filename='error.log',
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(handler, HandlerAggregate)
+    assert handler.id == 'file'
+    assert handler.name == 'File Handler'
+    assert handler.filename == 'error.log'
+
+
+# ** test: test_logger_aggregate_new_success
+def test_logger_aggregate_new_success():
+    '''
+    Test creating a LoggerAggregate via Aggregate.new().
+    '''
+
+    # Create a logger aggregate.
+    logger = LoggerAggregate.new(
+        id='main',
+        name='Main Logger',
+        level='INFO',
+        handlers=['console', 'file'],
+        propagate=True,
+    )
+
+    # Assert the aggregate is valid.
+    assert isinstance(logger, LoggerAggregate)
+    assert logger.id == 'main'
+    assert logger.name == 'Main Logger'
+    assert logger.level == 'INFO'
+    assert logger.handlers == ['console', 'file']
+    assert logger.propagate is True
+
+
+# ** test: test_formatter_yaml_object_map_returns_aggregate
+def test_formatter_yaml_object_map_returns_aggregate(formatter_config_data: FormatterYamlObject):
+    '''
+    Test that FormatterYamlObject.map() returns a FormatterAggregate instance.
+
+    :param formatter_config_data: The formatter YAML object fixture.
+    :type formatter_config_data: FormatterYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = formatter_config_data.map()
+    assert isinstance(result, FormatterAggregate)
+
+
+# ** test: test_handler_yaml_object_map_returns_aggregate
+def test_handler_yaml_object_map_returns_aggregate(handler_config_data: HandlerYamlObject):
+    '''
+    Test that HandlerYamlObject.map() returns a HandlerAggregate instance.
+
+    :param handler_config_data: The handler YAML object fixture.
+    :type handler_config_data: HandlerYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = handler_config_data.map()
+    assert isinstance(result, HandlerAggregate)
+
+
+# ** test: test_logger_yaml_object_map_returns_aggregate
+def test_logger_yaml_object_map_returns_aggregate(logger_config_data: LoggerYamlObject):
+    '''
+    Test that LoggerYamlObject.map() returns a LoggerAggregate instance.
+
+    :param logger_config_data: The logger YAML object fixture.
+    :type logger_config_data: LoggerYamlObject
+    '''
+
+    # Map and verify the return type.
+    result = logger_config_data.map()
+    assert isinstance(result, LoggerAggregate)


### PR DESCRIPTION
Rebases the v2.0.0a3 release branch into main after all mapper package work is complete.

Includes:
- Mapper implementations (#591–#596)
- Release finalization (#597): version bump to 2.0.0a3, mapper guide, README/AGENTS.md updates
- Tag v2.0.0a3 published

Co-Authored-By: Oz <oz-agent@warp.dev>