### PR TITLE
Interfaces – Add Domain Service Interfaces

### DIFF
--- a/docs/guides/interfaces.md
+++ b/docs/guides/interfaces.md
@@ -1,0 +1,238 @@
+# Interfaces – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/interfaces/`  
+**Version:** 2.0.0a4
+
+## Overview
+
+The interfaces layer defines abstract service contracts that domain events, contexts, and repositories depend on. Every interface extends `Service` (ABC) from `tiferet/interfaces/settings.py` and declares the expected behavior for a vertical concern — data access, configuration management, file I/O, or database operations — without prescribing how it is implemented.
+
+There are two categories of service interfaces in Tiferet:
+
+- **Infrastructure services** — abstract low-level I/O operations that are independent of any domain model (`FileService`, `ConfigurationService`, `SqliteService`). These are general-purpose contracts consumed by middleware, repositories, and utilities.
+- **Domain services** — abstract persistence and query operations scoped to a specific domain aggregate (`AppService`, `CliService`, `DIService`, `ErrorService`, `FeatureService`, `LoggingService`). These are the primary contracts consumed by domain events.
+
+This guide covers the cross-cutting strategies and design decisions that apply across all interface modules.
+
+## The Standard CRUD Pattern
+
+Most domain services follow a consistent five-method CRUD pattern:
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `exists` | `(id: str) -> bool` | Check presence before get or save |
+| `get` | `(id: str) -> Aggregate` | Retrieve a single aggregate by ID |
+| `list` | `(...) -> List[Aggregate]` | Retrieve all aggregates, optionally filtered |
+| `save` | `(aggregate) -> None` | Persist a new or updated aggregate |
+| `delete` | `(id: str) -> None` | Remove an aggregate by ID (idempotent) |
+
+`exists` is used by domain events to enforce uniqueness before creation, or to confirm presence before retrieval. `delete` operations are always idempotent — calling delete on a non-existent ID must not raise an error.
+
+### Example — ErrorService
+
+```python
+class ErrorService(Service):
+
+    @abstractmethod
+    def exists(self, id: str) -> bool: ...
+
+    @abstractmethod
+    def get(self, id: str) -> ErrorAggregate: ...
+
+    @abstractmethod
+    def list(self) -> List[ErrorAggregate]: ...
+
+    @abstractmethod
+    def save(self, error: ErrorAggregate) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...
+```
+
+`AppService`, `CliService`, `ErrorService`, and `FeatureService` all follow this pattern exactly. Variations are introduced only where the domain genuinely requires them.
+
+## Domain-Specific Variations
+
+### FeatureService — Filtered List
+
+`FeatureService.list` accepts an optional `group_id` parameter to filter results by feature group. This is the only standard CRUD method with a parameter, and its presence in the signature reflects the hierarchical `group.feature_key` ID structure of the Feature domain.
+
+```python
+def list(self, group_id: Optional[str] = None) -> List[FeatureAggregate]: ...
+```
+
+### CliService — Extra Query Method
+
+`CliService` adds `get_parent_arguments()` beyond the standard five methods. This method returns all top-level `CliArgumentAggregate` objects — arguments that apply to the CLI root rather than to any specific command. It is not part of the CRUD contract but serves a specific runtime need of `CliContext`.
+
+```python
+def get_parent_arguments(self) -> List[CliArgumentAggregate]: ...
+```
+
+### DIService — Non-Standard Naming
+
+`DIService` manages two distinct resources: service configurations and constants. Because both live in the same configuration file but require separate operations, the method names are domain-specific rather than generic CRUD:
+
+| Standard | DIService equivalent |
+|---|---|
+| `exists` | `configuration_exists` |
+| `get` | `get_configuration` |
+| `list` | `list_all` (returns a tuple: configurations + constants dict) |
+| `save` | `save_configuration` |
+| `delete` | `delete_configuration` |
+| *(none)* | `save_constants` |
+
+The `list_all` return type is `Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]` — a paired result that loads the full DI container state in one call. `save_constants` has no CRUD equivalent because constants are a flat key-value dict, not an aggregate.
+
+### LoggingService — Split by Sub-Entity Type
+
+`LoggingService` manages three distinct sub-entities (formatters, handlers, loggers) that are always loaded together but saved and deleted independently. This yields a `list_all` bulk-read pattern paired with entity-specific write methods:
+
+```python
+def list_all(self) -> Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]: ...
+def save_formatter(self, formatter: FormatterAggregate) -> None: ...
+def save_handler(self, handler: HandlerAggregate) -> None: ...
+def save_logger(self, logger: LoggerAggregate) -> None: ...
+def delete_formatter(self, formatter_id: str) -> None: ...
+def delete_handler(self, handler_id: str) -> None: ...
+def delete_logger(self, logger_id: str) -> None: ...
+```
+
+There are no `exists` or `get` methods on `LoggingService` because the standard usage is to load all logging configuration at once and configure the logging system in a single pass.
+
+## The `NotImplementedError` Message Convention
+
+Every abstract method body raises `NotImplementedError` with a descriptive string in the format `'<method> method is required for <ServiceClass>.'`. This makes errors from unimplemented concrete classes immediately actionable:
+
+```python
+raise NotImplementedError('get method is required for ErrorService.')
+raise NotImplementedError('configuration_exists method is required for DIService.')
+```
+
+The message pattern is consistent across all interfaces. Deviating from it (e.g., using a generic `'Not implemented'` message) reduces debuggability when a concrete class forgets to implement a method.
+
+## Aggregate Return Types
+
+Domain service interfaces always declare return types as **Aggregates**, not plain `DomainObject` instances. Concrete repository implementations return aggregates so that callers — typically domain events — can invoke mutation methods without type-casting:
+
+```python
+# Domain event calls service, receives an aggregate, and mutates it directly.
+feature = self.feature_service.get(id)           # returns FeatureAggregate
+feature.add_step(attribute_id=attribute_id, ...)  # mutation method on aggregate
+self.feature_service.save(feature)
+```
+
+If the interface declared a plain `Feature` return type, domain events would need to convert it to an aggregate before mutation, creating unnecessary overhead and reducing clarity.
+
+Infrastructure services (`FileService`, `ConfigurationService`, `SqliteService`) are the exception — they have no domain aggregate concept and return raw I/O types (`IO[Any]`, `Any`).
+
+## How Services Are Consumed by Domain Events
+
+Services are injected into domain events via constructor parameters. The event depends only on the abstract interface — never on a concrete implementation:
+
+```python
+# ** event: get_feature
+class GetFeature(DomainEvent):
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> FeatureAggregate:
+
+        # Retrieve the feature from the service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            feature_id=id,
+        )
+
+        # Return the feature aggregate.
+        return feature
+```
+
+The concrete implementation (`FeatureYamlRepository`, or a mock in tests) is wired at runtime by the dependency injection container. Tests always mock the service interface:
+
+```python
+mock_feature_service = mock.Mock(spec=FeatureService)
+mock_feature_service.get.return_value = sample_feature
+
+result = DomainEvent.handle(
+    GetFeature,
+    dependencies={'feature_service': mock_feature_service},
+    id='group.sample_feature',
+)
+```
+
+## When to Deviate from the Standard CRUD Pattern
+
+Use the standard `exists / get / list / save / delete` names whenever possible. Deviate only when:
+
+1. **The domain manages multiple sub-entities of different types** and a single generic name would be ambiguous (`LoggingService` splits by formatter/handler/logger).
+2. **The resource is not an aggregate** — constants are a plain dict, not a model with an ID, so `save_constants` is appropriate and `save(constants)` would be misleading.
+3. **A meaningful qualifier adds clarity** — `configuration_exists` is clearer than `exists` when a service manages both configurations and constants under the same contract.
+
+Do not rename standard methods for stylistic reasons. If `get` and `exists` cover the use case, use them.
+
+## Adding a New Service Interface
+
+1. Create a new module in `tiferet/interfaces/` (e.g., `tiferet/interfaces/myservice.py`).
+2. Extend `Service` from `.settings`.
+3. Import the relevant aggregate type(s) from `..mappers`.
+4. Define all methods with `@abstractmethod`, RST docstrings, and a descriptive `NotImplementedError` message.
+5. Export the new service class from `tiferet/interfaces/__init__.py` under `# ** app`.
+
+```python
+# tiferet/interfaces/myservice.py
+"""Tiferet Interfaces MyService"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** app
+from ..mappers import MyAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: my_service
+class MyService(Service):
+    '''
+    Service interface for managing my domain objects.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a my domain object exists by ID.
+
+        :param id: The identifier.
+        :type id: str
+        :return: True if it exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('exists method is required for MyService.')
+```
+
+## Related Documentation
+
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service base class reference and artifact comment conventions
+- [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — DomainObject base class and conventions
+- [docs/core/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md) — Aggregate and TransferObject base class reference
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and dependency injection
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comments and formatting rules

--- a/tiferet/interfaces/__init__.py
+++ b/tiferet/interfaces/__init__.py
@@ -4,6 +4,12 @@
 
 # ** app
 from .settings import Service
-from .file import FileService
 from .config import ConfigurationService
+from .file import FileService
 from .sqlite import SqliteService
+from .app import AppService
+from .cli import CliService
+from .di import DIService
+from .error import ErrorService
+from .feature import FeatureService
+from .logging import LoggingService

--- a/tiferet/interfaces/app.py
+++ b/tiferet/interfaces/app.py
@@ -1,0 +1,87 @@
+"""Tiferet Interfaces App"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** app
+from ..mappers import AppInterfaceAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: app_service
+class AppService(Service):
+    '''
+    Service interface for managing app interface configurations.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if an app interface exists by ID.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: True if the app interface exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('exists method is required for AppService.')
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> AppInterfaceAggregate:
+        '''
+        Retrieve an app interface by ID.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: The app interface aggregate.
+        :rtype: AppInterfaceAggregate
+        '''
+        # Not implemented.
+        raise NotImplementedError('get method is required for AppService.')
+
+    # * method: list
+    @abstractmethod
+    def list(self) -> List[AppInterfaceAggregate]:
+        '''
+        List all app interfaces.
+
+        :return: A list of app interface aggregates.
+        :rtype: List[AppInterfaceAggregate]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list method is required for AppService.')
+
+    # * method: save
+    @abstractmethod
+    def save(self, interface: AppInterfaceAggregate) -> None:
+        '''
+        Save or update an app interface.
+
+        :param interface: The app interface aggregate to save.
+        :type interface: AppInterfaceAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save method is required for AppService.')
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete an app interface by ID. This operation should be idempotent.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete method is required for AppService.')

--- a/tiferet/interfaces/cli.py
+++ b/tiferet/interfaces/cli.py
@@ -1,0 +1,99 @@
+"""Tiferet Interfaces CLI"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** app
+from ..mappers import CliArgumentAggregate, CliCommandAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: cli_service
+class CliService(Service):
+    '''
+    Service interface for managing CLI command configurations.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a CLI command exists by ID.
+
+        :param id: The CLI command identifier.
+        :type id: str
+        :return: True if the CLI command exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('exists method is required for CliService.')
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> CliCommandAggregate:
+        '''
+        Retrieve a CLI command by ID.
+
+        :param id: The CLI command identifier.
+        :type id: str
+        :return: The CLI command aggregate.
+        :rtype: CliCommandAggregate
+        '''
+        # Not implemented.
+        raise NotImplementedError('get method is required for CliService.')
+
+    # * method: list
+    @abstractmethod
+    def list(self) -> List[CliCommandAggregate]:
+        '''
+        List all CLI commands.
+
+        :return: A list of CLI command aggregates.
+        :rtype: List[CliCommandAggregate]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list method is required for CliService.')
+
+    # * method: save
+    @abstractmethod
+    def save(self, command: CliCommandAggregate) -> None:
+        '''
+        Save or update a CLI command.
+
+        :param command: The CLI command aggregate to save.
+        :type command: CliCommandAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save method is required for CliService.')
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete a CLI command by ID. This operation should be idempotent.
+
+        :param id: The CLI command identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete method is required for CliService.')
+
+    # * method: get_parent_arguments
+    @abstractmethod
+    def get_parent_arguments(self) -> List[CliArgumentAggregate]:
+        '''
+        Get all parent-level CLI arguments.
+
+        :return: A list of parent CLI argument aggregates.
+        :rtype: List[CliArgumentAggregate]
+        '''
+        # Not implemented.
+        raise NotImplementedError('get_parent_arguments method is required for CliService.')

--- a/tiferet/interfaces/di.py
+++ b/tiferet/interfaces/di.py
@@ -1,0 +1,108 @@
+"""Tiferet Interfaces DI"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import (
+    Any,
+    Dict,
+    List,
+    Tuple,
+)
+
+# ** app
+from ..mappers.di import ServiceConfigurationAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: di_service
+class DIService(Service):
+    '''
+    Service interface for managing service configurations and constants.
+    '''
+
+    # * method: configuration_exists
+    @abstractmethod
+    def configuration_exists(self, id: str) -> bool:
+        '''
+        Check if a service configuration exists by ID.
+
+        :param id: The service configuration identifier.
+        :type id: str
+        :return: True if the service configuration exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('configuration_exists method is required for DIService.')
+
+    # * method: get_configuration
+    @abstractmethod
+    def get_configuration(self, configuration_id: str, flag: str = None) -> ServiceConfigurationAggregate:
+        '''
+        Retrieve a service configuration by ID, optionally filtered by flag.
+
+        :param configuration_id: The service configuration identifier.
+        :type configuration_id: str
+        :param flag: Optional flag to filter the configuration.
+        :type flag: str
+        :return: The service configuration aggregate.
+        :rtype: ServiceConfigurationAggregate
+        '''
+        # Not implemented.
+        raise NotImplementedError('get_configuration method is required for DIService.')
+
+    # * method: list_all
+    @abstractmethod
+    def list_all(self) -> Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]:
+        '''
+        List all service configurations and constants.
+
+        :return: A tuple containing a list of service configuration aggregates and a dictionary of constants.
+        :rtype: Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list_all method is required for DIService.')
+
+    # * method: save_configuration
+    @abstractmethod
+    def save_configuration(self, configuration: ServiceConfigurationAggregate) -> None:
+        '''
+        Save or update a service configuration.
+
+        :param configuration: The service configuration aggregate to save.
+        :type configuration: ServiceConfigurationAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save_configuration method is required for DIService.')
+
+    # * method: delete_configuration
+    @abstractmethod
+    def delete_configuration(self, configuration_id: str) -> None:
+        '''
+        Delete a service configuration by ID. This operation should be idempotent.
+
+        :param configuration_id: The service configuration identifier.
+        :type configuration_id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete_configuration method is required for DIService.')
+
+    # * method: save_constants
+    @abstractmethod
+    def save_constants(self, constants: Dict[str, Any] = {}) -> None:
+        '''
+        Save or update constants.
+
+        :param constants: The constants to save.
+        :type constants: Dict[str, Any]
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save_constants method is required for DIService.')

--- a/tiferet/interfaces/error.py
+++ b/tiferet/interfaces/error.py
@@ -1,0 +1,87 @@
+"""Tiferet Interfaces Error"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** app
+from ..mappers import ErrorAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: error_service
+class ErrorService(Service):
+    '''
+    Service interface for managing error definitions.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if an error exists by ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: True if the error exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('exists method is required for ErrorService.')
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> ErrorAggregate:
+        '''
+        Retrieve an error by ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: The error aggregate.
+        :rtype: ErrorAggregate
+        '''
+        # Not implemented.
+        raise NotImplementedError('get method is required for ErrorService.')
+
+    # * method: list
+    @abstractmethod
+    def list(self) -> List[ErrorAggregate]:
+        '''
+        List all errors.
+
+        :return: A list of error aggregates.
+        :rtype: List[ErrorAggregate]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list method is required for ErrorService.')
+
+    # * method: save
+    @abstractmethod
+    def save(self, error: ErrorAggregate) -> None:
+        '''
+        Save or update an error.
+
+        :param error: The error aggregate to save.
+        :type error: ErrorAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save method is required for ErrorService.')
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete an error by ID. This operation should be idempotent.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete method is required for ErrorService.')

--- a/tiferet/interfaces/feature.py
+++ b/tiferet/interfaces/feature.py
@@ -1,0 +1,89 @@
+"""Tiferet Interfaces Feature"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List, Optional
+
+# ** app
+from ..mappers import FeatureAggregate
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: feature_service
+class FeatureService(Service):
+    '''
+    Service interface for managing feature workflow configurations.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a feature exists by ID.
+
+        :param id: The feature identifier.
+        :type id: str
+        :return: True if the feature exists, otherwise False.
+        :rtype: bool
+        '''
+        # Not implemented.
+        raise NotImplementedError('exists method is required for FeatureService.')
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> FeatureAggregate:
+        '''
+        Retrieve a feature by ID.
+
+        :param id: The feature identifier.
+        :type id: str
+        :return: The feature aggregate.
+        :rtype: FeatureAggregate
+        '''
+        # Not implemented.
+        raise NotImplementedError('get method is required for FeatureService.')
+
+    # * method: list
+    @abstractmethod
+    def list(self, group_id: Optional[str] = None) -> List[FeatureAggregate]:
+        '''
+        List all features, optionally filtered by group.
+
+        :param group_id: Optional group identifier to filter features.
+        :type group_id: str | None
+        :return: A list of feature aggregates.
+        :rtype: List[FeatureAggregate]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list method is required for FeatureService.')
+
+    # * method: save
+    @abstractmethod
+    def save(self, feature: FeatureAggregate) -> None:
+        '''
+        Save or update a feature.
+
+        :param feature: The feature aggregate to save.
+        :type feature: FeatureAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save method is required for FeatureService.')
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete a feature by ID. This operation should be idempotent.
+
+        :param id: The feature identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete method is required for FeatureService.')

--- a/tiferet/interfaces/logging.py
+++ b/tiferet/interfaces/logging.py
@@ -1,0 +1,119 @@
+"""Tiferet Interfaces Logging"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List, Tuple
+
+# ** app
+from ..mappers import (
+    FormatterAggregate,
+    HandlerAggregate,
+    LoggerAggregate,
+)
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: logging_service
+class LoggingService(Service):
+    '''
+    Service interface for managing logging configurations.
+    '''
+
+    # * method: list_all
+    @abstractmethod
+    def list_all(self) -> Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]:
+        '''
+        List all logging configurations.
+
+        :return: A tuple of formatter, handler, and logger aggregates.
+        :rtype: Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]
+        '''
+        # Not implemented.
+        raise NotImplementedError('list_all method is required for LoggingService.')
+
+    # * method: save_formatter
+    @abstractmethod
+    def save_formatter(self, formatter: FormatterAggregate) -> None:
+        '''
+        Save a formatter configuration.
+
+        :param formatter: The formatter aggregate to save.
+        :type formatter: FormatterAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save_formatter method is required for LoggingService.')
+
+    # * method: save_handler
+    @abstractmethod
+    def save_handler(self, handler: HandlerAggregate) -> None:
+        '''
+        Save a handler configuration.
+
+        :param handler: The handler aggregate to save.
+        :type handler: HandlerAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save_handler method is required for LoggingService.')
+
+    # * method: save_logger
+    @abstractmethod
+    def save_logger(self, logger: LoggerAggregate) -> None:
+        '''
+        Save a logger configuration.
+
+        :param logger: The logger aggregate to save.
+        :type logger: LoggerAggregate
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('save_logger method is required for LoggingService.')
+
+    # * method: delete_formatter
+    @abstractmethod
+    def delete_formatter(self, formatter_id: str) -> None:
+        '''
+        Delete a formatter configuration by its ID.
+
+        :param formatter_id: The ID of the formatter to delete.
+        :type formatter_id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete_formatter method is required for LoggingService.')
+
+    # * method: delete_handler
+    @abstractmethod
+    def delete_handler(self, handler_id: str) -> None:
+        '''
+        Delete a handler configuration by its ID.
+
+        :param handler_id: The ID of the handler to delete.
+        :type handler_id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete_handler method is required for LoggingService.')
+
+    # * method: delete_logger
+    @abstractmethod
+    def delete_logger(self, logger_id: str) -> None:
+        '''
+        Delete a logger configuration by its ID.
+
+        :param logger_id: The ID of the logger to delete.
+        :type logger_id: str
+        :return: None
+        :rtype: None
+        '''
+        # Not implemented.
+        raise NotImplementedError('delete_logger method is required for LoggingService.')


### PR DESCRIPTION
Closes #602

## Summary

Adds six domain service interface modules to `tiferet/interfaces/` and updates `__init__.py` to export all 10 services. Also adds `docs/guides/interfaces.md` as an expanded-scope deliverable.

## Changes

### Interface Modules (ported from `v2.0-proto`)
- `interfaces/app.py` — `AppService`: standard CRUD for app interface configurations
- `interfaces/cli.py` — `CliService`: standard CRUD + `get_parent_arguments()`
- `interfaces/di.py` — `DIService`: domain-specific methods for service configs and constants
- `interfaces/error.py` — `ErrorService`: standard CRUD for error definitions
- `interfaces/feature.py` — `FeatureService`: standard CRUD with optional `group_id` filter on `list()`
- `interfaces/logging.py` — `LoggingService`: `list_all` + per-sub-entity save/delete methods

### Exports
- `interfaces/__init__.py` updated to export exactly 10 services under `# ** app`. `CacheService` and `ContainerService` excluded.

### Docs (expanded scope)
- `docs/guides/interfaces.md` — cross-cutting strategies guide covering: service categories, standard CRUD pattern, domain-specific variations and rationale, `NotImplementedError` convention, aggregate return types, DI consumption pattern, and checklist for adding new interfaces.

## Verification

`python -c "from tiferet.interfaces import *"` passes with no errors.

Co-Authored-By: Oz <oz-agent@warp.dev>