### PR TITLE
Repositories – App Repository Package Structure Refactor (#598)

### DIFF
--- a/tiferet/repos/app.py
+++ b/tiferet/repos/app.py
@@ -1,0 +1,184 @@
+"""Tiferet App YAML Repository"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** app
+from ..interfaces import AppService
+from ..mappers import (
+    TransferObject,
+    AppInterfaceAggregate,
+    AppInterfaceYamlObject,
+)
+from ..utils import Yaml
+
+# *** repos
+
+# ** repo: app_yaml_repository
+class AppYamlRepository(AppService):
+    '''
+    The app YAML repository.
+    '''
+
+    # * attribute: yaml_file
+    yaml_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, app_yaml_file: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the app YAML repository.
+
+        :param app_yaml_file: The YAML configuration file path.
+        :type app_yaml_file: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.yaml_file = app_yaml_file
+        self.encoding = encoding
+        self.default_role = 'to_data.yaml'
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if an app interface exists by ID.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: True if the app interface exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Load the interfaces mapping from the configuration file.
+        interfaces_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('interfaces', {})
+        )
+
+        # Return whether the interface id exists in the mapping.
+        return id in interfaces_data
+
+    # * method: get
+    def get(self, id: str) -> AppInterfaceAggregate | None:
+        '''
+        Retrieve an app interface by ID.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: The app interface aggregate or None if not found.
+        :rtype: AppInterfaceAggregate | None
+        '''
+
+        # Load the specific interface data from the configuration file.
+        interface_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('interfaces', {}).get(id)
+        )
+
+        # If no data is found, return None.
+        if not interface_data:
+            return None
+
+        # Map the data to an AppInterfaceAggregate and return it.
+        return TransferObject.from_data(
+            AppInterfaceYamlObject,
+            id=id,
+            **interface_data,
+        ).map()
+
+    # * method: list
+    def list(self) -> List[AppInterfaceAggregate]:
+        '''
+        List all app interfaces.
+
+        :return: A list of app interface aggregates.
+        :rtype: List[AppInterfaceAggregate]
+        '''
+
+        # Load all interfaces data from the configuration file.
+        interfaces_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('interfaces', {})
+        )
+
+        # Map each interface entry to an AppInterfaceAggregate.
+        return [
+            TransferObject.from_data(
+                AppInterfaceYamlObject,
+                id=interface_id,
+                **interface_data,
+            ).map()
+            for interface_id, interface_data in interfaces_data.items()
+        ]
+
+    # * method: save
+    def save(self, interface: AppInterfaceAggregate) -> None:
+        '''
+        Save or update an app interface.
+
+        :param interface: The app interface aggregate to save.
+        :type interface: AppInterfaceAggregate
+        :return: None
+        :rtype: None
+        '''
+
+        # Convert the app interface model to configuration data.
+        interface_data = AppInterfaceYamlObject.from_model(interface)
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load()
+
+        # Update or insert the interface entry.
+        full_data.setdefault('interfaces', {})[interface.id] = interface_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding,
+        ).save(data=full_data)
+
+    # * method: delete
+    def delete(self, id: str) -> None:
+        '''
+        Delete an app interface by ID. This operation is idempotent.
+
+        :param id: The app interface identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load()
+
+        # Remove the interface entry if it exists (idempotent).
+        full_data.get('interfaces', {}).pop(id, None)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding,
+        ).save(data=full_data)

--- a/tiferet/repos/tests/test_app.py
+++ b/tiferet/repos/tests/test_app.py
@@ -1,0 +1,231 @@
+"""Tiferet App Configuration Repository Tests"""
+
+# *** imports
+
+# ** core
+from typing import Dict
+
+# ** infra
+import pytest, yaml
+
+# ** app
+from ...mappers import (
+    TransferObject,
+    AppInterfaceYamlObject,
+)
+from ..app import AppYamlRepository
+
+
+# *** constants
+
+# ** constant: test_app_id
+TEST_APP_ID = 'test.app'
+
+# ** constant: another_app_id
+ANOTHER_APP_ID = 'another.app'
+
+# ** constant: app_data
+APP_DATA: Dict[str, Dict] = {
+    'interfaces': {
+        TEST_APP_ID: {
+            'name': 'Test App',
+            'description': 'A test app interface.',
+            'module': 'tiferet.apps.test',
+            'class': 'TestApp',
+            'attrs': {},
+            'const': {},
+        },
+        ANOTHER_APP_ID: {
+            'name': 'Another App',
+            'description': 'Another test app interface.',
+            'module': 'tiferet.apps.another',
+            'class': 'AnotherApp',
+            'attrs': {},
+            'const': {},
+        },
+    },
+}
+
+# *** fixtures
+
+# ** fixture: app_config_file
+@pytest.fixture
+def app_config_file(tmp_path) -> str:
+    '''
+    Fixture to provide the path to the app YAML configuration file.
+
+    :return: The app YAML configuration file path.
+    :rtype: str
+    '''
+
+    # Create a temporary YAML file with sample app configuration content.
+    file_path = tmp_path / 'test_app.yaml'
+
+    # Write the sample app configuration to the YAML file.
+    with open(file_path, 'w', encoding='utf-8') as yaml_file:
+        yaml.safe_dump(APP_DATA, yaml_file)
+
+    # Return the file path as a string.
+    return str(file_path)
+
+# ** fixture: app_config_repo
+@pytest.fixture
+def app_config_repo(app_config_file: str) -> AppYamlRepository:
+    '''
+    Fixture to create an instance of the App Configuration Repository.
+
+    :param app_config_file: The app YAML configuration file path.
+    :type app_config_file: str
+    :return: An instance of AppYamlRepository.
+    :rtype: AppYamlRepository
+    '''
+
+    # Create and return the AppYamlRepository instance.
+    return AppYamlRepository(app_config_file)
+
+# *** tests
+
+# ** test_int: app_config_repo_exists
+def test_int_app_config_repo_exists(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the exists method of the AppYamlRepository.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # Check if the app interfaces exist.
+    assert app_config_repo.exists(TEST_APP_ID)
+    assert app_config_repo.exists(ANOTHER_APP_ID)
+    assert not app_config_repo.exists('missing.app')
+
+# ** test_int: app_config_repo_get
+def test_int_app_config_repo_get(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the get method of the AppYamlRepository.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # Get app interfaces by id.
+    app = app_config_repo.get(TEST_APP_ID)
+    another_app = app_config_repo.get(ANOTHER_APP_ID)
+
+    # Check the first app interface.
+    assert app
+    assert app.id == TEST_APP_ID
+    assert app.name == 'Test App'
+    assert app.module_path == 'tiferet.apps.test'
+    assert app.class_name == 'TestApp'
+
+    # Check the second app interface.
+    assert another_app
+    assert another_app.id == ANOTHER_APP_ID
+    assert another_app.name == 'Another App'
+    assert another_app.module_path == 'tiferet.apps.another'
+    assert another_app.class_name == 'AnotherApp'
+
+# ** test_int: app_config_repo_get_not_found
+def test_int_app_config_repo_get_not_found(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the get method of the AppYamlRepository for a non-existent app interface.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # Attempt to get a non-existent app interface.
+    app = app_config_repo.get('missing.app')
+
+    # Check that the app interface is None.
+    assert not app
+
+# ** test_int: app_config_repo_list
+def test_int_app_config_repo_list(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the list method of the AppYamlRepository for all app interfaces.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # List all app interfaces.
+    interfaces = app_config_repo.list()
+
+    # Check the interfaces.
+    assert interfaces
+    assert len(interfaces) == 2
+    interface_ids = [interface.id for interface in interfaces]
+    assert TEST_APP_ID in interface_ids
+    assert ANOTHER_APP_ID in interface_ids
+
+# ** test_int: app_config_repo_save
+def test_int_app_config_repo_save(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the save method of the AppYamlRepository.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # Create constant for new test app interface.
+    new_app_id = 'new.app'
+
+    # Create new app interface config data and map to an aggregate.
+    app = TransferObject.from_data(
+        AppInterfaceYamlObject,
+        id=new_app_id,
+        name='New App',
+        description='A new test app interface.',
+        module_path='tiferet.apps.new',
+        class_name='NewApp',
+        attributes={},
+        constants={},
+    ).map()
+
+    # Save the new app interface.
+    app_config_repo.save(app)
+
+    # Reload the app interface to verify it was saved.
+    new_app = app_config_repo.get(new_app_id)
+
+    # Check the new app interface.
+    assert new_app
+    assert new_app.id == new_app_id
+    assert new_app.name == 'New App'
+    assert new_app.module_path == 'tiferet.apps.new'
+    assert new_app.class_name == 'NewApp'
+
+# ** test_int: app_config_repo_delete
+def test_int_app_config_repo_delete(
+        app_config_repo: AppYamlRepository,
+    ) -> None:
+    '''
+    Test the delete method of the AppYamlRepository.
+
+    :param app_config_repo: The app configuration repository.
+    :type app_config_repo: AppYamlRepository
+    '''
+
+    # Delete an existing app interface.
+    app_config_repo.delete(ANOTHER_APP_ID)
+
+    # Attempt to get the deleted app interface.
+    deleted_app = app_config_repo.get(ANOTHER_APP_ID)
+
+    # Check that the app interface is None.
+    assert not deleted_app
+
+    # Ensure that deleting a non-existent app interface is idempotent.
+    app_config_repo.delete('missing.app')


### PR DESCRIPTION
## Summary

Introduces `AppYamlRepository` as a flat module in `tiferet/repos/app.py`, implementing `AppService` from `tiferet/interfaces/app.py` with YAML-backed CRUD operations for app interface configurations.

### Changes
- **`tiferet/repos/app.py`** — `AppYamlRepository` with 5 methods (`exists`, `get`, `list`, `save`, `delete`) using the three-attribute foundation (`yaml_file`, `encoding`, `default_role`) and `Yaml` utility for file I/O.
- **`tiferet/repos/tests/test_app.py`** — 6 integration tests using `tmp_path` fixtures against real temporary YAML files.
- **`tiferet/repos/tests/__init__.py`** — Package init for relative imports.

### Acceptance Criteria
- All return types align with `AppService` interface (`AppInterfaceAggregate`).
- `get()` returns `None` for non-existent IDs.
- `delete()` is idempotent.
- All 6 integration tests pass.
- Full compliance with artifact comment hierarchy and RST docstrings.

Closes #598

Co-Authored-By: Oz <oz-agent@warp.dev>