### PR TITLE
Repositories – Feature Repository Package Structure Refactor (#600)

### DIFF
--- a/tiferet/repos/feature.py
+++ b/tiferet/repos/feature.py
@@ -1,0 +1,245 @@
+"""Tiferet Feature YAML Repository"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict, List
+
+# ** app
+from ..interfaces import FeatureService
+from ..mappers import (
+    TransferObject,
+    FeatureAggregate,
+    FeatureYamlObject,
+)
+from ..utils import Yaml
+
+# *** repos
+
+# ** repo: feature_yaml_repository
+class FeatureYamlRepository(FeatureService):
+    '''
+    The feature YAML repository.
+    '''
+
+    # * attribute: yaml_file
+    yaml_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, feature_yaml_file: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the feature YAML repository.
+
+        :param feature_yaml_file: The YAML configuration file path.
+        :type feature_yaml_file: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.yaml_file = feature_yaml_file
+        self.encoding = encoding
+        self.default_role = 'to_data.yaml'
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a feature exists by ID.
+
+        :param id: The feature identifier in the format "<group_id>.<feature_key>".
+        :type id: str
+        :return: True if the feature exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Split the feature id into group and feature key.
+        group_id, feature_key = id.split('.', 1)
+
+        # Load the group-specific feature data from the configuration file.
+        group_data: Dict[str, Any] = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('features', {}).get(group_id, None)
+        )
+
+        # If the group does not exist, return False.
+        if not group_data:
+            return False
+
+        # Return whether the feature key exists in the group.
+        return feature_key in group_data
+
+    # * method: get
+    def get(self, id: str) -> FeatureAggregate | None:
+        '''
+        Retrieve a feature by ID.
+
+        :param id: The feature identifier in the format "<group_id>.<feature_key>".
+        :type id: str
+        :return: The feature aggregate or None if not found.
+        :rtype: FeatureAggregate | None
+        '''
+
+        # Split the feature id into group and feature key.
+        group_id, feature_key = id.split('.', 1)
+
+        # Load the group-specific feature data from the configuration file.
+        group_data: Dict[str, Any] = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('features', {}).get(group_id, None)
+        )
+
+        # If the group does not exist, return None.
+        if not group_data:
+            return None
+
+        # Retrieve the specific feature data.
+        feature_data = group_data.get(feature_key)
+
+        # If the feature does not exist, return None.
+        if not feature_data:
+            return None
+
+        # Map the feature data to a FeatureAggregate and return it.
+        return TransferObject.from_data(
+            FeatureYamlObject,
+            id=f'{group_id}.{feature_key}',
+            **feature_data,
+        ).map()
+
+    # * method: list
+    def list(self, group_id: str | None = None) -> List[FeatureAggregate]:
+        '''
+        List all features, optionally filtered by group.
+
+        :param group_id: Optional group identifier to filter features.
+        :type group_id: str | None
+        :return: A list of feature aggregates.
+        :rtype: List[FeatureAggregate]
+        '''
+
+        # Load all groups and feature definitions from the configuration file.
+        groups_data: Dict[str, Dict[str, Any]] = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('features', {})
+        )
+
+        # Initialize the list of FeatureYamlObject objects.
+        features: List[FeatureYamlObject] = []
+
+        # If a specific group is requested, limit to that group.
+        if group_id:
+            group_features = groups_data.get(group_id, {})
+            for feature_key, feature_data in group_features.items():
+                features.append(TransferObject.from_data(
+                    FeatureYamlObject,
+                    id=f'{group_id}.{feature_key}',
+                    **feature_data,
+                ))
+
+        # Otherwise, flatten all groups.
+        else:
+            for group, group_features in groups_data.items():
+                for feature_key, feature_data in group_features.items():
+                    features.append(TransferObject.from_data(
+                        FeatureYamlObject,
+                        id=f'{group}.{feature_key}',
+                        **feature_data,
+                    ))
+
+        # Map all FeatureYamlObject instances to FeatureAggregates and return them.
+        return [feature.map() for feature in features]
+
+    # * method: save
+    def save(self, feature: FeatureAggregate) -> None:
+        '''
+        Save or update a feature.
+
+        :param feature: The feature aggregate to save.
+        :type feature: FeatureAggregate
+        :return: None
+        :rtype: None
+        '''
+
+        # Convert the feature model to a FeatureYamlObject.
+        feature_data = FeatureYamlObject.from_model(feature)
+
+        # Split the feature id for nested update.
+        group_id, feature_key = feature.id.split('.', 1)
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load()
+
+        # Update or insert the feature entry using nested setdefault.
+        full_data.setdefault('features', {}).setdefault(group_id, {})[feature_key] = feature_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding,
+        ).save(data=full_data)
+
+    # * method: delete
+    def delete(self, id: str) -> None:
+        '''
+        Delete a feature by ID. This operation is idempotent.
+
+        :param id: The feature identifier in the format "<group_id>.<feature_key>".
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Load all features data from the configuration file.
+        features_data: Dict[str, Dict[str, Any]] = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('features', {})
+        )
+
+        # Split the feature id into group and feature key.
+        group_id, feature_key = id.split('.', 1)
+
+        # Retrieve the group data.
+        group_data = features_data.get(group_id, {})
+
+        # Pop the feature entry if it exists (idempotent).
+        group_data.pop(feature_key, None)
+
+        # If the group becomes empty, remove it from the features mapping.
+        if not group_data and group_id in features_data:
+            features_data.pop(group_id, None)
+        else:
+            features_data[group_id] = group_data
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load()
+
+        # Update the features section.
+        full_data['features'] = features_data
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding,
+        ).save(data=full_data)

--- a/tiferet/repos/tests/test_feature.py
+++ b/tiferet/repos/tests/test_feature.py
@@ -1,0 +1,284 @@
+"""Tiferet Feature Configuration Repository Tests"""
+
+# *** imports
+
+# ** core
+from typing import Dict
+
+# ** infra
+import pytest, yaml
+
+# ** app
+from ...mappers import TransferObject, FeatureYamlObject
+from ..feature import FeatureYamlRepository
+
+
+# *** constants
+
+# ** constant: test_feature_id
+TEST_FEATURE_ID = 'test_group.test_feature'
+
+# ** constant: another_feature_id
+ANOTHER_FEATURE_ID = 'test_group.another_feature'
+
+# ** constant: other_group_feature_id
+OTHER_GROUP_FEATURE_ID = 'other_group.other_feature'
+
+# ** constant: feature_data
+FEATURE_DATA: Dict[str, Dict] = {
+    'features': {
+        'test_group': {
+            'test_feature': {
+                'name': 'Test Feature',
+                'description': 'A test feature with a command.',
+                'commands': [
+                    {
+                        'name': 'Test Command',
+                        'attribute_id': 'test.attribute',
+                        'params': {
+                            'key': 'value'
+                        }
+                    }
+                ],
+                'log_params': {},
+            },
+            'another_feature': {
+                'name': 'Another Feature',
+                'description': 'Another test feature.',
+                'commands': [],
+                'log_params': {},
+            },
+        },
+        'other_group': {
+            'other_feature': {
+                'name': 'Other Group Feature',
+                'description': 'A feature in another group.',
+                'commands': [],
+                'log_params': {},
+            },
+        },
+    },
+}
+
+
+# *** fixtures
+
+# ** fixture: feature_yaml_file
+@pytest.fixture
+def feature_yaml_file(tmp_path) -> str:
+    '''
+    Fixture to provide the path to the feature YAML configuration file.
+
+    :return: The feature YAML configuration file path.
+    :rtype: str
+    '''
+
+    # Create a temporary YAML file with sample feature configuration content.
+    file_path = tmp_path / 'test_feature.yaml'
+
+    # Write the sample feature configuration to the YAML file.
+    with open(file_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(FEATURE_DATA, f)
+
+    # Return the file path as a string.
+    return str(file_path)
+
+# ** fixture: feature_config_repo
+@pytest.fixture
+def feature_config_repo(feature_yaml_file: str) -> FeatureYamlRepository:
+    '''
+    Fixture to create an instance of the Feature Configuration Repository.
+
+    :param feature_yaml_file: The feature YAML configuration file path.
+    :type feature_yaml_file: str
+    :return: An instance of FeatureYamlRepository.
+    :rtype: FeatureYamlRepository
+    '''
+
+    # Create and return the FeatureYamlRepository instance.
+    return FeatureYamlRepository(feature_yaml_file=feature_yaml_file)
+
+
+# *** tests
+
+# ** test_int: feature_config_repo_exists
+def test_int_feature_config_repo_exists(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the exists method of the FeatureYamlRepository.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # Check if the features exist.
+    assert feature_config_repo.exists(TEST_FEATURE_ID)
+    assert feature_config_repo.exists(ANOTHER_FEATURE_ID)
+    assert feature_config_repo.exists(OTHER_GROUP_FEATURE_ID)
+    assert not feature_config_repo.exists('nonexistent.group.feature')
+
+# ** test_int: feature_config_repo_get
+def test_int_feature_config_repo_get(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the get method of the FeatureYamlRepository.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # Get features by id.
+    feature = feature_config_repo.get(TEST_FEATURE_ID)
+    another_feature = feature_config_repo.get(ANOTHER_FEATURE_ID)
+    other_group_feature = feature_config_repo.get(OTHER_GROUP_FEATURE_ID)
+
+    # Check the first feature.
+    assert feature
+    assert feature.id == TEST_FEATURE_ID
+    assert feature.name == 'Test Feature'
+    assert feature.group_id == 'test_group'
+    assert feature.feature_key == 'test_feature'
+
+    # Check the second feature.
+    assert another_feature
+    assert another_feature.id == ANOTHER_FEATURE_ID
+    assert another_feature.name == 'Another Feature'
+    assert another_feature.group_id == 'test_group'
+    assert another_feature.feature_key == 'another_feature'
+
+    # Check the feature from the other group.
+    assert other_group_feature
+    assert other_group_feature.id == OTHER_GROUP_FEATURE_ID
+    assert other_group_feature.name == 'Other Group Feature'
+    assert other_group_feature.group_id == 'other_group'
+    assert other_group_feature.feature_key == 'other_feature'
+
+# ** test_int: feature_config_repo_get_not_found
+def test_int_feature_config_repo_get_not_found(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the get method of the FeatureYamlRepository for a non-existent feature.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # Attempt to get a non-existent feature.
+    feature = feature_config_repo.get('missing.group.feature')
+
+    # Check that the feature is None.
+    assert not feature
+
+# ** test_int: feature_config_repo_list_all
+def test_int_feature_config_repo_list_all(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the list method of the FeatureYamlRepository for all features.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # List all features.
+    features = feature_config_repo.list()
+
+    # Check the features.
+    assert features
+    assert len(features) == 3
+    feature_ids = [feature.id for feature in features]
+    assert TEST_FEATURE_ID in feature_ids
+    assert ANOTHER_FEATURE_ID in feature_ids
+    assert OTHER_GROUP_FEATURE_ID in feature_ids
+
+# ** test_int: feature_config_repo_list_by_group
+def test_int_feature_config_repo_list_by_group(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the list method of the FeatureYamlRepository filtered by group.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # List features for a specific group.
+    features = feature_config_repo.list(group_id='test_group')
+
+    # Check the features.
+    assert features
+    assert len(features) == 2
+    feature_ids = [feature.id for feature in features]
+    assert TEST_FEATURE_ID in feature_ids
+    assert ANOTHER_FEATURE_ID in feature_ids
+
+    # List features for a non-existent group.
+    missing_group_features = feature_config_repo.list(group_id='missing_group')
+
+    # Check that no features are returned for the missing group.
+    assert missing_group_features == []
+
+# ** test_int: feature_config_repo_save
+def test_int_feature_config_repo_save(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the save method of the FeatureYamlRepository.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # Create constant for new test feature.
+    new_feature_id = 'new_group.new_feature'
+
+    # Create new feature config data and map to a model.
+    feature = TransferObject.from_data(
+        FeatureYamlObject,
+        id=new_feature_id,
+        name='New Feature',
+        description='A new test feature.',
+        commands=[],
+        log_params={},
+    ).map()
+
+    # Save the new feature.
+    feature_config_repo.save(feature)
+
+    # Reload the feature to verify it was saved.
+    new_feature = feature_config_repo.get(new_feature_id)
+
+    # Check the new feature.
+    assert new_feature
+    assert new_feature.id == new_feature_id
+    assert new_feature.name == 'New Feature'
+    assert new_feature.group_id == 'new_group'
+    assert new_feature.feature_key == 'new_feature'
+
+# ** test_int: feature_config_repo_delete
+def test_int_feature_config_repo_delete(
+        feature_config_repo: FeatureYamlRepository,
+    ) -> None:
+    '''
+    Test the delete method of the FeatureYamlRepository.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureYamlRepository
+    '''
+
+    # Delete an existing feature.
+    feature_config_repo.delete(ANOTHER_FEATURE_ID)
+
+    # Attempt to get the deleted feature.
+    deleted_feature = feature_config_repo.get(ANOTHER_FEATURE_ID)
+
+    # Check that the feature is None.
+    assert not deleted_feature
+
+    # Also ensure that deleting the last feature in a group removes the group.
+    feature_config_repo.delete(TEST_FEATURE_ID)
+    remaining_features = feature_config_repo.list(group_id='test_group')
+    assert remaining_features == []


### PR DESCRIPTION
## Summary

Introduces `FeatureYamlRepository` as a flat module in `tiferet/repos/feature.py`, implementing `FeatureService` from `tiferet/interfaces/feature.py` with YAML-backed CRUD operations for grouped feature workflow configurations.

## Changes

- **`tiferet/repos/feature.py`** — New `FeatureYamlRepository` with:
  - Composite ID handling (`group_id.feature_key`) across all methods
  - `exists()` / `get()` with group-scoped `start_node` navigation
  - `list()` with optional `group_id` filtering, flattening all groups otherwise
  - `save()` using nested `setdefault` for automatic group creation
  - `delete()` with empty-group pruning

- **`tiferet/repos/tests/test_feature.py`** — 7 integration test functions covering all 8 scenarios:
  1. `exists` — all 3 features + non-existent
  2. `get` — verifies `id`, `name`, `group_id`, `feature_key` for all 3
  3. `get_not_found` — returns `None` for missing ID
  4. `list_all` — all 3 features across groups
  5. `list_by_group` — 2 for `test_group`, empty for `missing_group`
  6. `save` — new group/feature with field verification on reload
  7. `delete` — feature removal + empty-group pruning

## Closes #600

Co-Authored-By: Oz <oz-agent@warp.dev>