### PR TITLE
Repositories – Logging Repository Package Structure Refactor (#604)

### DIFF
--- a/tiferet/repos/logging.py
+++ b/tiferet/repos/logging.py
@@ -1,0 +1,282 @@
+"""Tiferet Logging YAML Repository"""
+
+# *** imports
+
+# ** core
+from typing import (
+    Tuple,
+    List
+)
+
+# ** app
+from ..interfaces import LoggingService
+from ..mappers import (
+    LoggingSettingsYamlObject,
+    FormatterAggregate,
+    FormatterYamlObject,
+    HandlerAggregate,
+    HandlerYamlObject,
+    LoggerAggregate,
+    LoggerYamlObject,
+    TransferObject
+)
+from ..utils import Yaml
+
+# *** repos
+
+# ** repo: logging_yaml_repository
+class LoggingYamlRepository(LoggingService):
+    '''
+    YAML-backed repository for logging configurations (formatters, handlers, loggers).
+    '''
+
+    # * attribute: yaml_file
+    yaml_file: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * init
+    def __init__(self, logging_yaml_file: str, encoding: str = 'utf-8'):
+        '''
+        Initialize the logging YAML repository.
+
+        :param logging_yaml_file: Path to YAML logging config file
+        :type logging_yaml_file: str
+        :param encoding: File encoding (default 'utf-8')
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.yaml_file = logging_yaml_file
+        self.default_role = 'to_data.yaml'
+        self.encoding = encoding
+
+    # * method: list_all
+    def list_all(self) -> Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]:
+        '''
+        List all formatter, handler, and logger configurations.
+
+        :return: Tuple of (formatters, handlers, loggers)
+        :rtype: Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]
+        '''
+
+        # Load the logging settings data from the yaml configuration file.
+        data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load(
+            data_factory=lambda d: LoggingSettingsYamlObject.from_data(**d),
+            start_node=lambda d: d.get('logging', {})
+        )
+
+        # Return the formatters, handlers, and loggers.
+        return (
+            [f.map() for f in data.formatters.values()],
+            [h.map() for h in data.handlers.values()],
+            [l.map() for l in data.loggers.values()]
+        )
+
+    # * method: save_formatter
+    def save_formatter(self, formatter: FormatterAggregate):
+        '''
+        Save/update a formatter configuration.
+
+        :param formatter: The formatter configuration to save.
+        :type formatter: FormatterAggregate
+        '''
+
+        # Create formatter data object from the model.
+        formatter_data = TransferObject.from_model(
+            FormatterYamlObject,
+            formatter
+        )
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the formatter entry.
+        full_data.setdefault('logging', {}).setdefault('formatters', {})[formatter.id] = formatter_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)
+
+    # * method: save_handler
+    def save_handler(self, handler: HandlerAggregate):
+        '''
+        Save/update a handler configuration.
+
+        :param handler: The handler configuration to save.
+        :type handler: HandlerAggregate
+        '''
+
+        # Create handler data object from the model.
+        handler_data = TransferObject.from_model(
+            HandlerYamlObject,
+            handler
+        )
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the handler entry.
+        full_data.setdefault('logging', {}).setdefault('handlers', {})[handler.id] = handler_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)
+
+    # * method: save_logger
+    def save_logger(self, logger: LoggerAggregate):
+        '''
+        Save/update a logger configuration.
+
+        :param logger: The logger configuration to save.
+        :type logger: LoggerAggregate
+        '''
+
+        # Create logger data object from the model.
+        logger_data = TransferObject.from_model(
+            LoggerYamlObject,
+            logger
+        )
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the logger entry.
+        full_data.setdefault('logging', {}).setdefault('loggers', {})[logger.id] = logger_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)
+
+    # * method: delete_formatter
+    def delete_formatter(self, formatter_id: str):
+        '''
+        Delete a formatter by ID (idempotent).
+
+        :param formatter_id: The ID of the formatter to delete.
+        :type formatter_id: str
+        '''
+
+        # Load all formatters data from the yaml file.
+        formatter_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load(
+            start_node=lambda d: d.get('logging', {}).get('formatters', {})
+        )
+
+        # Pop the formatter data whether it exists or not.
+        formatter_data.pop(formatter_id, None)
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the formatters section.
+        full_data.setdefault('logging', {})['formatters'] = formatter_data
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)
+
+    # * method: delete_handler
+    def delete_handler(self, handler_id: str):
+        '''
+        Delete a handler by ID (idempotent).
+
+        :param handler_id: The ID of the handler to delete.
+        :type handler_id: str
+        '''
+
+        # Load all handlers data from the yaml file.
+        handler_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load(
+            start_node=lambda d: d.get('logging', {}).get('handlers', {})
+        )
+
+        # Pop the handler data whether it exists or not.
+        handler_data.pop(handler_id, None)
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the handlers section.
+        full_data.setdefault('logging', {})['handlers'] = handler_data
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)
+
+    # * method: delete_logger
+    def delete_logger(self, logger_id: str):
+        '''
+        Delete a logger by ID (idempotent).
+
+        :param logger_id: The ID of the logger to delete.
+        :type logger_id: str
+        '''
+
+        # Load all loggers data from the yaml file.
+        logger_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load(
+            start_node=lambda d: d.get('logging', {}).get('loggers', {})
+        )
+
+        # Pop the logger data whether it exists or not.
+        logger_data.pop(logger_id, None)
+
+        # Load the full configuration file.
+        full_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding
+        ).load()
+
+        # Update the loggers section.
+        full_data.setdefault('logging', {})['loggers'] = logger_data
+
+        # Persist the updated configuration file.
+        Yaml(
+            self.yaml_file,
+            mode='w',
+            encoding=self.encoding
+        ).save(data=full_data)

--- a/tiferet/repos/tests/test_logging.py
+++ b/tiferet/repos/tests/test_logging.py
@@ -1,0 +1,378 @@
+"""Tiferet Logging Repository Tests"""
+
+# *** imports
+
+# ** infra
+import pytest, yaml
+
+# ** app
+from ...mappers import TransferObject, FormatterYamlObject, HandlerYamlObject, LoggerYamlObject
+from ..logging import LoggingYamlRepository
+
+# *** constants
+
+# ** constant: test_formatter_id
+TEST_FORMATTER_ID = 'test_formatter'
+
+# ** constant: test_handler_id
+TEST_HANDLER_ID = 'test_handler'
+
+# ** constant: test_logger_id
+TEST_LOGGER_ID = 'test_logger'
+
+# ** constant: logging_data
+LOGGING_DATA = {
+    'logging': {
+        'formatters': {
+            TEST_FORMATTER_ID: {
+                'name': 'Test Formatter',
+                'description': 'A test formatter',
+                'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                'datefmt': '%Y-%m-%d %H:%M:%S'
+            }
+        },
+        'handlers': {
+            TEST_HANDLER_ID: {
+                'name': 'Test Handler',
+                'description': 'A test handler',
+                'module_path': 'logging',
+                'class_name': 'StreamHandler',
+                'level': 'INFO',
+                'formatter': TEST_FORMATTER_ID,
+                'stream': 'ext://sys.stdout'
+            }
+        },
+        'loggers': {
+            TEST_LOGGER_ID: {
+                'name': 'Test Logger',
+                'description': 'A test logger',
+                'level': 'DEBUG',
+                'handlers': [TEST_HANDLER_ID],
+                'propagate': False,
+                'is_root': False
+            }
+        }
+    }
+}
+
+# *** fixtures
+
+# ** fixture: logging_config_file
+@pytest.fixture
+def logging_config_file(tmp_path) -> str:
+    '''
+    Fixture to provide the path to the logging YAML configuration file.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: The logging YAML configuration file path.
+    :rtype: str
+    '''
+
+    # Create a temporary YAML file with sample logging configuration content.
+    file_path = tmp_path / 'test_logging.yaml'
+
+    # Write the sample logging configuration to the YAML file.
+    with open(file_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(LOGGING_DATA, f)
+
+    # Return the file path as a string.
+    return str(file_path)
+
+# ** fixture: logging_config_repo
+@pytest.fixture
+def logging_config_repo(logging_config_file: str) -> LoggingYamlRepository:
+    '''
+    Fixture to create an instance of the Logging Configuration Repository.
+
+    :param logging_config_file: The logging YAML configuration file path.
+    :type logging_config_file: str
+    :return: An instance of LoggingYamlRepository.
+    :rtype: LoggingYamlRepository
+    '''
+
+    # Create and return the LoggingYamlRepository instance.
+    return LoggingYamlRepository(logging_config_file)
+
+# *** tests
+
+# ** test_int: logging_config_repo_list_all
+def test_int_logging_config_repo_list_all(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the list_all method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # List all formatters, handlers, and loggers.
+    formatters, handlers, loggers = logging_config_repo.list_all()
+
+    # Check formatters.
+    assert formatters
+    assert len(formatters) == 1
+    assert formatters[0].id == TEST_FORMATTER_ID
+    assert formatters[0].name == 'Test Formatter'
+    assert formatters[0].format == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+    # Check handlers.
+    assert handlers
+    assert len(handlers) == 1
+    assert handlers[0].id == TEST_HANDLER_ID
+    assert handlers[0].name == 'Test Handler'
+    assert handlers[0].level == 'INFO'
+    assert handlers[0].formatter == TEST_FORMATTER_ID
+
+    # Check loggers.
+    assert loggers
+    assert len(loggers) == 1
+    assert loggers[0].id == TEST_LOGGER_ID
+    assert loggers[0].name == 'Test Logger'
+    assert loggers[0].level == 'DEBUG'
+    assert TEST_HANDLER_ID in loggers[0].handlers
+
+# ** test_int: logging_config_repo_save_formatter
+def test_int_logging_config_repo_save_formatter(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the save_formatter method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Create constant for new test formatter.
+    NEW_FORMATTER_ID = 'new_test_formatter'
+
+    # Create new formatter.
+    formatter = TransferObject.from_data(
+        FormatterYamlObject,
+        id=NEW_FORMATTER_ID,
+        name='New Test Formatter',
+        description='A new test formatter',
+        format='%(levelname)s - %(message)s',
+        datefmt='%H:%M:%S'
+    ).map()
+
+    # Save the formatter.
+    logging_config_repo.save_formatter(formatter)
+
+    # Reload the formatters to verify the changes.
+    formatters, _, _ = logging_config_repo.list_all()
+
+    # Check that the new formatter exists.
+    formatter_ids = [f.id for f in formatters]
+    assert NEW_FORMATTER_ID in formatter_ids
+
+    # Get the new formatter and verify its attributes.
+    new_formatter = next(f for f in formatters if f.id == NEW_FORMATTER_ID)
+    assert new_formatter.name == 'New Test Formatter'
+    assert new_formatter.format == '%(levelname)s - %(message)s'
+
+# ** test_int: logging_config_repo_save_handler
+def test_int_logging_config_repo_save_handler(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the save_handler method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Create constant for new test handler.
+    NEW_HANDLER_ID = 'new_test_handler'
+
+    # Create new handler.
+    handler = TransferObject.from_data(
+        HandlerYamlObject,
+        id=NEW_HANDLER_ID,
+        name='New Test Handler',
+        description='A new test handler',
+        module_path='logging',
+        class_name='FileHandler',
+        level='ERROR',
+        formatter=TEST_FORMATTER_ID,
+        filename='test.log'
+    ).map()
+
+    # Save the handler.
+    logging_config_repo.save_handler(handler)
+
+    # Reload the handlers to verify the changes.
+    _, handlers, _ = logging_config_repo.list_all()
+
+    # Check that the new handler exists.
+    handler_ids = [h.id for h in handlers]
+    assert NEW_HANDLER_ID in handler_ids
+
+    # Get the new handler and verify its attributes.
+    new_handler = next(h for h in handlers if h.id == NEW_HANDLER_ID)
+    assert new_handler.name == 'New Test Handler'
+    assert new_handler.level == 'ERROR'
+    assert new_handler.class_name == 'FileHandler'
+
+# ** test_int: logging_config_repo_save_logger
+def test_int_logging_config_repo_save_logger(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the save_logger method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Create constant for new test logger.
+    NEW_LOGGER_ID = 'new_test_logger'
+
+    # Create new logger.
+    logger = TransferObject.from_data(
+        LoggerYamlObject,
+        id=NEW_LOGGER_ID,
+        name='New Test Logger',
+        description='A new test logger',
+        level='WARNING',
+        handlers=[TEST_HANDLER_ID],
+        propagate=True,
+        is_root=False
+    ).map()
+
+    # Save the logger.
+    logging_config_repo.save_logger(logger)
+
+    # Reload the loggers to verify the changes.
+    _, _, loggers = logging_config_repo.list_all()
+
+    # Check that the new logger exists.
+    logger_ids = [l.id for l in loggers]
+    assert NEW_LOGGER_ID in logger_ids
+
+    # Get the new logger and verify its attributes.
+    new_logger = next(l for l in loggers if l.id == NEW_LOGGER_ID)
+    assert new_logger.name == 'New Test Logger'
+    assert new_logger.level == 'WARNING'
+    assert new_logger.propagate == True
+
+# ** test_int: logging_config_repo_delete_formatter
+def test_int_logging_config_repo_delete_formatter(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the delete_formatter method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Delete an existing formatter.
+    logging_config_repo.delete_formatter(TEST_FORMATTER_ID)
+
+    # Attempt to list all formatters.
+    formatters, _, _ = logging_config_repo.list_all()
+
+    # Check that the formatter is deleted.
+    formatter_ids = [f.id for f in formatters]
+    assert TEST_FORMATTER_ID not in formatter_ids
+
+# ** test_int: logging_config_repo_delete_handler
+def test_int_logging_config_repo_delete_handler(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the delete_handler method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Delete an existing handler.
+    logging_config_repo.delete_handler(TEST_HANDLER_ID)
+
+    # Attempt to list all handlers.
+    _, handlers, _ = logging_config_repo.list_all()
+
+    # Check that the handler is deleted.
+    handler_ids = [h.id for h in handlers]
+    assert TEST_HANDLER_ID not in handler_ids
+
+# ** test_int: logging_config_repo_delete_logger
+def test_int_logging_config_repo_delete_logger(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test the delete_logger method of the LoggingYamlRepository.
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Delete an existing logger.
+    logging_config_repo.delete_logger(TEST_LOGGER_ID)
+
+    # Attempt to list all loggers.
+    _, _, loggers = logging_config_repo.list_all()
+
+    # Check that the logger is deleted.
+    logger_ids = [l.id for l in loggers]
+    assert TEST_LOGGER_ID not in logger_ids
+
+# ** test_int: logging_config_repo_delete_idempotent
+def test_int_logging_config_repo_delete_idempotent(
+        logging_config_repo: LoggingYamlRepository,
+    ):
+    '''
+    Test that delete methods are idempotent (no error on non-existent ID).
+
+    :param logging_config_repo: The logging configuration repository.
+    :type logging_config_repo: LoggingYamlRepository
+    '''
+
+    # Delete a non-existent formatter (should not raise error).
+    logging_config_repo.delete_formatter('NON_EXISTENT_FORMATTER')
+
+    # Delete a non-existent handler (should not raise error).
+    logging_config_repo.delete_handler('NON_EXISTENT_HANDLER')
+
+    # Delete a non-existent logger (should not raise error).
+    logging_config_repo.delete_logger('NON_EXISTENT_LOGGER')
+
+    # If we reach here, the test passes (no exceptions raised).
+    assert True
+
+# ** test_int: logging_config_repo_empty_sections
+def test_int_logging_config_repo_empty_sections(tmp_path):
+    '''
+    Test that the repository handles empty/missing sections gracefully.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Create a YAML file with empty logging sections.
+    file_path = tmp_path / 'empty_logging.yaml'
+    empty_data = {
+        'logging': {
+            'formatters': {},
+            'handlers': {},
+            'loggers': {}
+        }
+    }
+
+    # Write the empty data to the YAML file.
+    with open(file_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(empty_data, f)
+
+    # Create repository instance.
+    repo = LoggingYamlRepository(str(file_path))
+
+    # List all (should return empty lists).
+    formatters, handlers, loggers = repo.list_all()
+
+    # Check that all lists are empty.
+    assert len(formatters) == 0
+    assert len(handlers) == 0
+    assert len(loggers) == 0


### PR DESCRIPTION
## Summary

Migrates `LoggingYamlRepository` from the `v2.0-proto` branch to `main`, implementing the `LoggingService` interface as a concrete YAML-backed repository.

## Changes

### New: `tiferet/repos/logging.py`
- `LoggingYamlRepository` implementing `LoggingService` with the three-attribute foundation (`yaml_file`, `default_role`, `encoding`).
- Three-model composition: formatters, handlers, and loggers managed within a single YAML file.
- `list_all()` returns a tuple of all three model types via `LoggingSettingsYamlObject`.
- Type-specific save methods: `save_formatter`, `save_handler`, `save_logger`.
- Type-specific delete methods: `delete_formatter`, `delete_handler`, `delete_logger` (all idempotent).

### New: `tiferet/repos/tests/test_logging.py`
- 9 integration tests covering list_all, save (×3), delete (×3), idempotent delete, and empty sections.

## Testing
All 9 tests pass.

Closes #604

Co-Authored-By: Oz <oz-agent@warp.dev>