### PR TITLE
Constants – Add di_service to DEFAULT_ATTRIBUTES (#606)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -15,6 +15,14 @@ DEFAULT_ATTRIBUTES = [
         },
     },
     {
+        'attribute_id': 'di_service',
+        'module_path': 'tiferet.repos.di',
+        'class_name': 'DIYamlRepository',
+        'parameters': {
+            'di_yaml_file': 'app/configs/di.yml',
+        },
+    },
+    {
         'attribute_id': 'error_service',
         'module_path': 'tiferet.repos.config.error',
         'class_name': 'ErrorConfigurationRepository',


### PR DESCRIPTION
## Summary

Adds `di_service` to `DEFAULT_ATTRIBUTES` in `tiferet/assets/constants.py`, pointing to `DIYamlRepository` in `tiferet.repos.di` with parameter `di_yaml_file: app/configs/di.yml`.

The legacy `container_service` entry is retained for backward compatibility, as the contexts layer is not yet updated to work with the new DI domain objects.

## Changes

- `tiferet/assets/constants.py` — added `di_service` entry after `container_service` in `DEFAULT_ATTRIBUTES`

## Notes

- Updating `error_service`, `feature_service`, `logging_repo`, and the app service constants to their new repo locations was attempted but reverted, as the legacy contexts depend on attribute names from the old domain models (e.g. `feature.commands`, `app_interface.attributes`) that differ from the new ones. Those updates are deferred to a future story when the contexts layer is modernized.

Closes #606

Co-Authored-By: Oz <oz-agent@warp.dev>