### PR TITLE
Documents – README and AGENTS.md Cleanup & Refactor (#601)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ result = DomainEvent.handle(
 - Extend `Service` (ABC) from `tiferet/interfaces/settings.py`.
 - All methods marked `@abstractmethod`.
 - Artifact comments use `# *** interfaces` / `# ** interface: <name>`.
-- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
+- Services: `AppService`, `CliService`, `ConfigurationService`, `DIService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
 
 ## Mappers
 
@@ -186,7 +186,7 @@ Split into two classes:
 
 Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backed:
 
-- `AppYamlRepository`, `CliYamlRepository`, `ContainerYamlRepository`
+- `AppYamlRepository`, `CliYamlRepository`, `DIYamlRepository`
 - `ErrorYamlRepository`, `FeatureYamlRepository`, `LoggingYamlRepository`
 
 ## Error Handling
@@ -202,7 +202,7 @@ Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backe
 Applications are configured via YAML files in `app/configs/`:
 
 - `app.yml` — Interface definitions (name, module_path, class_name, attributes)
-- `container.yml` — Dependency injection container attributes (module_path, class_name, parameters)
+- `di.yml` — Dependency injection service configurations (module_path, class_name, parameters)
 - `feature.yml` — Feature workflows (commands with attribute_id, parameters, data_key)
 - `error.yml` — Error definitions with multilingual messages
 - `cli.yml` — CLI command definitions with arguments

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ project_root/
         ├── __init__.py
         ├── app.yml
         ├── cli.yml
-        ├── container.yml
+        ├── di.yml
         ├── error.yml
         ├── feature.yml
         └── logging.yml
 ```
 
-The `app/events/` directory holds domain event classes for arithmetic operations (`calc.py`) and input validation (`settings.py`). The `app/configs/` directory contains configuration files for application settings (`app.yml`), CLI commands (`cli.yml`), dependency injection (`container.yml`), error handling (`error.yml`), feature workflows (`feature.yml`), and logging (`logging.yml`). The `basic_calc.py` script at the root initializes and runs the application. We recommend keeping the `app` directory name for internal projects to ensure consistency, though it can be customized for package releases. The `calc_cli.py` script provides a flexible command-line interface, easily integrated with shell scripts or external systems.
+The `app/events/` directory holds domain event classes for arithmetic operations (`calc.py`) and input validation (`settings.py`). The `app/configs/` directory contains configuration files for application settings (`app.yml`), CLI commands (`cli.yml`), dependency injection (`di.yml`), error handling (`error.yml`), feature workflows (`feature.yml`), and logging (`logging.yml`). The `basic_calc.py` script at the root initializes and runs the application. We recommend keeping the `app` directory name for internal projects to ensure consistency, though it can be customized for package releases. The `calc_cli.py` script provides a flexible command-line interface, easily integrated with shell scripts or external systems.
 
 ## Crafting the Calculator Application
 With Tiferet installed and your project structured, it's time to build your calculator application. This section guides you through creating a base domain event for numeric validation, defining arithmetic domain events, and setting up the application's behavior with configurations. By weaving together domain events and configurations, you'll experience Tiferet's elegant design, harmonizing functionality with clarity and precision.

--- a/docs/core/repos.md
+++ b/docs/core/repos.md
@@ -1,0 +1,408 @@
+# Repositories in Tiferet
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+
+## Overview
+
+Repositories are the concrete data-access layer in the Tiferet framework. Every repository implements a Service interface from `tiferet/interfaces/` and encapsulates the interaction between a data utility (e.g., `Yaml`) and the domain's transfer objects and aggregates.
+
+Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service configuration (`container.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. Consuming code depends only on the abstract Service interface, never on a concrete repository class.
+
+### Role in Runtime
+- **Service implementations**: Repositories are the concrete classes that satisfy the Service interfaces injected into domain events and contexts.
+- **Data-utility wiring**: Each repository composes a data utility (e.g., `Yaml`) with the domain's transfer objects to perform reads and writes against configuration files.
+- **DI resolution**: Repositories are instantiated by the dependency injection container at runtime, not by direct import.
+
+### Example: Error Domain
+
+```python
+class ErrorYamlRepository(ErrorService):
+    # Implements ErrorService interface
+    # Uses Yaml utility for file I/O
+    # Uses ErrorYamlObject for serialization
+    # Returns ErrorAggregate instances
+```
+
+## Structured Code Design
+
+Repository classes follow the standard Tiferet artifact comment structure:
+
+- `# *** repos` — top-level section for repository modules.
+- `# ** repo: <name>` — individual repository (snake_case).
+- `# * attribute: <name>` — instance attributes.
+- `# * init` — constructor.
+- `# * method: <name>` — methods implementing the Service interface.
+
+**Spacing rules:**
+- One empty line between `# *** repos` and first `# ** repo`.
+- One empty line between each `# *` section.
+- One empty line after docstrings and between code snippets within methods.
+
+**Example** — `tiferet/repos/error.py`:
+```python
+"""Tiferet Error YAML Repository"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** app
+from ..interfaces import ErrorService
+from ..mappers import (
+    TransferObject,
+    ErrorAggregate,
+    ErrorYamlObject,
+)
+from ..utils import Yaml
+
+# *** repos
+
+# ** repo: error_yaml_repository
+class ErrorYamlRepository(ErrorService):
+    '''
+    The error YAML repository.
+    '''
+
+    # * attribute: yaml_file
+    yaml_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, error_yaml_file: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the error YAML repository.
+
+        :param error_yaml_file: The YAML configuration file path.
+        :type error_yaml_file: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.yaml_file = error_yaml_file
+        self.encoding = encoding
+        self.default_role = 'to_data.yaml'
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if an error exists by ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: True if the error exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Load the errors mapping from the configuration file.
+        errors_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('errors', {})
+        )
+
+        # Return whether the error id exists in the mapping.
+        return id in errors_data
+```
+
+## The Three-Attribute Foundation
+
+Every YAML-backed repository shares three instance attributes:
+
+- **`yaml_file`** (`str`) — Path to the YAML configuration file.
+- **`encoding`** (`str`) — File encoding, defaulting to `'utf-8'`.
+- **`default_role`** (`str`) — The TransferObject serialization role used for writes, typically `'to_data.yaml'`.
+
+The constructor parameter follows the convention `<domain>_yaml_file` (e.g., `error_yaml_file`, `feature_yaml_file`, `cli_yaml_file`). This domain-prefixed naming enables clean DI wiring in `container.yml`.
+
+```python
+# * init
+def __init__(self, error_yaml_file: str, encoding: str = 'utf-8') -> None:
+    self.yaml_file = error_yaml_file
+    self.encoding = encoding
+    self.default_role = 'to_data.yaml'
+```
+
+## Import Organization
+
+Repositories follow the standard three-section import layout:
+
+```python
+# *** imports
+
+# ** core
+from typing import List
+
+# ** app
+from ..interfaces import ErrorService           # Service interface
+from ..mappers import (                          # Transfer objects and aggregates
+    TransferObject,
+    ErrorAggregate,
+    ErrorYamlObject,
+)
+from ..utils import Yaml                         # Data utility
+```
+
+The `# ** app` section imports three categories:
+1. The **Service interface** being implemented.
+2. The **transfer objects and aggregates** used for mapping.
+3. The **data utility** used for file I/O.
+
+No `# ** infra` section is needed — repositories do not import third-party libraries directly; all external interaction flows through Tiferet utilities.
+
+## Method Patterns
+
+### Reading: `exists`, `get`, `list`
+
+All read methods compose a `Yaml` utility instance with a `start_node` lambda to navigate the YAML structure:
+
+```python
+# Load a section.
+errors_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    start_node=lambda data: data.get('errors', {})
+)
+
+# Load a single entry by ID.
+error_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    start_node=lambda data: data.get('errors', {}).get(id)
+)
+```
+
+Mapping from raw YAML data to domain aggregates uses `TransferObject.from_data` with the YAML dictionary key injected as the `id`:
+
+```python
+return TransferObject.from_data(
+    ErrorYamlObject,
+    id=id,
+    **error_data,
+).map()
+```
+
+### Writing: `save`
+
+Save methods follow a three-step sequence:
+1. **Serialize** the aggregate via `YamlObject.from_model()`.
+2. **Load the full file** to preserve sibling sections.
+3. **Update** the target section with `setdefault` and persist.
+
+```python
+# Serialize.
+error_data = ErrorYamlObject.from_model(error)
+
+# Load full file.
+full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+
+# Update and persist.
+full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
+Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+```
+
+### Deleting: `delete`
+
+Delete operations are always **idempotent** — deleting a non-existent entry must not raise an error:
+
+```python
+# Load the full configuration file.
+full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+
+# Remove the entry if it exists (idempotent).
+full_data.get('errors', {}).pop(id, None)
+
+# Persist the updated configuration file.
+Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+```
+
+## Naming Convention
+
+Repository classes follow the pattern `<Domain>YamlRepository`:
+
+- `AppYamlRepository` implements `AppService`
+- `CliYamlRepository` implements `CliService`
+- `DIYamlRepository` implements `DIService`
+- `ErrorYamlRepository` implements `ErrorService`
+- `FeatureYamlRepository` implements `FeatureService`
+- `LoggingYamlRepository` implements `LoggingService`
+
+The `Yaml` suffix identifies the backing utility. Other utility-backed implementations (e.g., JSON, SQLite) would follow the same interface with a different suffix (e.g., `ErrorJsonRepository`, `ErrorSqliteRepository`).
+
+## Creating and Extending Repositories
+
+### 1. Define the Repository
+
+- Place under `# *** repos` and `# ** repo: <name>` in a domain-specific module.
+- Extend the corresponding Service interface from `tiferet/interfaces/`.
+- Set the three-attribute foundation in `__init__`.
+- Implement each Service method using the read/write patterns described above.
+
+**Example** — `CalculatorYamlRepository`:
+```python
+"""Tiferet Calculator YAML Repository"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** app
+from ..interfaces.calculator import CalculatorService
+from ..mappers.calculator import (
+    TransferObject,
+    CalculatorResultAggregate,
+    CalculatorResultYamlObject,
+)
+from ..utils import Yaml
+
+# *** repos
+
+# ** repo: calculator_yaml_repository
+class CalculatorYamlRepository(CalculatorService):
+    '''
+    The calculator YAML repository.
+    '''
+
+    # * attribute: yaml_file
+    yaml_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, calculator_yaml_file: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the calculator YAML repository.
+
+        :param calculator_yaml_file: The YAML configuration file path.
+        :type calculator_yaml_file: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.yaml_file = calculator_yaml_file
+        self.encoding = encoding
+        self.default_role = 'to_data.yaml'
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a calculator result exists by ID.
+
+        :param id: The result identifier.
+        :type id: str
+        :return: True if the result exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Load the results mapping from the configuration file.
+        results_data = Yaml(
+            self.yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get('results', {})
+        )
+
+        # Return whether the result id exists in the mapping.
+        return id in results_data
+```
+
+### 2. Register via DI
+
+Add the repository to the DI configuration file (`container.yml` or equivalent) with `module_path` and `class_name`. No `__init__.py` export is needed:
+
+```yaml
+services:
+  calculator_service:
+    module_path: tiferet.repos.calculator
+    class_name: CalculatorYamlRepository
+    params:
+      calculator_yaml_file: app/configs/calculator.yml
+```
+
+### 3. Write Tests
+
+Create tests in `tiferet/repos/tests/test_<domain>.py` using `tmp_path` fixtures with real temporary YAML files.
+
+### Best Practices
+- Use artifact comments consistently (`# *** repos`, `# ** repo:`, `# *`).
+- Follow the three-attribute foundation for all YAML-backed repos.
+- Use `TransferObject.from_data` for reads and `YamlObject.from_model` for writes.
+- Make delete operations idempotent.
+- Use `setdefault` for safe section updates on save.
+- Use `start_node` lambdas for all read operations.
+- Include RST docstrings with `:param`, `:type`, `:return`, `:rtype`.
+
+## Testing Repositories
+
+Repository tests are **integration tests** that operate against real temporary YAML files, not mocks. This is because the repository's value lies in the specific interaction between the utility and the transfer objects.
+
+**Structure:**
+- `# *** constants` — sample data dictionaries.
+- `# *** fixtures` / `# ** fixture: <name>` — `tmp_path`-based YAML file and repository instance.
+- `# *** tests` / `# ** test_int: <name>` — integration test cases.
+
+**Example** — Error repository test fixture:
+```python
+# ** fixture: error_yaml_file
+@pytest.fixture
+def error_yaml_file(tmp_path) -> str:
+    file_path = tmp_path / 'test_error.yaml'
+    with open(file_path, 'w', encoding='utf-8') as yaml_file:
+        yaml.safe_dump(ERROR_DATA, yaml_file)
+    return str(file_path)
+
+# ** fixture: error_config_repo
+@pytest.fixture
+def error_config_repo(error_yaml_file: str) -> ErrorYamlRepository:
+    return ErrorYamlRepository(error_yaml_file)
+```
+
+Standard test cases cover:
+- **exists** — positive and negative lookups.
+- **get** — retrieval by ID; `None` for missing entries.
+- **list** — full enumeration with count and field assertions.
+- **save** — round-trip: save then retrieve and verify fields.
+- **delete** — delete then confirm `exists` returns `False`; idempotent delete of non-existent IDs.
+
+## Package Layout
+
+Repositories are defined in `tiferet/repos/`:
+
+- `__init__.py` — Empty exports (repositories are never exported).
+- `app.py` — `AppYamlRepository`.
+- `cli.py` — `CliYamlRepository`.
+- `container.py` — `ContainerYamlRepository` (legacy).
+- `di.py` — `DIYamlRepository`.
+- `error.py` — `ErrorYamlRepository`.
+- `feature.py` — `FeatureYamlRepository`.
+- `logging.py` — `LoggingYamlRepository`.
+
+Tests live in `tiferet/repos/tests/`.
+
+## Migration from Proxies
+
+Repositories are the v2.0 successor to Proxies (`tiferet/proxies/`). Key changes:
+
+- **Package rename**: `tiferet/proxies/yaml/<domain>.py` → `tiferet/repos/<domain>.py`. The nested middleware-specific directory structure is flattened because the utility suffix in the class name (`YamlRepository`) already identifies the backing technology.
+- **Base class**: Proxies extended `YamlConfigurationProxy` (a middleware base class). Repositories extend the Service interface directly and compose the `Yaml` utility internally.
+- **Artifact comments**: `# *** proxies` / `# ** proxy:` → `# *** repos` / `# ** repo:`.
+- **Data mapping**: Proxies used `DataObject` (`from_data`, `map`). Repositories use `TransferObject` (`from_data`, `map`) and `Aggregate` for the same operations with clearer separation of concerns.
+- **Contract alignment**: Proxies implemented `Repository` contracts. Repositories implement `Service` interfaces — the unified v2.0 contract type.
+
+The `tiferet/proxies/` package remains available for backward compatibility. New repositories should be created in `tiferet/repos/`.
+
+## Conclusion
+
+Repositories provide the concrete data-access layer for the Tiferet framework, implementing Service interfaces with utility-backed persistence. Their structured design ensures consistency, testability, and clean DI resolution. Repositories are never exported directly — consuming code depends only on the abstract Service interface.
+
+Explore source in `tiferet/repos/` and tests in `tiferet/repos/tests/` for implementation details.

--- a/docs/guides/repos.md
+++ b/docs/guides/repos.md
@@ -1,0 +1,262 @@
+# Repos – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/repos/`  
+**Version:** 2.0.0a4
+
+## Overview
+
+Repositories are the concrete data-access layer in Tiferet. Each repository implements a Service interface and encapsulates the interaction between a data utility (e.g., `Yaml`) and the domain's transfer objects and aggregates. Repositories are highly situational — their functionality is shaped by the specific structural requirements of the configuration format they manage.
+
+This guide covers the cross-cutting strategies and design decisions that apply to all repository modules, rather than any single domain.
+
+## The Service Interface Contract
+
+Every repository implements a Service interface from `tiferet/interfaces/`. The interface defines the abstract CRUD operations; the repository provides the concrete data-utility wiring.
+
+| Repository | Implements | Utility |
+|---|---|---|
+| `AppYamlRepository` | `AppService` | `Yaml` |
+| `CliYamlRepository` | `CliService` | `Yaml` |
+| `ContainerYamlRepository` | `ContainerService` | `Yaml` |
+| `DIYamlRepository` | `DIService` | `Yaml` |
+| `ErrorYamlRepository` | `ErrorService` | `Yaml` |
+| `FeatureYamlRepository` | `FeatureService` | `Yaml` |
+| `LoggingYamlRepository` | `LoggingService` | `Yaml` |
+
+The naming convention is `<Domain>YamlRepository`. Other utility-backed implementations (e.g., JSON, SQLite) would follow the same interface with a different suffix.
+
+## No Package Exports
+
+Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service configuration (`container.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. This keeps the dependency graph clean — consuming code depends only on the abstract Service interface, never on a concrete repository.
+
+## Three-Attribute Foundation
+
+Every repository shares three instance attributes set during construction:
+
+```python
+# * attribute: yaml_file
+yaml_file: str
+
+# * attribute: default_role
+default_role: str
+
+# * attribute: encoding
+encoding: str
+```
+
+- **`yaml_file`** — path to the YAML configuration file.
+- **`default_role`** — the TransferObject serialization role used for writes (typically `'to_data.yaml'`).
+- **`encoding`** — file encoding (default `'utf-8'`).
+
+The constructor parameter follows the convention `<domain>_yaml_file` (e.g., `error_yaml_file`, `feature_yaml_file`).
+
+## Reading Patterns
+
+### Start-node navigation
+
+The `Yaml` utility's `start_node` callback navigates into the YAML structure before returning data to the caller. This isolates the repository from the top-level file layout.
+
+```python
+# Single entry by ID.
+error_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    start_node=lambda data: data.get('errors').get(id)
+)
+
+# Entire section.
+interfaces_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    start_node=lambda data: data.get('interfaces', {})
+)
+```
+
+Repositories use `start_node` for all read operations. The lambda receives the full parsed YAML dict and returns the relevant subsection.
+
+### Data-factory callback
+
+For complex loading that needs to construct multiple transfer objects in a single pass, use the `data_factory` callback:
+
+```python
+def data_factory(data):
+    attrs = [
+        TransferObject.from_data(ServiceConfigurationYamlObject, id=id, **attr_data)
+        for id, attr_data in data.get('services', {}).items()
+    ] if data.get('services') else []
+    consts = data.get('const', {}) if data.get('const') else {}
+    return attrs, consts
+
+services_data, consts = Yaml(self.yaml_file, encoding=self.encoding).load(
+    data_factory=data_factory
+)
+```
+
+Use `data_factory` when the YAML file contains **multiple sibling sections** that must be returned together (e.g., `attrs` + `const`, or `formatters` + `handlers` + `loggers`).
+
+### ID derivation from YAML keys
+
+YAML configuration files store entries as dictionaries keyed by identifier. The ID is not stored inside the value — it is derived from the key and injected during mapping:
+
+```python
+return TransferObject.from_data(
+    ErrorYamlObject,
+    id=id,          # Key becomes the domain object's ID.
+    **error_data    # Value contains the remaining fields.
+).map()
+```
+
+This pattern is universal across all repositories.
+
+## Writing Patterns
+
+### Save: load → update → persist
+
+Every save method follows the same three-step sequence:
+
+1. **Serialize** the domain object via `TransferObject.from_model()` and `to_primitive(default_role)`.
+2. **Load the full file** to preserve sibling sections.
+3. **Update** the target section with `setdefault` and write back.
+
+```python
+# Serialize.
+error_data = TransferObject.from_model(ErrorYamlObject, error)
+
+# Load full file.
+full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+
+# Update and persist.
+full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
+Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+```
+
+The `setdefault` call ensures the section exists even on a fresh file.
+
+### Delete: load section → pop → persist
+
+Deletes are always **idempotent** — deleting a non-existent entry is a no-op:
+
+```python
+# Load the section.
+errors_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    start_node=lambda data: data.get('errors', {})
+)
+
+# Remove the entry (no error if missing).
+errors_data.pop(id, None)
+
+# Load full, update, persist.
+full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+full_data['errors'] = errors_data
+Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+```
+
+## Grouped YAML Structures
+
+Some domains use **nested grouping** where entries are organized under a parent key. Features are the canonical example — each feature has a composite ID (`group_id.feature_key`) and is stored under its group:
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Number
+      steps: [...]
+    subtract:
+      name: Subtract Number
+      steps: [...]
+```
+
+The repository splits the composite ID and navigates two levels deep:
+
+```python
+group_id, feature_key = id.split('.', 1)
+group_data = data.get('features', {}).get(group_id, {})
+feature_data = group_data.get(feature_key)
+```
+
+Saves use nested `setdefault`:
+
+```python
+full_data.setdefault('features', {}).setdefault(group_id, {})[feature_key] = feature_data.to_primitive(self.default_role)
+```
+
+Deletes check for empty groups and prune them:
+
+```python
+group_data.pop(feature_name, None)
+if not group_data and group_id in features_data:
+    features_data.pop(group_id, None)
+```
+
+## Multi-Section Files
+
+Some YAML files contain **multiple parallel sections** that represent different entity types. Two patterns handle this:
+
+### Tuple return (container / DI)
+
+The repository's `list_all` returns a tuple of section results:
+
+```python
+def list_all(self) -> Tuple[List[ServiceConfiguration], Dict[str, str]]:
+    # data_factory returns (services_list, constants_dict)
+```
+
+Each section is parsed independently within the `data_factory`.
+
+### Composite transfer object (logging)
+
+The logging repository uses `LoggingSettingsYamlObject` — a transfer object that composes `FormatterYamlObject`, `HandlerYamlObject`, and `LoggerYamlObject` into a single object representing the entire file:
+
+```python
+data = Yaml(self.yaml_file, encoding=self.encoding).load(
+    data_factory=lambda d: LoggingSettingsYamlObject.from_data(**d),
+    start_node=lambda d: d.get('logging', {})
+)
+return (
+    [f.map() for f in data.formatters.values()],
+    [h.map() for h in data.handlers.values()],
+    [l.map() for l in data.loggers.values()],
+)
+```
+
+Use the composite pattern when the sections are tightly coupled and always loaded together. Use the tuple pattern when sections are logically independent.
+
+## Testing Repositories
+
+Repository tests use `pytest` with temporary YAML files created via `tmp_path`:
+
+```python
+@pytest.fixture
+def yaml_file(tmp_path) -> str:
+    file_path = tmp_path / 'test_config.yaml'
+    with open(file_path, 'w', encoding='utf-8') as f:
+        yaml.dump(SAMPLE_DATA, f)
+    return str(file_path)
+```
+
+Standard test cases cover:
+
+- **exists** — positive and negative lookups.
+- **get** — retrieval by ID; `None` for missing entries.
+- **list / list_all** — full enumeration with count and field assertions.
+- **save** — round-trip: save then retrieve and verify fields.
+- **delete** — delete then confirm `exists` returns `False`.
+- **save_constants** (where applicable) — merge semantics and overwrite behavior.
+
+Tests operate against real temporary files, not mocks, because the repository's value is in the specific interaction between the utility and the transfer objects.
+
+## Creating a New Repository
+
+1. **Define the Service interface** in `tiferet/interfaces/<domain>.py` with abstract CRUD methods.
+2. **Implement the repository** in `tiferet/repos/<domain>.py`:
+   - Extend the Service interface.
+   - Set the three-attribute foundation in `__init__`.
+   - Implement each method using the read/write patterns above.
+3. **Write tests** in `tiferet/repos/tests/test_<domain>.py` with sample YAML data and `tmp_path` fixtures.
+4. **Register via DI** — add the repository to the container/DI configuration file with `module_path` and `class_name`. No `__init__.py` export needed.
+
+## Related Documentation
+
+- [docs/core/repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md) — Repository base patterns and structured code design
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions
+- [docs/guides/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/mappers.md) — Aggregate and TransferObject patterns
+- [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/yaml.md) — YamlLoader utility guide
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comments and formatting


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` and `README.md` to reflect v2.0.0a4 naming changes (`container` → `di`), and adds repository documentation files.

## Changes

### AGENTS.md
- **Interfaces (Services):** Replace `ContainerService` with `DIService`
- **Repositories:** Replace `ContainerYamlRepository` with `DIYamlRepository`
- **Configuration:** Rename `container.yml` → `di.yml` with updated description

### README.md
- **Project structure:** Rename `container.yml` → `di.yml` in tree
- **Description:** Update reference from `container.yml` to `di.yml`

### New Files (deviation from TRD)
- `docs/core/repos.md` — Repository base patterns and structured code design
- `docs/guides/repos.md` — Repository strategies and cross-cutting patterns

## Deviations from TRD
- Used `v2.0-proto` as source of truth (per collaborator request)
- Added `docs/core/repos.md` and `docs/guides/repos.md` to deliverables (not in original TRD scope)

## Acceptance Criteria
- [x] `AGENTS.md` services list includes `DIService` instead of `ContainerService`
- [x] `AGENTS.md` repositories list includes `DIYamlRepository` instead of `ContainerYamlRepository`
- [x] `AGENTS.md` configuration section references `di.yml` instead of `container.yml`
- [x] `README.md` project structure shows `di.yml` instead of `container.yml`
- [x] `README.md` description text references `di.yml`
- [x] No other content changes to either document

Closes #601

Co-Authored-By: Oz <oz-agent@warp.dev>