### PR TITLE
Release – v2.0.0a4 Version Bump, Tag, GitHub Release (#607)

### DIFF
--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -69,4 +69,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a3'
+__version__ = '2.0.0a4'


### PR DESCRIPTION
Closes #607

- Version bumped to `2.0.0a4` in `tiferet/__init__.py`
- All tests pass (939 passed, 7 skipped, 0 failures)
- Annotated tag `v2.0.0a4` created and pushed
- GitHub pre-release published: https://github.com/greatstrength/tiferet/releases/tag/v2.0.0a4

Co-Authored-By: Oz <oz-agent@warp.dev>