### PR TITLE
Domain – App: Introduce service_id on AppServiceDependency; deprecate attribute_id

### DIFF
--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** March 11, 2026  
+**Version:** 2.0.0a5
 
 ## Overview
 
@@ -23,12 +23,13 @@ These domain objects are **immutable value objects**: they carry no mutation met
 
 Represents a single injectable service dependency binding for an application interface.
 
-| Attribute      | Type                   | Required | Default | Description                                       |
-|----------------|------------------------|----------|---------|---------------------------------------------------|
-| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.            |
-| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.             |
-| `attribute_id` | `StringType`           | Yes      | —       | The attribute id for the application dependency.   |
-| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.     |
+| Attribute      | Type                   | Required | Default | Description                                                                      |
+|----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
+| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.                                           |
+| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.                                            |
+| `service_id`   | `StringType`           | No *(todo: required)* | — | The canonical service id for the application dependency.             |
+| `attribute_id` | `StringType`           | No *(obsolete)* | — | The attribute id for the application dependency. Superseded by `service_id`. |
+| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.                                    |
 
 No methods. Pure data structure.
 
@@ -54,9 +55,9 @@ Represents the complete configuration of an application entry point.
 
 #### Methods
 
-**`get_service(attribute_id: str) -> AppServiceDependency`**
+**`get_service(service_id: str) -> AppServiceDependency`**
 
-Returns the `AppServiceDependency` whose `attribute_id` matches the given value, or `None` if no match is found.
+Returns the `AppServiceDependency` whose `service_id` matches the given value, or `None` if no match is found. For backward compatibility, also falls back to matching on `attribute_id` (this fallback will be removed once `attribute_id` is fully migrated).
 
 ```python
 service = app_interface.get_service('cli_repo')
@@ -76,7 +77,7 @@ The App domain objects participate in the application bootstrapping flow:
 
 ## Configuration Mapping
 
-Application interfaces are defined in `app/configs/app.yml`. Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects:
+Application interfaces are defined in `app/configs/app.yml`. Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects. Each key under `attrs` becomes the `service_id` of the corresponding `AppServiceDependency`:
 
 ```yaml
 interfaces:
@@ -139,7 +140,7 @@ from tiferet.domain import DomainObject, AppServiceDependency, AppInterface
 
 dep = DomainObject.new(
     AppServiceDependency,
-    attribute_id='cli_repo',
+    service_id='cli_repo',
     module_path='tiferet.proxies.yaml.cli',
     class_name='CliYamlProxy',
     parameters={'cli_config_file': 'app/configs/cli.yml'},

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -35,9 +35,17 @@ class AppServiceDependency(DomainObject):
         ),
     )
 
+    # * attribute: service_id
+    # + todo: set to required when attribute_id is removed
+    service_id = StringType(
+        metadata=dict(
+            description='The service id for the application dependency.'
+        ),
+    )
+
     # * attribute: attribute_id
+    # - obsolete: replaced by service_id
     attribute_id = StringType(
-        required=True,
         metadata=dict(
             description='The attribute id for the application dependency.'
         ),
@@ -135,15 +143,16 @@ class AppInterface(DomainObject):
     )
 
     # * method: get_service
-    def get_service(self, attribute_id: str) -> AppServiceDependency:
+    def get_service(self, service_id: str) -> AppServiceDependency:
         '''
-        Get the service dependency by attribute id.
+        Get the service dependency by service id.
 
-        :param attribute_id: The attribute id of the service dependency.
-        :type attribute_id: str
+        :param service_id: The service id of the service dependency.
+        :type service_id: str
         :return: The service dependency.
         :rtype: AppServiceDependency
         '''
 
-        # Get the service dependency by attribute id.
-        return next((dep for dep in self.services if dep.attribute_id == attribute_id), None)
+        # Get the service dependency by service id.
+        # + todo: remove attribute_id support when attribute_id is removed from AppServiceDependency
+        return next((dep for dep in self.services if dep.service_id == service_id or dep.attribute_id == service_id), None)

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -27,7 +27,7 @@ def app_dependency() -> AppServiceDependency:
     # Create and return a new AppServiceDependency.
     return DomainObject.new(
         AppServiceDependency,
-        attribute_id='test_attribute',
+        service_id='test_service',
         module_path='test_module_path',
         class_name='test_class_name',
         parameters={'param1': 'value1', 'param2': 'value2'},
@@ -62,19 +62,19 @@ def app_interface(app_dependency: AppServiceDependency) -> AppInterface:
 # ** test: app_interface_get_service
 def test_app_interface_get_service(app_interface: AppInterface) -> None:
     '''
-    Test successful retrieval of a service dependency by attribute id.
+    Test successful retrieval of a service dependency by service id.
 
     :param app_interface: The AppInterface fixture.
     :type app_interface: AppInterface
     '''
 
-    # Retrieve the service dependency by attribute id.
-    service = app_interface.get_service('test_attribute')
+    # Retrieve the service dependency by service id.
+    service = app_interface.get_service('test_service')
 
     # Assert the service dependency fields match.
     assert service.module_path == 'test_module_path'
     assert service.class_name == 'test_class_name'
-    assert service.attribute_id == 'test_attribute'
+    assert service.service_id == 'test_service'
     assert service.parameters == {'param1': 'value1', 'param2': 'value2'}
 
 # ** test: app_interface_get_service_invalid


### PR DESCRIPTION
Closes #643

## Summary
Ports the `service_id` introduction on `AppServiceDependency` from `v2.0-proto` into `v2.0a5-release`.

## Changes
- **`tiferet/domain/app.py`**: Add `service_id` (non-required, `# + todo`) to `AppServiceDependency`; retain `attribute_id` as non-required (`# - obsolete`); update `AppInterface.get_service()` to accept `service_id` with `attribute_id` fallback.
- **`tiferet/domain/tests/test_app.py`**: Update fixture and assertions to use `service_id`.
- **`docs/guides/domain/app.md`**: Bump version to 2.0.0a5, update attribute table, method description, and YAML config explanation.

## Tests
All 939 tests pass.

Co-Authored-By: Oz <oz-agent@warp.dev>