### PR TITLE
Mappers – App: Migrate attribute_id to service_id and Remove JSON Serialization Roles (#645)

### DIFF
--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -63,7 +63,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         )
 
     # * method: add_service
-    def add_service(self, module_path: str, class_name: str, attribute_id: str, parameters: Dict[str, str] = {}) -> None:
+    def add_service(self, module_path: str, class_name: str, service_id: str, parameters: Dict[str, str] = {}) -> None:
         '''
         Add a service dependency to the app interface.
 
@@ -71,8 +71,8 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         :type module_path: str
         :param class_name: The class name for the service dependency.
         :type class_name: str
-        :param attribute_id: The id for the service dependency.
-        :type attribute_id: str
+        :param service_id: The id for the service dependency.
+        :type service_id: str
         :param parameters: Additional parameters for the service dependency.
         :type parameters: dict
         :return: None
@@ -84,7 +84,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
             AppServiceDependency,
             module_path=module_path,
             class_name=class_name,
-            attribute_id=attribute_id,
+            service_id=service_id,
             parameters=parameters,
         )
 
@@ -92,39 +92,49 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         self.services.append(dependency)
 
     # * method: remove_service
-    def remove_service(self, attribute_id: str) -> AppServiceDependency:
+    # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
+    def remove_service(self, service_id: str = None, attribute_id: str = None) -> AppServiceDependency:
         '''
-        Remove and return a service dependency by its attribute_id (idempotent).
+        Remove and return a service dependency by its service_id (idempotent).
 
-        If a service dependency with the given attribute_id exists, it is removed.
+        If a service dependency with the given service_id exists, it is removed.
         If no matching service dependency exists, no action is taken (silent success).
 
-        :param attribute_id: The attribute_id of the service dependency to remove.
+        :param service_id: The service_id of the service dependency to remove.
+        :type service_id: str
+        :param attribute_id: Deprecated alias for service_id.
         :type attribute_id: str
         :return: The removed AppServiceDependency or None.
         :rtype: AppServiceDependency
         '''
 
-        # Iterate over services and remove the first match by attribute_id.
+        # Fall back to attribute_id if service_id is not provided.
+        if service_id is None and attribute_id is not None:
+            service_id = attribute_id
+
+        # Iterate over services and remove the first match by service_id.
+        # + todo: remove attribute_id fallback once attribute_id is removed from AppServiceDependency
         for index, dep in enumerate(self.services):
-            if dep.attribute_id == attribute_id:
+            if dep.service_id == service_id or dep.attribute_id == service_id:
                 return self.services.pop(index)
 
         # If no service dependency matches, return None without modifying the list.
         return None
 
     # * method: set_service
+    # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
     def set_service(
         self,
-        attribute_id: str,
-        module_path: str,
-        class_name: str,
+        service_id: str = None,
+        module_path: str = None,
+        class_name: str = None,
         parameters: Dict[str, Any] = None,
+        attribute_id: str = None,
     ) -> None:
         '''
-        Set or update a service dependency by attribute_id (PUT semantics).
+        Set or update a service dependency by service_id (PUT semantics).
 
-        If a service dependency with the given attribute_id exists:
+        If a service dependency with the given service_id exists:
           - Update module_path and class_name.
           - Merge parameters (favor new values; remove keys with None value).
           - Clear parameters if parameters is None.
@@ -132,20 +142,26 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         If no service dependency exists:
           - Create new AppServiceDependency and append to services.
 
-        :param attribute_id: The service dependency identifier.
-        :type attribute_id: str
+        :param service_id: The service dependency identifier.
+        :type service_id: str
         :param module_path: The module path.
         :type module_path: str
         :param class_name: The class name.
         :type class_name: str
         :param parameters: New parameters (None to clear).
         :type parameters: Dict[str, Any]
+        :param attribute_id: Deprecated alias for service_id.
+        :type attribute_id: str
         :return: None
         :rtype: None
         '''
 
-        # Find the existing service dependency by attribute_id.
-        dep = self.get_service(attribute_id)
+        # Fall back to attribute_id if service_id is not provided.
+        if service_id is None and attribute_id is not None:
+            service_id = attribute_id
+
+        # Find the existing service dependency by service_id.
+        dep = self.get_service(service_id)
 
         # If the service dependency exists, update its type fields and merge parameters.
         if dep is not None:
@@ -169,7 +185,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         else:
             new_dep = DomainObject.new(
                 AppServiceDependency,
-                attribute_id=attribute_id,
+                service_id=service_id,
                 module_path=module_path,
                 class_name=class_name,
                 parameters=parameters or {},
@@ -257,10 +273,10 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
     A YAML data representation of an app service dependency object.
     '''
 
-    # * attribute: attribute_id
-    attribute_id = StringType(
+    # * attribute: service_id
+    service_id = StringType(
         metadata=dict(
-            description='The attribute id for the application dependency that is not required for assembly.'
+            description='The service id for the application dependency that is not required for assembly.'
         ),
     )
 
@@ -282,18 +298,17 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
 
         serialize_when_none = False
         roles = {
-            'to_model': TransferObject.deny('parameters', 'attribute_id'),
-            'to_data.yaml': TransferObject.deny('attribute_id'),
-            'to_data.json': TransferObject.deny('attribute_id'),
+            'to_model': TransferObject.deny('parameters', 'service_id'),
+            'to_data.yaml': TransferObject.deny('service_id'),
         }
 
     # * method: map
-    def map(self, attribute_id: str, **kwargs) -> AppServiceDependency:
+    def map(self, service_id: str, **kwargs) -> AppServiceDependency:
         '''
         Maps the app service dependency data to an app service dependency object.
 
-        :param attribute_id: The id for the app service dependency.
-        :type attribute_id: str
+        :param service_id: The id for the app service dependency.
+        :type service_id: str
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: A new app service dependency object.
@@ -303,7 +318,7 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
         # Map to the app service dependency object.
         return super().map(
             AppServiceDependency,
-            attribute_id=attribute_id,
+            service_id=service_id,
             parameters=self.parameters,
             **self.to_primitive('to_model'),
             **kwargs
@@ -325,7 +340,6 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
         roles = {
             'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
             'to_data.yaml': TransferObject.deny('id'),
-            'to_data.json': TransferObject.deny('id'),
         }
 
     # * attribute: module_path
@@ -386,7 +400,7 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
             AppInterfaceAggregate,
             module_path=self.module_path,
             class_name=self.class_name,
-            services=[dep.map(attribute_id=dep_id) for dep_id, dep in self.services.items()],
+            services=[dep.map(service_id=dep_id) for dep_id, dep in self.services.items()],
             constants=self.constants,
             **self.to_primitive('to_model'),
             **kwargs
@@ -407,12 +421,12 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
         '''
 
         # Create a new AppInterfaceYamlObject from the model, converting
-        # the services list into a dictionary keyed by attribute_id.
+        # the services list into a dictionary keyed by service_id.
         return TransferObject.from_model(
             AppInterfaceYamlObject,
             app_interface,
             services={
-                dep.attribute_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
+                dep.service_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
                 for dep in app_interface.services
             },
             **kwargs,

--- a/tiferet/mappers/tests/test_app.py
+++ b/tiferet/mappers/tests/test_app.py
@@ -7,610 +7,434 @@ import pytest
 
 # ** app
 from ...domain import AppServiceDependency, DomainObject
-from ...assets import TiferetError
+from ...assets import TiferetError, const
 from ..settings import TransferObject, DEFAULT_MODULE_PATH, DEFAULT_CLASS_NAME
-from ..app import AppInterfaceAggregate, AppInterfaceYamlObject, AppServiceDependencyYamlObject
+from ..app import (
+    AppInterfaceAggregate,
+    AppInterfaceYamlObject,
+    AppServiceDependencyYamlObject,
+)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: app_interface_yaml_obj
-@pytest.fixture
-def app_interface_yaml_obj() -> AppInterfaceYamlObject:
+# *** constants
+
+# ** constant: aggregate_sample_data
+AGGREGATE_SAMPLE_DATA = {
+    'id': 'test.interface',
+    'name': 'Test Interface',
+    'description': 'The test app interface.',
+    'module_path': DEFAULT_MODULE_PATH,
+    'class_name': DEFAULT_CLASS_NAME,
+    'flags': ['test_feature', 'test_data'],
+    'logger_id': 'default',
+    'services': [
+        {
+            'service_id': 'test_attribute',
+            'module_path': 'test.module.path',
+            'class_name': 'TestClassName',
+            'parameters': {'test_param': 'test_value', 'debug': '1'},
+        },
+        {
+            'service_id': 'logging',
+            'module_path': 'tiferet.utils.logging',
+            'class_name': 'LoggingService',
+            'parameters': {},
+        },
+    ],
+    'constants': {
+        'APP_NAME': 'Tiferet Test',
+        'VERSION': '2.0.0a1',
+        'DEBUG': '1',
+    },
+}
+
+# ** constant: equality_fields
+EQUALITY_FIELDS = [
+    'id',
+    'name',
+    'description',
+    'module_path',
+    'class_name',
+    'logger_id',
+    'flags',
+    'constants',
+    'services',
+]
+
+# ** constant: svc_tuple
+def SVC_TUPLE(s):
     '''
-    A fixture for an app interface yaml data object.
-
-    :return: The app interface yaml data object.
-    :rtype: AppInterfaceYamlObject
+    Normalize a single service (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return the app interface yaml data object.
-    return TransferObject.from_data(
-        AppInterfaceYamlObject,
-        id='app_yaml_data',
-        name='Test App YAML Data',
-        module_path=DEFAULT_MODULE_PATH,
-        class_name=DEFAULT_CLASS_NAME,
-        flags=['test_app_yaml_data'],
-        services=dict(
-            test_attribute=dict(
-                module_path='test_module_path',
-                class_name='test_class_name',
-                parameters=dict(
-                    test_param='test_value',
-                )
-            )
-        ),
-        constants=dict(
-            test_const='test_const_value',
+    if isinstance(s, dict):
+        return (
+            s['service_id'],
+            s['module_path'],
+            s['class_name'],
+            tuple(sorted(s.get('parameters', {}).items())),
         )
+    return (
+        s.service_id,
+        s.module_path,
+        s.class_name,
+        tuple(sorted((s.parameters or {}).items())),
     )
 
-# ** fixture: app_interface_aggr
-@pytest.fixture
-def app_interface_aggr() -> AppInterfaceAggregate:
-    '''
-    Fixture to provide a sample AppInterface model for round-trip testing.
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'flags': lambda v: sorted(v or []),
+    'constants': lambda v: dict(sorted((k, v) for k, v in (v or {}).items())),
+    'services': lambda svcs: tuple(sorted(SVC_TUPLE(s) for s in (svcs or []))),
+}
 
-    :return: A sample AppInterface instance.
-    :rtype: AppInterfaceAggregate
+
+# *** classes
+
+# ** class: TestAppInterfaceAggregate
+class TestAppInterfaceAggregate(AggregateTestBase):
+    '''
+    Tests for AppInterfaceAggregate construction, set_attribute, and domain-specific mutations.
     '''
 
-    # Create and return a sample AppInterfaceAggregate instance.
-    app_interface_data = {
+    aggregate_cls = AppInterfaceAggregate
+
+    sample_data = AGGREGATE_SAMPLE_DATA
+
+    equality_fields = EQUALITY_FIELDS
+
+    field_normalizers = FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name',         'Updated Interface',      None),
+        ('description',  'New description text',   None),
+        ('logger_id',    'custom.logger.id',       None),
+        ('flags',        ['flag1', 'flag2'],       None),
+        # invalid
+        ('invalid_attr', 'value',                  const.INVALID_MODEL_ATTRIBUTE_ID),
+        ('module_path',  '',                       const.INVALID_APP_INTERFACE_TYPE_ID),
+        ('class_name',   '   ',                    const.INVALID_APP_INTERFACE_TYPE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
+        '''
+        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return AppInterfaceAggregate.new(
+            app_interface_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** fixtures
+
+    # ** fixture: aggr_factory
+    @pytest.fixture
+    def aggr_factory(self):
+        '''
+        Factory for creating AppInterfaceAggregate with customizable services/constants.
+        '''
+
+        def factory(services=None, constants=None, **overrides):
+
+            # Start from a copy of the shared sample data.
+            data = self.sample_data.copy()
+
+            # Override services and constants if provided.
+            if services is not None:
+                data['services'] = services
+            if constants is not None:
+                data['constants'] = constants
+            data.update(overrides)
+
+            # Create and return the aggregate.
+            return AppInterfaceAggregate.new(app_interface_data=data)
+
+        return factory
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_constants_clear_when_none
+    def test_set_constants_clear_when_none(self, aggr_factory):
+        '''
+        Test that set_constants clears all constants when called with None.
+        '''
+
+        # Create aggregate with seeded constants and clear them.
+        aggr = aggr_factory(constants={'a': '1', 'b': '2'})
+        aggr.set_constants(None)
+
+        # All constants should be cleared.
+        assert aggr.constants == {}
+
+    # ** test: set_constants_merge_and_override
+    def test_set_constants_merge_and_override(self, aggr_factory):
+        '''
+        Test that set_constants merges new constants and overrides existing keys.
+        '''
+
+        # Create aggregate with seeded constants and merge new ones.
+        aggr = aggr_factory(constants={'keep': 'orig', 'old': 'v1'})
+        aggr.set_constants({'old': 'v2', 'new': '42'})
+
+        # Existing keys should be preserved or overridden as appropriate.
+        assert aggr.constants == {'keep': 'orig', 'old': 'v2', 'new': '42'}
+
+    # ** test: set_constants_remove_none_values
+    def test_set_constants_remove_none_values(self, aggr_factory):
+        '''
+        Test that set_constants removes keys whose new value is None.
+        '''
+
+        # Create aggregate with seeded constants and remove one via None.
+        aggr = aggr_factory(constants={'keep': '1', 'drop': 'x'})
+        aggr.set_constants({'drop': None, 'add': 'yes'})
+
+        # The key set to None should be removed.
+        assert aggr.constants == {'keep': '1', 'add': 'yes'}
+
+    # ** test: remove_service_various_positions_and_missing
+    @pytest.mark.parametrize(
+        "initial_ids, remove_id, expected_removed, expected_remaining",
+        [
+            (["first", "middle", "last"], "middle", "middle", ["first", "last"]),
+            (["first", "middle", "last"], "first",  "first",  ["middle", "last"]),
+            (["first", "middle", "last"], "last",   "last",   ["first", "middle"]),
+            (["a", "b"],                  "c",      None,     ["a", "b"]),
+            ([],                          "x",      None,     []),
+        ]
+    )
+    def test_remove_service_various_positions_and_missing(
+        self,
+        aggr_factory,
+        initial_ids,
+        remove_id,
+        expected_removed,
+        expected_remaining,
+    ):
+        '''
+        Test that remove_service removes and returns a matching service, or None if missing.
+        '''
+
+        # Build services from the initial ids.
+        services = [
+            DomainObject.new(
+                AppServiceDependency,
+                service_id=aid,
+                module_path=f"mod.{aid}",
+                class_name=f"{aid.capitalize()}Class",
+                parameters={'p': aid},
+            )
+            for aid in initial_ids
+        ]
+
+        # Create aggregate and attempt removal.
+        aggr = aggr_factory(services=services)
+        removed = aggr.remove_service(remove_id)
+
+        # Verify the removed service (or None).
+        if expected_removed:
+            assert removed is not None
+            assert removed.service_id == expected_removed
+        else:
+            assert removed is None
+
+        # Verify the remaining services.
+        assert [s.service_id for s in aggr.services] == expected_remaining
+
+    # ** test: set_service_update_existing_merge_params
+    def test_set_service_update_existing_merge_params(self, aggregate):
+        '''
+        Test that set_service updates an existing service and merges parameters.
+        '''
+
+        # Update the existing test_attribute service with new type and merged parameters.
+        aggregate.set_service(
+            service_id='test_attribute',
+            module_path='new.mod.path',
+            class_name='NewImplementation',
+            parameters={'old': None, 'keep': 'yes', 'extra': '123', 'debug': '0'},
+        )
+
+        # Verify type fields were updated.
+        svc = aggregate.get_service('test_attribute')
+        assert svc.module_path == 'new.mod.path'
+        assert svc.class_name == 'NewImplementation'
+
+        # Existing params merged, None-valued keys removed, new keys added.
+        assert svc.parameters == {
+            'test_param': 'test_value',
+            'keep': 'yes',
+            'extra': '123',
+            'debug': '0',
+        }
+
+    # ** test: set_service_create_new
+    def test_set_service_create_new(self, aggregate):
+        '''
+        Test that set_service creates a new service when none exists.
+        '''
+
+        # Verify the service does not exist yet.
+        assert aggregate.get_service('brand_new') is None
+
+        # Create a new service via set_service.
+        aggregate.set_service(
+            service_id='brand_new',
+            module_path='pkg.sub.module',
+            class_name='FreshService',
+            parameters={'p1': 'v1', 'p2': '42'},
+        )
+
+        # Verify the new service was created with the correct values.
+        svc = aggregate.get_service('brand_new')
+        assert svc is not None
+        assert svc.module_path == 'pkg.sub.module'
+        assert svc.class_name == 'FreshService'
+        assert svc.parameters == {'p1': 'v1', 'p2': '42'}
+
+
+# ** class: TestAppInterfaceYamlObject
+class TestAppInterfaceYamlObject(TransferObjectTestBase):
+    '''
+    Tests for AppInterfaceYamlObject mapping, round-trip, and nested AppServiceDependencyYamlObject.
+    '''
+
+    transfer_cls = AppInterfaceYamlObject
+    aggregate_cls = AppInterfaceAggregate
+
+    # YAML-format sample data (services as dict keyed by service_id).
+    sample_data = {
         'id': 'test.interface',
         'name': 'Test Interface',
         'description': 'The test app interface.',
         'module_path': DEFAULT_MODULE_PATH,
         'class_name': DEFAULT_CLASS_NAME,
         'flags': ['test_feature', 'test_data'],
-        'services': [
-            {
-                'attribute_id': 'test_attribute',
-                'module_path': 'test_module_path',
-                'class_name': 'test_class_name',
-                'parameters': {
-                    'test_param': 'test_value',
-                },
-            }
-        ],
+        'logger_id': 'default',
+        'services': {
+            'test_attribute': {
+                'module_path': 'test.module.path',
+                'class_name': 'TestClassName',
+                'parameters': {'test_param': 'test_value', 'debug': '1'},
+            },
+            'logging': {
+                'module_path': 'tiferet.utils.logging',
+                'class_name': 'LoggingService',
+                'parameters': {},
+            },
+        },
         'constants': {
-            'TEST_CONST': 'test_const_value',
-        }
-    }
-
-    return AppInterfaceAggregate.new(app_interface_data=app_interface_data)
-
-# *** tests
-
-# ** test: app_interface_aggregate_new
-def test_app_interface_aggregate_new(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test creating an AppInterfaceAggregate.
-
-    :param app_interface_aggr: The app interface aggregate fixture.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(app_interface_aggr, AppInterfaceAggregate)
-    assert app_interface_aggr.id == 'test.interface'
-    assert app_interface_aggr.name == 'Test Interface'
-    assert app_interface_aggr.module_path == DEFAULT_MODULE_PATH
-    assert app_interface_aggr.class_name == DEFAULT_CLASS_NAME
-
-# ** test: app_interface_aggregate_set_attribute_valid_updates
-def test_app_interface_aggregate_set_attribute_valid_updates(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute successfully updates supported attributes and validates the aggregate.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Update multiple supported attributes.
-    app_interface_aggr.set_attribute('name', 'Updated App')
-    app_interface_aggr.set_attribute('description', 'Updated description')
-    app_interface_aggr.set_attribute('logger_id', 'updated_logger')
-    app_interface_aggr.set_attribute('flags', ['updated_flag'])
-
-    # Assert that the attributes were updated.
-    assert app_interface_aggr.name == 'Updated App'
-    assert app_interface_aggr.description == 'Updated description'
-    assert app_interface_aggr.logger_id == 'updated_logger'
-    assert app_interface_aggr.flags == ['updated_flag']
-
-# ** test: app_interface_aggregate_set_attribute_invalid_name
-def test_app_interface_aggregate_set_attribute_invalid_name(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute rejects an unsupported attribute name.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to update an unsupported attribute and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('invalid_attribute', 'value')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
-    assert exc_info.value.kwargs.get('attribute') == 'invalid_attribute'
-
-# ** test: app_interface_aggregate_set_attribute_invalid_module_path
-def test_app_interface_aggregate_set_attribute_invalid_module_path(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute enforces non-empty string for module_path.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to set an empty module_path and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('module_path', '')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
-    assert exc_info.value.kwargs.get('attribute') == 'module_path'
-
-# ** test: app_interface_aggregate_set_attribute_invalid_class_name
-def test_app_interface_aggregate_set_attribute_invalid_class_name(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute enforces non-empty string for class_name.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to set a blank class_name and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('class_name', '   ')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
-    assert exc_info.value.kwargs.get('attribute') == 'class_name'
-
-# ** test: app_interface_aggregate_set_constants_clears_when_none
-def test_app_interface_aggregate_set_constants_clears_when_none(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants clears all constants when called with None.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'existing': 'value',
-        'another': 'value',
-    }
-
-    # Call set_constants with None to clear all constants.
-    app_interface_aggr.set_constants(None)
-
-    # All constants should be cleared.
-    assert app_interface_aggr.constants == {}
-
-# ** test: app_interface_aggregate_set_constants_merges_and_overrides
-def test_app_interface_aggregate_set_constants_merges_and_overrides(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants merges new constants and overrides existing keys.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'keep': 'original',
-        'override': 'old',
-    }
-
-    # Merge new constants, overriding existing keys and adding new ones.
-    app_interface_aggr.set_constants(
-        {
-            'override': 'new',
-            'add': 'added',
+            'APP_NAME': 'Tiferet Test',
+            'VERSION': '2.0.0a1',
+            'DEBUG': '1',
         },
-    )
-
-    # Existing keys should be preserved or overridden as appropriate.
-    assert app_interface_aggr.constants == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
     }
 
-# ** test: app_interface_aggregate_set_constants_removes_none_valued_keys
-def test_app_interface_aggregate_set_constants_removes_none_valued_keys(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants removes keys whose new value is None.
+    # Aggregate-format expected data (services as list, defaults filled in).
+    aggregate_sample_data = AGGREGATE_SAMPLE_DATA
 
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
+    equality_fields = EQUALITY_FIELDS
 
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'keep': 'value',
-        'remove': 'value',
+    field_normalizers = FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
+        '''
+        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return AppInterfaceAggregate.new(
+            app_interface_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
+
+    # *** child mapper: AppServiceDependencyYamlObject
+
+    # ** constant: dependency_sample_data
+    dependency_sample_data = {
+        'module_path': 'example.service.module',
+        'class_name': 'ExampleServiceImpl',
+        'parameters': {'timeout': '30', 'retries': '3', 'ssl': '1'},
     }
 
-    # Provide an update that sets one key to None.
-    app_interface_aggr.set_constants(
-        {
-            'remove': None,
-        },
-    )
+    # ** test: app_service_dependency_yaml_map_basic
+    def test_app_service_dependency_yaml_map_basic(self):
+        '''
+        Test mapping an AppServiceDependencyYamlObject to an AppServiceDependency.
+        '''
 
-    # The key set to None should be removed, and others preserved.
-    assert app_interface_aggr.constants == {
-        'keep': 'value',
-    }
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            **self.dependency_sample_data,
+        )
+        dep = yaml_obj.map(service_id='injected_svc')
 
-# ** test: app_interface_aggregate_set_constants_mixed_operations
-def test_app_interface_aggregate_set_constants_mixed_operations(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants supports mixed operations of clearing, overriding,
-    adding, and preserving keys in a single call.
+        # Verify the mapped entity.
+        assert isinstance(dep, AppServiceDependency)
+        assert dep.service_id == 'injected_svc'
+        assert dep.module_path == 'example.service.module'
+        assert dep.class_name == 'ExampleServiceImpl'
+        assert dep.parameters == {'timeout': '30', 'retries': '3', 'ssl': '1'}
 
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
+    # ** test: app_service_dependency_yaml_aliasing_params
+    def test_app_service_dependency_yaml_aliasing_params(self):
+        '''
+        Test that the "params" serialized_name alias is correctly deserialized.
+        '''
 
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'remove': 'value',
-        'override': 'old',
-        'preserve': 'present',
-    }
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            module_path='alias.test.mod',
+            class_name='AliasImpl',
+            params={'alias_key': 'value'},
+        )
+        dep = yaml_obj.map(service_id='aliased_dep')
 
-    # Perform a mixed update.
-    app_interface_aggr.set_constants(
-        {
-            'remove': None,
-            'override': 'new',
-            'add': 'added',
-        },
-    )
+        # Verify aliased parameters were deserialized correctly.
+        assert dep.parameters == {'alias_key': 'value'}
 
-    # Verify mixed behavior across keys.
-    assert app_interface_aggr.constants == {
-        'override': 'new',
-        'preserve': 'present',
-        'add': 'added',
-    }
+    # ** test: app_service_dependency_yaml_roles_to_model_excludes
+    def test_app_service_dependency_yaml_roles_to_model_excludes(self):
+        '''
+        Test that to_model role excludes parameters and service_id.
+        '''
 
-# ** test: app_interface_aggregate_remove_service_removes_matching_from_middle_start_end
-def test_app_interface_aggregate_remove_service_removes_matching_from_middle_start_end() -> None:
-    '''
-    Test that remove_service removes and returns services when attribute_id
-    matches for items in the middle, start, and end positions.
-    '''
+        # Create YAML object with fields that should be excluded.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            module_path='ex.test.mod',
+            class_name='ExcludeTest',
+            parameters={'secret': 'dontleak'},
+            service_id='should_ignore',
+        )
+        primitive = yaml_obj.to_primitive('to_model')
 
-    # Create three service dependencies with distinct attribute_ids.
-    first = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='first',
-        module_path='module.first',
-        class_name='FirstClass',
-    )
-    middle = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='middle',
-        module_path='module.middle',
-        class_name='MiddleClass',
-    )
-    last = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='last',
-        module_path='module.last',
-        class_name='LastClass',
-    )
+        # Verify excluded fields are absent.
+        assert 'parameters' not in primitive
+        assert 'service_id' not in primitive
+        assert primitive['module_path'] == 'ex.test.mod'
+        assert primitive['class_name'] == 'ExcludeTest'
 
-    # Create an app interface aggregate seeded with the three services.
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[first, middle, last],
-    ))
+    # ** test: app_service_dependency_yaml_round_trip_via_parent
+    def test_app_service_dependency_yaml_round_trip_via_parent(self, aggregate):
+        '''
+        Test that services are preserved through the parent AppInterfaceYamlObject round-trip.
+        '''
 
-    # Remove the middle service and verify it is returned and removed.
-    removed_middle = app_interface.remove_service('middle')
-    assert removed_middle is not None
-    assert removed_middle.attribute_id == 'middle'
-    assert [svc.attribute_id for svc in app_interface.services] == ['first', 'last']
+        # Convert aggregate to YAML object and back.
+        yaml_top = AppInterfaceYamlObject.from_model(aggregate)
+        round_tripped = yaml_top.map()
 
-    # Remove the first service and verify it is returned and removed.
-    removed_first = app_interface.remove_service('first')
-    assert removed_first is not None
-    assert removed_first.attribute_id == 'first'
-    assert [svc.attribute_id for svc in app_interface.services] == ['last']
-
-    # Remove the last remaining service and verify it is returned and removed.
-    removed_last = app_interface.remove_service('last')
-    assert removed_last is not None
-    assert removed_last.attribute_id == 'last'
-    assert app_interface.services == []
-
-# ** test: app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify
-def test_app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify() -> None:
-    '''
-    Test that remove_service returns None and leaves the services list
-    unchanged when no service with the given attribute_id exists.
-    '''
-
-    # Create two service dependencies and an app interface aggregate seeded with them.
-    first = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='first',
-        module_path='module.first',
-        class_name='FirstClass',
-    )
-    second = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='second',
-        module_path='module.second',
-        class_name='SecondClass',
-    )
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[first, second],
-    ))
-
-    # Capture the original list of services for comparison.
-    original_services = list(app_interface.services)
-
-    # Attempt to remove a non-existent service.
-    result = app_interface.remove_service('missing')
-
-    # Verify the method returns None and the list is unchanged.
-    assert result is None
-    assert app_interface.services == original_services
-
-# ** test: app_interface_aggregate_remove_service_on_empty_services_returns_none
-def test_app_interface_aggregate_remove_service_on_empty_services_returns_none() -> None:
-    '''
-    Test that remove_service returns None when called on an app interface aggregate with
-    an empty services list.
-    '''
-
-    # Create an app interface aggregate with no services.
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[],
-    ))
-
-    # Attempt to remove any service and verify None is returned.
-    result = app_interface.remove_service('anything')
-    assert result is None
-
-# ** test: app_interface_aggregate_set_service_updates_existing_and_merges_parameters
-def test_app_interface_aggregate_set_service_updates_existing_and_merges_parameters(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service updates an existing dependency and merges parameters,
-    removing keys whose values are None.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing parameters on the dependency.
-    dependency = app_interface_aggr.get_service('test_attribute')
-    dependency.parameters = {
-        'keep': 'original',
-        'override': 'old',
-        'remove': 'value',
-    }
-
-    # Perform an update with new type information and parameter overrides.
-    app_interface_aggr.set_service(
-        attribute_id='test_attribute',
-        module_path='updated.module',
-        class_name='UpdatedClass',
-        parameters={
-            'override': 'new',
-            'remove': None,
-            'add': 'added',
-        },
-    )
-
-    # Reload the dependency and assert type fields were updated.
-    updated = app_interface_aggr.get_service('test_attribute')
-    assert updated.module_path == 'updated.module'
-    assert updated.class_name == 'UpdatedClass'
-
-    # Existing parameters should be merged, with None-valued keys removed.
-    assert updated.parameters == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
-    }
-
-# ** test: app_interface_aggregate_set_service_clears_parameters_when_none
-def test_app_interface_aggregate_set_service_clears_parameters_when_none(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service clears parameters when parameters is None.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed parameters on the dependency.
-    dependency = app_interface_aggr.get_service('test_attribute')
-    dependency.parameters = {
-        'existing': 'value',
-    }
-
-    # Call set_service with parameters=None.
-    app_interface_aggr.set_service(
-        attribute_id='test_attribute',
-        module_path='cleared.module',
-        class_name='ClearedClass',
-        parameters=None,
-    )
-
-    # Parameters should be cleared while type fields are updated.
-    updated = app_interface_aggr.get_service('test_attribute')
-    assert updated.module_path == 'cleared.module'
-    assert updated.class_name == 'ClearedClass'
-    assert updated.parameters == {}
-
-# ** test: app_interface_aggregate_set_service_creates_new
-def test_app_interface_aggregate_set_service_creates_new(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service creates a new dependency when none exists.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Ensure that no dependency exists with the new attribute_id.
-    assert app_interface_aggr.get_service('new_attribute') is None
-
-    # Create a new dependency via set_service.
-    app_interface_aggr.set_service(
-        attribute_id='new_attribute',
-        module_path='new.module',
-        class_name='NewClass',
-        parameters={
-            'param': 'value',
-        },
-    )
-
-    # Verify that the dependency was created with the correct values.
-    new_svc = app_interface_aggr.get_service('new_attribute')
-    assert new_svc is not None
-    assert new_svc.module_path == 'new.module'
-    assert new_svc.class_name == 'NewClass'
-    assert new_svc.parameters == {'param': 'value'}
-
-# ** test: app_attribute_yaml_object_map
-def test_app_attribute_yaml_object_map():
-    '''
-    Test mapping an AppServiceDependencyYamlObject to an AppServiceDependency entity.
-    '''
-
-    # Create an AppServiceDependencyYamlObject.
-    yaml_obj = TransferObject.from_data(
-        AppServiceDependencyYamlObject,
-        module_path='test.module',
-        class_name='TestClass',
-        parameters={'key': 'value'},
-    )
-
-    # Map to entity.
-    entity = yaml_obj.map(attribute_id='test_attr')
-
-    # Assert the mapping is correct.
-    assert isinstance(entity, AppServiceDependency)
-    assert entity.attribute_id == 'test_attr'
-    assert entity.module_path == 'test.module'
-    assert entity.class_name == 'TestClass'
-    assert entity.parameters == {'key': 'value'}
-
-# ** test: app_interface_yaml_object_from_model
-def test_app_interface_yaml_object_from_model(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test creating an AppInterfaceYamlObject from an AppInterfaceAggregate.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Create YamlObject from aggregate using the custom from_model method.
-    yaml_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
-
-    # Assert the conversion is correct.
-    assert isinstance(yaml_obj, AppInterfaceYamlObject)
-    assert yaml_obj.id == app_interface_aggr.id
-    assert yaml_obj.name == app_interface_aggr.name
-    assert yaml_obj.module_path == app_interface_aggr.module_path
-    assert yaml_obj.class_name == app_interface_aggr.class_name
-    assert 'test_attribute' in yaml_obj.services
-    assert yaml_obj.constants == app_interface_aggr.constants
-
-# ** test: app_settings_yaml_data_map
-def test_app_settings_yaml_data_map(app_interface_yaml_obj: AppInterfaceYamlObject):
-    '''
-    Tests the mapping of an app interface yaml data object to an app interface object.
-
-    :param app_interface_yaml_obj: The app interface yaml data object.
-    :type app_interface_yaml_obj: AppInterfaceYamlObject
-    '''
-
-    # Map the app interface yaml data to an app interface object.
-    app_settings = app_interface_yaml_obj.map()
-
-    # Assert the mapped app interface is valid.
-    assert isinstance(app_settings, AppInterfaceAggregate)
-    assert app_settings.id == app_interface_yaml_obj.id
-    assert app_settings.name == app_interface_yaml_obj.name
-    assert app_settings.flags == app_interface_yaml_obj.flags
-
-    # Assert that the module path and class name are correctly set.
-    assert app_settings.module_path == DEFAULT_MODULE_PATH
-    assert app_settings.class_name == DEFAULT_CLASS_NAME
-
-    # Assert that the mapped service contains the correct data.
-    svc = next(
-        svc for svc in app_settings.services if svc.attribute_id == 'test_attribute')
-    assert svc is not None
-    assert isinstance(svc, AppServiceDependency)
-    assert svc.module_path == 'test_module_path'
-    assert svc.class_name == 'test_class_name'
-
-    # Assert that the parameters are correctly set.
-    param = next(
-        (p for p in svc.parameters if p == 'test_param'), None)
-    assert param is not None
-    assert param == 'test_param'
-    assert svc.parameters['test_param'] == 'test_value'
-
-    # Assert that the constants are correctly set.
-    assert app_settings.constants
-    assert app_settings.constants['test_const'] == 'test_const_value'
-
-# ** test: app_interface_config_data_round_trip
-def test_app_interface_config_data_round_trip(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test round-trip mapping: app interface aggregate -> app interface yaml object -> app interface aggregate.
-
-    :param app_interface_aggr: The app interface aggregate fixture.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Convert aggregate to yaml object and back to aggregate.
-    data_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
-    round_tripped = data_obj.map()
-
-    # Assert core fields match.
-    assert round_tripped.id == app_interface_aggr.id
-    assert round_tripped.name == app_interface_aggr.name
-    assert round_tripped.module_path == app_interface_aggr.module_path
-    assert round_tripped.class_name == app_interface_aggr.class_name
-
-    # Assert services match field-by-field.
-    assert len(round_tripped.services) == len(app_interface_aggr.services)
-    for orig_svc, rt_svc in zip(app_interface_aggr.services, round_tripped.services):
-        assert rt_svc.attribute_id == orig_svc.attribute_id
-        assert rt_svc.module_path == orig_svc.module_path
-        assert rt_svc.class_name == orig_svc.class_name
-        assert rt_svc.parameters == orig_svc.parameters
-
-    # Assert constants match.
-    assert round_tripped.constants == app_interface_aggr.constants
+        # Use nested helper to verify services list preserved.
+        self.assert_nested_list_matches(
+            round_tripped.services,
+            aggregate.services,
+            key_field='service_id',
+            compare_fields=['module_path', 'class_name', 'parameters'],
+        )


### PR DESCRIPTION
## Summary

Ports the `mappers/app.py` cleanup from the `v2.0-proto` prototype (commit `7b6a0f2`) to the `v2.0a5-release` branch.

### Changes

**`tiferet/mappers/app.py`**
- Rename `attribute_id` → `service_id` in `AppInterfaceAggregate` methods (`add_service`, `remove_service`, `set_service`)
- Add backward-compatible `attribute_id` parameter to `remove_service` and `set_service` with `# + todo:` markers for future removal
- Add `dep.attribute_id` fallback in `remove_service` iteration for legacy domain objects
- Rename field override in `AppServiceDependencyYamlObject` from `attribute_id` to `service_id`; update serialization roles
- Update `AppInterfaceYamlObject.map()` to pass `service_id=dep_id` and `from_model()` to key by `dep.service_id`
- Remove `to_data.json` role from both `AppServiceDependencyYamlObject` and `AppInterfaceYamlObject`

**`tiferet/mappers/tests/test_app.py`**
- Full rewrite from standalone fixtures/functions to class-based tests using `AggregateTestBase` / `TransferObjectTestBase` from #642
- `TestAppInterfaceAggregate` — aggregate construction, parametrized `set_attribute`, domain-specific mutation tests (`set_constants`, `remove_service`, `set_service`)
- `TestAppInterfaceYamlObject` — YAML mapping, round-trip, nested `AppServiceDependencyYamlObject` tests
- All `attribute_id` references updated to `service_id`

### Test Results
- 100/100 mapper tests pass
- 72/72 mapper + command app tests pass

Closes #645

Co-Authored-By: Oz <oz-agent@warp.dev>