### PR TITLE
Mappers – DI: Remove JSON Serialization Roles and Migrate Tests to Shared Test Harness (#647)

### DIFF
--- a/tiferet/mappers/di.py
+++ b/tiferet/mappers/di.py
@@ -101,7 +101,6 @@ class FlaggedDependencyYamlObject(FlaggedDependency, TransferObject):
         roles = {
             'to_model': TransferObject.deny(),
             'to_data.yaml': TransferObject.deny('flag'),
-            'to_data.json': TransferObject.deny('flag'),
         }
 
     # * attribute: parameters
@@ -317,7 +316,6 @@ class ServiceConfigurationYamlObject(ServiceConfiguration, TransferObject):
         roles = {
             'to_model': TransferObject.deny('dependencies', 'parameters'),
             'to_data.yaml': TransferObject.deny('id'),
-            'to_data.json': TransferObject.deny('id'),
         }
 
     # * attribute: dependencies

--- a/tiferet/mappers/tests/test_di.py
+++ b/tiferet/mappers/tests/test_di.py
@@ -2,560 +2,613 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
+from ...domain import DomainObject, FlaggedDependency
+from ...events import a
+from ..settings import TransferObject
 from ..di import (
     FlaggedDependencyAggregate,
     FlaggedDependencyYamlObject,
     ServiceConfigurationAggregate,
     ServiceConfigurationYamlObject,
 )
-from ...domain import (
-    DomainObject,
-    FlaggedDependency,
-)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: flagged_dependency_aggregate
-@pytest.fixture
-def flagged_dependency_aggregate() -> FlaggedDependencyAggregate:
+# *** constants
+
+# ** constant: flagged_dep_aggregate_sample_data
+FLAGGED_DEP_AGGREGATE_SAMPLE_DATA = {
+    'module_path': 'tests.repos.test',
+    'class_name': 'TestRepoProxy',
+    'flag': 'test',
+    'parameters': {'keep': 'original', 'override': 'old'},
+}
+
+# ** constant: flagged_dep_equality_fields
+FLAGGED_DEP_EQUALITY_FIELDS = [
+    'module_path',
+    'class_name',
+    'flag',
+    'parameters',
+]
+
+# ** constant: svc_config_aggregate_sample_data
+SVC_CONFIG_AGGREGATE_SAMPLE_DATA = {
+    'id': 'test_repo',
+    'module_path': 'tests.repos.test',
+    'class_name': 'DefaultTestRepoProxy',
+    'parameters': {'default_param': 'default_value'},
+    'dependencies': [
+        {
+            'module_path': 'tests.repos.test',
+            'class_name': 'TestRepoProxy',
+            'flag': 'existing',
+            'parameters': {'param1': 'value1'},
+        },
+    ],
+}
+
+# ** constant: svc_config_equality_fields
+SVC_CONFIG_EQUALITY_FIELDS = [
+    'id',
+    'module_path',
+    'class_name',
+    'parameters',
+    'dependencies',
+]
+
+# ** constant: dep_tuple
+def DEP_TUPLE(d):
     '''
-    Provides a fixture for a FlaggedDependencyAggregate instance.
-
-    :return: The FlaggedDependencyAggregate instance.
-    :rtype: FlaggedDependencyAggregate
+    Normalize a single dependency (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return a FlaggedDependencyAggregate.
-    return FlaggedDependencyAggregate.new(
-        flagged_dependency_data=dict(
+    if isinstance(d, dict):
+        return (
+            d['flag'],
+            d['module_path'],
+            d['class_name'],
+            tuple(sorted(d.get('parameters', {}).items())),
+        )
+    return (
+        d.flag,
+        d.module_path,
+        d.class_name,
+        tuple(sorted((d.parameters or {}).items())),
+    )
+
+# ** constant: svc_config_field_normalizers
+SVC_CONFIG_FIELD_NORMALIZERS = {
+    'dependencies': lambda deps: tuple(sorted(DEP_TUPLE(d) for d in (deps or []))),
+}
+
+
+# *** classes
+
+# ** class: TestFlaggedDependencyAggregate
+class TestFlaggedDependencyAggregate(AggregateTestBase):
+    '''
+    Tests for FlaggedDependencyAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = FlaggedDependencyAggregate
+
+    sample_data = FLAGGED_DEP_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FLAGGED_DEP_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('module_path', 'new.module.path', None),
+        ('class_name',  'NewClassName',    None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FlaggedDependencyAggregate:
+        '''
+        Override to use FlaggedDependencyAggregate.new(flagged_dependency_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FlaggedDependencyAggregate.new(
+            flagged_dependency_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_parameters_clears_when_none
+    def test_set_parameters_clears_when_none(self, aggregate):
+        '''
+        Test that set_parameters clears all parameters when called with None.
+        '''
+
+        # Call set_parameters with None to clear all parameters.
+        aggregate.set_parameters(None)
+
+        # All parameters should be cleared.
+        assert aggregate.parameters == {}
+
+    # ** test: set_parameters_merges_and_prunes_none_values
+    def test_set_parameters_merges_and_prunes_none_values(self, aggregate):
+        '''
+        Test that set_parameters merges new values and removes keys whose value is None.
+        '''
+
+        # Merge: override existing, add new, remove by setting to None.
+        aggregate.set_parameters({
+            'override': 'new',
+            'remove': None,
+            'add': 'added',
+        })
+
+        # 'keep' preserved, 'override' updated, 'remove' pruned, 'add' added.
+        assert aggregate.parameters == {
+            'keep': 'original',
+            'override': 'new',
+            'add': 'added',
+        }
+
+
+# ** class: TestServiceConfigurationAggregate
+class TestServiceConfigurationAggregate(AggregateTestBase):
+    '''
+    Tests for ServiceConfigurationAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = ServiceConfigurationAggregate
+
+    sample_data = SVC_CONFIG_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = SVC_CONFIG_EQUALITY_FIELDS
+
+    field_normalizers = SVC_CONFIG_FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name',         'Updated Service', None),
+        ('module_path',  'updated.module',  None),
+        ('class_name',   'UpdatedClass',    None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> ServiceConfigurationAggregate:
+        '''
+        Override to use ServiceConfigurationAggregate.new(service_configuration_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return ServiceConfigurationAggregate.new(
+            service_configuration_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_default_type_updates
+    def test_set_default_type_updates(self, aggregate):
+        '''
+        Test that set_default_type updates module_path, class_name, and parameters.
+        '''
+
+        # Update the default type with new values.
+        aggregate.set_default_type(
+            module_path='updated.module',
+            class_name='UpdatedClass',
+            parameters={'new_param': 'new_value'},
+        )
+
+        # Assert the fields were updated correctly.
+        assert aggregate.module_path == 'updated.module'
+        assert aggregate.class_name == 'UpdatedClass'
+        assert aggregate.parameters == {'new_param': 'new_value'}
+
+    # ** test: set_default_type_clears_when_both_none
+    def test_set_default_type_clears_when_both_none(self, aggregate):
+        '''
+        Test that set_default_type clears module_path, class_name, and parameters
+        when both type fields are None.
+        '''
+
+        # Call with both type fields as None to clear the default type.
+        aggregate.set_default_type(
+            module_path=None,
+            class_name=None,
+        )
+
+        # Both type fields and parameters should be cleared.
+        assert aggregate.module_path is None
+        assert aggregate.class_name is None
+        assert aggregate.parameters == {}
+
+    # ** test: set_dependency_creates_new
+    def test_set_dependency_creates_new(self, aggregate):
+        '''
+        Test that set_dependency appends a new FlaggedDependency when the flag is not found.
+        '''
+
+        # Confirm the flag does not already exist.
+        assert aggregate.get_dependency('new_flag') is None
+
+        # Add a new dependency via set_dependency.
+        aggregate.set_dependency(
+            flag='new_flag',
             module_path='tests.repos.test',
-            class_name='TestRepoProxy',
-            flag='test',
-            parameters={'keep': 'original', 'override': 'old'},
+            class_name='NewTestRepoProxy',
+            parameters={'new_param': 'new_value'},
         )
-    )
 
-# ** fixture: service_configuration_aggregate
-@pytest.fixture
-def service_configuration_aggregate() -> ServiceConfigurationAggregate:
-    '''
-    Provides a fixture for a ServiceConfigurationAggregate instance.
+        # Verify the dependency was created with the correct values.
+        dep = aggregate.get_dependency('new_flag')
+        assert dep is not None
+        assert isinstance(dep, FlaggedDependency)
+        assert dep.module_path == 'tests.repos.test'
+        assert dep.class_name == 'NewTestRepoProxy'
+        assert dep.parameters == {'new_param': 'new_value'}
+        assert len(aggregate.dependencies) == 2
 
-    :return: The ServiceConfigurationAggregate instance.
-    :rtype: ServiceConfigurationAggregate
-    '''
+    # ** test: set_dependency_updates_existing
+    def test_set_dependency_updates_existing(self, aggregate):
+        '''
+        Test that set_dependency updates an existing dependency in place, merging
+        parameters and pruning None-valued keys.
+        '''
 
-    # Create and return a ServiceConfigurationAggregate with one seeded dependency.
-    return ServiceConfigurationAggregate.new(
-        service_configuration_data=dict(
-            id='test_repo',
-            module_path='tests.repos.test',
-            class_name='DefaultTestRepoProxy',
-            parameters={'default_param': 'default_value'},
-            dependencies=[
-                DomainObject.new(
-                    FlaggedDependency,
-                    module_path='tests.repos.test',
-                    class_name='TestRepoProxy',
-                    flag='existing',
-                    parameters={'param1': 'value1'},
-                )
-            ],
+        # Update the existing 'existing' dependency.
+        aggregate.set_dependency(
+            flag='existing',
+            module_path='tests.repos.updated',
+            class_name='UpdatedRepoProxy',
+            parameters={'param1': None, 'param2': 'value2'},
         )
-    )
 
-# ** fixture: flagged_dependency_yaml_object
-@pytest.fixture
-def flagged_dependency_yaml_object() -> FlaggedDependencyYamlObject:
+        # Verify module_path and class_name were updated.
+        dep = aggregate.get_dependency('existing')
+        assert dep.module_path == 'tests.repos.updated'
+        assert dep.class_name == 'UpdatedRepoProxy'
+
+        # 'param1' had None value so it should be removed; 'param2' should be added.
+        assert dep.parameters == {'param2': 'value2'}
+
+        # The list should still have only one dependency.
+        assert len(aggregate.dependencies) == 1
+
+    # ** test: remove_dependency
+    def test_remove_dependency(self, aggregate):
+        '''
+        Test that remove_dependency filters out the dependency matching the given flag.
+        '''
+
+        # Confirm the dependency exists before removal.
+        assert aggregate.get_dependency('existing') is not None
+
+        # Remove the dependency.
+        aggregate.remove_dependency('existing')
+
+        # Verify it is gone and the list is empty.
+        assert aggregate.get_dependency('existing') is None
+        assert aggregate.dependencies == []
+
+    # ** test: remove_dependency_missing_flag_is_noop
+    def test_remove_dependency_missing_flag_is_noop(self, aggregate):
+        '''
+        Test that remove_dependency with an unmatched flag leaves the list unchanged.
+        '''
+
+        # Record the initial count.
+        initial_count = len(aggregate.dependencies)
+
+        # Attempt to remove a non-existent flag.
+        aggregate.remove_dependency('nonexistent')
+
+        # The list should be unchanged.
+        assert len(aggregate.dependencies) == initial_count
+
+
+# ** class: TestServiceConfigurationYamlObject
+class TestServiceConfigurationYamlObject(TransferObjectTestBase):
     '''
-    Provides a fixture for FlaggedDependency YAML object.
-
-    :return: The FlaggedDependencyYamlObject instance.
-    :rtype: FlaggedDependencyYamlObject
-    '''
-
-    # Create and return a FlaggedDependencyYamlObject.
-    return TransferObject.from_data(
-        FlaggedDependencyYamlObject,
-        module_path='tests.repos.test',
-        class_name='TestRepoProxy',
-        flag='test',
-        params=dict(
-            test_param='test_value'
-        )
-    )
-
-# ** fixture: service_configuration_yaml_object
-@pytest.fixture
-def service_configuration_yaml_object() -> ServiceConfigurationYamlObject:
-    '''
-    Provides a fixture for ServiceConfiguration YAML object.
-
-    :return: The ServiceConfigurationYamlObject instance.
-    :rtype: ServiceConfigurationYamlObject
-    '''
-
-    # Create and return a ServiceConfigurationYamlObject.
-    return TransferObject.from_data(
-        ServiceConfigurationYamlObject,
-        id='test_repo',
-        module_path='tests.repos.test',
-        class_name='DefaultTestRepoProxy',
-        deps=dict(
-            test=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy',
-                params={'test_param': 'test_value'}
-            ),
-            test2=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy2',
-                params={'param2': 'value2'}
-            )
-        ),
-        params=dict(
-            test_param='test_value',
-            param0='value0'
-        )
-    )
-
-# ** fixture: flagged_dependency_model
-@pytest.fixture
-def flagged_dependency_model(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Fixture to create a FlaggedDependency model instance for testing.
-
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    :return: The FlaggedDependency model instance.
-    :rtype: FlaggedDependency
+    Tests for ServiceConfigurationYamlObject mapping, round-trip, and nested FlaggedDependencyYamlObject.
     '''
 
-    # Map the YAML object to a FlaggedDependency model.
-    model = flagged_dependency_yaml_object.map()
-    model.class_name = 'TestRepoProxy2'
-    model.parameters = {'test_param2': 'test_value2'}
+    transfer_cls = ServiceConfigurationYamlObject
+    aggregate_cls = ServiceConfigurationAggregate
 
-    # Return the model object.
-    return model
-
-# *** tests
-
-# ** test: service_configuration_yaml_object_to_primitive_to_data_yaml
-def test_service_configuration_yaml_object_to_primitive_to_data_yaml(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be serialized to primitive data for YAML.
-
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
-
-    # Serialize the data to primitive format for YAML.
-    primitive_data = service_configuration_yaml_object.to_primitive(role='to_data.yaml')
-
-    # Check if the primitive data is correct.
-    assert isinstance(primitive_data, dict)
-    assert primitive_data == {
+    # YAML-format sample data (dependencies as dict keyed by flag).
+    sample_data = {
+        'id': 'test_repo',
         'module_path': 'tests.repos.test',
         'class_name': 'DefaultTestRepoProxy',
         'deps': {
             'test': {
                 'module_path': 'tests.repos.test',
                 'class_name': 'TestRepoProxy',
-                'params': {'test_param': 'test_value'}
+                'params': {'test_param': 'test_value'},
             },
             'test2': {
                 'module_path': 'tests.repos.test',
                 'class_name': 'TestRepoProxy2',
-                'params': {'param2': 'value2'}
+                'params': {'param2': 'value2'},
             },
         },
         'params': {
             'test_param': 'test_value',
-            'param0': 'value0'
-        }
+            'param0': 'value0',
+        },
     }
 
-# ** test: flagged_dependency_yaml_data_from_data
-def test_flagged_dependency_yaml_data_from_data(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Test that the FlaggedDependencyYamlObject can be initialized from data.
+    # Aggregate-format expected data (dependencies as list, defaults filled in).
+    aggregate_sample_data = {
+        'id': 'test_repo',
+        'module_path': 'tests.repos.test',
+        'class_name': 'DefaultTestRepoProxy',
+        'parameters': {'test_param': 'test_value', 'param0': 'value0'},
+        'dependencies': [
+            {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy',
+                'flag': 'test',
+                'parameters': {'test_param': 'test_value'},
+            },
+            {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy2',
+                'flag': 'test2',
+                'parameters': {'param2': 'value2'},
+            },
+        ],
+    }
 
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    '''
+    equality_fields = SVC_CONFIG_EQUALITY_FIELDS
 
-    # Check if the data is correctly initialized.
-    assert flagged_dependency_yaml_object.module_path == 'tests.repos.test'
-    assert flagged_dependency_yaml_object.class_name == 'TestRepoProxy'
-    assert flagged_dependency_yaml_object.flag == 'test'
-    assert flagged_dependency_yaml_object.parameters == {'test_param': 'test_value'}
+    field_normalizers = SVC_CONFIG_FIELD_NORMALIZERS
 
-# ** test: flagged_dependency_yaml_data_map
-def test_flagged_dependency_yaml_data_map(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Test that the FlaggedDependencyYamlObject can be mapped to a FlaggedDependency object.
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> ServiceConfigurationAggregate:
+        '''
+        Override to use ServiceConfigurationAggregate.new(service_configuration_data=...) signature.
+        '''
 
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    '''
+        # Create an aggregate using the custom factory.
+        return ServiceConfigurationAggregate.new(
+            service_configuration_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
 
-    # Map the data to a flagged dependency object.
-    mapped_dep = flagged_dependency_yaml_object.map()
+    # *** domain-specific tests
 
-    # Check if the mapped object is of the correct type.
-    assert isinstance(mapped_dep, FlaggedDependency)
-    assert mapped_dep.module_path == 'tests.repos.test'
-    assert mapped_dep.class_name == 'TestRepoProxy'
-    assert mapped_dep.flag == 'test'
-    assert mapped_dep.parameters == {'test_param': 'test_value'}
+    # ** test: to_primitive_to_data_yaml
+    def test_to_primitive_to_data_yaml(self):
+        '''
+        Test that ServiceConfigurationYamlObject serializes correctly to YAML primitive format.
+        '''
 
-# ** test: flagged_dependency_yaml_data_from_model
-def test_flagged_dependency_yaml_data_from_model(flagged_dependency_model: FlaggedDependency):
-    '''
-    Test that the FlaggedDependencyYamlObject can be created from a model object.
+        # Create a YAML object from sample data.
+        yaml_obj = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            **self.sample_data,
+        )
 
-    :param flagged_dependency_model: The FlaggedDependency model instance.
-    :type flagged_dependency_model: FlaggedDependency
-    '''
+        # Serialize to primitive format for YAML.
+        primitive = yaml_obj.to_primitive(role='to_data.yaml')
 
-    # Create a new data object from the model object.
-    data_from_model = FlaggedDependencyYamlObject.from_model(flagged_dependency_model)
+        # Verify id is excluded and the remaining structure is correct.
+        assert isinstance(primitive, dict)
+        assert 'id' not in primitive
+        assert primitive == {
+            'module_path': 'tests.repos.test',
+            'class_name': 'DefaultTestRepoProxy',
+            'deps': {
+                'test': {
+                    'module_path': 'tests.repos.test',
+                    'class_name': 'TestRepoProxy',
+                    'params': {'test_param': 'test_value'},
+                },
+                'test2': {
+                    'module_path': 'tests.repos.test',
+                    'class_name': 'TestRepoProxy2',
+                    'params': {'param2': 'value2'},
+                },
+            },
+            'params': {
+                'test_param': 'test_value',
+                'param0': 'value0',
+            },
+        }
 
-    # Assert the data object is valid.
-    assert isinstance(data_from_model, FlaggedDependencyYamlObject)
-    assert data_from_model.module_path == flagged_dependency_model.module_path
-    assert data_from_model.class_name == flagged_dependency_model.class_name
-    assert data_from_model.flag == flagged_dependency_model.flag
-    assert data_from_model.parameters == flagged_dependency_model.parameters
+    # ** test: to_model_role_excludes_dependencies_and_parameters
+    def test_to_model_role_excludes_dependencies_and_parameters(self):
+        '''
+        Test that the to_model role excludes dependencies and parameters.
+        '''
 
-# ** test: service_configuration_yaml_data_from_data
-def test_service_configuration_yaml_data_from_data(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be initialized from data.
+        # Create YAML object.
+        yaml_obj = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            **self.sample_data,
+        )
+        primitive = yaml_obj.to_primitive('to_model')
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # Verify excluded fields.
+        assert 'dependencies' not in primitive
+        assert 'parameters' not in primitive
+        assert primitive['id'] == 'test_repo'
+        assert primitive['module_path'] == 'tests.repos.test'
+        assert primitive['class_name'] == 'DefaultTestRepoProxy'
 
-    # Check if the data is correctly initialized.
-    assert service_configuration_yaml_object.id == 'test_repo'
-    assert len(service_configuration_yaml_object.dependencies) == 2
+    # ** test: flags_alias_round_trip
+    def test_flags_alias_round_trip(self):
+        '''
+        Test that the ``flags`` alias for dependencies is accepted on input and
+        that dependencies are still serialized under ``deps``.
+        '''
 
-    # Check if dependencies are correctly initialized.
-    for flag, dep in service_configuration_yaml_object.dependencies.items():
-        assert flag in ['test', 'test2']
-        assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+        # Create a ServiceConfigurationYamlObject using the legacy 'flags' alias.
+        data_object = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            id='test_repo_flags',
+            module_path='tests.repos.test',
+            class_name='DefaultTestRepoProxy',
+            flags=dict(
+                flag1=dict(
+                    module_path='tests.repos.test',
+                    class_name='TestRepoProxy',
+                    params={'test_param': 'test_value'},
+                ),
+            ),
+            params=dict(
+                test_param='test_value',
+            ),
+        )
 
-# ** test: service_configuration_yaml_data_map
-def test_service_configuration_yaml_data_map(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be mapped to a ServiceConfiguration aggregate.
+        # The alias should populate the dependencies mapping keyed by flag.
+        assert isinstance(data_object, ServiceConfigurationYamlObject)
+        assert 'flag1' in data_object.dependencies
+        assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyYamlObject)
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # When serializing to data, dependencies should still be emitted as 'deps'.
+        primitive = data_object.to_primitive(role='to_data.yaml')
+        assert 'flags' not in primitive
+        assert 'deps' in primitive
+        assert 'flag1' in primitive['deps']
 
-    # Map the data to a service configuration aggregate.
-    mapped_attr = service_configuration_yaml_object.map()
+    # ** test: from_model_with_added_dependency
+    def test_from_model_with_added_dependency(self):
+        '''
+        Test that from_model correctly converts an aggregate with added dependencies.
+        '''
 
-    # Assert the mapped object is valid.
-    assert isinstance(mapped_attr, ServiceConfigurationAggregate)
-    assert mapped_attr.id == 'test_repo'
-    assert mapped_attr.module_path == 'tests.repos.test'
-    assert mapped_attr.class_name == 'DefaultTestRepoProxy'
-    assert mapped_attr.parameters == {'test_param': 'test_value', 'param0': 'value0'}
-    assert len(mapped_attr.dependencies) == 2
+        # Create an aggregate and add a third dependency.
+        aggregate = self.make_aggregate()
+        aggregate.set_dependency(
+            flag='test3',
+            module_path='tests.repos.test',
+            class_name='TestRepoProxy3',
+            parameters={'param3': 'value3'},
+        )
 
-    # Assert the dependencies are correctly mapped.
-    for dep in mapped_attr.dependencies:
+        # Convert to YAML object.
+        data_object = ServiceConfigurationYamlObject.from_model(aggregate)
+
+        # Verify the YAML object has all three dependencies.
+        assert isinstance(data_object, ServiceConfigurationYamlObject)
+        assert data_object.id == 'test_repo'
+        assert len(data_object.dependencies) == 3
+
+        # All dependencies should be FlaggedDependencyYamlObject instances.
+        for dep in data_object.dependencies.values():
+            assert isinstance(dep, FlaggedDependencyYamlObject)
+
+    # *** child mapper: FlaggedDependencyYamlObject
+
+    # ** constant: flagged_dep_sample_data
+    flagged_dep_sample_data = {
+        'module_path': 'tests.repos.test',
+        'class_name': 'TestRepoProxy',
+        'flag': 'test',
+        'params': {'test_param': 'test_value'},
+    }
+
+    # ** test: flagged_dependency_yaml_map_basic
+    def test_flagged_dependency_yaml_map_basic(self):
+        '''
+        Test mapping a FlaggedDependencyYamlObject to a FlaggedDependency.
+        '''
+
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            **self.flagged_dep_sample_data,
+        )
+        dep = yaml_obj.map()
+
+        # Verify the mapped entity.
         assert isinstance(dep, FlaggedDependency)
         assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+        assert dep.class_name == 'TestRepoProxy'
+        assert dep.flag == 'test'
+        assert dep.parameters == {'test_param': 'test_value'}
 
-# ** test: service_configuration_yaml_data_from_model
-def test_service_configuration_yaml_data_from_model(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be created from a model object.
+    # ** test: flagged_dependency_yaml_aliasing_params
+    def test_flagged_dependency_yaml_aliasing_params(self):
+        '''
+        Test that the "params" serialized_name alias is correctly deserialized.
+        '''
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            module_path='alias.test.mod',
+            class_name='AliasImpl',
+            flag='aliased',
+            params={'alias_key': 'value'},
+        )
+        dep = yaml_obj.map()
 
-    # Create a new model object from the fixture.
-    model_object = service_configuration_yaml_object.map()
+        # Verify aliased parameters were deserialized correctly.
+        assert dep.parameters == {'alias_key': 'value'}
 
-    # Add another dependency to the model object.
-    model_object.set_dependency(
-        flag='test3',
-        module_path='tests.repos.test',
-        class_name='TestRepoProxy3',
-        parameters={'param3': 'value3'}
-    )
+    # ** test: flagged_dependency_yaml_from_model
+    def test_flagged_dependency_yaml_from_model(self):
+        '''
+        Test that FlaggedDependencyYamlObject can be created from a FlaggedDependency model.
+        '''
 
-    # Create a new data object from the model object.
-    data_object = ServiceConfigurationYamlObject.from_model(model_object)
+        # Create a FlaggedDependency model.
+        model = DomainObject.new(
+            FlaggedDependency,
+            module_path='tests.repos.test',
+            class_name='TestRepoProxy2',
+            flag='test',
+            parameters={'test_param2': 'test_value2'},
+        )
 
-    # Assert the data object is valid.
-    assert isinstance(data_object, ServiceConfigurationYamlObject)
-    assert data_object.id == 'test_repo'
-    assert len(data_object.dependencies) == 3
+        # Create a YAML object from the model.
+        yaml_obj = FlaggedDependencyYamlObject.from_model(model)
 
-    # Check if all dependencies are of type FlaggedDependencyYamlObject.
-    for dep in data_object.dependencies.values():
-        assert isinstance(dep, FlaggedDependencyYamlObject)
-        assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2', 'TestRepoProxy3']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}, {'param3': 'value3'}]
+        # Verify the YAML object has the correct values.
+        assert isinstance(yaml_obj, FlaggedDependencyYamlObject)
+        assert yaml_obj.module_path == model.module_path
+        assert yaml_obj.class_name == model.class_name
+        assert yaml_obj.flag == model.flag
+        assert yaml_obj.parameters == model.parameters
 
-# ** test: service_configuration_yaml_data_flags_alias_round_trip
-def test_service_configuration_yaml_data_flags_alias_round_trip() -> None:
-    '''
-    Test that the ``flags`` alias for dependencies is accepted on input and
-    that dependencies are still serialized under ``deps``.
-    '''
+    # ** test: flagged_dependency_yaml_roles_to_data_yaml_excludes_flag
+    def test_flagged_dependency_yaml_roles_to_data_yaml_excludes_flag(self):
+        '''
+        Test that to_data.yaml role excludes the flag field.
+        '''
 
-    # Create a ServiceConfigurationYamlObject using the legacy 'flags' alias.
-    data_object = TransferObject.from_data(
-        ServiceConfigurationYamlObject,
-        id='test_repo_flags',
-        module_path='tests.repos.test',
-        class_name='DefaultTestRepoProxy',
-        flags=dict(
-            flag1=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy',
-                params={'test_param': 'test_value'},
-            ),
-        ),
-        params=dict(
-            test_param='test_value',
-        ),
-    )
+        # Create a YAML object.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            **self.flagged_dep_sample_data,
+        )
 
-    # The alias should populate the dependencies mapping keyed by flag.
-    assert isinstance(data_object, ServiceConfigurationYamlObject)
-    assert 'flag1' in data_object.dependencies
-    assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyYamlObject)
+        # Serialize with to_data.yaml role.
+        primitive = yaml_obj.to_primitive('to_data.yaml')
 
-    # When serializing to data, dependencies should still be emitted as 'deps'.
-    primitive = data_object.to_primitive(role='to_data.yaml')
-    assert 'flags' not in primitive
-    assert 'deps' in primitive
-    assert 'flag1' in primitive['deps']
+        # Flag should be excluded; other fields present.
+        assert 'flag' not in primitive
+        assert primitive['module_path'] == 'tests.repos.test'
+        assert primitive['class_name'] == 'TestRepoProxy'
 
-# ** test: flagged_dependency_aggregate_new
-def test_flagged_dependency_aggregate_new(flagged_dependency_aggregate: FlaggedDependencyAggregate):
-    '''
-    Test that FlaggedDependencyAggregate.new() creates a valid aggregate.
+    # ** test: flagged_dependency_yaml_round_trip_via_parent
+    def test_flagged_dependency_yaml_round_trip_via_parent(self, aggregate):
+        '''
+        Test that dependencies are preserved through the parent ServiceConfigurationYamlObject round-trip.
+        '''
 
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
+        # Convert aggregate to YAML object and back.
+        yaml_top = ServiceConfigurationYamlObject.from_model(aggregate)
+        round_tripped = yaml_top.map()
 
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(flagged_dependency_aggregate, FlaggedDependencyAggregate)
-    assert flagged_dependency_aggregate.module_path == 'tests.repos.test'
-    assert flagged_dependency_aggregate.class_name == 'TestRepoProxy'
-    assert flagged_dependency_aggregate.flag == 'test'
-    assert flagged_dependency_aggregate.parameters == {'keep': 'original', 'override': 'old'}
-
-# ** test: flagged_dependency_aggregate_set_parameters_clears_when_none
-def test_flagged_dependency_aggregate_set_parameters_clears_when_none(
-    flagged_dependency_aggregate: FlaggedDependencyAggregate,
-):
-    '''
-    Test that set_parameters clears all parameters when called with None.
-
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
-
-    # Call set_parameters with None to clear all parameters.
-    flagged_dependency_aggregate.set_parameters(None)
-
-    # All parameters should be cleared.
-    assert flagged_dependency_aggregate.parameters == {}
-
-# ** test: flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values
-def test_flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values(
-    flagged_dependency_aggregate: FlaggedDependencyAggregate,
-):
-    '''
-    Test that set_parameters merges new values and removes keys whose value is None.
-
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
-
-    # Merge: override existing, add new, remove by setting to None.
-    flagged_dependency_aggregate.set_parameters({
-        'override': 'new',
-        'remove': None,
-        'add': 'added',
-    })
-
-    # 'keep' preserved, 'override' updated, 'remove' pruned, 'add' added.
-    assert flagged_dependency_aggregate.parameters == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
-    }
-
-# ** test: service_configuration_aggregate_new
-def test_service_configuration_aggregate_new(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that ServiceConfigurationAggregate.new() creates a valid aggregate.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(service_configuration_aggregate, ServiceConfigurationAggregate)
-    assert service_configuration_aggregate.id == 'test_repo'
-    assert service_configuration_aggregate.module_path == 'tests.repos.test'
-    assert service_configuration_aggregate.class_name == 'DefaultTestRepoProxy'
-    assert service_configuration_aggregate.parameters == {'default_param': 'default_value'}
-    assert len(service_configuration_aggregate.dependencies) == 1
-
-# ** test: service_configuration_aggregate_set_default_type_updates
-def test_service_configuration_aggregate_set_default_type_updates(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_default_type updates module_path, class_name, and parameters.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Update the default type with new values.
-    service_configuration_aggregate.set_default_type(
-        module_path='updated.module',
-        class_name='UpdatedClass',
-        parameters={'new_param': 'new_value'},
-    )
-
-    # Assert the fields were updated correctly.
-    assert service_configuration_aggregate.module_path == 'updated.module'
-    assert service_configuration_aggregate.class_name == 'UpdatedClass'
-    assert service_configuration_aggregate.parameters == {'new_param': 'new_value'}
-
-# ** test: service_configuration_aggregate_set_default_type_clears_when_both_none
-def test_service_configuration_aggregate_set_default_type_clears_when_both_none(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_default_type clears module_path, class_name, and parameters
-    when both type fields are None.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Call with both type fields as None to clear the default type.
-    service_configuration_aggregate.set_default_type(
-        module_path=None,
-        class_name=None,
-    )
-
-    # Both type fields and parameters should be cleared.
-    assert service_configuration_aggregate.module_path is None
-    assert service_configuration_aggregate.class_name is None
-    assert service_configuration_aggregate.parameters == {}
-
-# ** test: service_configuration_aggregate_set_dependency_creates_new
-def test_service_configuration_aggregate_set_dependency_creates_new(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_dependency appends a new FlaggedDependency when the flag is not found.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Confirm the flag does not already exist.
-    assert service_configuration_aggregate.get_dependency('new_flag') is None
-
-    # Add a new dependency via set_dependency.
-    service_configuration_aggregate.set_dependency(
-        flag='new_flag',
-        module_path='tests.repos.test',
-        class_name='NewTestRepoProxy',
-        parameters={'new_param': 'new_value'},
-    )
-
-    # Verify the dependency was created with the correct values.
-    dep = service_configuration_aggregate.get_dependency('new_flag')
-    assert dep is not None
-    assert isinstance(dep, FlaggedDependency)
-    assert dep.module_path == 'tests.repos.test'
-    assert dep.class_name == 'NewTestRepoProxy'
-    assert dep.parameters == {'new_param': 'new_value'}
-    assert len(service_configuration_aggregate.dependencies) == 2
-
-# ** test: service_configuration_aggregate_set_dependency_updates_existing
-def test_service_configuration_aggregate_set_dependency_updates_existing(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_dependency updates an existing dependency in place, merging
-    parameters and pruning None-valued keys.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Update the existing 'existing' dependency.
-    service_configuration_aggregate.set_dependency(
-        flag='existing',
-        module_path='tests.repos.updated',
-        class_name='UpdatedRepoProxy',
-        parameters={'param1': None, 'param2': 'value2'},
-    )
-
-    # Verify module_path and class_name were updated.
-    dep = service_configuration_aggregate.get_dependency('existing')
-    assert dep.module_path == 'tests.repos.updated'
-    assert dep.class_name == 'UpdatedRepoProxy'
-
-    # 'param1' had None value so it should be removed; 'param2' should be added.
-    assert dep.parameters == {'param2': 'value2'}
-
-    # The list should still have only one dependency.
-    assert len(service_configuration_aggregate.dependencies) == 1
-
-# ** test: service_configuration_aggregate_remove_dependency
-def test_service_configuration_aggregate_remove_dependency(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that remove_dependency filters out the dependency matching the given flag.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Confirm the dependency exists before removal.
-    assert service_configuration_aggregate.get_dependency('existing') is not None
-
-    # Remove the dependency.
-    service_configuration_aggregate.remove_dependency('existing')
-
-    # Verify it is gone and the list is empty.
-    assert service_configuration_aggregate.get_dependency('existing') is None
-    assert service_configuration_aggregate.dependencies == []
+        # Verify dependencies list preserved using nested helper.
+        self.assert_nested_list_matches(
+            round_tripped.dependencies,
+            aggregate.dependencies,
+            key_field='flag',
+            compare_fields=['module_path', 'class_name', 'parameters'],
+        )


### PR DESCRIPTION
Closes #647

## Summary

- **`tiferet/mappers/di.py`** — Removed `to_data.json` roles from `FlaggedDependencyYamlObject.Options.roles` and `ServiceConfigurationYamlObject.Options.roles`.
- **`tiferet/mappers/tests/test_di.py`** — Full rewrite from 17 flat function-based tests to 29 class-based tests using the shared `AggregateTestBase` / `TransferObjectTestBase` harness from #642.

### Test Classes
- `TestFlaggedDependencyAggregate` — aggregate construction, parametrized `set_attribute`, `set_parameters` mutations
- `TestServiceConfigurationAggregate` — aggregate construction, parametrized `set_attribute`, `set_default_type`, `set_dependency`, `remove_dependency` (including noop)
- `TestServiceConfigurationYamlObject` — inherited map/from_model/round_trip, YAML serialization, role exclusion, alias round-trip, `from_model` with mutation, and nested `FlaggedDependencyYamlObject` child mapper tests

### Test Results
- `pytest tiferet/mappers/tests/test_di.py` — 29/29 passed
- `pytest tiferet/` — 972 passed, 7 skipped, 0 failures

Co-Authored-By: Oz <oz-agent@warp.dev>