### PR TITLE
Mappers – Migrate test_feature.py to Harness Pattern, Swap attribute_id to service_id, Remove to_data.json Roles (#652)

### DIFF
--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -136,7 +136,6 @@ class FeatureEventYamlObject(FeatureEvent, TransferObject):
         roles = {
             'to_model': TransferObject.deny('type'),
             'to_data.yaml': TransferObject.deny('type'),
-            'to_data.json': TransferObject.deny('type')
         }
 
     # * attribute: parameters
@@ -264,19 +263,20 @@ class FeatureAggregate(Feature, Aggregate):
     def add_step(
         self,
         name: str,
-        attribute_id: str,
+        service_id: str = None,
         parameters: Dict[str, Any] | None = None,
         data_key: str | None = None,
         pass_on_error: bool = False,
         position: int | None = None,
+        attribute_id: str = None,
     ) -> FeatureEvent:
         '''
         Add a feature event step using raw attributes.
 
         :param name: Step name.
         :type name: str
-        :param attribute_id: Container attribute ID.
-        :type attribute_id: str
+        :param service_id: Service configuration ID (primary).
+        :type service_id: str
         :param parameters: Optional parameters dictionary.
         :type parameters: dict | None
         :param data_key: Optional result data key.
@@ -285,14 +285,20 @@ class FeatureAggregate(Feature, Aggregate):
         :type pass_on_error: bool
         :param position: Insertion position (None to append).
         :type position: int | None
+        :param attribute_id: Deprecated fallback for service_id.
+        :type attribute_id: str
         :return: Created FeatureEvent instance.
         :rtype: FeatureEvent
         '''
 
+        # Resolve service_id from the primary or deprecated fallback.
+        service_id = service_id or attribute_id
+
         # Create the feature event from raw attributes.
         step = FeatureEventAggregate.new(
             name=name,
-            attribute_id=attribute_id,
+            service_id=service_id,
+            attribute_id=service_id,
             parameters=parameters or {},
             data_key=data_key,
             pass_on_error=pass_on_error,
@@ -422,7 +428,6 @@ class FeatureYamlObject(Feature, TransferObject):
         roles = {
             'to_model': TransferObject.deny('steps'),
             'to_data.yaml': TransferObject.deny('feature_key', 'group_id', 'id'),
-            'to_data.json': TransferObject.deny('feature_key', 'group_id', 'id')
         }
 
     # * attribute: steps

--- a/tiferet/mappers/tests/test_feature.py
+++ b/tiferet/mappers/tests/test_feature.py
@@ -2,406 +2,447 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
+from ...domain import DomainObject, FeatureEvent
+from ...events import a
+from ..settings import TransferObject
 from ..feature import (
     FeatureEventAggregate,
     FeatureEventYamlObject,
     FeatureAggregate,
     FeatureYamlObject,
 )
-from ...domain import (
-    Feature,
-    FeatureEvent,
-)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: feature_event_yaml_object
-@pytest.fixture
-def feature_event_yaml_object() -> FeatureEventYamlObject:
+# *** constants
+
+# ** constant: feature_event_aggregate_sample_data
+FEATURE_EVENT_AGGREGATE_SAMPLE_DATA = {
+    'name': 'Test Event',
+    'service_id': 'test_event_handler',
+    'parameters': {'key': 'value'},
+    'data_key': 'result',
+    'pass_on_error': True,
+}
+
+# ** constant: feature_event_equality_fields
+FEATURE_EVENT_EQUALITY_FIELDS = [
+    'name',
+    'service_id',
+    'parameters',
+    'data_key',
+    'pass_on_error',
+]
+
+# ** constant: feature_aggregate_sample_data
+FEATURE_AGGREGATE_SAMPLE_DATA = {
+    'name': 'Add Number',
+    'group_id': 'calc',
+    'feature_key': 'add_number',
+    'id': 'calc.add_number',
+    'description': 'Add Number',
+}
+
+# ** constant: feature_equality_fields
+FEATURE_EQUALITY_FIELDS = [
+    'id',
+    'name',
+    'group_id',
+    'feature_key',
+    'description',
+    'steps',
+]
+
+# ** constant: step_tuple
+def STEP_TUPLE(s):
     '''
-    Provides a feature event YAML object fixture with pass_on_error,
-    data_key, and params alias.
-
-    :return: The feature event YAML object instance.
-    :rtype: FeatureEventYamlObject
+    Normalize a single step (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return a feature event YAML object.
-    return TransferObject.from_data(
-        FeatureEventYamlObject,
-        name='Test Event',
-        attribute_id='test_event_handler',
-        params={'key': 'value'},
-        data_key='result',
-        pass_on_error=True,
+    if isinstance(s, dict):
+        return (
+            s.get('name', ''),
+            s.get('service_id', ''),
+            tuple(sorted(s.get('parameters', {}).items())),
+        )
+    return (
+        getattr(s, 'name', ''),
+        getattr(s, 'service_id', ''),
+        tuple(sorted((getattr(s, 'parameters', None) or {}).items())),
     )
 
+# ** constant: feature_field_normalizers
+FEATURE_FIELD_NORMALIZERS = {
+    'steps': lambda steps: tuple(sorted(STEP_TUPLE(s) for s in (steps or []))),
+}
 
-# ** fixture: feature_yaml_object
-@pytest.fixture
-def feature_yaml_object() -> FeatureYamlObject:
+
+# *** classes
+
+# ** class: TestFeatureEventAggregate
+class TestFeatureEventAggregate(AggregateTestBase):
     '''
-    Provides a feature YAML object fixture with one step containing params.
-
-    :return: The feature YAML object instance.
-    :rtype: FeatureYamlObject
+    Tests for FeatureEventAggregate construction, set_attribute, and domain-specific mutations.
     '''
 
-    # Create and return a feature YAML object.
-    return TransferObject.from_data(
-        FeatureYamlObject,
-        id='calc.add',
-        name='Add Number',
-        group_id='calc',
-        feature_key='add',
-        description='Adds one number to another',
-        steps=[{
+    aggregate_cls = FeatureEventAggregate
+
+    sample_data = FEATURE_EVENT_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FEATURE_EVENT_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Event', None),
+        ('service_id', 'updated_handler', None),
+        ('data_key', 'new_key', None),
+    ]
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_pass_on_error
+    def test_set_pass_on_error(self, aggregate):
+        '''
+        Verifies string normalization ("false", "False", truthy).
+        '''
+
+        # String "false" should normalize to False.
+        aggregate.set_pass_on_error('false')
+        assert aggregate.pass_on_error is False
+
+        # String "False" should normalize to False.
+        aggregate.set_pass_on_error('False')
+        assert aggregate.pass_on_error is False
+
+        # Truthy string should normalize to True.
+        aggregate.set_pass_on_error('true')
+        assert aggregate.pass_on_error is True
+
+        # Boolean True should remain True.
+        aggregate.set_pass_on_error(True)
+        assert aggregate.pass_on_error is True
+
+    # ** test: set_parameters
+    def test_set_parameters(self, aggregate):
+        '''
+        Verifies merge, None-prune, and no-op on None.
+        '''
+
+        # Merge new parameters (new_key added, key updated).
+        aggregate.set_parameters({'key': '10', 'new_key': '3'})
+        assert aggregate.parameters == {'key': '10', 'new_key': '3'}
+
+        # Prune keys with None values.
+        aggregate.set_parameters({'new_key': None})
+        assert aggregate.parameters == {'key': '10'}
+
+        # None input is a no-op.
+        aggregate.set_parameters(None)
+        assert aggregate.parameters == {'key': '10'}
+
+    # ** test: set_attribute_delegation
+    def test_set_attribute_delegation(self, aggregate):
+        '''
+        Verifies delegation to specialized helpers.
+        '''
+
+        # set_attribute for parameters should delegate to set_parameters.
+        aggregate.set_attribute('parameters', {'y': '2'})
+        assert 'y' in aggregate.parameters
+
+        # set_attribute for pass_on_error should delegate to set_pass_on_error.
+        aggregate.set_attribute('pass_on_error', 'false')
+        assert aggregate.pass_on_error is False
+
+        # set_attribute for other attributes should use setattr.
+        aggregate.set_attribute('name', 'Renamed Event')
+        assert aggregate.name == 'Renamed Event'
+
+
+# ** class: TestFeatureAggregate
+class TestFeatureAggregate(AggregateTestBase):
+    '''
+    Tests for FeatureAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = FeatureAggregate
+
+    sample_data = FEATURE_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FEATURE_EQUALITY_FIELDS
+
+    field_normalizers = FEATURE_FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Feature', None),
+        ('description', 'Updated description', None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FeatureAggregate:
+        '''
+        Override to use FeatureAggregate.new() custom factory.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FeatureAggregate.new(**(data or self.sample_data))
+
+    # *** domain-specific tests
+
+    # ** test: smart_derivation
+    def test_smart_derivation(self, aggregate):
+        '''
+        Verifies smart derivation (name -> feature_key -> id).
+        '''
+
+        # Assert smart derivation of feature_key and id.
+        assert aggregate.feature_key == 'add_number'
+        assert aggregate.id == 'calc.add_number'
+        assert aggregate.description == 'Add Number'
+
+    # ** test: add_step
+    def test_add_step(self, aggregate):
+        '''
+        Verifies step append.
+        '''
+
+        # Add a step.
+        step = aggregate.add_step(
+            name='Step One',
+            service_id='step_one_event',
+        )
+
+        # Assert the step was appended.
+        assert len(aggregate.steps) == 1
+        assert aggregate.steps[0] is step
+        assert step.name == 'Step One'
+        assert step.service_id == 'step_one_event'
+
+    # ** test: add_step_position
+    def test_add_step_position(self, aggregate):
+        '''
+        Verifies step insertion at position 0.
+        '''
+
+        # Add two steps, inserting the second at position 0.
+        aggregate.add_step(name='Step One', service_id='step_one_event')
+        inserted = aggregate.add_step(
+            name='Step Zero',
+            service_id='step_zero_event',
+            position=0,
+        )
+
+        # Assert the step was inserted at position 0.
+        assert len(aggregate.steps) == 2
+        assert aggregate.steps[0] is inserted
+        assert aggregate.steps[0].name == 'Step Zero'
+        assert aggregate.steps[1].name == 'Step One'
+
+    # ** test: remove_step
+    def test_remove_step(self, aggregate):
+        '''
+        Verifies removal and invalid position handling.
+        '''
+
+        # Add two steps.
+        aggregate.add_step(name='Step One', service_id='step_one_event')
+        aggregate.add_step(name='Step Two', service_id='step_two_event')
+
+        # Remove the first step.
+        removed = aggregate.remove_step(0)
+        assert removed is not None
+        assert removed.name == 'Step One'
+        assert len(aggregate.steps) == 1
+
+        # Attempt to remove at invalid positions.
+        assert aggregate.remove_step(-1) is None
+        assert aggregate.remove_step(99) is None
+
+    # ** test: reorder_step
+    def test_reorder_step(self, aggregate):
+        '''
+        Verifies move with clamping.
+        '''
+
+        # Add three steps.
+        aggregate.add_step(name='A', service_id='a_event')
+        aggregate.add_step(name='B', service_id='b_event')
+        aggregate.add_step(name='C', service_id='c_event')
+
+        # Move step A (position 0) to position 2.
+        moved = aggregate.reorder_step(0, 2)
+        assert moved is not None
+        assert moved.name == 'A'
+        assert aggregate.steps[0].name == 'B'
+        assert aggregate.steps[1].name == 'C'
+        assert aggregate.steps[2].name == 'A'
+
+    # ** test: rename
+    def test_rename(self, aggregate):
+        '''
+        Verifies name update without id change.
+        '''
+
+        # Record original id and rename the feature.
+        original_id = aggregate.id
+        aggregate.rename('New Name')
+
+        # Assert the name was updated but the id was not.
+        assert aggregate.name == 'New Name'
+        assert aggregate.id == original_id
+
+    # ** test: set_description
+    def test_set_description(self, aggregate):
+        '''
+        Verifies set and clear.
+        '''
+
+        # Set a description.
+        aggregate.set_description('A custom description')
+        assert aggregate.description == 'A custom description'
+
+        # Clear the description.
+        aggregate.set_description(None)
+        assert aggregate.description is None
+
+
+# ** class: TestFeatureYamlObject
+class TestFeatureYamlObject(TransferObjectTestBase):
+    '''
+    Tests for FeatureYamlObject mapping, round-trip, and nested FeatureEventYamlObject.
+    '''
+
+    transfer_cls = FeatureYamlObject
+    aggregate_cls = FeatureAggregate
+
+    # YAML-format sample data (steps with params alias and service_id).
+    sample_data = {
+        'id': 'calc.add',
+        'name': 'Add Number',
+        'group_id': 'calc',
+        'feature_key': 'add',
+        'description': 'Adds one number to another',
+        'steps': [{
             'name': 'Add a and b',
-            'attribute_id': 'add_number_event',
+            'service_id': 'add_number_event',
             'params': {'precision': '2'},
         }],
-    )
-
-
-# *** tests
-
-# ** test: feature_event_data_init
-def test_feature_event_data_init(feature_event_yaml_object: FeatureEventYamlObject):
-    '''
-    Verifies from_data() initialization including params alias.
-
-    :param feature_event_yaml_object: The feature event YAML object.
-    :type feature_event_yaml_object: FeatureEventYamlObject
-    '''
-
-    # Assert basic attributes.
-    assert feature_event_yaml_object.name == 'Test Event'
-    assert feature_event_yaml_object.attribute_id == 'test_event_handler'
-    assert feature_event_yaml_object.data_key == 'result'
-    assert feature_event_yaml_object.pass_on_error is True
-
-    # Assert the params alias resolved correctly.
-    assert feature_event_yaml_object.parameters == {'key': 'value'}
-
-
-# ** test: feature_event_data_map
-def test_feature_event_data_map(feature_event_yaml_object: FeatureEventYamlObject):
-    '''
-    Verifies map() produces a FeatureEvent with correct fields.
-
-    :param feature_event_yaml_object: The feature event YAML object.
-    :type feature_event_yaml_object: FeatureEventYamlObject
-    '''
-
-    # Map the feature event data to a feature event aggregate.
-    event = feature_event_yaml_object.map()
-
-    # Assert the mapped object is a FeatureEventAggregate.
-    assert isinstance(event, FeatureEventAggregate)
-    assert event.name == 'Test Event'
-    assert event.attribute_id == 'test_event_handler'
-    assert event.parameters == {'key': 'value'}
-    assert event.data_key == 'result'
-    assert event.pass_on_error is True
-
-
-# ** test: feature_data_from_data
-def test_feature_data_from_data(feature_yaml_object: FeatureYamlObject):
-    '''
-    Verifies nested steps initialization.
-
-    :param feature_yaml_object: The feature YAML object.
-    :type feature_yaml_object: FeatureYamlObject
-    '''
-
-    # Assert basic attributes.
-    assert feature_yaml_object.id == 'calc.add'
-    assert feature_yaml_object.name == 'Add Number'
-    assert feature_yaml_object.group_id == 'calc'
-    assert feature_yaml_object.feature_key == 'add'
-    assert feature_yaml_object.description == 'Adds one number to another'
-
-    # Assert the steps were initialized as FeatureEventYamlObject instances.
-    assert len(feature_yaml_object.steps) == 1
-    step = feature_yaml_object.steps[0]
-    assert isinstance(step, FeatureEventYamlObject)
-    assert step.name == 'Add a and b'
-    assert step.attribute_id == 'add_number_event'
-    assert step.parameters == {'precision': '2'}
-
-
-# ** test: feature_data_map
-def test_feature_data_map(feature_yaml_object: FeatureYamlObject):
-    '''
-    Verifies map() produces a FeatureAggregate with nested steps.
-
-    :param feature_yaml_object: The feature YAML object.
-    :type feature_yaml_object: FeatureYamlObject
-    '''
-
-    # Map the feature data to a feature aggregate.
-    feature = feature_yaml_object.map()
-
-    # Assert the mapped object is a FeatureAggregate.
-    assert isinstance(feature, FeatureAggregate)
-    assert feature.id == 'calc.add'
-    assert feature.name == 'Add Number'
-    assert feature.group_id == 'calc'
-    assert feature.feature_key == 'add'
-
-    # Assert nested steps were mapped correctly.
-    assert len(feature.steps) == 1
-    step = feature.steps[0]
-    assert isinstance(step, FeatureEventAggregate)
-    assert step.name == 'Add a and b'
-    assert step.attribute_id == 'add_number_event'
-    assert step.parameters == {'precision': '2'}
-
-
-# ** test: feature_aggregate_new
-def test_feature_aggregate_new():
-    '''
-    Verifies smart derivation (name → feature_key → id).
-    '''
-
-    # Create a feature aggregate with only name and group_id.
-    feature = FeatureAggregate.new(
-        name='Add Number',
-        group_id='calc',
-    )
-
-    # Assert smart derivation of feature_key and id.
-    assert feature.feature_key == 'add_number'
-    assert feature.id == 'calc.add_number'
-    assert feature.description == 'Add Number'
-
-
-# ** test: feature_aggregate_add_step
-def test_feature_aggregate_add_step():
-    '''
-    Verifies step append.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-
-    # Add a step.
-    step = feature.add_step(
-        name='Step One',
-        attribute_id='step_one_event',
-    )
-
-    # Assert the step was appended.
-    assert len(feature.steps) == 1
-    assert feature.steps[0] is step
-    assert step.name == 'Step One'
-    assert step.attribute_id == 'step_one_event'
-
-
-# ** test: feature_aggregate_add_step_position
-def test_feature_aggregate_add_step_position():
-    '''
-    Verifies step insertion at position 0.
-    '''
-
-    # Create a feature aggregate with an existing step.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='Step One', attribute_id='step_one_event')
-
-    # Insert a new step at position 0.
-    inserted = feature.add_step(
-        name='Step Zero',
-        attribute_id='step_zero_event',
-        position=0,
-    )
-
-    # Assert the step was inserted at position 0.
-    assert len(feature.steps) == 2
-    assert feature.steps[0] is inserted
-    assert feature.steps[0].name == 'Step Zero'
-    assert feature.steps[1].name == 'Step One'
-
-
-# ** test: feature_aggregate_remove_step
-def test_feature_aggregate_remove_step():
-    '''
-    Verifies removal and invalid position handling.
-    '''
-
-    # Create a feature aggregate with steps.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='Step One', attribute_id='step_one_event')
-    feature.add_step(name='Step Two', attribute_id='step_two_event')
-
-    # Remove the first step.
-    removed = feature.remove_step(0)
-    assert removed is not None
-    assert removed.name == 'Step One'
-    assert len(feature.steps) == 1
-
-    # Attempt to remove at an invalid position.
-    assert feature.remove_step(-1) is None
-    assert feature.remove_step(99) is None
-
-
-# ** test: feature_aggregate_reorder_step
-def test_feature_aggregate_reorder_step():
-    '''
-    Verifies move with clamping.
-    '''
-
-    # Create a feature aggregate with steps.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='A', attribute_id='a_event')
-    feature.add_step(name='B', attribute_id='b_event')
-    feature.add_step(name='C', attribute_id='c_event')
-
-    # Move step A (position 0) to position 2.
-    moved = feature.reorder_step(0, 2)
-    assert moved is not None
-    assert moved.name == 'A'
-    assert feature.steps[0].name == 'B'
-    assert feature.steps[1].name == 'C'
-    assert feature.steps[2].name == 'A'
-
-
-# ** test: feature_aggregate_rename
-def test_feature_aggregate_rename():
-    '''
-    Verifies name update without id change.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Old Name',
-        group_id='test',
-    )
-    original_id = feature.id
-
-    # Rename the feature.
-    feature.rename('New Name')
-
-    # Assert the name was updated but the id was not.
-    assert feature.name == 'New Name'
-    assert feature.id == original_id
-
-
-# ** test: feature_aggregate_set_description
-def test_feature_aggregate_set_description():
-    '''
-    Verifies set and clear.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-
-    # Set a description.
-    feature.set_description('A custom description')
-    assert feature.description == 'A custom description'
-
-    # Clear the description.
-    feature.set_description(None)
-    assert feature.description is None
-
-
-# ** test: feature_event_aggregate_set_pass_on_error
-def test_feature_event_aggregate_set_pass_on_error():
-    '''
-    Verifies string normalization ("false", "False", truthy).
-    '''
-
-    # Create a feature event aggregate.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-    )
-
-    # String "false" should normalize to False.
-    event.set_pass_on_error('false')
-    assert event.pass_on_error is False
-
-    # String "False" should normalize to False.
-    event.set_pass_on_error('False')
-    assert event.pass_on_error is False
-
-    # Truthy string should normalize to True.
-    event.set_pass_on_error('true')
-    assert event.pass_on_error is True
-
-    # Boolean True should remain True.
-    event.set_pass_on_error(True)
-    assert event.pass_on_error is True
-
-
-# ** test: feature_event_aggregate_set_parameters
-def test_feature_event_aggregate_set_parameters():
-    '''
-    Verifies merge, None-prune, and no-op on None.
-    '''
-
-    # Create a feature event aggregate with initial parameters.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-        parameters={'a': '1', 'b': '2'},
-    )
-
-    # Merge new parameters (c added, a updated).
-    event.set_parameters({'a': '10', 'c': '3'})
-    assert event.parameters == {'a': '10', 'b': '2', 'c': '3'}
-
-    # Prune keys with None values.
-    event.set_parameters({'b': None})
-    assert event.parameters == {'a': '10', 'c': '3'}
-
-    # None input is a no-op.
-    event.set_parameters(None)
-    assert event.parameters == {'a': '10', 'c': '3'}
-
-
-# ** test: feature_event_aggregate_set_attribute
-def test_feature_event_aggregate_set_attribute():
-    '''
-    Verifies delegation to specialized helpers.
-    '''
-
-    # Create a feature event aggregate.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-        parameters={'x': '1'},
-    )
-
-    # set_attribute for parameters should delegate to set_parameters.
-    event.set_attribute('parameters', {'y': '2'})
-    assert event.parameters == {'x': '1', 'y': '2'}
-
-    # set_attribute for pass_on_error should delegate to set_pass_on_error.
-    event.set_attribute('pass_on_error', 'false')
-    assert event.pass_on_error is False
-
-    # set_attribute for other attributes should use setattr.
-    event.set_attribute('name', 'Renamed Event')
-    assert event.name == 'Renamed Event'
+    }
+
+    # Aggregate-format expected data (defaults filled in).
+    aggregate_sample_data = {
+        'id': 'calc.add',
+        'name': 'Add Number',
+        'group_id': 'calc',
+        'feature_key': 'add',
+        'description': 'Adds one number to another',
+        'steps': [{
+            'name': 'Add a and b',
+            'service_id': 'add_number_event',
+            'parameters': {'precision': '2'},
+        }],
+    }
+
+    equality_fields = FEATURE_EQUALITY_FIELDS
+
+    field_normalizers = FEATURE_FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FeatureAggregate:
+        '''
+        Override to use FeatureAggregate.new() custom factory.
+        '''
+
+        # Create an aggregate using the custom factory.
+        data = data or self.aggregate_sample_data
+
+        # Build steps as FeatureEventAggregate instances.
+        steps = [
+            FeatureEventAggregate.new(**step)
+            for step in data.get('steps', [])
+        ]
+
+        # Create the feature aggregate with mapped steps.
+        return FeatureAggregate.new(
+            **{k: v for k, v in data.items() if k != 'steps'},
+            steps=steps,
+        )
+
+    # *** child mapper: FeatureEventYamlObject
+
+    # ** constant: feature_event_sample_data
+    feature_event_sample_data = {
+        'name': 'Test Event',
+        'service_id': 'test_event_handler',
+        'params': {'key': 'value'},
+        'data_key': 'result',
+        'pass_on_error': True,
+    }
+
+    # ** test: feature_event_yaml_map_basic
+    def test_feature_event_yaml_map_basic(self):
+        '''
+        Test mapping a FeatureEventYamlObject to a FeatureEventAggregate.
+        '''
+
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            FeatureEventYamlObject,
+            **self.feature_event_sample_data,
+        )
+        event = yaml_obj.map()
+
+        # Verify the mapped entity.
+        assert isinstance(event, FeatureEventAggregate)
+        assert event.name == 'Test Event'
+        assert event.service_id == 'test_event_handler'
+        assert event.parameters == {'key': 'value'}
+        assert event.data_key == 'result'
+        assert event.pass_on_error is True
+
+    # ** test: feature_event_yaml_params_alias
+    def test_feature_event_yaml_params_alias(self):
+        '''
+        Test that the "params" alias is correctly deserialized.
+        '''
+
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            FeatureEventYamlObject,
+            name='Alias Event',
+            service_id='alias_handler',
+            params={'alias_key': 'value'},
+        )
+        event = yaml_obj.map()
+
+        # Verify aliased parameters were deserialized correctly.
+        assert event.parameters == {'alias_key': 'value'}
+
+    # ** test: feature_event_yaml_from_model
+    def test_feature_event_yaml_from_model(self):
+        '''
+        Test that FeatureEventYamlObject can be created from a FeatureEvent model.
+        '''
+
+        # Create a FeatureEvent model.
+        model = DomainObject.new(
+            FeatureEvent,
+            name='Test Event',
+            service_id='test_event_handler',
+            parameters={'key': 'value'},
+            data_key='result',
+            pass_on_error=True,
+        )
+
+        # Create a YAML object from the model.
+        yaml_obj = FeatureEventYamlObject.from_model(model)
+
+        # Verify the YAML object has the correct values.
+        assert isinstance(yaml_obj, FeatureEventYamlObject)
+        assert yaml_obj.name == model.name
+        assert yaml_obj.service_id == model.service_id
+        assert yaml_obj.parameters == model.parameters


### PR DESCRIPTION
## Summary

Migrates `tiferet/mappers/tests/test_feature.py` from legacy standalone test style to the harness-based class pattern and applies two mapper source cleanups.

## Changes

### `tiferet/mappers/feature.py`
- Removed `to_data.json` roles from `FeatureEventYamlObject.Options.roles` and `FeatureYamlObject.Options.roles`.
- Updated `FeatureAggregate.add_step`: `service_id` is now the primary parameter; `attribute_id` retained as deprecated fallback. Created steps receive both fields set to the resolved value for backward compatibility.

### `tiferet/mappers/tests/test_feature.py`
- Rewrote with three harness-based test classes:
  - `TestFeatureEventAggregate(AggregateTestBase)` — inherits `test_new`, parametrized `test_set_attribute`; domain-specific tests for `set_pass_on_error`, `set_parameters`, `set_attribute_delegation`.
  - `TestFeatureAggregate(AggregateTestBase)` — inherits `test_new`, `test_set_attribute` (including invalid attr error); domain-specific tests for smart derivation, step CRUD, `rename`, `set_description`.
  - `TestFeatureYamlObject(TransferObjectTestBase)` — inherits `test_map`, `test_from_model`, `test_round_trip`; child mapper tests for `FeatureEventYamlObject`.
- Module-level constants: `FEATURE_EVENT_AGGREGATE_SAMPLE_DATA`, `FEATURE_EVENT_EQUALITY_FIELDS`, `FEATURE_AGGREGATE_SAMPLE_DATA`, `FEATURE_EQUALITY_FIELDS`, `STEP_TUPLE` normalizer, `FEATURE_FIELD_NORMALIZERS`.
- All sample data and assertions use `service_id` instead of `attribute_id`.

## Validation
- 24 feature mapper tests pass.
- All 149 mapper tests pass.
- Zero `attribute_id` references in test data/assertions.
- Zero `to_data.json` references in mapper source.

Closes #652

Co-Authored-By: Oz <oz-agent@warp.dev>