### PR TITLE
Release – v2.0.0a5 Version Bump and Documentation Update (#653)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a3`
+- **Version:** `2.0.0a5`
 
 ## Architecture
 
@@ -202,8 +202,8 @@ Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backe
 Applications are configured via YAML files in `app/configs/`:
 
 - `app.yml` — Interface definitions (name, module_path, class_name, attributes)
-- `di.yml` — Dependency injection service configurations (module_path, class_name, parameters)
-- `feature.yml` — Feature workflows (commands with attribute_id, parameters, data_key)
+- `container.yml` — Dependency injection container attributes (module_path, class_name, parameters)
+- `feature.yml` — Feature workflows (steps with service_id, parameters, data_key; `attribute_id` supported as deprecated fallback)
 - `error.yml` — Error definitions with multilingual messages
 - `cli.yml` — CLI command definitions with arguments
 - `logging.yml` — Logging formatters, handlers, loggers

--- a/README.md
+++ b/README.md
@@ -660,7 +660,6 @@ Practical guides for working with Tiferet's domain layers:
 - [Error (Structured Error Handling)](docs/guides/domain/error.md) — Error definitions, multilingual messages, formatting flow
 - [Feature (Workflow Orchestration)](docs/guides/domain/feature.md) — Features, steps, parameter resolution, execution flow
 - [Logging (Observability)](docs/guides/domain/logging.md) — Formatters, handlers, loggers, dictConfig assembly
-- [Mappers – Strategies and Patterns](docs/guides/mappers.md) — Aggregate and TransferObject design decisions, nested sub-objects, role strategies, and round-trip mapping
 
 ### Utility Guides
 

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -185,7 +185,189 @@ Tests validate factory creation, mutation, mapping, serialization, and error han
 
 **Example** – Aggregate tests cover `new` (with/without validation, strict/non-strict), `set_attribute` (success and invalid attribute error).
 
-**Example** – TransferObject tests cover `from_data`, `from_model` (with/without kwargs), `map` (custom new and fallback), `allow`/`deny` transforms.
+#### `MapperAssertions` (mixin)
+Provides shared assertion helpers used by both base classes:
+- **`assert_model_matches(model, sample, equality_fields, field_normalizers)`** — Compares model attributes against a sample dict using configured fields. Per-field normalizers allow custom comparison logic for complex types.
+- **`assert_nested_list_matches(actual_list, expected_list, key_field, compare_fields)`** — Compares lists of domain objects by a key field (e.g., `service_id`, `flag`), useful for verifying nested collections through round-trips.
+
+#### `AggregateTestBase`
+Base class for testing Aggregate components. Subclasses define class attributes and inherit automatic tests.
+
+**Required class attributes:**
+- `aggregate_cls` — The Aggregate class under test.
+- `sample_data` — Dict of aggregate-format sample data.
+- `equality_fields` — List of field names to compare.
+- `set_attribute_params` — List of `(attr, value, expect_error_code | None)` tuples.
+
+**Optional class attributes:**
+- `field_normalizers` — Dict mapping field names to normalizer callables for complex comparisons.
+
+**Inherited tests:**
+- `test_new` — Verifies `Aggregate.new()` instantiation and field values.
+- `test_set_attribute` — Parametrized test for valid and invalid attribute mutations. Parametrization is driven by `conftest.pytest_generate_tests`.
+
+**Override hook:**
+- `make_aggregate(data=None)` — Override when the aggregate has a custom `new()` signature (e.g., `AppInterfaceAggregate.new(app_interface_data=...)` instead of `Aggregate.new(cls, **kwargs)`).
+
+#### `TransferObjectTestBase`
+Base class for testing TransferObject components.
+
+**Required class attributes:**
+- `transfer_cls` — The TransferObject class under test.
+- `aggregate_cls` — The target Aggregate class.
+- `sample_data` — Dict of YAML-format sample data (as it appears in configuration).
+- `aggregate_sample_data` — Dict of aggregate-format expected data (with defaults filled in, lists instead of dicts, etc.).
+- `equality_fields` — List of field names to compare.
+
+**Optional class attributes:**
+- `field_normalizers` — Per-field normalizer callables.
+- `map_kwargs` — Extra kwargs to pass to `.map()`.
+
+**Inherited tests:**
+- `test_map` — Verifies `from_data()` → `map()` produces a valid aggregate.
+- `test_from_model` — Verifies aggregate → TransferObject conversion.
+- `test_round_trip` — Verifies aggregate → TransferObject → aggregate preserves data.
+
+**Override hook:**
+- `make_aggregate(data=None)` — Same purpose as `AggregateTestBase`.
+
+#### `conftest.py` Hook
+The `pytest_generate_tests` hook dynamically parametrizes `test_set_attribute` for any `AggregateTestBase` subclass, reading from the class's `set_attribute_params` attribute.
+
+### Test File Structure
+
+Harness-based test files follow this structure:
+
+```python
+"""Tiferet <Domain> Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import TransferObject
+from ..<domain> import SomeAggregate, SomeYamlObject
+from .settings import AggregateTestBase, TransferObjectTestBase
+
+
+# *** constants
+
+# ** constant: aggregate_sample_data
+AGGREGATE_SAMPLE_DATA = { ... }
+
+# ** constant: equality_fields
+EQUALITY_FIELDS = [ ... ]
+
+# ** constant: item_tuple
+def ITEM_TUPLE(item):
+    '''Normalize a nested item (dict or domain object) into a comparable tuple.'''
+    ...
+
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'items': lambda items: tuple(sorted(ITEM_TUPLE(i) for i in (items or []))),
+}
+
+
+# *** classes
+
+# ** class: TestSomeAggregate
+class TestSomeAggregate(AggregateTestBase):
+    '''Tests for SomeAggregate.'''
+
+    aggregate_cls = SomeAggregate
+    sample_data = AGGREGATE_SAMPLE_DATA
+    equality_fields = EQUALITY_FIELDS
+    field_normalizers = FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        ('name',         'Updated Name',  None),
+        ('invalid_attr', 'value',         'INVALID_MODEL_ATTRIBUTE'),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data=None):
+        '''Override for custom new() signature.'''
+        return SomeAggregate.new(
+            some_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: rename
+    def test_rename(self, aggregate):
+        '''Test domain-specific mutation.'''
+        aggregate.rename('New Name')
+        assert aggregate.name == 'New Name'
+
+
+# ** class: TestSomeYamlObject
+class TestSomeYamlObject(TransferObjectTestBase):
+    '''Tests for SomeYamlObject.'''
+
+    transfer_cls = SomeYamlObject
+    aggregate_cls = SomeAggregate
+    sample_data = { ... }  # YAML-format
+    aggregate_sample_data = AGGREGATE_SAMPLE_DATA
+    equality_fields = EQUALITY_FIELDS
+    field_normalizers = FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data=None):
+        '''Override for custom new() signature.'''
+        return SomeAggregate.new(
+            some_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
+
+    # *** child mapper: ChildYamlObject
+
+    # ** test: child_yaml_map_basic
+    def test_child_yaml_map_basic(self):
+        '''Test child mapper mapping.'''
+        ...
+```
+
+### Key Patterns
+
+#### Module-Level Constants
+Shared sample data, equality fields, and normalizers are defined as module-level constants under `# *** constants`. This avoids duplication when both the Aggregate and TransferObject test classes need the same data.
+
+#### Normalizer Functions
+For fields containing nested domain objects (e.g., lists of services, arguments, dependencies), define a normalizer function that converts both dicts and domain objects into comparable tuples:
+
+```python
+# ** constant: svc_tuple
+def SVC_TUPLE(s):
+    '''Normalize a service (dict or domain object) into a comparable tuple.'''
+    if isinstance(s, dict):
+        return (s['service_id'], s['module_path'], s['class_name'],
+                tuple(sorted(s.get('parameters', {}).items())))
+    return (s.service_id, s.module_path, s.class_name,
+            tuple(sorted((s.parameters or {}).items())))
+
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'services': lambda svcs: tuple(sorted(SVC_TUPLE(s) for s in (svcs or []))),
+}
+```
+
+#### Child Mapper Tests
+When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyYamlObject` inside `AppInterfaceYamlObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
+
+#### Standalone Tests
+Small leaf-level mappers without mutation logic (e.g., `ErrorMessageYamlObject`) may use standalone test functions instead of the harness, placed after the class-based tests.
+
+### Migration Status
+
+The following test modules have been migrated to the harness-based style:
+- `test_app.py`, `test_cli.py`, `test_di.py`, `test_error.py`, `test_feature.py`, `test_logging.py`
+
+The following use the legacy standalone style and are candidates for migration:
+- `test_container.py`
+
+`test_settings.py` tests the base classes themselves and appropriately uses standalone functions.
 
 ## Package Layout
 

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -69,4 +69,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a4'
+__version__ = '2.0.0a5'


### PR DESCRIPTION
## Summary

Bumps the framework version to `2.0.0a5` and updates all documentation to reflect the current state of the milestone 19 work.

### Changes

**Version bump:**
- `tiferet/__init__.py`: `__version__` → `2.0.0a5`

**AGENTS.md:**
- Version updated to `2.0.0a5`
- Configuration section: `di.yml` → `container.yml`, `attribute_id` → `service_id` with deprecated fallback

**docs/core/mappers.md:**
- Added full test harness documentation (`MapperAssertions`, `AggregateTestBase`, `TransferObjectTestBase`)
- Updated migration status: `test_feature.py` and `test_logging.py` migrated; only `test_container.py` remains

**README.md:**
- Removed duplicate Mappers guide link

Closes #653

Co-Authored-By: Oz <oz-agent@warp.dev>