### PR TITLE
Rebase v2.0a5-release into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a3`
+- **Version:** `2.0.0a5`
 
 ## Architecture
 
@@ -202,8 +202,8 @@ Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backe
 Applications are configured via YAML files in `app/configs/`:
 
 - `app.yml` — Interface definitions (name, module_path, class_name, attributes)
-- `di.yml` — Dependency injection service configurations (module_path, class_name, parameters)
-- `feature.yml` — Feature workflows (commands with attribute_id, parameters, data_key)
+- `container.yml` — Dependency injection container attributes (module_path, class_name, parameters)
+- `feature.yml` — Feature workflows (steps with service_id, parameters, data_key; `attribute_id` supported as deprecated fallback)
 - `error.yml` — Error definitions with multilingual messages
 - `cli.yml` — CLI command definitions with arguments
 - `logging.yml` — Logging formatters, handlers, loggers

--- a/README.md
+++ b/README.md
@@ -660,7 +660,6 @@ Practical guides for working with Tiferet's domain layers:
 - [Error (Structured Error Handling)](docs/guides/domain/error.md) — Error definitions, multilingual messages, formatting flow
 - [Feature (Workflow Orchestration)](docs/guides/domain/feature.md) — Features, steps, parameter resolution, execution flow
 - [Logging (Observability)](docs/guides/domain/logging.md) — Formatters, handlers, loggers, dictConfig assembly
-- [Mappers – Strategies and Patterns](docs/guides/mappers.md) — Aggregate and TransferObject design decisions, nested sub-objects, role strategies, and round-trip mapping
 
 ### Utility Guides
 

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -185,7 +185,189 @@ Tests validate factory creation, mutation, mapping, serialization, and error han
 
 **Example** – Aggregate tests cover `new` (with/without validation, strict/non-strict), `set_attribute` (success and invalid attribute error).
 
-**Example** – TransferObject tests cover `from_data`, `from_model` (with/without kwargs), `map` (custom new and fallback), `allow`/`deny` transforms.
+#### `MapperAssertions` (mixin)
+Provides shared assertion helpers used by both base classes:
+- **`assert_model_matches(model, sample, equality_fields, field_normalizers)`** — Compares model attributes against a sample dict using configured fields. Per-field normalizers allow custom comparison logic for complex types.
+- **`assert_nested_list_matches(actual_list, expected_list, key_field, compare_fields)`** — Compares lists of domain objects by a key field (e.g., `service_id`, `flag`), useful for verifying nested collections through round-trips.
+
+#### `AggregateTestBase`
+Base class for testing Aggregate components. Subclasses define class attributes and inherit automatic tests.
+
+**Required class attributes:**
+- `aggregate_cls` — The Aggregate class under test.
+- `sample_data` — Dict of aggregate-format sample data.
+- `equality_fields` — List of field names to compare.
+- `set_attribute_params` — List of `(attr, value, expect_error_code | None)` tuples.
+
+**Optional class attributes:**
+- `field_normalizers` — Dict mapping field names to normalizer callables for complex comparisons.
+
+**Inherited tests:**
+- `test_new` — Verifies `Aggregate.new()` instantiation and field values.
+- `test_set_attribute` — Parametrized test for valid and invalid attribute mutations. Parametrization is driven by `conftest.pytest_generate_tests`.
+
+**Override hook:**
+- `make_aggregate(data=None)` — Override when the aggregate has a custom `new()` signature (e.g., `AppInterfaceAggregate.new(app_interface_data=...)` instead of `Aggregate.new(cls, **kwargs)`).
+
+#### `TransferObjectTestBase`
+Base class for testing TransferObject components.
+
+**Required class attributes:**
+- `transfer_cls` — The TransferObject class under test.
+- `aggregate_cls` — The target Aggregate class.
+- `sample_data` — Dict of YAML-format sample data (as it appears in configuration).
+- `aggregate_sample_data` — Dict of aggregate-format expected data (with defaults filled in, lists instead of dicts, etc.).
+- `equality_fields` — List of field names to compare.
+
+**Optional class attributes:**
+- `field_normalizers` — Per-field normalizer callables.
+- `map_kwargs` — Extra kwargs to pass to `.map()`.
+
+**Inherited tests:**
+- `test_map` — Verifies `from_data()` → `map()` produces a valid aggregate.
+- `test_from_model` — Verifies aggregate → TransferObject conversion.
+- `test_round_trip` — Verifies aggregate → TransferObject → aggregate preserves data.
+
+**Override hook:**
+- `make_aggregate(data=None)` — Same purpose as `AggregateTestBase`.
+
+#### `conftest.py` Hook
+The `pytest_generate_tests` hook dynamically parametrizes `test_set_attribute` for any `AggregateTestBase` subclass, reading from the class's `set_attribute_params` attribute.
+
+### Test File Structure
+
+Harness-based test files follow this structure:
+
+```python
+"""Tiferet <Domain> Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..settings import TransferObject
+from ..<domain> import SomeAggregate, SomeYamlObject
+from .settings import AggregateTestBase, TransferObjectTestBase
+
+
+# *** constants
+
+# ** constant: aggregate_sample_data
+AGGREGATE_SAMPLE_DATA = { ... }
+
+# ** constant: equality_fields
+EQUALITY_FIELDS = [ ... ]
+
+# ** constant: item_tuple
+def ITEM_TUPLE(item):
+    '''Normalize a nested item (dict or domain object) into a comparable tuple.'''
+    ...
+
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'items': lambda items: tuple(sorted(ITEM_TUPLE(i) for i in (items or []))),
+}
+
+
+# *** classes
+
+# ** class: TestSomeAggregate
+class TestSomeAggregate(AggregateTestBase):
+    '''Tests for SomeAggregate.'''
+
+    aggregate_cls = SomeAggregate
+    sample_data = AGGREGATE_SAMPLE_DATA
+    equality_fields = EQUALITY_FIELDS
+    field_normalizers = FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        ('name',         'Updated Name',  None),
+        ('invalid_attr', 'value',         'INVALID_MODEL_ATTRIBUTE'),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data=None):
+        '''Override for custom new() signature.'''
+        return SomeAggregate.new(
+            some_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: rename
+    def test_rename(self, aggregate):
+        '''Test domain-specific mutation.'''
+        aggregate.rename('New Name')
+        assert aggregate.name == 'New Name'
+
+
+# ** class: TestSomeYamlObject
+class TestSomeYamlObject(TransferObjectTestBase):
+    '''Tests for SomeYamlObject.'''
+
+    transfer_cls = SomeYamlObject
+    aggregate_cls = SomeAggregate
+    sample_data = { ... }  # YAML-format
+    aggregate_sample_data = AGGREGATE_SAMPLE_DATA
+    equality_fields = EQUALITY_FIELDS
+    field_normalizers = FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data=None):
+        '''Override for custom new() signature.'''
+        return SomeAggregate.new(
+            some_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
+
+    # *** child mapper: ChildYamlObject
+
+    # ** test: child_yaml_map_basic
+    def test_child_yaml_map_basic(self):
+        '''Test child mapper mapping.'''
+        ...
+```
+
+### Key Patterns
+
+#### Module-Level Constants
+Shared sample data, equality fields, and normalizers are defined as module-level constants under `# *** constants`. This avoids duplication when both the Aggregate and TransferObject test classes need the same data.
+
+#### Normalizer Functions
+For fields containing nested domain objects (e.g., lists of services, arguments, dependencies), define a normalizer function that converts both dicts and domain objects into comparable tuples:
+
+```python
+# ** constant: svc_tuple
+def SVC_TUPLE(s):
+    '''Normalize a service (dict or domain object) into a comparable tuple.'''
+    if isinstance(s, dict):
+        return (s['service_id'], s['module_path'], s['class_name'],
+                tuple(sorted(s.get('parameters', {}).items())))
+    return (s.service_id, s.module_path, s.class_name,
+            tuple(sorted((s.parameters or {}).items())))
+
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'services': lambda svcs: tuple(sorted(SVC_TUPLE(s) for s in (svcs or []))),
+}
+```
+
+#### Child Mapper Tests
+When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyYamlObject` inside `AppInterfaceYamlObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
+
+#### Standalone Tests
+Small leaf-level mappers without mutation logic (e.g., `ErrorMessageYamlObject`) may use standalone test functions instead of the harness, placed after the class-based tests.
+
+### Migration Status
+
+The following test modules have been migrated to the harness-based style:
+- `test_app.py`, `test_cli.py`, `test_di.py`, `test_error.py`, `test_feature.py`, `test_logging.py`
+
+The following use the legacy standalone style and are candidates for migration:
+- `test_container.py`
+
+`test_settings.py` tests the base classes themselves and appropriately uses standalone functions.
 
 ## Package Layout
 

--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** March 11, 2026  
+**Version:** 2.0.0a5
 
 ## Overview
 
@@ -23,12 +23,13 @@ These domain objects are **immutable value objects**: they carry no mutation met
 
 Represents a single injectable service dependency binding for an application interface.
 
-| Attribute      | Type                   | Required | Default | Description                                       |
-|----------------|------------------------|----------|---------|---------------------------------------------------|
-| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.            |
-| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.             |
-| `attribute_id` | `StringType`           | Yes      | —       | The attribute id for the application dependency.   |
-| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.     |
+| Attribute      | Type                   | Required | Default | Description                                                                      |
+|----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
+| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.                                           |
+| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.                                            |
+| `service_id`   | `StringType`           | No *(todo: required)* | — | The canonical service id for the application dependency.             |
+| `attribute_id` | `StringType`           | No *(obsolete)* | — | The attribute id for the application dependency. Superseded by `service_id`. |
+| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.                                    |
 
 No methods. Pure data structure.
 
@@ -54,9 +55,9 @@ Represents the complete configuration of an application entry point.
 
 #### Methods
 
-**`get_service(attribute_id: str) -> AppServiceDependency`**
+**`get_service(service_id: str) -> AppServiceDependency`**
 
-Returns the `AppServiceDependency` whose `attribute_id` matches the given value, or `None` if no match is found.
+Returns the `AppServiceDependency` whose `service_id` matches the given value, or `None` if no match is found. For backward compatibility, also falls back to matching on `attribute_id` (this fallback will be removed once `attribute_id` is fully migrated).
 
 ```python
 service = app_interface.get_service('cli_repo')
@@ -76,7 +77,7 @@ The App domain objects participate in the application bootstrapping flow:
 
 ## Configuration Mapping
 
-Application interfaces are defined in `app/configs/app.yml`. Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects:
+Application interfaces are defined in `app/configs/app.yml`. Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects. Each key under `attrs` becomes the `service_id` of the corresponding `AppServiceDependency`:
 
 ```yaml
 interfaces:
@@ -139,7 +140,7 @@ from tiferet.domain import DomainObject, AppServiceDependency, AppInterface
 
 dep = DomainObject.new(
     AppServiceDependency,
-    attribute_id='cli_repo',
+    service_id='cli_repo',
     module_path='tiferet.proxies.yaml.cli',
     class_name='CliYamlProxy',
     parameters={'cli_config_file': 'app/configs/cli.yml'},

--- a/docs/guides/domain/feature.md
+++ b/docs/guides/domain/feature.md
@@ -3,8 +3,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** March 11, 2026  
+**Version:** 2.0.0a5
 
 ## Overview
 
@@ -35,7 +35,8 @@ Concrete step type that extends `FeatureStep`. Represents the execution of a dom
 
 | Attribute        | Type                    | Required | Default | Description                                                        |
 |------------------|-------------------------|----------|---------|--------------------------------------------------------------------|
-| `attribute_id`   | `StringType`            | Yes      | —       | The container attribute ID for the domain event.                   |
+| `service_id`     | `StringType`            | No *(todo: required)* | — | The service configuration ID for the feature event.          |
+| `attribute_id`   | `StringType`            | No *(obsolete)*       | — | The container attribute ID for the domain event. Replaced by `service_id`. |
 | `flags`          | `ListType(StringType)`  | No       | `[]`    | Feature flags that activate this event.                            |
 | `parameters`     | `DictType(StringType)`  | No       | `{}`    | Custom parameters for the event.                                   |
 | `return_to_data` | `BooleanType`           | No       | `False` | Whether to return the result to the feature data context (obsolete). |
@@ -85,7 +86,7 @@ The Feature domain objects participate in runtime workflow execution through the
 
 1. `FeatureContext.execute_feature(feature_id, data)` receives a feature ID from the application interface.
 2. The `Feature` is loaded from the `FeatureService` (backed by `feature.yml` configuration).
-3. `FeatureContext` iterates over `feature.steps`, resolving each `FeatureEvent.attribute_id` from the DI container.
+3. `FeatureContext` iterates over `feature.steps`, resolving each `FeatureEvent.service_id` (with `attribute_id` fallback during migration) from the DI container.
 4. Each resolved domain event is executed with the merged request data and step parameters.
 5. If `data_key` is set, the result is stored back into the data context under that key for downstream steps.
 6. If `pass_on_error` is `True`, errors from that step are caught and the workflow continues.
@@ -101,13 +102,13 @@ features:
       name: 'Add Number'
       description: 'Adds one number to another'
       commands:
-        - attribute_id: add_number_event
+        - service_id: add_number_event
           name: Add `a` and `b`
     sqrt:
       name: 'Square Root'
       description: 'Calculates the square root of a number'
       commands:
-        - attribute_id: exponentiate_number_event
+        - service_id: exponentiate_number_event
           name: Calculate square root of `a`
           params:
             b: '0.5'
@@ -143,7 +144,7 @@ Concrete implementations (e.g., `FeatureYamlRepository`) satisfy this interface.
 ## Relationships to Other Domains
 
 - **App:** `FeatureContext` is loaded as part of the application interface bootstrap, receiving `FeatureService` and container resolution via dependency injection.
-- **DI:** `FeatureEvent.attribute_id` references a `ServiceConfiguration` entry in `container.yml`, which is resolved at runtime by the DI container.
+- **DI:** `FeatureEvent.service_id` references a `ServiceConfiguration` entry in `di.yml`, which is resolved at runtime by the DI container. During migration, `attribute_id` is supported as a fallback.
 - **Error:** Domain events use `verify()` and `raise_error()` to raise `TiferetError` when features are not found or parameters are invalid. These are resolved to `Error` domain objects for formatted responses.
 - **CLI:** CLI commands map to features via `group_key` and `key`, enabling command-line execution of feature workflows.
 
@@ -155,7 +156,7 @@ from tiferet.domain import DomainObject, Feature, FeatureEvent
 step = DomainObject.new(
     FeatureEvent,
     name='Add a and b',
-    attribute_id='add_number_event',
+    service_id='add_number_event',
     parameters={'b': '0.5'},
 )
 
@@ -169,7 +170,7 @@ feature = DomainObject.new(
     steps=[step],
 )
 
-# feature.get_step(0).attribute_id == 'add_number_event'
+# feature.get_step(0).service_id == 'add_number_event'
 ```
 
 ## Related Documentation

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -69,4 +69,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a4'
+__version__ = '2.0.0a5'

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -35,9 +35,17 @@ class AppServiceDependency(DomainObject):
         ),
     )
 
+    # * attribute: service_id
+    # + todo: set to required when attribute_id is removed
+    service_id = StringType(
+        metadata=dict(
+            description='The service id for the application dependency.'
+        ),
+    )
+
     # * attribute: attribute_id
+    # - obsolete: replaced by service_id
     attribute_id = StringType(
-        required=True,
         metadata=dict(
             description='The attribute id for the application dependency.'
         ),
@@ -135,15 +143,16 @@ class AppInterface(DomainObject):
     )
 
     # * method: get_service
-    def get_service(self, attribute_id: str) -> AppServiceDependency:
+    def get_service(self, service_id: str) -> AppServiceDependency:
         '''
-        Get the service dependency by attribute id.
+        Get the service dependency by service id.
 
-        :param attribute_id: The attribute id of the service dependency.
-        :type attribute_id: str
+        :param service_id: The service id of the service dependency.
+        :type service_id: str
         :return: The service dependency.
         :rtype: AppServiceDependency
         '''
 
-        # Get the service dependency by attribute id.
-        return next((dep for dep in self.services if dep.attribute_id == attribute_id), None)
+        # Get the service dependency by service id.
+        # + todo: remove attribute_id support when attribute_id is removed from AppServiceDependency
+        return next((dep for dep in self.services if dep.service_id == service_id or dep.attribute_id == service_id), None)

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -44,9 +44,17 @@ class FeatureEvent(FeatureStep):
     A feature event step that executes a domain event from the container.
     '''
 
+    # * attribute: service_id
+    # + todo: set to required when attribute_id is removed
+    service_id = StringType(
+        metadata=dict(
+            description='The service configuration ID for the feature event.'
+        )
+    )
+
     # * attribute: attribute_id
+    # - obsolete: replaced by service_id
     attribute_id = StringType(
-        required=True,
         metadata=dict(
             description='The container attribute ID for the feature event.'
         )

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -27,7 +27,7 @@ def app_dependency() -> AppServiceDependency:
     # Create and return a new AppServiceDependency.
     return DomainObject.new(
         AppServiceDependency,
-        attribute_id='test_attribute',
+        service_id='test_service',
         module_path='test_module_path',
         class_name='test_class_name',
         parameters={'param1': 'value1', 'param2': 'value2'},
@@ -62,19 +62,19 @@ def app_interface(app_dependency: AppServiceDependency) -> AppInterface:
 # ** test: app_interface_get_service
 def test_app_interface_get_service(app_interface: AppInterface) -> None:
     '''
-    Test successful retrieval of a service dependency by attribute id.
+    Test successful retrieval of a service dependency by service id.
 
     :param app_interface: The AppInterface fixture.
     :type app_interface: AppInterface
     '''
 
-    # Retrieve the service dependency by attribute id.
-    service = app_interface.get_service('test_attribute')
+    # Retrieve the service dependency by service id.
+    service = app_interface.get_service('test_service')
 
     # Assert the service dependency fields match.
     assert service.module_path == 'test_module_path'
     assert service.class_name == 'test_class_name'
-    assert service.attribute_id == 'test_attribute'
+    assert service.service_id == 'test_service'
     assert service.parameters == {'param1': 'value1', 'param2': 'value2'}
 
 # ** test: app_interface_get_service_invalid

--- a/tiferet/domain/tests/test_feature.py
+++ b/tiferet/domain/tests/test_feature.py
@@ -48,7 +48,7 @@ def test_feature_step_type_defaults_to_event() -> None:
     event = DomainObject.new(
         FeatureEvent,
         name='Test Event',
-        attribute_id='test_event_attr',
+        service_id='test_event_service',
     )
 
     # Assert type defaults to 'event'.
@@ -71,7 +71,7 @@ def test_feature_event_flags_creation_and_round_trip() -> None:
     event = DomainObject.new(
         FeatureEvent,
         name='Flagged Event',
-        attribute_id='flagged_event_attr',
+        service_id='flagged_event_service',
         flags=['flag1', 'flag2'],
     )
 
@@ -98,12 +98,12 @@ def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
     step_0 = DomainObject.new(
         FeatureEvent,
         name='Step Zero',
-        attribute_id='step_zero_attr',
+        service_id='step_zero_service',
     )
     step_1 = DomainObject.new(
         FeatureEvent,
         name='Step One',
-        attribute_id='step_one_attr',
+        service_id='step_one_service',
     )
 
     # Add steps to the feature.

--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -63,7 +63,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         )
 
     # * method: add_service
-    def add_service(self, module_path: str, class_name: str, attribute_id: str, parameters: Dict[str, str] = {}) -> None:
+    def add_service(self, module_path: str, class_name: str, service_id: str, parameters: Dict[str, str] = {}) -> None:
         '''
         Add a service dependency to the app interface.
 
@@ -71,8 +71,8 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         :type module_path: str
         :param class_name: The class name for the service dependency.
         :type class_name: str
-        :param attribute_id: The id for the service dependency.
-        :type attribute_id: str
+        :param service_id: The id for the service dependency.
+        :type service_id: str
         :param parameters: Additional parameters for the service dependency.
         :type parameters: dict
         :return: None
@@ -84,7 +84,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
             AppServiceDependency,
             module_path=module_path,
             class_name=class_name,
-            attribute_id=attribute_id,
+            service_id=service_id,
             parameters=parameters,
         )
 
@@ -92,39 +92,49 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         self.services.append(dependency)
 
     # * method: remove_service
-    def remove_service(self, attribute_id: str) -> AppServiceDependency:
+    # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
+    def remove_service(self, service_id: str = None, attribute_id: str = None) -> AppServiceDependency:
         '''
-        Remove and return a service dependency by its attribute_id (idempotent).
+        Remove and return a service dependency by its service_id (idempotent).
 
-        If a service dependency with the given attribute_id exists, it is removed.
+        If a service dependency with the given service_id exists, it is removed.
         If no matching service dependency exists, no action is taken (silent success).
 
-        :param attribute_id: The attribute_id of the service dependency to remove.
+        :param service_id: The service_id of the service dependency to remove.
+        :type service_id: str
+        :param attribute_id: Deprecated alias for service_id.
         :type attribute_id: str
         :return: The removed AppServiceDependency or None.
         :rtype: AppServiceDependency
         '''
 
-        # Iterate over services and remove the first match by attribute_id.
+        # Fall back to attribute_id if service_id is not provided.
+        if service_id is None and attribute_id is not None:
+            service_id = attribute_id
+
+        # Iterate over services and remove the first match by service_id.
+        # + todo: remove attribute_id fallback once attribute_id is removed from AppServiceDependency
         for index, dep in enumerate(self.services):
-            if dep.attribute_id == attribute_id:
+            if dep.service_id == service_id or dep.attribute_id == service_id:
                 return self.services.pop(index)
 
         # If no service dependency matches, return None without modifying the list.
         return None
 
     # * method: set_service
+    # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
     def set_service(
         self,
-        attribute_id: str,
-        module_path: str,
-        class_name: str,
+        service_id: str = None,
+        module_path: str = None,
+        class_name: str = None,
         parameters: Dict[str, Any] = None,
+        attribute_id: str = None,
     ) -> None:
         '''
-        Set or update a service dependency by attribute_id (PUT semantics).
+        Set or update a service dependency by service_id (PUT semantics).
 
-        If a service dependency with the given attribute_id exists:
+        If a service dependency with the given service_id exists:
           - Update module_path and class_name.
           - Merge parameters (favor new values; remove keys with None value).
           - Clear parameters if parameters is None.
@@ -132,20 +142,26 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         If no service dependency exists:
           - Create new AppServiceDependency and append to services.
 
-        :param attribute_id: The service dependency identifier.
-        :type attribute_id: str
+        :param service_id: The service dependency identifier.
+        :type service_id: str
         :param module_path: The module path.
         :type module_path: str
         :param class_name: The class name.
         :type class_name: str
         :param parameters: New parameters (None to clear).
         :type parameters: Dict[str, Any]
+        :param attribute_id: Deprecated alias for service_id.
+        :type attribute_id: str
         :return: None
         :rtype: None
         '''
 
-        # Find the existing service dependency by attribute_id.
-        dep = self.get_service(attribute_id)
+        # Fall back to attribute_id if service_id is not provided.
+        if service_id is None and attribute_id is not None:
+            service_id = attribute_id
+
+        # Find the existing service dependency by service_id.
+        dep = self.get_service(service_id)
 
         # If the service dependency exists, update its type fields and merge parameters.
         if dep is not None:
@@ -169,7 +185,7 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         else:
             new_dep = DomainObject.new(
                 AppServiceDependency,
-                attribute_id=attribute_id,
+                service_id=service_id,
                 module_path=module_path,
                 class_name=class_name,
                 parameters=parameters or {},
@@ -257,10 +273,10 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
     A YAML data representation of an app service dependency object.
     '''
 
-    # * attribute: attribute_id
-    attribute_id = StringType(
+    # * attribute: service_id
+    service_id = StringType(
         metadata=dict(
-            description='The attribute id for the application dependency that is not required for assembly.'
+            description='The service id for the application dependency that is not required for assembly.'
         ),
     )
 
@@ -282,18 +298,17 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
 
         serialize_when_none = False
         roles = {
-            'to_model': TransferObject.deny('parameters', 'attribute_id'),
-            'to_data.yaml': TransferObject.deny('attribute_id'),
-            'to_data.json': TransferObject.deny('attribute_id'),
+            'to_model': TransferObject.deny('parameters', 'service_id'),
+            'to_data.yaml': TransferObject.deny('service_id'),
         }
 
     # * method: map
-    def map(self, attribute_id: str, **kwargs) -> AppServiceDependency:
+    def map(self, service_id: str, **kwargs) -> AppServiceDependency:
         '''
         Maps the app service dependency data to an app service dependency object.
 
-        :param attribute_id: The id for the app service dependency.
-        :type attribute_id: str
+        :param service_id: The id for the app service dependency.
+        :type service_id: str
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: A new app service dependency object.
@@ -303,7 +318,7 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
         # Map to the app service dependency object.
         return super().map(
             AppServiceDependency,
-            attribute_id=attribute_id,
+            service_id=service_id,
             parameters=self.parameters,
             **self.to_primitive('to_model'),
             **kwargs
@@ -325,7 +340,6 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
         roles = {
             'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
             'to_data.yaml': TransferObject.deny('id'),
-            'to_data.json': TransferObject.deny('id'),
         }
 
     # * attribute: module_path
@@ -386,7 +400,7 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
             AppInterfaceAggregate,
             module_path=self.module_path,
             class_name=self.class_name,
-            services=[dep.map(attribute_id=dep_id) for dep_id, dep in self.services.items()],
+            services=[dep.map(service_id=dep_id) for dep_id, dep in self.services.items()],
             constants=self.constants,
             **self.to_primitive('to_model'),
             **kwargs
@@ -407,12 +421,12 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
         '''
 
         # Create a new AppInterfaceYamlObject from the model, converting
-        # the services list into a dictionary keyed by attribute_id.
+        # the services list into a dictionary keyed by service_id.
         return TransferObject.from_model(
             AppInterfaceYamlObject,
             app_interface,
             services={
-                dep.attribute_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
+                dep.service_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
                 for dep in app_interface.services
             },
             **kwargs,

--- a/tiferet/mappers/di.py
+++ b/tiferet/mappers/di.py
@@ -101,7 +101,6 @@ class FlaggedDependencyYamlObject(FlaggedDependency, TransferObject):
         roles = {
             'to_model': TransferObject.deny(),
             'to_data.yaml': TransferObject.deny('flag'),
-            'to_data.json': TransferObject.deny('flag'),
         }
 
     # * attribute: parameters
@@ -317,7 +316,6 @@ class ServiceConfigurationYamlObject(ServiceConfiguration, TransferObject):
         roles = {
             'to_model': TransferObject.deny('dependencies', 'parameters'),
             'to_data.yaml': TransferObject.deny('id'),
-            'to_data.json': TransferObject.deny('id'),
         }
 
     # * attribute: dependencies

--- a/tiferet/mappers/error.py
+++ b/tiferet/mappers/error.py
@@ -128,7 +128,6 @@ class ErrorMessageYamlObject(ErrorMessage, TransferObject):
         roles = {
             'to_model': TransferObject.deny(),
             'to_data.yaml': TransferObject.deny(),
-            'to_data.json': TransferObject.deny(),
         }
 
     # * method: map
@@ -186,7 +185,6 @@ class ErrorYamlObject(Error, TransferObject):
         roles = {
             'to_model': TransferObject.deny('message'),
             'to_data.yaml': TransferObject.deny('id'),
-            'to_data.json': TransferObject.deny('id'),
         }
 
     # * attribute: message

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -136,7 +136,6 @@ class FeatureEventYamlObject(FeatureEvent, TransferObject):
         roles = {
             'to_model': TransferObject.deny('type'),
             'to_data.yaml': TransferObject.deny('type'),
-            'to_data.json': TransferObject.deny('type')
         }
 
     # * attribute: parameters
@@ -264,19 +263,20 @@ class FeatureAggregate(Feature, Aggregate):
     def add_step(
         self,
         name: str,
-        attribute_id: str,
+        service_id: str = None,
         parameters: Dict[str, Any] | None = None,
         data_key: str | None = None,
         pass_on_error: bool = False,
         position: int | None = None,
+        attribute_id: str = None,
     ) -> FeatureEvent:
         '''
         Add a feature event step using raw attributes.
 
         :param name: Step name.
         :type name: str
-        :param attribute_id: Container attribute ID.
-        :type attribute_id: str
+        :param service_id: Service configuration ID (primary).
+        :type service_id: str
         :param parameters: Optional parameters dictionary.
         :type parameters: dict | None
         :param data_key: Optional result data key.
@@ -285,14 +285,20 @@ class FeatureAggregate(Feature, Aggregate):
         :type pass_on_error: bool
         :param position: Insertion position (None to append).
         :type position: int | None
+        :param attribute_id: Deprecated fallback for service_id.
+        :type attribute_id: str
         :return: Created FeatureEvent instance.
         :rtype: FeatureEvent
         '''
 
+        # Resolve service_id from the primary or deprecated fallback.
+        service_id = service_id or attribute_id
+
         # Create the feature event from raw attributes.
         step = FeatureEventAggregate.new(
             name=name,
-            attribute_id=attribute_id,
+            service_id=service_id,
+            attribute_id=service_id,
             parameters=parameters or {},
             data_key=data_key,
             pass_on_error=pass_on_error,
@@ -422,7 +428,6 @@ class FeatureYamlObject(Feature, TransferObject):
         roles = {
             'to_model': TransferObject.deny('steps'),
             'to_data.yaml': TransferObject.deny('feature_key', 'group_id', 'id'),
-            'to_data.json': TransferObject.deny('feature_key', 'group_id', 'id')
         }
 
     # * attribute: steps

--- a/tiferet/mappers/tests/conftest.py
+++ b/tiferet/mappers/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Tiferet Mapper Test Configuration"""
+
+# *** imports
+
+# ** app
+from .settings import AggregateTestBase
+
+# *** hooks
+
+# ** hook: pytest_generate_tests
+def pytest_generate_tests(metafunc):
+    '''
+    Dynamically parametrize test_set_attribute for AggregateTestBase subclasses.
+    '''
+
+    # Only apply to AggregateTestBase subclasses with set_attribute_params defined.
+    cls = metafunc.cls
+    if cls and issubclass(cls, AggregateTestBase) and metafunc.function.__name__ == 'test_set_attribute':
+        params = getattr(cls, 'set_attribute_params', [])
+        metafunc.parametrize('attr, value, expect_error_code', params)

--- a/tiferet/mappers/tests/settings.py
+++ b/tiferet/mappers/tests/settings.py
@@ -1,0 +1,310 @@
+"""Tiferet Mapper Test Settings"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...assets import TiferetError
+from ..settings import Aggregate, TransferObject
+
+# *** classes
+
+# ** class: MapperAssertions
+class MapperAssertions:
+    '''
+    Internal mixin providing shared assertion helpers for mapper tests.
+    '''
+
+    # * attribute: equality_fields
+    equality_fields: list[str] = []
+
+    # * attribute: field_normalizers
+    field_normalizers: dict[str, callable] = {}
+
+    # * method: assert_model_matches
+    def assert_model_matches(
+        self,
+        model,
+        sample: dict,
+        equality_fields: list[str] = None,
+        field_normalizers: dict = None,
+    ):
+        '''
+        Compare model attributes against a sample data dict using configured fields and normalizers.
+
+        :param model: The model instance to check.
+        :param sample: The expected values dict.
+        :type sample: dict
+        :param equality_fields: Fields to compare (defaults to self.equality_fields).
+        :type equality_fields: list[str]
+        :param field_normalizers: Per-field normalizers (defaults to self.field_normalizers).
+        :type field_normalizers: dict
+        '''
+
+        # Use defaults from the class if not provided.
+        equality_fields = equality_fields or self.equality_fields
+        field_normalizers = field_normalizers or self.field_normalizers
+
+        # Compare each field.
+        for field in equality_fields:
+            if field not in sample:
+                continue
+
+            expected = sample[field]
+            actual = getattr(model, field, None)
+
+            normalizer = field_normalizers.get(field)
+            if normalizer:
+                expected = normalizer(expected)
+                actual = normalizer(actual)
+
+            assert actual == expected, (
+                f"Mismatch on field '{field}':\n"
+                f"  expected: {expected!r}\n"
+                f"  actual:   {actual!r}"
+            )
+
+    # * method: assert_nested_list_matches
+    def assert_nested_list_matches(
+        self,
+        actual_list: list,
+        expected_list: list | dict,
+        key_field: str = 'attribute_id',
+        compare_fields: list[str] = None,
+    ):
+        '''
+        Helper for comparing lists of domain objects (e.g. services) by key.
+
+        :param actual_list: The list of actual domain objects.
+        :type actual_list: list
+        :param expected_list: The expected list or dict keyed by key_field.
+        :type expected_list: list | dict
+        :param key_field: The field to use as comparison key.
+        :type key_field: str
+        :param compare_fields: Which fields to check per item.
+        :type compare_fields: list[str]
+        '''
+
+        # Default to empty compare_fields (will use all non-private fields).
+        if compare_fields is None:
+            compare_fields = []
+
+        # Index actual items by key.
+        actual_by_key = {getattr(item, key_field): item for item in actual_list}
+
+        # Index expected items by key.
+        if isinstance(expected_list, dict):
+            expected_by_key = expected_list
+        else:
+            expected_by_key = {getattr(item, key_field): item for item in expected_list}
+
+        # Assert key sets match.
+        assert set(actual_by_key) == set(expected_by_key), "Key sets differ"
+
+        # Compare fields for each key.
+        for key, expected in expected_by_key.items():
+            actual = actual_by_key[key]
+            fields = compare_fields or [f for f in vars(expected) if not f.startswith('_')]
+            for f in fields:
+                if f == key_field:
+                    continue
+                va = getattr(actual, f, None)
+                ve = getattr(expected, f, None)
+                assert va == ve, f"Nested mismatch at {key}.{f}: {va!r} != {ve!r}"
+
+
+# ** class: AggregateTestBase
+class AggregateTestBase(MapperAssertions):
+    '''
+    Base class for testing Aggregate components.
+
+    Subclasses define:
+    - aggregate_cls          — the Aggregate class under test
+    - sample_data            — aggregate-format sample data
+    - equality_fields        — fields to compare
+    - field_normalizers      — optional per-field normalizers
+    - set_attribute_params   — tuples of (attr, value, expect_error_code | None)
+    '''
+
+    # * attribute: aggregate_cls
+    aggregate_cls: type[Aggregate] = None
+
+    # * attribute: sample_data
+    sample_data: dict = {}
+
+    # * attribute: set_attribute_params
+    set_attribute_params: list[tuple[str, any, str | None]] = []
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> Aggregate:
+        '''
+        Create an aggregate from data. Override for custom new() signatures.
+
+        :param data: The data to create from (defaults to self.sample_data).
+        :type data: dict
+        :return: A new aggregate instance.
+        :rtype: Aggregate
+        '''
+
+        # Create an aggregate using the standard Aggregate.new factory.
+        return Aggregate.new(self.aggregate_cls, **(data or self.sample_data))
+
+    # * fixture: aggregate
+    @pytest.fixture
+    def aggregate(self):
+        '''
+        Fixture providing an aggregate instance from sample_data.
+        '''
+
+        # Skip if no aggregate class is defined.
+        if not self.aggregate_cls:
+            pytest.skip("aggregate_cls not defined")
+
+        # Create and return the aggregate.
+        return self.make_aggregate()
+
+    # * method: test_new
+    def test_new(self, aggregate):
+        '''
+        Verify aggregate instantiation and field values match sample_data.
+        '''
+
+        # Assert the aggregate is the correct type.
+        assert isinstance(aggregate, self.aggregate_cls)
+
+        # Assert the aggregate fields match the sample data.
+        self.assert_model_matches(aggregate, self.sample_data)
+
+    # * method: test_set_attribute
+    def test_set_attribute(self, aggregate, attr, value, expect_error_code):
+        '''
+        Parametrized test for set_attribute (valid and invalid).
+        Parametrization is handled by conftest.pytest_generate_tests.
+        '''
+
+        # If an error is expected, verify the correct error code is raised.
+        if expect_error_code:
+            with pytest.raises(TiferetError) as exc_info:
+                aggregate.set_attribute(attr, value)
+            assert exc_info.value.error_code == expect_error_code
+
+        # Otherwise verify the attribute was updated.
+        else:
+            aggregate.set_attribute(attr, value)
+            assert getattr(aggregate, attr) == value
+
+
+# ** class: TransferObjectTestBase
+class TransferObjectTestBase(MapperAssertions):
+    '''
+    Base class for testing TransferObject components.
+
+    Subclasses define:
+    - transfer_cls            — the TransferObject class under test
+    - aggregate_cls           — the target Aggregate class
+    - sample_data             — YAML-format sample data for from_data
+    - aggregate_sample_data   — aggregate-format expected data (defaults filled in)
+    - equality_fields         — fields to compare on mapped results
+    - field_normalizers       — optional per-field normalizers
+    - map_kwargs              — extra kwargs to pass to .map()
+    '''
+
+    # * attribute: transfer_cls
+    transfer_cls: type[TransferObject] = None
+
+    # * attribute: aggregate_cls
+    aggregate_cls: type[Aggregate] = None
+
+    # * attribute: sample_data
+    sample_data: dict = {}
+
+    # * attribute: aggregate_sample_data
+    aggregate_sample_data: dict = {}
+
+    # * attribute: map_kwargs
+    map_kwargs: dict = {}
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> Aggregate:
+        '''
+        Create an aggregate for from_model / round_trip tests.
+        Override for custom new() signatures.
+
+        :param data: The data to create from (defaults to self.aggregate_sample_data).
+        :type data: dict
+        :return: A new aggregate instance.
+        :rtype: Aggregate
+        '''
+
+        # Create an aggregate using the standard Aggregate.new factory.
+        return Aggregate.new(self.aggregate_cls, **(data or self.aggregate_sample_data))
+
+    # * fixture: aggregate
+    @pytest.fixture
+    def aggregate(self):
+        '''
+        Fixture providing an aggregate instance from aggregate_sample_data.
+        '''
+
+        # Skip if no aggregate class is defined.
+        if not self.aggregate_cls:
+            pytest.skip("aggregate_cls not defined")
+
+        # Create and return the aggregate.
+        return self.make_aggregate()
+
+    # * method: test_map
+    def test_map(self):
+        '''
+        Verify TransferObject.from_data -> map() produces a valid aggregate.
+        '''
+
+        # Skip if no transfer class is defined.
+        if not self.transfer_cls:
+            pytest.skip("transfer_cls not defined")
+
+        # Create a transfer object from YAML-format sample data.
+        yaml_obj = TransferObject.from_data(self.transfer_cls, **self.sample_data)
+
+        # Map to an aggregate.
+        mapped = yaml_obj.map(**self.map_kwargs)
+
+        # Assert the mapped aggregate is the correct type and matches expected data.
+        assert isinstance(mapped, self.aggregate_cls)
+        self.assert_model_matches(mapped, self.aggregate_sample_data)
+
+    # * method: test_from_model
+    def test_from_model(self, aggregate):
+        '''
+        Verify aggregate -> TransferObject conversion.
+        '''
+
+        # Skip if no transfer class is defined.
+        if not self.transfer_cls:
+            pytest.skip("transfer_cls not defined")
+
+        # Convert the aggregate to a transfer object.
+        yaml_obj = self.transfer_cls.from_model(aggregate)
+
+        # Assert the result is the correct type.
+        assert isinstance(yaml_obj, self.transfer_cls)
+
+    # * method: test_round_trip
+    def test_round_trip(self, aggregate):
+        '''
+        Verify aggregate -> TransferObject -> aggregate round-trip.
+        '''
+
+        # Skip if no transfer class is defined.
+        if not self.transfer_cls:
+            pytest.skip("transfer_cls not defined")
+
+        # Convert aggregate to transfer object and back.
+        yaml_obj = self.transfer_cls.from_model(aggregate)
+        round_tripped = yaml_obj.map(**self.map_kwargs)
+
+        # Assert the round-tripped aggregate matches expected data.
+        assert isinstance(round_tripped, self.aggregate_cls)
+        self.assert_model_matches(round_tripped, self.aggregate_sample_data)

--- a/tiferet/mappers/tests/test_app.py
+++ b/tiferet/mappers/tests/test_app.py
@@ -7,610 +7,434 @@ import pytest
 
 # ** app
 from ...domain import AppServiceDependency, DomainObject
-from ...assets import TiferetError
+from ...assets import TiferetError, const
 from ..settings import TransferObject, DEFAULT_MODULE_PATH, DEFAULT_CLASS_NAME
-from ..app import AppInterfaceAggregate, AppInterfaceYamlObject, AppServiceDependencyYamlObject
+from ..app import (
+    AppInterfaceAggregate,
+    AppInterfaceYamlObject,
+    AppServiceDependencyYamlObject,
+)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: app_interface_yaml_obj
-@pytest.fixture
-def app_interface_yaml_obj() -> AppInterfaceYamlObject:
+# *** constants
+
+# ** constant: aggregate_sample_data
+AGGREGATE_SAMPLE_DATA = {
+    'id': 'test.interface',
+    'name': 'Test Interface',
+    'description': 'The test app interface.',
+    'module_path': DEFAULT_MODULE_PATH,
+    'class_name': DEFAULT_CLASS_NAME,
+    'flags': ['test_feature', 'test_data'],
+    'logger_id': 'default',
+    'services': [
+        {
+            'service_id': 'test_attribute',
+            'module_path': 'test.module.path',
+            'class_name': 'TestClassName',
+            'parameters': {'test_param': 'test_value', 'debug': '1'},
+        },
+        {
+            'service_id': 'logging',
+            'module_path': 'tiferet.utils.logging',
+            'class_name': 'LoggingService',
+            'parameters': {},
+        },
+    ],
+    'constants': {
+        'APP_NAME': 'Tiferet Test',
+        'VERSION': '2.0.0a1',
+        'DEBUG': '1',
+    },
+}
+
+# ** constant: equality_fields
+EQUALITY_FIELDS = [
+    'id',
+    'name',
+    'description',
+    'module_path',
+    'class_name',
+    'logger_id',
+    'flags',
+    'constants',
+    'services',
+]
+
+# ** constant: svc_tuple
+def SVC_TUPLE(s):
     '''
-    A fixture for an app interface yaml data object.
-
-    :return: The app interface yaml data object.
-    :rtype: AppInterfaceYamlObject
+    Normalize a single service (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return the app interface yaml data object.
-    return TransferObject.from_data(
-        AppInterfaceYamlObject,
-        id='app_yaml_data',
-        name='Test App YAML Data',
-        module_path=DEFAULT_MODULE_PATH,
-        class_name=DEFAULT_CLASS_NAME,
-        flags=['test_app_yaml_data'],
-        services=dict(
-            test_attribute=dict(
-                module_path='test_module_path',
-                class_name='test_class_name',
-                parameters=dict(
-                    test_param='test_value',
-                )
-            )
-        ),
-        constants=dict(
-            test_const='test_const_value',
+    if isinstance(s, dict):
+        return (
+            s['service_id'],
+            s['module_path'],
+            s['class_name'],
+            tuple(sorted(s.get('parameters', {}).items())),
         )
+    return (
+        s.service_id,
+        s.module_path,
+        s.class_name,
+        tuple(sorted((s.parameters or {}).items())),
     )
 
-# ** fixture: app_interface_aggr
-@pytest.fixture
-def app_interface_aggr() -> AppInterfaceAggregate:
-    '''
-    Fixture to provide a sample AppInterface model for round-trip testing.
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'flags': lambda v: sorted(v or []),
+    'constants': lambda v: dict(sorted((k, v) for k, v in (v or {}).items())),
+    'services': lambda svcs: tuple(sorted(SVC_TUPLE(s) for s in (svcs or []))),
+}
 
-    :return: A sample AppInterface instance.
-    :rtype: AppInterfaceAggregate
+
+# *** classes
+
+# ** class: TestAppInterfaceAggregate
+class TestAppInterfaceAggregate(AggregateTestBase):
+    '''
+    Tests for AppInterfaceAggregate construction, set_attribute, and domain-specific mutations.
     '''
 
-    # Create and return a sample AppInterfaceAggregate instance.
-    app_interface_data = {
+    aggregate_cls = AppInterfaceAggregate
+
+    sample_data = AGGREGATE_SAMPLE_DATA
+
+    equality_fields = EQUALITY_FIELDS
+
+    field_normalizers = FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name',         'Updated Interface',      None),
+        ('description',  'New description text',   None),
+        ('logger_id',    'custom.logger.id',       None),
+        ('flags',        ['flag1', 'flag2'],       None),
+        # invalid
+        ('invalid_attr', 'value',                  const.INVALID_MODEL_ATTRIBUTE_ID),
+        ('module_path',  '',                       const.INVALID_APP_INTERFACE_TYPE_ID),
+        ('class_name',   '   ',                    const.INVALID_APP_INTERFACE_TYPE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
+        '''
+        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return AppInterfaceAggregate.new(
+            app_interface_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** fixtures
+
+    # ** fixture: aggr_factory
+    @pytest.fixture
+    def aggr_factory(self):
+        '''
+        Factory for creating AppInterfaceAggregate with customizable services/constants.
+        '''
+
+        def factory(services=None, constants=None, **overrides):
+
+            # Start from a copy of the shared sample data.
+            data = self.sample_data.copy()
+
+            # Override services and constants if provided.
+            if services is not None:
+                data['services'] = services
+            if constants is not None:
+                data['constants'] = constants
+            data.update(overrides)
+
+            # Create and return the aggregate.
+            return AppInterfaceAggregate.new(app_interface_data=data)
+
+        return factory
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_constants_clear_when_none
+    def test_set_constants_clear_when_none(self, aggr_factory):
+        '''
+        Test that set_constants clears all constants when called with None.
+        '''
+
+        # Create aggregate with seeded constants and clear them.
+        aggr = aggr_factory(constants={'a': '1', 'b': '2'})
+        aggr.set_constants(None)
+
+        # All constants should be cleared.
+        assert aggr.constants == {}
+
+    # ** test: set_constants_merge_and_override
+    def test_set_constants_merge_and_override(self, aggr_factory):
+        '''
+        Test that set_constants merges new constants and overrides existing keys.
+        '''
+
+        # Create aggregate with seeded constants and merge new ones.
+        aggr = aggr_factory(constants={'keep': 'orig', 'old': 'v1'})
+        aggr.set_constants({'old': 'v2', 'new': '42'})
+
+        # Existing keys should be preserved or overridden as appropriate.
+        assert aggr.constants == {'keep': 'orig', 'old': 'v2', 'new': '42'}
+
+    # ** test: set_constants_remove_none_values
+    def test_set_constants_remove_none_values(self, aggr_factory):
+        '''
+        Test that set_constants removes keys whose new value is None.
+        '''
+
+        # Create aggregate with seeded constants and remove one via None.
+        aggr = aggr_factory(constants={'keep': '1', 'drop': 'x'})
+        aggr.set_constants({'drop': None, 'add': 'yes'})
+
+        # The key set to None should be removed.
+        assert aggr.constants == {'keep': '1', 'add': 'yes'}
+
+    # ** test: remove_service_various_positions_and_missing
+    @pytest.mark.parametrize(
+        "initial_ids, remove_id, expected_removed, expected_remaining",
+        [
+            (["first", "middle", "last"], "middle", "middle", ["first", "last"]),
+            (["first", "middle", "last"], "first",  "first",  ["middle", "last"]),
+            (["first", "middle", "last"], "last",   "last",   ["first", "middle"]),
+            (["a", "b"],                  "c",      None,     ["a", "b"]),
+            ([],                          "x",      None,     []),
+        ]
+    )
+    def test_remove_service_various_positions_and_missing(
+        self,
+        aggr_factory,
+        initial_ids,
+        remove_id,
+        expected_removed,
+        expected_remaining,
+    ):
+        '''
+        Test that remove_service removes and returns a matching service, or None if missing.
+        '''
+
+        # Build services from the initial ids.
+        services = [
+            DomainObject.new(
+                AppServiceDependency,
+                service_id=aid,
+                module_path=f"mod.{aid}",
+                class_name=f"{aid.capitalize()}Class",
+                parameters={'p': aid},
+            )
+            for aid in initial_ids
+        ]
+
+        # Create aggregate and attempt removal.
+        aggr = aggr_factory(services=services)
+        removed = aggr.remove_service(remove_id)
+
+        # Verify the removed service (or None).
+        if expected_removed:
+            assert removed is not None
+            assert removed.service_id == expected_removed
+        else:
+            assert removed is None
+
+        # Verify the remaining services.
+        assert [s.service_id for s in aggr.services] == expected_remaining
+
+    # ** test: set_service_update_existing_merge_params
+    def test_set_service_update_existing_merge_params(self, aggregate):
+        '''
+        Test that set_service updates an existing service and merges parameters.
+        '''
+
+        # Update the existing test_attribute service with new type and merged parameters.
+        aggregate.set_service(
+            service_id='test_attribute',
+            module_path='new.mod.path',
+            class_name='NewImplementation',
+            parameters={'old': None, 'keep': 'yes', 'extra': '123', 'debug': '0'},
+        )
+
+        # Verify type fields were updated.
+        svc = aggregate.get_service('test_attribute')
+        assert svc.module_path == 'new.mod.path'
+        assert svc.class_name == 'NewImplementation'
+
+        # Existing params merged, None-valued keys removed, new keys added.
+        assert svc.parameters == {
+            'test_param': 'test_value',
+            'keep': 'yes',
+            'extra': '123',
+            'debug': '0',
+        }
+
+    # ** test: set_service_create_new
+    def test_set_service_create_new(self, aggregate):
+        '''
+        Test that set_service creates a new service when none exists.
+        '''
+
+        # Verify the service does not exist yet.
+        assert aggregate.get_service('brand_new') is None
+
+        # Create a new service via set_service.
+        aggregate.set_service(
+            service_id='brand_new',
+            module_path='pkg.sub.module',
+            class_name='FreshService',
+            parameters={'p1': 'v1', 'p2': '42'},
+        )
+
+        # Verify the new service was created with the correct values.
+        svc = aggregate.get_service('brand_new')
+        assert svc is not None
+        assert svc.module_path == 'pkg.sub.module'
+        assert svc.class_name == 'FreshService'
+        assert svc.parameters == {'p1': 'v1', 'p2': '42'}
+
+
+# ** class: TestAppInterfaceYamlObject
+class TestAppInterfaceYamlObject(TransferObjectTestBase):
+    '''
+    Tests for AppInterfaceYamlObject mapping, round-trip, and nested AppServiceDependencyYamlObject.
+    '''
+
+    transfer_cls = AppInterfaceYamlObject
+    aggregate_cls = AppInterfaceAggregate
+
+    # YAML-format sample data (services as dict keyed by service_id).
+    sample_data = {
         'id': 'test.interface',
         'name': 'Test Interface',
         'description': 'The test app interface.',
         'module_path': DEFAULT_MODULE_PATH,
         'class_name': DEFAULT_CLASS_NAME,
         'flags': ['test_feature', 'test_data'],
-        'services': [
-            {
-                'attribute_id': 'test_attribute',
-                'module_path': 'test_module_path',
-                'class_name': 'test_class_name',
-                'parameters': {
-                    'test_param': 'test_value',
-                },
-            }
-        ],
+        'logger_id': 'default',
+        'services': {
+            'test_attribute': {
+                'module_path': 'test.module.path',
+                'class_name': 'TestClassName',
+                'parameters': {'test_param': 'test_value', 'debug': '1'},
+            },
+            'logging': {
+                'module_path': 'tiferet.utils.logging',
+                'class_name': 'LoggingService',
+                'parameters': {},
+            },
+        },
         'constants': {
-            'TEST_CONST': 'test_const_value',
-        }
-    }
-
-    return AppInterfaceAggregate.new(app_interface_data=app_interface_data)
-
-# *** tests
-
-# ** test: app_interface_aggregate_new
-def test_app_interface_aggregate_new(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test creating an AppInterfaceAggregate.
-
-    :param app_interface_aggr: The app interface aggregate fixture.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(app_interface_aggr, AppInterfaceAggregate)
-    assert app_interface_aggr.id == 'test.interface'
-    assert app_interface_aggr.name == 'Test Interface'
-    assert app_interface_aggr.module_path == DEFAULT_MODULE_PATH
-    assert app_interface_aggr.class_name == DEFAULT_CLASS_NAME
-
-# ** test: app_interface_aggregate_set_attribute_valid_updates
-def test_app_interface_aggregate_set_attribute_valid_updates(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute successfully updates supported attributes and validates the aggregate.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Update multiple supported attributes.
-    app_interface_aggr.set_attribute('name', 'Updated App')
-    app_interface_aggr.set_attribute('description', 'Updated description')
-    app_interface_aggr.set_attribute('logger_id', 'updated_logger')
-    app_interface_aggr.set_attribute('flags', ['updated_flag'])
-
-    # Assert that the attributes were updated.
-    assert app_interface_aggr.name == 'Updated App'
-    assert app_interface_aggr.description == 'Updated description'
-    assert app_interface_aggr.logger_id == 'updated_logger'
-    assert app_interface_aggr.flags == ['updated_flag']
-
-# ** test: app_interface_aggregate_set_attribute_invalid_name
-def test_app_interface_aggregate_set_attribute_invalid_name(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute rejects an unsupported attribute name.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to update an unsupported attribute and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('invalid_attribute', 'value')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
-    assert exc_info.value.kwargs.get('attribute') == 'invalid_attribute'
-
-# ** test: app_interface_aggregate_set_attribute_invalid_module_path
-def test_app_interface_aggregate_set_attribute_invalid_module_path(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute enforces non-empty string for module_path.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to set an empty module_path and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('module_path', '')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
-    assert exc_info.value.kwargs.get('attribute') == 'module_path'
-
-# ** test: app_interface_aggregate_set_attribute_invalid_class_name
-def test_app_interface_aggregate_set_attribute_invalid_class_name(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_attribute enforces non-empty string for class_name.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Attempt to set a blank class_name and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        app_interface_aggr.set_attribute('class_name', '   ')
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_APP_INTERFACE_TYPE'
-    assert exc_info.value.kwargs.get('attribute') == 'class_name'
-
-# ** test: app_interface_aggregate_set_constants_clears_when_none
-def test_app_interface_aggregate_set_constants_clears_when_none(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants clears all constants when called with None.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'existing': 'value',
-        'another': 'value',
-    }
-
-    # Call set_constants with None to clear all constants.
-    app_interface_aggr.set_constants(None)
-
-    # All constants should be cleared.
-    assert app_interface_aggr.constants == {}
-
-# ** test: app_interface_aggregate_set_constants_merges_and_overrides
-def test_app_interface_aggregate_set_constants_merges_and_overrides(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants merges new constants and overrides existing keys.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'keep': 'original',
-        'override': 'old',
-    }
-
-    # Merge new constants, overriding existing keys and adding new ones.
-    app_interface_aggr.set_constants(
-        {
-            'override': 'new',
-            'add': 'added',
+            'APP_NAME': 'Tiferet Test',
+            'VERSION': '2.0.0a1',
+            'DEBUG': '1',
         },
-    )
-
-    # Existing keys should be preserved or overridden as appropriate.
-    assert app_interface_aggr.constants == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
     }
 
-# ** test: app_interface_aggregate_set_constants_removes_none_valued_keys
-def test_app_interface_aggregate_set_constants_removes_none_valued_keys(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants removes keys whose new value is None.
+    # Aggregate-format expected data (services as list, defaults filled in).
+    aggregate_sample_data = AGGREGATE_SAMPLE_DATA
 
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
+    equality_fields = EQUALITY_FIELDS
 
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'keep': 'value',
-        'remove': 'value',
+    field_normalizers = FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
+        '''
+        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return AppInterfaceAggregate.new(
+            app_interface_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
+
+    # *** child mapper: AppServiceDependencyYamlObject
+
+    # ** constant: dependency_sample_data
+    dependency_sample_data = {
+        'module_path': 'example.service.module',
+        'class_name': 'ExampleServiceImpl',
+        'parameters': {'timeout': '30', 'retries': '3', 'ssl': '1'},
     }
 
-    # Provide an update that sets one key to None.
-    app_interface_aggr.set_constants(
-        {
-            'remove': None,
-        },
-    )
+    # ** test: app_service_dependency_yaml_map_basic
+    def test_app_service_dependency_yaml_map_basic(self):
+        '''
+        Test mapping an AppServiceDependencyYamlObject to an AppServiceDependency.
+        '''
 
-    # The key set to None should be removed, and others preserved.
-    assert app_interface_aggr.constants == {
-        'keep': 'value',
-    }
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            **self.dependency_sample_data,
+        )
+        dep = yaml_obj.map(service_id='injected_svc')
 
-# ** test: app_interface_aggregate_set_constants_mixed_operations
-def test_app_interface_aggregate_set_constants_mixed_operations(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test that set_constants supports mixed operations of clearing, overriding,
-    adding, and preserving keys in a single call.
+        # Verify the mapped entity.
+        assert isinstance(dep, AppServiceDependency)
+        assert dep.service_id == 'injected_svc'
+        assert dep.module_path == 'example.service.module'
+        assert dep.class_name == 'ExampleServiceImpl'
+        assert dep.parameters == {'timeout': '30', 'retries': '3', 'ssl': '1'}
 
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
+    # ** test: app_service_dependency_yaml_aliasing_params
+    def test_app_service_dependency_yaml_aliasing_params(self):
+        '''
+        Test that the "params" serialized_name alias is correctly deserialized.
+        '''
 
-    # Seed existing constants on the aggregate.
-    app_interface_aggr.constants = {
-        'remove': 'value',
-        'override': 'old',
-        'preserve': 'present',
-    }
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            module_path='alias.test.mod',
+            class_name='AliasImpl',
+            params={'alias_key': 'value'},
+        )
+        dep = yaml_obj.map(service_id='aliased_dep')
 
-    # Perform a mixed update.
-    app_interface_aggr.set_constants(
-        {
-            'remove': None,
-            'override': 'new',
-            'add': 'added',
-        },
-    )
+        # Verify aliased parameters were deserialized correctly.
+        assert dep.parameters == {'alias_key': 'value'}
 
-    # Verify mixed behavior across keys.
-    assert app_interface_aggr.constants == {
-        'override': 'new',
-        'preserve': 'present',
-        'add': 'added',
-    }
+    # ** test: app_service_dependency_yaml_roles_to_model_excludes
+    def test_app_service_dependency_yaml_roles_to_model_excludes(self):
+        '''
+        Test that to_model role excludes parameters and service_id.
+        '''
 
-# ** test: app_interface_aggregate_remove_service_removes_matching_from_middle_start_end
-def test_app_interface_aggregate_remove_service_removes_matching_from_middle_start_end() -> None:
-    '''
-    Test that remove_service removes and returns services when attribute_id
-    matches for items in the middle, start, and end positions.
-    '''
+        # Create YAML object with fields that should be excluded.
+        yaml_obj = TransferObject.from_data(
+            AppServiceDependencyYamlObject,
+            module_path='ex.test.mod',
+            class_name='ExcludeTest',
+            parameters={'secret': 'dontleak'},
+            service_id='should_ignore',
+        )
+        primitive = yaml_obj.to_primitive('to_model')
 
-    # Create three service dependencies with distinct attribute_ids.
-    first = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='first',
-        module_path='module.first',
-        class_name='FirstClass',
-    )
-    middle = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='middle',
-        module_path='module.middle',
-        class_name='MiddleClass',
-    )
-    last = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='last',
-        module_path='module.last',
-        class_name='LastClass',
-    )
+        # Verify excluded fields are absent.
+        assert 'parameters' not in primitive
+        assert 'service_id' not in primitive
+        assert primitive['module_path'] == 'ex.test.mod'
+        assert primitive['class_name'] == 'ExcludeTest'
 
-    # Create an app interface aggregate seeded with the three services.
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[first, middle, last],
-    ))
+    # ** test: app_service_dependency_yaml_round_trip_via_parent
+    def test_app_service_dependency_yaml_round_trip_via_parent(self, aggregate):
+        '''
+        Test that services are preserved through the parent AppInterfaceYamlObject round-trip.
+        '''
 
-    # Remove the middle service and verify it is returned and removed.
-    removed_middle = app_interface.remove_service('middle')
-    assert removed_middle is not None
-    assert removed_middle.attribute_id == 'middle'
-    assert [svc.attribute_id for svc in app_interface.services] == ['first', 'last']
+        # Convert aggregate to YAML object and back.
+        yaml_top = AppInterfaceYamlObject.from_model(aggregate)
+        round_tripped = yaml_top.map()
 
-    # Remove the first service and verify it is returned and removed.
-    removed_first = app_interface.remove_service('first')
-    assert removed_first is not None
-    assert removed_first.attribute_id == 'first'
-    assert [svc.attribute_id for svc in app_interface.services] == ['last']
-
-    # Remove the last remaining service and verify it is returned and removed.
-    removed_last = app_interface.remove_service('last')
-    assert removed_last is not None
-    assert removed_last.attribute_id == 'last'
-    assert app_interface.services == []
-
-# ** test: app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify
-def test_app_interface_aggregate_remove_service_missing_returns_none_and_does_not_modify() -> None:
-    '''
-    Test that remove_service returns None and leaves the services list
-    unchanged when no service with the given attribute_id exists.
-    '''
-
-    # Create two service dependencies and an app interface aggregate seeded with them.
-    first = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='first',
-        module_path='module.first',
-        class_name='FirstClass',
-    )
-    second = DomainObject.new(
-        AppServiceDependency,
-        attribute_id='second',
-        module_path='module.second',
-        class_name='SecondClass',
-    )
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[first, second],
-    ))
-
-    # Capture the original list of services for comparison.
-    original_services = list(app_interface.services)
-
-    # Attempt to remove a non-existent service.
-    result = app_interface.remove_service('missing')
-
-    # Verify the method returns None and the list is unchanged.
-    assert result is None
-    assert app_interface.services == original_services
-
-# ** test: app_interface_aggregate_remove_service_on_empty_services_returns_none
-def test_app_interface_aggregate_remove_service_on_empty_services_returns_none() -> None:
-    '''
-    Test that remove_service returns None when called on an app interface aggregate with
-    an empty services list.
-    '''
-
-    # Create an app interface aggregate with no services.
-    app_interface = AppInterfaceAggregate.new(app_interface_data=dict(
-        id='test',
-        name='Test App',
-        module_path='tiferet.contexts.app',
-        class_name='AppContext',
-        services=[],
-    ))
-
-    # Attempt to remove any service and verify None is returned.
-    result = app_interface.remove_service('anything')
-    assert result is None
-
-# ** test: app_interface_aggregate_set_service_updates_existing_and_merges_parameters
-def test_app_interface_aggregate_set_service_updates_existing_and_merges_parameters(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service updates an existing dependency and merges parameters,
-    removing keys whose values are None.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed existing parameters on the dependency.
-    dependency = app_interface_aggr.get_service('test_attribute')
-    dependency.parameters = {
-        'keep': 'original',
-        'override': 'old',
-        'remove': 'value',
-    }
-
-    # Perform an update with new type information and parameter overrides.
-    app_interface_aggr.set_service(
-        attribute_id='test_attribute',
-        module_path='updated.module',
-        class_name='UpdatedClass',
-        parameters={
-            'override': 'new',
-            'remove': None,
-            'add': 'added',
-        },
-    )
-
-    # Reload the dependency and assert type fields were updated.
-    updated = app_interface_aggr.get_service('test_attribute')
-    assert updated.module_path == 'updated.module'
-    assert updated.class_name == 'UpdatedClass'
-
-    # Existing parameters should be merged, with None-valued keys removed.
-    assert updated.parameters == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
-    }
-
-# ** test: app_interface_aggregate_set_service_clears_parameters_when_none
-def test_app_interface_aggregate_set_service_clears_parameters_when_none(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service clears parameters when parameters is None.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Seed parameters on the dependency.
-    dependency = app_interface_aggr.get_service('test_attribute')
-    dependency.parameters = {
-        'existing': 'value',
-    }
-
-    # Call set_service with parameters=None.
-    app_interface_aggr.set_service(
-        attribute_id='test_attribute',
-        module_path='cleared.module',
-        class_name='ClearedClass',
-        parameters=None,
-    )
-
-    # Parameters should be cleared while type fields are updated.
-    updated = app_interface_aggr.get_service('test_attribute')
-    assert updated.module_path == 'cleared.module'
-    assert updated.class_name == 'ClearedClass'
-    assert updated.parameters == {}
-
-# ** test: app_interface_aggregate_set_service_creates_new
-def test_app_interface_aggregate_set_service_creates_new(
-    app_interface_aggr: AppInterfaceAggregate,
-) -> None:
-    '''
-    Test that set_service creates a new dependency when none exists.
-
-    :param app_interface_aggr: The app interface aggregate to test.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Ensure that no dependency exists with the new attribute_id.
-    assert app_interface_aggr.get_service('new_attribute') is None
-
-    # Create a new dependency via set_service.
-    app_interface_aggr.set_service(
-        attribute_id='new_attribute',
-        module_path='new.module',
-        class_name='NewClass',
-        parameters={
-            'param': 'value',
-        },
-    )
-
-    # Verify that the dependency was created with the correct values.
-    new_svc = app_interface_aggr.get_service('new_attribute')
-    assert new_svc is not None
-    assert new_svc.module_path == 'new.module'
-    assert new_svc.class_name == 'NewClass'
-    assert new_svc.parameters == {'param': 'value'}
-
-# ** test: app_attribute_yaml_object_map
-def test_app_attribute_yaml_object_map():
-    '''
-    Test mapping an AppServiceDependencyYamlObject to an AppServiceDependency entity.
-    '''
-
-    # Create an AppServiceDependencyYamlObject.
-    yaml_obj = TransferObject.from_data(
-        AppServiceDependencyYamlObject,
-        module_path='test.module',
-        class_name='TestClass',
-        parameters={'key': 'value'},
-    )
-
-    # Map to entity.
-    entity = yaml_obj.map(attribute_id='test_attr')
-
-    # Assert the mapping is correct.
-    assert isinstance(entity, AppServiceDependency)
-    assert entity.attribute_id == 'test_attr'
-    assert entity.module_path == 'test.module'
-    assert entity.class_name == 'TestClass'
-    assert entity.parameters == {'key': 'value'}
-
-# ** test: app_interface_yaml_object_from_model
-def test_app_interface_yaml_object_from_model(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test creating an AppInterfaceYamlObject from an AppInterfaceAggregate.
-
-    :param app_interface_aggr: The app interface aggregate.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Create YamlObject from aggregate using the custom from_model method.
-    yaml_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
-
-    # Assert the conversion is correct.
-    assert isinstance(yaml_obj, AppInterfaceYamlObject)
-    assert yaml_obj.id == app_interface_aggr.id
-    assert yaml_obj.name == app_interface_aggr.name
-    assert yaml_obj.module_path == app_interface_aggr.module_path
-    assert yaml_obj.class_name == app_interface_aggr.class_name
-    assert 'test_attribute' in yaml_obj.services
-    assert yaml_obj.constants == app_interface_aggr.constants
-
-# ** test: app_settings_yaml_data_map
-def test_app_settings_yaml_data_map(app_interface_yaml_obj: AppInterfaceYamlObject):
-    '''
-    Tests the mapping of an app interface yaml data object to an app interface object.
-
-    :param app_interface_yaml_obj: The app interface yaml data object.
-    :type app_interface_yaml_obj: AppInterfaceYamlObject
-    '''
-
-    # Map the app interface yaml data to an app interface object.
-    app_settings = app_interface_yaml_obj.map()
-
-    # Assert the mapped app interface is valid.
-    assert isinstance(app_settings, AppInterfaceAggregate)
-    assert app_settings.id == app_interface_yaml_obj.id
-    assert app_settings.name == app_interface_yaml_obj.name
-    assert app_settings.flags == app_interface_yaml_obj.flags
-
-    # Assert that the module path and class name are correctly set.
-    assert app_settings.module_path == DEFAULT_MODULE_PATH
-    assert app_settings.class_name == DEFAULT_CLASS_NAME
-
-    # Assert that the mapped service contains the correct data.
-    svc = next(
-        svc for svc in app_settings.services if svc.attribute_id == 'test_attribute')
-    assert svc is not None
-    assert isinstance(svc, AppServiceDependency)
-    assert svc.module_path == 'test_module_path'
-    assert svc.class_name == 'test_class_name'
-
-    # Assert that the parameters are correctly set.
-    param = next(
-        (p for p in svc.parameters if p == 'test_param'), None)
-    assert param is not None
-    assert param == 'test_param'
-    assert svc.parameters['test_param'] == 'test_value'
-
-    # Assert that the constants are correctly set.
-    assert app_settings.constants
-    assert app_settings.constants['test_const'] == 'test_const_value'
-
-# ** test: app_interface_config_data_round_trip
-def test_app_interface_config_data_round_trip(app_interface_aggr: AppInterfaceAggregate):
-    '''
-    Test round-trip mapping: app interface aggregate -> app interface yaml object -> app interface aggregate.
-
-    :param app_interface_aggr: The app interface aggregate fixture.
-    :type app_interface_aggr: AppInterfaceAggregate
-    '''
-
-    # Convert aggregate to yaml object and back to aggregate.
-    data_obj = AppInterfaceYamlObject.from_model(app_interface_aggr)
-    round_tripped = data_obj.map()
-
-    # Assert core fields match.
-    assert round_tripped.id == app_interface_aggr.id
-    assert round_tripped.name == app_interface_aggr.name
-    assert round_tripped.module_path == app_interface_aggr.module_path
-    assert round_tripped.class_name == app_interface_aggr.class_name
-
-    # Assert services match field-by-field.
-    assert len(round_tripped.services) == len(app_interface_aggr.services)
-    for orig_svc, rt_svc in zip(app_interface_aggr.services, round_tripped.services):
-        assert rt_svc.attribute_id == orig_svc.attribute_id
-        assert rt_svc.module_path == orig_svc.module_path
-        assert rt_svc.class_name == orig_svc.class_name
-        assert rt_svc.parameters == orig_svc.parameters
-
-    # Assert constants match.
-    assert round_tripped.constants == app_interface_aggr.constants
+        # Use nested helper to verify services list preserved.
+        self.assert_nested_list_matches(
+            round_tripped.services,
+            aggregate.services,
+            key_field='service_id',
+            compare_fields=['module_path', 'class_name', 'parameters'],
+        )

--- a/tiferet/mappers/tests/test_cli.py
+++ b/tiferet/mappers/tests/test_cli.py
@@ -2,301 +2,365 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
 from ...domain import CliArgument, CliCommand, DomainObject
-from ...assets import TiferetError
+from ...events import a
 from ..settings import TransferObject
 from ..cli import CliArgumentAggregate, CliCommandAggregate, CliCommandYamlObject
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: cli_command_yaml_object
-@pytest.fixture
-def cli_command_yaml_object() -> CliCommandYamlObject:
+# *** constants
+
+# ** constant: argument_aggregate_sample_data
+ARGUMENT_AGGREGATE_SAMPLE_DATA = {
+    'name_or_flags': ['-v', '--verbose'],
+    'description': 'Enable verbose output.',
+    'type': 'str',
+    'required': False,
+    'default': 'false',
+    'action': 'store_true',
+}
+
+# ** constant: command_aggregate_sample_data
+COMMAND_AGGREGATE_SAMPLE_DATA = {
+    'id': 'calc.add',
+    'name': 'Add Number Command',
+    'description': 'Adds two numbers.',
+    'key': 'add',
+    'group_key': 'calc',
+    'arguments': [
+        {
+            'name_or_flags': ['a'],
+            'description': 'The first number to add.',
+            'type': 'str',
+        },
+        {
+            'name_or_flags': ['b'],
+            'description': 'The second number to add.',
+            'type': 'str',
+        },
+    ],
+}
+
+# ** constant: argument_equality_fields
+ARGUMENT_EQUALITY_FIELDS = [
+    'name_or_flags',
+    'description',
+    'type',
+    'required',
+    'default',
+    'action',
+]
+
+# ** constant: command_equality_fields
+COMMAND_EQUALITY_FIELDS = [
+    'id',
+    'name',
+    'description',
+    'key',
+    'group_key',
+    'arguments',
+]
+
+# ** constant: arg_tuple
+def ARG_TUPLE(arg):
     '''
-    A fixture for a CLI command YAML data object with two arguments using the args alias.
-
-    :return: The CLI command YAML data object.
-    :rtype: CliCommandYamlObject
+    Normalize a single CLI argument (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return the CLI command YAML data object.
-    return TransferObject.from_data(
-        CliCommandYamlObject,
-        id='calc.add',
-        name='Add Number Command',
-        description='Adds two numbers.',
-        key='add',
-        group_key='calc',
-        args=[
-            dict(
-                name_or_flags=['a'],
-                description='The first number to add.',
-                type='str',
-            ),
-            dict(
-                name_or_flags=['b'],
-                description='The second number to add.',
-                type='str',
-            ),
+    if isinstance(arg, dict):
+        return (
+            tuple(arg.get('name_or_flags', [])),
+            arg.get('description'),
+            arg.get('type'),
+        )
+    return (
+        tuple(arg.name_or_flags or []),
+        arg.description,
+        arg.type,
+    )
+
+# ** constant: command_field_normalizers
+COMMAND_FIELD_NORMALIZERS = {
+    'arguments': lambda args: tuple(sorted(ARG_TUPLE(arg) for arg in (args or []))),
+}
+
+
+# *** classes
+
+# ** class: TestCliArgumentAggregate
+class TestCliArgumentAggregate(AggregateTestBase):
+    '''
+    Tests for CliArgumentAggregate construction and set_attribute.
+    '''
+
+    aggregate_cls = CliArgumentAggregate
+
+    sample_data = ARGUMENT_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = ARGUMENT_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('description', 'Updated description.', None),
+        ('type', 'int', None),
+        ('required', True, None),
+        ('default', 'new_default', None),
+        ('action', 'store_false', None),
+        # invalid
+        ('name_or_flags', ['b'], a.const.INVALID_MODEL_ATTRIBUTE_ID),
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+
+# ** class: TestCliCommandAggregate
+class TestCliCommandAggregate(AggregateTestBase):
+    '''
+    Tests for CliCommandAggregate construction, set_attribute, and add_argument mutations.
+    '''
+
+    aggregate_cls = CliCommandAggregate
+
+    sample_data = COMMAND_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = COMMAND_EQUALITY_FIELDS
+
+    field_normalizers = COMMAND_FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Command Name', None),
+        ('description', 'New description text.', None),
+        ('key', 'subtract', None),
+        ('group_key', 'math', None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # ** test: add_argument_appends
+    def test_add_argument_appends(self, aggregate):
+        '''
+        Test that add_argument correctly appends a CliArgument to the aggregate.
+        '''
+
+        # Add an argument to the command.
+        aggregate.add_argument(
+            name_or_flags=['c'],
+            description='The third operand.',
+            type='int',
+        )
+
+        # Assert the argument was appended.
+        assert len(aggregate.arguments) == 3
+        added = aggregate.arguments[-1]
+        assert isinstance(added, CliArgument)
+        assert added.name_or_flags == ['c']
+        assert added.description == 'The third operand.'
+        assert added.type == 'int'
+
+    # ** test: add_argument_multiple
+    def test_add_argument_multiple(self, aggregate):
+        '''
+        Test that multiple add_argument calls accumulate correctly.
+        '''
+
+        # Add two arguments sequentially.
+        aggregate.add_argument(
+            name_or_flags=['c'],
+            description='Third operand.',
+            type='float',
+        )
+        aggregate.add_argument(
+            name_or_flags=['-v', '--verbose'],
+            description='Enable verbose output.',
+            action='store_true',
+        )
+
+        # Assert both arguments were added.
+        assert len(aggregate.arguments) == 4
+        assert aggregate.arguments[-2].name_or_flags == ['c']
+        assert aggregate.arguments[-2].type == 'float'
+        assert aggregate.arguments[-1].name_or_flags == ['-v', '--verbose']
+        assert aggregate.arguments[-1].action == 'store_true'
+
+    # ** test: add_argument_to_empty
+    def test_add_argument_to_empty(self):
+        '''
+        Test that add_argument works on a command created with no initial arguments.
+        '''
+
+        # Create an aggregate with no arguments.
+        aggregate = CliCommandAggregate.new(
+            id='calc.divide',
+            name='Divide Number Command',
+            key='divide',
+            group_key='calc',
+        )
+
+        # Add an argument.
+        aggregate.add_argument(
+            name_or_flags=['a'],
+            description='The numerator.',
+            type='int',
+        )
+
+        # Assert the argument was added to the empty list.
+        assert len(aggregate.arguments) == 1
+        assert aggregate.arguments[0].name_or_flags == ['a']
+        assert aggregate.arguments[0].description == 'The numerator.'
+        assert aggregate.arguments[0].type == 'int'
+
+
+# ** class: TestCliCommandYamlObject
+class TestCliCommandYamlObject(TransferObjectTestBase):
+    '''
+    Tests for CliCommandYamlObject mapping, round-trip, and CLI-specific serialization.
+    '''
+
+    transfer_cls = CliCommandYamlObject
+
+    aggregate_cls = CliCommandAggregate
+
+    # YAML-format sample data (uses 'args' alias).
+    sample_data = {
+        'id': 'calc.add',
+        'name': 'Add Number Command',
+        'description': 'Adds two numbers.',
+        'key': 'add',
+        'group_key': 'calc',
+        'args': [
+            {
+                'name_or_flags': ['a'],
+                'description': 'The first number to add.',
+                'type': 'str',
+            },
+            {
+                'name_or_flags': ['b'],
+                'description': 'The second number to add.',
+                'type': 'str',
+            },
         ],
-    )
+    }
 
-# *** tests
+    aggregate_sample_data = COMMAND_AGGREGATE_SAMPLE_DATA
 
-# ** test: cli_command_yaml_object_from_data
-def test_cli_command_yaml_object_from_data(cli_command_yaml_object: CliCommandYamlObject):
-    '''
-    Test that the CliCommandYamlObject can be initialized from data with correct
-    attributes and two arguments using the args alias.
+    equality_fields = COMMAND_EQUALITY_FIELDS
 
-    :param cli_command_yaml_object: The CLI command YAML data object.
-    :type cli_command_yaml_object: CliCommandYamlObject
-    '''
+    field_normalizers = COMMAND_FIELD_NORMALIZERS
 
-    # Assert the data is correctly initialized.
-    assert isinstance(cli_command_yaml_object, CliCommandYamlObject)
-    assert cli_command_yaml_object.id == 'calc.add'
-    assert cli_command_yaml_object.name == 'Add Number Command'
-    assert cli_command_yaml_object.description == 'Adds two numbers.'
-    assert cli_command_yaml_object.key == 'add'
-    assert cli_command_yaml_object.group_key == 'calc'
+    # ** test: args_alias_deserialization
+    def test_args_alias_deserialization(self):
+        '''
+        Test that the 'args' serialized_name alias is correctly deserialized to arguments.
+        '''
 
-    # Assert the arguments are correctly initialized.
-    assert len(cli_command_yaml_object.arguments) == 2
-    assert cli_command_yaml_object.arguments[0].name_or_flags == ['a']
-    assert cli_command_yaml_object.arguments[0].description == 'The first number to add.'
-    assert cli_command_yaml_object.arguments[1].name_or_flags == ['b']
-    assert cli_command_yaml_object.arguments[1].description == 'The second number to add.'
+        # Create a YAML object using the 'args' alias.
+        yaml_obj = TransferObject.from_data(
+            CliCommandYamlObject,
+            **self.sample_data,
+        )
 
+        # Assert the arguments were correctly deserialized.
+        assert len(yaml_obj.arguments) == 2
+        assert yaml_obj.arguments[0].name_or_flags == ['a']
+        assert yaml_obj.arguments[0].description == 'The first number to add.'
+        assert yaml_obj.arguments[1].name_or_flags == ['b']
+        assert yaml_obj.arguments[1].description == 'The second number to add.'
 
-# ** test: cli_command_yaml_object_map
-def test_cli_command_yaml_object_map(cli_command_yaml_object: CliCommandYamlObject):
-    '''
-    Test that map() produces a CliCommandAggregate with correct arguments.
+    # ** test: to_primitive_excludes_id_and_inlines_args
+    def test_to_primitive_excludes_id_and_inlines_args(self):
+        '''
+        Test that to_primitive('to_data.yaml') excludes 'id' and includes 'args' with full argument dicts.
+        '''
 
-    :param cli_command_yaml_object: The CLI command YAML data object.
-    :type cli_command_yaml_object: CliCommandYamlObject
-    '''
+        # Create a YAML object and serialize to primitive.
+        yaml_obj = TransferObject.from_data(
+            CliCommandYamlObject,
+            **self.sample_data,
+        )
+        primitive = yaml_obj.to_primitive('to_data.yaml')
 
-    # Map the CLI command YAML data to a CLI command aggregate.
-    aggregate = cli_command_yaml_object.map()
+        # Assert 'id' is excluded and 'args' is present with full dicts.
+        assert isinstance(primitive, dict)
+        assert 'id' not in primitive
+        assert 'args' in primitive
+        assert len(primitive['args']) == 2
+        assert primitive['args'][0]['name_or_flags'] == ['a']
+        assert primitive['args'][1]['name_or_flags'] == ['b']
+        assert primitive['name'] == 'Add Number Command'
+        assert primitive['key'] == 'add'
+        assert primitive['group_key'] == 'calc'
 
-    # Assert the mapped aggregate is valid.
-    assert isinstance(aggregate, CliCommandAggregate)
-    assert aggregate.id == 'calc.add'
-    assert aggregate.name == 'Add Number Command'
-    assert aggregate.key == 'add'
-    assert aggregate.group_key == 'calc'
+    # ** test: to_model_role_excludes_arguments
+    def test_to_model_role_excludes_arguments(self):
+        '''
+        Test that to_primitive('to_model') excludes 'arguments' but retains 'id', 'name', etc.
+        '''
 
-    # Assert the arguments are correctly mapped.
-    assert len(aggregate.arguments) == 2
-    assert aggregate.arguments[0].name_or_flags == ['a']
-    assert aggregate.arguments[1].name_or_flags == ['b']
+        # Create a YAML object and serialize with to_model role.
+        yaml_obj = TransferObject.from_data(
+            CliCommandYamlObject,
+            **self.sample_data,
+        )
+        primitive = yaml_obj.to_primitive('to_model')
 
+        # Assert 'arguments' is excluded and other fields are retained.
+        assert 'arguments' not in primitive
+        assert primitive['id'] == 'calc.add'
+        assert primitive['name'] == 'Add Number Command'
+        assert primitive['key'] == 'add'
+        assert primitive['group_key'] == 'calc'
 
-# ** test: cli_command_yaml_object_to_primitive
-def test_cli_command_yaml_object_to_primitive(cli_command_yaml_object: CliCommandYamlObject):
-    '''
-    Test that custom to_primitive('to_data.yaml') serializes args correctly.
+    # ** test: from_model_via_domain_factory
+    def test_from_model_via_domain_factory(self):
+        '''
+        Test that from_model() from CliCommand.new() produces a valid YAML object with correct id derivation.
+        '''
 
-    :param cli_command_yaml_object: The CLI command YAML data object.
-    :type cli_command_yaml_object: CliCommandYamlObject
-    '''
+        # Create a CliCommand domain object using the factory method.
+        cli_command = CliCommand.new(
+            group_key='calc',
+            key='subtract',
+            name='Subtract Number Command',
+            description='Subtracts one number from another.',
+            arguments=[
+                DomainObject.new(
+                    CliArgument,
+                    name_or_flags=['a'],
+                    description='The number to subtract from.',
+                ),
+            ],
+        )
 
-    # Serialize the data to primitive format for YAML.
-    primitive = cli_command_yaml_object.to_primitive('to_data.yaml')
+        # Create a CliCommandYamlObject from the model.
+        yaml_obj = CliCommandYamlObject.from_model(cli_command)
 
-    # Assert the primitive data is a dict with the expected keys.
-    assert isinstance(primitive, dict)
-    assert 'id' not in primitive
-    assert 'args' in primitive
-    assert len(primitive['args']) == 2
-    assert primitive['args'][0]['name_or_flags'] == ['a']
-    assert primitive['args'][1]['name_or_flags'] == ['b']
-    assert primitive['name'] == 'Add Number Command'
-    assert primitive['key'] == 'add'
-    assert primitive['group_key'] == 'calc'
+        # Assert the YAML object is valid.
+        assert isinstance(yaml_obj, CliCommandYamlObject)
+        assert yaml_obj.id == 'calc.subtract'
+        assert yaml_obj.name == 'Subtract Number Command'
+        assert yaml_obj.key == 'subtract'
+        assert yaml_obj.group_key == 'calc'
+        assert len(yaml_obj.arguments) == 1
+        assert yaml_obj.arguments[0].name_or_flags == ['a']
 
+    # ** test: round_trip_preserves_arguments
+    def test_round_trip_preserves_arguments(self, aggregate):
+        '''
+        Test that arguments are preserved through from_model -> map() round-trip.
+        Uses direct ordered iteration because name_or_flags is a list (unhashable as dict key).
+        '''
 
-# ** test: cli_command_yaml_object_from_model
-def test_cli_command_yaml_object_from_model():
-    '''
-    Test that from_model() from CliCommand.new() produces a valid YAML object.
-    '''
+        # Convert aggregate to YAML object and back.
+        yaml_obj = CliCommandYamlObject.from_model(aggregate)
+        round_tripped = yaml_obj.map()
 
-    # Create a CliCommand domain object using the factory method.
-    cli_command = CliCommand.new(
-        group_key='calc',
-        key='subtract',
-        name='Subtract Number Command',
-        description='Subtracts one number from another.',
-        arguments=[
-            DomainObject.new(
-                CliArgument,
-                name_or_flags=['a'],
-                description='The number to subtract from.',
-            ),
-        ],
-    )
+        # Assert argument count matches.
+        assert len(round_tripped.arguments) == len(aggregate.arguments)
 
-    # Create a CliCommandYamlObject from the model.
-    yaml_obj = CliCommandYamlObject.from_model(cli_command)
-
-    # Assert the YAML object is valid.
-    assert isinstance(yaml_obj, CliCommandYamlObject)
-    assert yaml_obj.id == 'calc.subtract'
-    assert yaml_obj.name == 'Subtract Number Command'
-    assert yaml_obj.key == 'subtract'
-    assert yaml_obj.group_key == 'calc'
-    assert len(yaml_obj.arguments) == 1
-    assert yaml_obj.arguments[0].name_or_flags == ['a']
-
-
-# ** test: cli_command_aggregate_new
-def test_cli_command_aggregate_new():
-    '''
-    Test that CliCommandAggregate.new() creates an aggregate with correct fields.
-    '''
-
-    # Create a new CLI command aggregate.
-    aggregate = CliCommandAggregate.new(
-        id='calc.multiply',
-        name='Multiply Number Command',
-        description='Multiplies two numbers.',
-        key='multiply',
-        group_key='calc',
-        arguments=[],
-    )
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(aggregate, CliCommandAggregate)
-    assert aggregate.id == 'calc.multiply'
-    assert aggregate.name == 'Multiply Number Command'
-    assert aggregate.description == 'Multiplies two numbers.'
-    assert aggregate.key == 'multiply'
-    assert aggregate.group_key == 'calc'
-    assert aggregate.arguments == []
-
-
-# ** test: cli_command_aggregate_add_argument
-def test_cli_command_aggregate_add_argument():
-    '''
-    Test that add_argument() correctly adds a CliArgument to the aggregate.
-    '''
-
-    # Create a CLI command aggregate with no arguments.
-    aggregate = CliCommandAggregate.new(
-        id='calc.divide',
-        name='Divide Number Command',
-        key='divide',
-        group_key='calc',
-    )
-
-    # Add an argument to the command.
-    aggregate.add_argument(
-        name_or_flags=['a'],
-        description='The numerator.',
-        type='int',
-    )
-
-    # Assert the argument was added.
-    assert len(aggregate.arguments) == 1
-    assert isinstance(aggregate.arguments[0], CliArgument)
-    assert aggregate.arguments[0].name_or_flags == ['a']
-    assert aggregate.arguments[0].description == 'The numerator.'
-    assert aggregate.arguments[0].type == 'int'
-
-
-# ** test: cli_command_aggregate_set_attribute
-def test_cli_command_aggregate_set_attribute():
-    '''
-    Test that set_attribute() updates supported attributes on the CLI command aggregate.
-    '''
-
-    # Create a CLI command aggregate.
-    aggregate = CliCommandAggregate.new(
-        id='calc.exp',
-        name='Exponentiate Number Command',
-        key='exp',
-        group_key='calc',
-    )
-
-    # Update supported attributes.
-    aggregate.set_attribute('name', 'Updated Exp Command')
-    aggregate.set_attribute('description', 'Raises a number to a power.')
-
-    # Assert the attributes were updated.
-    assert aggregate.name == 'Updated Exp Command'
-    assert aggregate.description == 'Raises a number to a power.'
-
-
-# ** test: cli_argument_aggregate_new
-def test_cli_argument_aggregate_new():
-    '''
-    Test that CliArgumentAggregate.new() creates an aggregate with all supported fields.
-    '''
-
-    # Create a new CLI argument aggregate with all supported fields.
-    aggregate = CliArgumentAggregate.new(
-        name_or_flags=['-v', '--verbose'],
-        description='Enable verbose output.',
-        type='str',
-        required=False,
-        default='false',
-        action='store_true',
-    )
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(aggregate, CliArgumentAggregate)
-    assert aggregate.name_or_flags == ['-v', '--verbose']
-    assert aggregate.description == 'Enable verbose output.'
-    assert aggregate.type == 'str'
-    assert aggregate.required is False
-    assert aggregate.default == 'false'
-    assert aggregate.action == 'store_true'
-
-
-# ** test: cli_argument_aggregate_set_attribute
-def test_cli_argument_aggregate_set_attribute():
-    '''
-    Test that set_attribute() updates supported attributes on the CLI argument aggregate.
-    '''
-
-    # Create a CLI argument aggregate.
-    aggregate = CliArgumentAggregate.new(
-        name_or_flags=['a'],
-        description='Original description.',
-    )
-
-    # Update supported attributes.
-    aggregate.set_attribute('description', 'Updated description.')
-    aggregate.set_attribute('required', True)
-
-    # Assert the attributes were updated.
-    assert aggregate.description == 'Updated description.'
-    assert aggregate.required is True
-
-
-# ** test: cli_argument_aggregate_set_attribute_invalid
-def test_cli_argument_aggregate_set_attribute_invalid():
-    '''
-    Test that set_attribute() raises TiferetError for unsupported attributes (name_or_flags).
-    '''
-
-    # Create a CLI argument aggregate.
-    aggregate = CliArgumentAggregate.new(
-        name_or_flags=['a'],
-        description='Test argument.',
-    )
-
-    # Attempt to set an unsupported attribute and expect a TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        aggregate.set_attribute('name_or_flags', ['b'])
-
-    # Verify that the correct error code is raised.
-    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
-    assert exc_info.value.kwargs.get('attribute') == 'name_or_flags'
+        # Compare arguments in order.
+        for orig, rt in zip(aggregate.arguments, round_tripped.arguments):
+            assert rt.name_or_flags == orig.name_or_flags
+            assert rt.description == orig.description
+            assert rt.type == orig.type

--- a/tiferet/mappers/tests/test_di.py
+++ b/tiferet/mappers/tests/test_di.py
@@ -2,560 +2,613 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
+from ...domain import DomainObject, FlaggedDependency
+from ...events import a
+from ..settings import TransferObject
 from ..di import (
     FlaggedDependencyAggregate,
     FlaggedDependencyYamlObject,
     ServiceConfigurationAggregate,
     ServiceConfigurationYamlObject,
 )
-from ...domain import (
-    DomainObject,
-    FlaggedDependency,
-)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: flagged_dependency_aggregate
-@pytest.fixture
-def flagged_dependency_aggregate() -> FlaggedDependencyAggregate:
+# *** constants
+
+# ** constant: flagged_dep_aggregate_sample_data
+FLAGGED_DEP_AGGREGATE_SAMPLE_DATA = {
+    'module_path': 'tests.repos.test',
+    'class_name': 'TestRepoProxy',
+    'flag': 'test',
+    'parameters': {'keep': 'original', 'override': 'old'},
+}
+
+# ** constant: flagged_dep_equality_fields
+FLAGGED_DEP_EQUALITY_FIELDS = [
+    'module_path',
+    'class_name',
+    'flag',
+    'parameters',
+]
+
+# ** constant: svc_config_aggregate_sample_data
+SVC_CONFIG_AGGREGATE_SAMPLE_DATA = {
+    'id': 'test_repo',
+    'module_path': 'tests.repos.test',
+    'class_name': 'DefaultTestRepoProxy',
+    'parameters': {'default_param': 'default_value'},
+    'dependencies': [
+        {
+            'module_path': 'tests.repos.test',
+            'class_name': 'TestRepoProxy',
+            'flag': 'existing',
+            'parameters': {'param1': 'value1'},
+        },
+    ],
+}
+
+# ** constant: svc_config_equality_fields
+SVC_CONFIG_EQUALITY_FIELDS = [
+    'id',
+    'module_path',
+    'class_name',
+    'parameters',
+    'dependencies',
+]
+
+# ** constant: dep_tuple
+def DEP_TUPLE(d):
     '''
-    Provides a fixture for a FlaggedDependencyAggregate instance.
-
-    :return: The FlaggedDependencyAggregate instance.
-    :rtype: FlaggedDependencyAggregate
+    Normalize a single dependency (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return a FlaggedDependencyAggregate.
-    return FlaggedDependencyAggregate.new(
-        flagged_dependency_data=dict(
+    if isinstance(d, dict):
+        return (
+            d['flag'],
+            d['module_path'],
+            d['class_name'],
+            tuple(sorted(d.get('parameters', {}).items())),
+        )
+    return (
+        d.flag,
+        d.module_path,
+        d.class_name,
+        tuple(sorted((d.parameters or {}).items())),
+    )
+
+# ** constant: svc_config_field_normalizers
+SVC_CONFIG_FIELD_NORMALIZERS = {
+    'dependencies': lambda deps: tuple(sorted(DEP_TUPLE(d) for d in (deps or []))),
+}
+
+
+# *** classes
+
+# ** class: TestFlaggedDependencyAggregate
+class TestFlaggedDependencyAggregate(AggregateTestBase):
+    '''
+    Tests for FlaggedDependencyAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = FlaggedDependencyAggregate
+
+    sample_data = FLAGGED_DEP_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FLAGGED_DEP_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('module_path', 'new.module.path', None),
+        ('class_name',  'NewClassName',    None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FlaggedDependencyAggregate:
+        '''
+        Override to use FlaggedDependencyAggregate.new(flagged_dependency_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FlaggedDependencyAggregate.new(
+            flagged_dependency_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_parameters_clears_when_none
+    def test_set_parameters_clears_when_none(self, aggregate):
+        '''
+        Test that set_parameters clears all parameters when called with None.
+        '''
+
+        # Call set_parameters with None to clear all parameters.
+        aggregate.set_parameters(None)
+
+        # All parameters should be cleared.
+        assert aggregate.parameters == {}
+
+    # ** test: set_parameters_merges_and_prunes_none_values
+    def test_set_parameters_merges_and_prunes_none_values(self, aggregate):
+        '''
+        Test that set_parameters merges new values and removes keys whose value is None.
+        '''
+
+        # Merge: override existing, add new, remove by setting to None.
+        aggregate.set_parameters({
+            'override': 'new',
+            'remove': None,
+            'add': 'added',
+        })
+
+        # 'keep' preserved, 'override' updated, 'remove' pruned, 'add' added.
+        assert aggregate.parameters == {
+            'keep': 'original',
+            'override': 'new',
+            'add': 'added',
+        }
+
+
+# ** class: TestServiceConfigurationAggregate
+class TestServiceConfigurationAggregate(AggregateTestBase):
+    '''
+    Tests for ServiceConfigurationAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = ServiceConfigurationAggregate
+
+    sample_data = SVC_CONFIG_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = SVC_CONFIG_EQUALITY_FIELDS
+
+    field_normalizers = SVC_CONFIG_FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name',         'Updated Service', None),
+        ('module_path',  'updated.module',  None),
+        ('class_name',   'UpdatedClass',    None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> ServiceConfigurationAggregate:
+        '''
+        Override to use ServiceConfigurationAggregate.new(service_configuration_data=...) signature.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return ServiceConfigurationAggregate.new(
+            service_configuration_data=(data if data is not None else self.sample_data).copy()
+        )
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_default_type_updates
+    def test_set_default_type_updates(self, aggregate):
+        '''
+        Test that set_default_type updates module_path, class_name, and parameters.
+        '''
+
+        # Update the default type with new values.
+        aggregate.set_default_type(
+            module_path='updated.module',
+            class_name='UpdatedClass',
+            parameters={'new_param': 'new_value'},
+        )
+
+        # Assert the fields were updated correctly.
+        assert aggregate.module_path == 'updated.module'
+        assert aggregate.class_name == 'UpdatedClass'
+        assert aggregate.parameters == {'new_param': 'new_value'}
+
+    # ** test: set_default_type_clears_when_both_none
+    def test_set_default_type_clears_when_both_none(self, aggregate):
+        '''
+        Test that set_default_type clears module_path, class_name, and parameters
+        when both type fields are None.
+        '''
+
+        # Call with both type fields as None to clear the default type.
+        aggregate.set_default_type(
+            module_path=None,
+            class_name=None,
+        )
+
+        # Both type fields and parameters should be cleared.
+        assert aggregate.module_path is None
+        assert aggregate.class_name is None
+        assert aggregate.parameters == {}
+
+    # ** test: set_dependency_creates_new
+    def test_set_dependency_creates_new(self, aggregate):
+        '''
+        Test that set_dependency appends a new FlaggedDependency when the flag is not found.
+        '''
+
+        # Confirm the flag does not already exist.
+        assert aggregate.get_dependency('new_flag') is None
+
+        # Add a new dependency via set_dependency.
+        aggregate.set_dependency(
+            flag='new_flag',
             module_path='tests.repos.test',
-            class_name='TestRepoProxy',
-            flag='test',
-            parameters={'keep': 'original', 'override': 'old'},
+            class_name='NewTestRepoProxy',
+            parameters={'new_param': 'new_value'},
         )
-    )
 
-# ** fixture: service_configuration_aggregate
-@pytest.fixture
-def service_configuration_aggregate() -> ServiceConfigurationAggregate:
-    '''
-    Provides a fixture for a ServiceConfigurationAggregate instance.
+        # Verify the dependency was created with the correct values.
+        dep = aggregate.get_dependency('new_flag')
+        assert dep is not None
+        assert isinstance(dep, FlaggedDependency)
+        assert dep.module_path == 'tests.repos.test'
+        assert dep.class_name == 'NewTestRepoProxy'
+        assert dep.parameters == {'new_param': 'new_value'}
+        assert len(aggregate.dependencies) == 2
 
-    :return: The ServiceConfigurationAggregate instance.
-    :rtype: ServiceConfigurationAggregate
-    '''
+    # ** test: set_dependency_updates_existing
+    def test_set_dependency_updates_existing(self, aggregate):
+        '''
+        Test that set_dependency updates an existing dependency in place, merging
+        parameters and pruning None-valued keys.
+        '''
 
-    # Create and return a ServiceConfigurationAggregate with one seeded dependency.
-    return ServiceConfigurationAggregate.new(
-        service_configuration_data=dict(
-            id='test_repo',
-            module_path='tests.repos.test',
-            class_name='DefaultTestRepoProxy',
-            parameters={'default_param': 'default_value'},
-            dependencies=[
-                DomainObject.new(
-                    FlaggedDependency,
-                    module_path='tests.repos.test',
-                    class_name='TestRepoProxy',
-                    flag='existing',
-                    parameters={'param1': 'value1'},
-                )
-            ],
+        # Update the existing 'existing' dependency.
+        aggregate.set_dependency(
+            flag='existing',
+            module_path='tests.repos.updated',
+            class_name='UpdatedRepoProxy',
+            parameters={'param1': None, 'param2': 'value2'},
         )
-    )
 
-# ** fixture: flagged_dependency_yaml_object
-@pytest.fixture
-def flagged_dependency_yaml_object() -> FlaggedDependencyYamlObject:
+        # Verify module_path and class_name were updated.
+        dep = aggregate.get_dependency('existing')
+        assert dep.module_path == 'tests.repos.updated'
+        assert dep.class_name == 'UpdatedRepoProxy'
+
+        # 'param1' had None value so it should be removed; 'param2' should be added.
+        assert dep.parameters == {'param2': 'value2'}
+
+        # The list should still have only one dependency.
+        assert len(aggregate.dependencies) == 1
+
+    # ** test: remove_dependency
+    def test_remove_dependency(self, aggregate):
+        '''
+        Test that remove_dependency filters out the dependency matching the given flag.
+        '''
+
+        # Confirm the dependency exists before removal.
+        assert aggregate.get_dependency('existing') is not None
+
+        # Remove the dependency.
+        aggregate.remove_dependency('existing')
+
+        # Verify it is gone and the list is empty.
+        assert aggregate.get_dependency('existing') is None
+        assert aggregate.dependencies == []
+
+    # ** test: remove_dependency_missing_flag_is_noop
+    def test_remove_dependency_missing_flag_is_noop(self, aggregate):
+        '''
+        Test that remove_dependency with an unmatched flag leaves the list unchanged.
+        '''
+
+        # Record the initial count.
+        initial_count = len(aggregate.dependencies)
+
+        # Attempt to remove a non-existent flag.
+        aggregate.remove_dependency('nonexistent')
+
+        # The list should be unchanged.
+        assert len(aggregate.dependencies) == initial_count
+
+
+# ** class: TestServiceConfigurationYamlObject
+class TestServiceConfigurationYamlObject(TransferObjectTestBase):
     '''
-    Provides a fixture for FlaggedDependency YAML object.
-
-    :return: The FlaggedDependencyYamlObject instance.
-    :rtype: FlaggedDependencyYamlObject
-    '''
-
-    # Create and return a FlaggedDependencyYamlObject.
-    return TransferObject.from_data(
-        FlaggedDependencyYamlObject,
-        module_path='tests.repos.test',
-        class_name='TestRepoProxy',
-        flag='test',
-        params=dict(
-            test_param='test_value'
-        )
-    )
-
-# ** fixture: service_configuration_yaml_object
-@pytest.fixture
-def service_configuration_yaml_object() -> ServiceConfigurationYamlObject:
-    '''
-    Provides a fixture for ServiceConfiguration YAML object.
-
-    :return: The ServiceConfigurationYamlObject instance.
-    :rtype: ServiceConfigurationYamlObject
-    '''
-
-    # Create and return a ServiceConfigurationYamlObject.
-    return TransferObject.from_data(
-        ServiceConfigurationYamlObject,
-        id='test_repo',
-        module_path='tests.repos.test',
-        class_name='DefaultTestRepoProxy',
-        deps=dict(
-            test=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy',
-                params={'test_param': 'test_value'}
-            ),
-            test2=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy2',
-                params={'param2': 'value2'}
-            )
-        ),
-        params=dict(
-            test_param='test_value',
-            param0='value0'
-        )
-    )
-
-# ** fixture: flagged_dependency_model
-@pytest.fixture
-def flagged_dependency_model(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Fixture to create a FlaggedDependency model instance for testing.
-
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    :return: The FlaggedDependency model instance.
-    :rtype: FlaggedDependency
+    Tests for ServiceConfigurationYamlObject mapping, round-trip, and nested FlaggedDependencyYamlObject.
     '''
 
-    # Map the YAML object to a FlaggedDependency model.
-    model = flagged_dependency_yaml_object.map()
-    model.class_name = 'TestRepoProxy2'
-    model.parameters = {'test_param2': 'test_value2'}
+    transfer_cls = ServiceConfigurationYamlObject
+    aggregate_cls = ServiceConfigurationAggregate
 
-    # Return the model object.
-    return model
-
-# *** tests
-
-# ** test: service_configuration_yaml_object_to_primitive_to_data_yaml
-def test_service_configuration_yaml_object_to_primitive_to_data_yaml(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be serialized to primitive data for YAML.
-
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
-
-    # Serialize the data to primitive format for YAML.
-    primitive_data = service_configuration_yaml_object.to_primitive(role='to_data.yaml')
-
-    # Check if the primitive data is correct.
-    assert isinstance(primitive_data, dict)
-    assert primitive_data == {
+    # YAML-format sample data (dependencies as dict keyed by flag).
+    sample_data = {
+        'id': 'test_repo',
         'module_path': 'tests.repos.test',
         'class_name': 'DefaultTestRepoProxy',
         'deps': {
             'test': {
                 'module_path': 'tests.repos.test',
                 'class_name': 'TestRepoProxy',
-                'params': {'test_param': 'test_value'}
+                'params': {'test_param': 'test_value'},
             },
             'test2': {
                 'module_path': 'tests.repos.test',
                 'class_name': 'TestRepoProxy2',
-                'params': {'param2': 'value2'}
+                'params': {'param2': 'value2'},
             },
         },
         'params': {
             'test_param': 'test_value',
-            'param0': 'value0'
-        }
+            'param0': 'value0',
+        },
     }
 
-# ** test: flagged_dependency_yaml_data_from_data
-def test_flagged_dependency_yaml_data_from_data(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Test that the FlaggedDependencyYamlObject can be initialized from data.
+    # Aggregate-format expected data (dependencies as list, defaults filled in).
+    aggregate_sample_data = {
+        'id': 'test_repo',
+        'module_path': 'tests.repos.test',
+        'class_name': 'DefaultTestRepoProxy',
+        'parameters': {'test_param': 'test_value', 'param0': 'value0'},
+        'dependencies': [
+            {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy',
+                'flag': 'test',
+                'parameters': {'test_param': 'test_value'},
+            },
+            {
+                'module_path': 'tests.repos.test',
+                'class_name': 'TestRepoProxy2',
+                'flag': 'test2',
+                'parameters': {'param2': 'value2'},
+            },
+        ],
+    }
 
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    '''
+    equality_fields = SVC_CONFIG_EQUALITY_FIELDS
 
-    # Check if the data is correctly initialized.
-    assert flagged_dependency_yaml_object.module_path == 'tests.repos.test'
-    assert flagged_dependency_yaml_object.class_name == 'TestRepoProxy'
-    assert flagged_dependency_yaml_object.flag == 'test'
-    assert flagged_dependency_yaml_object.parameters == {'test_param': 'test_value'}
+    field_normalizers = SVC_CONFIG_FIELD_NORMALIZERS
 
-# ** test: flagged_dependency_yaml_data_map
-def test_flagged_dependency_yaml_data_map(flagged_dependency_yaml_object: FlaggedDependencyYamlObject):
-    '''
-    Test that the FlaggedDependencyYamlObject can be mapped to a FlaggedDependency object.
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> ServiceConfigurationAggregate:
+        '''
+        Override to use ServiceConfigurationAggregate.new(service_configuration_data=...) signature.
+        '''
 
-    :param flagged_dependency_yaml_object: The FlaggedDependencyYamlObject instance.
-    :type flagged_dependency_yaml_object: FlaggedDependencyYamlObject
-    '''
+        # Create an aggregate using the custom factory.
+        return ServiceConfigurationAggregate.new(
+            service_configuration_data=(data if data is not None else self.aggregate_sample_data).copy()
+        )
 
-    # Map the data to a flagged dependency object.
-    mapped_dep = flagged_dependency_yaml_object.map()
+    # *** domain-specific tests
 
-    # Check if the mapped object is of the correct type.
-    assert isinstance(mapped_dep, FlaggedDependency)
-    assert mapped_dep.module_path == 'tests.repos.test'
-    assert mapped_dep.class_name == 'TestRepoProxy'
-    assert mapped_dep.flag == 'test'
-    assert mapped_dep.parameters == {'test_param': 'test_value'}
+    # ** test: to_primitive_to_data_yaml
+    def test_to_primitive_to_data_yaml(self):
+        '''
+        Test that ServiceConfigurationYamlObject serializes correctly to YAML primitive format.
+        '''
 
-# ** test: flagged_dependency_yaml_data_from_model
-def test_flagged_dependency_yaml_data_from_model(flagged_dependency_model: FlaggedDependency):
-    '''
-    Test that the FlaggedDependencyYamlObject can be created from a model object.
+        # Create a YAML object from sample data.
+        yaml_obj = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            **self.sample_data,
+        )
 
-    :param flagged_dependency_model: The FlaggedDependency model instance.
-    :type flagged_dependency_model: FlaggedDependency
-    '''
+        # Serialize to primitive format for YAML.
+        primitive = yaml_obj.to_primitive(role='to_data.yaml')
 
-    # Create a new data object from the model object.
-    data_from_model = FlaggedDependencyYamlObject.from_model(flagged_dependency_model)
+        # Verify id is excluded and the remaining structure is correct.
+        assert isinstance(primitive, dict)
+        assert 'id' not in primitive
+        assert primitive == {
+            'module_path': 'tests.repos.test',
+            'class_name': 'DefaultTestRepoProxy',
+            'deps': {
+                'test': {
+                    'module_path': 'tests.repos.test',
+                    'class_name': 'TestRepoProxy',
+                    'params': {'test_param': 'test_value'},
+                },
+                'test2': {
+                    'module_path': 'tests.repos.test',
+                    'class_name': 'TestRepoProxy2',
+                    'params': {'param2': 'value2'},
+                },
+            },
+            'params': {
+                'test_param': 'test_value',
+                'param0': 'value0',
+            },
+        }
 
-    # Assert the data object is valid.
-    assert isinstance(data_from_model, FlaggedDependencyYamlObject)
-    assert data_from_model.module_path == flagged_dependency_model.module_path
-    assert data_from_model.class_name == flagged_dependency_model.class_name
-    assert data_from_model.flag == flagged_dependency_model.flag
-    assert data_from_model.parameters == flagged_dependency_model.parameters
+    # ** test: to_model_role_excludes_dependencies_and_parameters
+    def test_to_model_role_excludes_dependencies_and_parameters(self):
+        '''
+        Test that the to_model role excludes dependencies and parameters.
+        '''
 
-# ** test: service_configuration_yaml_data_from_data
-def test_service_configuration_yaml_data_from_data(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be initialized from data.
+        # Create YAML object.
+        yaml_obj = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            **self.sample_data,
+        )
+        primitive = yaml_obj.to_primitive('to_model')
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # Verify excluded fields.
+        assert 'dependencies' not in primitive
+        assert 'parameters' not in primitive
+        assert primitive['id'] == 'test_repo'
+        assert primitive['module_path'] == 'tests.repos.test'
+        assert primitive['class_name'] == 'DefaultTestRepoProxy'
 
-    # Check if the data is correctly initialized.
-    assert service_configuration_yaml_object.id == 'test_repo'
-    assert len(service_configuration_yaml_object.dependencies) == 2
+    # ** test: flags_alias_round_trip
+    def test_flags_alias_round_trip(self):
+        '''
+        Test that the ``flags`` alias for dependencies is accepted on input and
+        that dependencies are still serialized under ``deps``.
+        '''
 
-    # Check if dependencies are correctly initialized.
-    for flag, dep in service_configuration_yaml_object.dependencies.items():
-        assert flag in ['test', 'test2']
-        assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+        # Create a ServiceConfigurationYamlObject using the legacy 'flags' alias.
+        data_object = TransferObject.from_data(
+            ServiceConfigurationYamlObject,
+            id='test_repo_flags',
+            module_path='tests.repos.test',
+            class_name='DefaultTestRepoProxy',
+            flags=dict(
+                flag1=dict(
+                    module_path='tests.repos.test',
+                    class_name='TestRepoProxy',
+                    params={'test_param': 'test_value'},
+                ),
+            ),
+            params=dict(
+                test_param='test_value',
+            ),
+        )
 
-# ** test: service_configuration_yaml_data_map
-def test_service_configuration_yaml_data_map(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be mapped to a ServiceConfiguration aggregate.
+        # The alias should populate the dependencies mapping keyed by flag.
+        assert isinstance(data_object, ServiceConfigurationYamlObject)
+        assert 'flag1' in data_object.dependencies
+        assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyYamlObject)
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # When serializing to data, dependencies should still be emitted as 'deps'.
+        primitive = data_object.to_primitive(role='to_data.yaml')
+        assert 'flags' not in primitive
+        assert 'deps' in primitive
+        assert 'flag1' in primitive['deps']
 
-    # Map the data to a service configuration aggregate.
-    mapped_attr = service_configuration_yaml_object.map()
+    # ** test: from_model_with_added_dependency
+    def test_from_model_with_added_dependency(self):
+        '''
+        Test that from_model correctly converts an aggregate with added dependencies.
+        '''
 
-    # Assert the mapped object is valid.
-    assert isinstance(mapped_attr, ServiceConfigurationAggregate)
-    assert mapped_attr.id == 'test_repo'
-    assert mapped_attr.module_path == 'tests.repos.test'
-    assert mapped_attr.class_name == 'DefaultTestRepoProxy'
-    assert mapped_attr.parameters == {'test_param': 'test_value', 'param0': 'value0'}
-    assert len(mapped_attr.dependencies) == 2
+        # Create an aggregate and add a third dependency.
+        aggregate = self.make_aggregate()
+        aggregate.set_dependency(
+            flag='test3',
+            module_path='tests.repos.test',
+            class_name='TestRepoProxy3',
+            parameters={'param3': 'value3'},
+        )
 
-    # Assert the dependencies are correctly mapped.
-    for dep in mapped_attr.dependencies:
+        # Convert to YAML object.
+        data_object = ServiceConfigurationYamlObject.from_model(aggregate)
+
+        # Verify the YAML object has all three dependencies.
+        assert isinstance(data_object, ServiceConfigurationYamlObject)
+        assert data_object.id == 'test_repo'
+        assert len(data_object.dependencies) == 3
+
+        # All dependencies should be FlaggedDependencyYamlObject instances.
+        for dep in data_object.dependencies.values():
+            assert isinstance(dep, FlaggedDependencyYamlObject)
+
+    # *** child mapper: FlaggedDependencyYamlObject
+
+    # ** constant: flagged_dep_sample_data
+    flagged_dep_sample_data = {
+        'module_path': 'tests.repos.test',
+        'class_name': 'TestRepoProxy',
+        'flag': 'test',
+        'params': {'test_param': 'test_value'},
+    }
+
+    # ** test: flagged_dependency_yaml_map_basic
+    def test_flagged_dependency_yaml_map_basic(self):
+        '''
+        Test mapping a FlaggedDependencyYamlObject to a FlaggedDependency.
+        '''
+
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            **self.flagged_dep_sample_data,
+        )
+        dep = yaml_obj.map()
+
+        # Verify the mapped entity.
         assert isinstance(dep, FlaggedDependency)
         assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}]
+        assert dep.class_name == 'TestRepoProxy'
+        assert dep.flag == 'test'
+        assert dep.parameters == {'test_param': 'test_value'}
 
-# ** test: service_configuration_yaml_data_from_model
-def test_service_configuration_yaml_data_from_model(service_configuration_yaml_object: ServiceConfigurationYamlObject):
-    '''
-    Test that the ServiceConfigurationYamlObject can be created from a model object.
+    # ** test: flagged_dependency_yaml_aliasing_params
+    def test_flagged_dependency_yaml_aliasing_params(self):
+        '''
+        Test that the "params" serialized_name alias is correctly deserialized.
+        '''
 
-    :param service_configuration_yaml_object: The ServiceConfigurationYamlObject instance.
-    :type service_configuration_yaml_object: ServiceConfigurationYamlObject
-    '''
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            module_path='alias.test.mod',
+            class_name='AliasImpl',
+            flag='aliased',
+            params={'alias_key': 'value'},
+        )
+        dep = yaml_obj.map()
 
-    # Create a new model object from the fixture.
-    model_object = service_configuration_yaml_object.map()
+        # Verify aliased parameters were deserialized correctly.
+        assert dep.parameters == {'alias_key': 'value'}
 
-    # Add another dependency to the model object.
-    model_object.set_dependency(
-        flag='test3',
-        module_path='tests.repos.test',
-        class_name='TestRepoProxy3',
-        parameters={'param3': 'value3'}
-    )
+    # ** test: flagged_dependency_yaml_from_model
+    def test_flagged_dependency_yaml_from_model(self):
+        '''
+        Test that FlaggedDependencyYamlObject can be created from a FlaggedDependency model.
+        '''
 
-    # Create a new data object from the model object.
-    data_object = ServiceConfigurationYamlObject.from_model(model_object)
+        # Create a FlaggedDependency model.
+        model = DomainObject.new(
+            FlaggedDependency,
+            module_path='tests.repos.test',
+            class_name='TestRepoProxy2',
+            flag='test',
+            parameters={'test_param2': 'test_value2'},
+        )
 
-    # Assert the data object is valid.
-    assert isinstance(data_object, ServiceConfigurationYamlObject)
-    assert data_object.id == 'test_repo'
-    assert len(data_object.dependencies) == 3
+        # Create a YAML object from the model.
+        yaml_obj = FlaggedDependencyYamlObject.from_model(model)
 
-    # Check if all dependencies are of type FlaggedDependencyYamlObject.
-    for dep in data_object.dependencies.values():
-        assert isinstance(dep, FlaggedDependencyYamlObject)
-        assert dep.module_path == 'tests.repos.test'
-        assert dep.class_name in ['TestRepoProxy', 'TestRepoProxy2', 'TestRepoProxy3']
-        assert dep.parameters in [{'test_param': 'test_value'}, {'param2': 'value2'}, {'param3': 'value3'}]
+        # Verify the YAML object has the correct values.
+        assert isinstance(yaml_obj, FlaggedDependencyYamlObject)
+        assert yaml_obj.module_path == model.module_path
+        assert yaml_obj.class_name == model.class_name
+        assert yaml_obj.flag == model.flag
+        assert yaml_obj.parameters == model.parameters
 
-# ** test: service_configuration_yaml_data_flags_alias_round_trip
-def test_service_configuration_yaml_data_flags_alias_round_trip() -> None:
-    '''
-    Test that the ``flags`` alias for dependencies is accepted on input and
-    that dependencies are still serialized under ``deps``.
-    '''
+    # ** test: flagged_dependency_yaml_roles_to_data_yaml_excludes_flag
+    def test_flagged_dependency_yaml_roles_to_data_yaml_excludes_flag(self):
+        '''
+        Test that to_data.yaml role excludes the flag field.
+        '''
 
-    # Create a ServiceConfigurationYamlObject using the legacy 'flags' alias.
-    data_object = TransferObject.from_data(
-        ServiceConfigurationYamlObject,
-        id='test_repo_flags',
-        module_path='tests.repos.test',
-        class_name='DefaultTestRepoProxy',
-        flags=dict(
-            flag1=dict(
-                module_path='tests.repos.test',
-                class_name='TestRepoProxy',
-                params={'test_param': 'test_value'},
-            ),
-        ),
-        params=dict(
-            test_param='test_value',
-        ),
-    )
+        # Create a YAML object.
+        yaml_obj = TransferObject.from_data(
+            FlaggedDependencyYamlObject,
+            **self.flagged_dep_sample_data,
+        )
 
-    # The alias should populate the dependencies mapping keyed by flag.
-    assert isinstance(data_object, ServiceConfigurationYamlObject)
-    assert 'flag1' in data_object.dependencies
-    assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyYamlObject)
+        # Serialize with to_data.yaml role.
+        primitive = yaml_obj.to_primitive('to_data.yaml')
 
-    # When serializing to data, dependencies should still be emitted as 'deps'.
-    primitive = data_object.to_primitive(role='to_data.yaml')
-    assert 'flags' not in primitive
-    assert 'deps' in primitive
-    assert 'flag1' in primitive['deps']
+        # Flag should be excluded; other fields present.
+        assert 'flag' not in primitive
+        assert primitive['module_path'] == 'tests.repos.test'
+        assert primitive['class_name'] == 'TestRepoProxy'
 
-# ** test: flagged_dependency_aggregate_new
-def test_flagged_dependency_aggregate_new(flagged_dependency_aggregate: FlaggedDependencyAggregate):
-    '''
-    Test that FlaggedDependencyAggregate.new() creates a valid aggregate.
+    # ** test: flagged_dependency_yaml_round_trip_via_parent
+    def test_flagged_dependency_yaml_round_trip_via_parent(self, aggregate):
+        '''
+        Test that dependencies are preserved through the parent ServiceConfigurationYamlObject round-trip.
+        '''
 
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
+        # Convert aggregate to YAML object and back.
+        yaml_top = ServiceConfigurationYamlObject.from_model(aggregate)
+        round_tripped = yaml_top.map()
 
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(flagged_dependency_aggregate, FlaggedDependencyAggregate)
-    assert flagged_dependency_aggregate.module_path == 'tests.repos.test'
-    assert flagged_dependency_aggregate.class_name == 'TestRepoProxy'
-    assert flagged_dependency_aggregate.flag == 'test'
-    assert flagged_dependency_aggregate.parameters == {'keep': 'original', 'override': 'old'}
-
-# ** test: flagged_dependency_aggregate_set_parameters_clears_when_none
-def test_flagged_dependency_aggregate_set_parameters_clears_when_none(
-    flagged_dependency_aggregate: FlaggedDependencyAggregate,
-):
-    '''
-    Test that set_parameters clears all parameters when called with None.
-
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
-
-    # Call set_parameters with None to clear all parameters.
-    flagged_dependency_aggregate.set_parameters(None)
-
-    # All parameters should be cleared.
-    assert flagged_dependency_aggregate.parameters == {}
-
-# ** test: flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values
-def test_flagged_dependency_aggregate_set_parameters_merges_and_prunes_none_values(
-    flagged_dependency_aggregate: FlaggedDependencyAggregate,
-):
-    '''
-    Test that set_parameters merges new values and removes keys whose value is None.
-
-    :param flagged_dependency_aggregate: The FlaggedDependencyAggregate instance.
-    :type flagged_dependency_aggregate: FlaggedDependencyAggregate
-    '''
-
-    # Merge: override existing, add new, remove by setting to None.
-    flagged_dependency_aggregate.set_parameters({
-        'override': 'new',
-        'remove': None,
-        'add': 'added',
-    })
-
-    # 'keep' preserved, 'override' updated, 'remove' pruned, 'add' added.
-    assert flagged_dependency_aggregate.parameters == {
-        'keep': 'original',
-        'override': 'new',
-        'add': 'added',
-    }
-
-# ** test: service_configuration_aggregate_new
-def test_service_configuration_aggregate_new(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that ServiceConfigurationAggregate.new() creates a valid aggregate.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(service_configuration_aggregate, ServiceConfigurationAggregate)
-    assert service_configuration_aggregate.id == 'test_repo'
-    assert service_configuration_aggregate.module_path == 'tests.repos.test'
-    assert service_configuration_aggregate.class_name == 'DefaultTestRepoProxy'
-    assert service_configuration_aggregate.parameters == {'default_param': 'default_value'}
-    assert len(service_configuration_aggregate.dependencies) == 1
-
-# ** test: service_configuration_aggregate_set_default_type_updates
-def test_service_configuration_aggregate_set_default_type_updates(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_default_type updates module_path, class_name, and parameters.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Update the default type with new values.
-    service_configuration_aggregate.set_default_type(
-        module_path='updated.module',
-        class_name='UpdatedClass',
-        parameters={'new_param': 'new_value'},
-    )
-
-    # Assert the fields were updated correctly.
-    assert service_configuration_aggregate.module_path == 'updated.module'
-    assert service_configuration_aggregate.class_name == 'UpdatedClass'
-    assert service_configuration_aggregate.parameters == {'new_param': 'new_value'}
-
-# ** test: service_configuration_aggregate_set_default_type_clears_when_both_none
-def test_service_configuration_aggregate_set_default_type_clears_when_both_none(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_default_type clears module_path, class_name, and parameters
-    when both type fields are None.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Call with both type fields as None to clear the default type.
-    service_configuration_aggregate.set_default_type(
-        module_path=None,
-        class_name=None,
-    )
-
-    # Both type fields and parameters should be cleared.
-    assert service_configuration_aggregate.module_path is None
-    assert service_configuration_aggregate.class_name is None
-    assert service_configuration_aggregate.parameters == {}
-
-# ** test: service_configuration_aggregate_set_dependency_creates_new
-def test_service_configuration_aggregate_set_dependency_creates_new(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_dependency appends a new FlaggedDependency when the flag is not found.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Confirm the flag does not already exist.
-    assert service_configuration_aggregate.get_dependency('new_flag') is None
-
-    # Add a new dependency via set_dependency.
-    service_configuration_aggregate.set_dependency(
-        flag='new_flag',
-        module_path='tests.repos.test',
-        class_name='NewTestRepoProxy',
-        parameters={'new_param': 'new_value'},
-    )
-
-    # Verify the dependency was created with the correct values.
-    dep = service_configuration_aggregate.get_dependency('new_flag')
-    assert dep is not None
-    assert isinstance(dep, FlaggedDependency)
-    assert dep.module_path == 'tests.repos.test'
-    assert dep.class_name == 'NewTestRepoProxy'
-    assert dep.parameters == {'new_param': 'new_value'}
-    assert len(service_configuration_aggregate.dependencies) == 2
-
-# ** test: service_configuration_aggregate_set_dependency_updates_existing
-def test_service_configuration_aggregate_set_dependency_updates_existing(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that set_dependency updates an existing dependency in place, merging
-    parameters and pruning None-valued keys.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Update the existing 'existing' dependency.
-    service_configuration_aggregate.set_dependency(
-        flag='existing',
-        module_path='tests.repos.updated',
-        class_name='UpdatedRepoProxy',
-        parameters={'param1': None, 'param2': 'value2'},
-    )
-
-    # Verify module_path and class_name were updated.
-    dep = service_configuration_aggregate.get_dependency('existing')
-    assert dep.module_path == 'tests.repos.updated'
-    assert dep.class_name == 'UpdatedRepoProxy'
-
-    # 'param1' had None value so it should be removed; 'param2' should be added.
-    assert dep.parameters == {'param2': 'value2'}
-
-    # The list should still have only one dependency.
-    assert len(service_configuration_aggregate.dependencies) == 1
-
-# ** test: service_configuration_aggregate_remove_dependency
-def test_service_configuration_aggregate_remove_dependency(
-    service_configuration_aggregate: ServiceConfigurationAggregate,
-):
-    '''
-    Test that remove_dependency filters out the dependency matching the given flag.
-
-    :param service_configuration_aggregate: The ServiceConfigurationAggregate instance.
-    :type service_configuration_aggregate: ServiceConfigurationAggregate
-    '''
-
-    # Confirm the dependency exists before removal.
-    assert service_configuration_aggregate.get_dependency('existing') is not None
-
-    # Remove the dependency.
-    service_configuration_aggregate.remove_dependency('existing')
-
-    # Verify it is gone and the list is empty.
-    assert service_configuration_aggregate.get_dependency('existing') is None
-    assert service_configuration_aggregate.dependencies == []
+        # Verify dependencies list preserved using nested helper.
+        self.assert_nested_list_matches(
+            round_tripped.dependencies,
+            aggregate.dependencies,
+            key_field='flag',
+            compare_fields=['module_path', 'class_name', 'parameters'],
+        )

--- a/tiferet/mappers/tests/test_error.py
+++ b/tiferet/mappers/tests/test_error.py
@@ -2,242 +2,320 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
-from ..error import (
-    ErrorYamlObject,
-    ErrorAggregate,
-    ErrorMessageYamlObject,
-)
 from ...domain import (
+    DomainObject,
     Error,
     ErrorMessage,
 )
+from ...events import a
+from ..settings import TransferObject
+from ..error import (
+    ErrorAggregate,
+    ErrorYamlObject,
+    ErrorMessageYamlObject,
+)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: error_yaml_object
-@pytest.fixture
-def error_yaml_object() -> ErrorYamlObject:
+# *** constants
+
+# ** constant: error_sample_data
+ERROR_SAMPLE_DATA = {
+    'id': 'TEST_ERROR',
+    'name': 'TEST_ERROR',
+    'error_code': 'TEST_ERROR',
+    'message': [
+        {'lang': 'en', 'text': 'Test error message.'},
+    ],
+}
+
+# ** constant: error_equality_fields
+ERROR_EQUALITY_FIELDS = ['id', 'name', 'error_code']
+
+
+# *** classes
+
+# ** class: TestErrorAggregate
+class TestErrorAggregate(AggregateTestBase):
     '''
-    Provides an error YAML object fixture.
-
-    :return: The error YAML object instance.
-    :rtype: ErrorYamlObject
+    Tests for ErrorAggregate construction, set_attribute, and domain-specific mutations.
     '''
 
-    # Create and return an error YAML object.
-    return TransferObject.from_data(
-        ErrorYamlObject,
-        id='TEST_ERROR',
-        name='TEST_ERROR',
-        error_code='TEST_ERROR',
-        message=[{
-            'lang': 'en',
-            'text': 'Test error message.'
-        }]
+    aggregate_cls = ErrorAggregate
+
+    sample_data = ERROR_SAMPLE_DATA
+
+    equality_fields = ERROR_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Error', None),
+        ('description', 'A new description', None),
+        # invalid
+        ('invalid_attribute', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # *** domain-specific mutation tests
+
+    # ** test: rename
+    def test_rename(self, aggregate):
+        '''
+        Test that rename() updates the error name.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Rename the error.
+        aggregate.rename('Renamed Error')
+
+        # Assert the name was updated.
+        assert aggregate.name == 'Renamed Error'
+
+    # ** test: set_message_new
+    def test_set_message_new(self, aggregate):
+        '''
+        Test that set_message() adds a new language message alongside existing ones.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Add a new Spanish message.
+        aggregate.set_message('es', 'Mensaje de error de prueba.')
+
+        # Assert both messages exist.
+        assert len(aggregate.message) == 2
+        assert aggregate.message[1].lang == 'es'
+        assert aggregate.message[1].text == 'Mensaje de error de prueba.'
+
+    # ** test: set_message_update
+    def test_set_message_update(self, aggregate):
+        '''
+        Test that set_message() updates an existing language message in-place (no duplication).
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Update the existing English message.
+        aggregate.set_message('en', 'Updated message')
+
+        # Assert only one message exists and it was updated.
+        assert len(aggregate.message) == 1
+        assert aggregate.message[0].text == 'Updated message'
+
+    # ** test: remove_message
+    def test_remove_message(self, aggregate):
+        '''
+        Test that remove_message() removes a message from a multi-message aggregate.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Add a second message, then remove the first.
+        aggregate.set_message('es', 'Mensaje de prueba')
+        aggregate.remove_message('en')
+
+        # Assert only the Spanish message remains.
+        assert len(aggregate.message) == 1
+        assert aggregate.message[0].lang == 'es'
+
+    # ** test: remove_message_nonexistent
+    def test_remove_message_nonexistent(self, aggregate):
+        '''
+        Test that removing a non-existent language is a no-op.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Record the initial count.
+        initial_count = len(aggregate.message)
+
+        # Attempt to remove a non-existent language.
+        aggregate.remove_message('fr')
+
+        # Assert the message list is unchanged.
+        assert len(aggregate.message) == initial_count
+
+
+# ** class: TestErrorYamlObject
+class TestErrorYamlObject(TransferObjectTestBase):
+    '''
+    Tests for ErrorYamlObject mapping, round-trip, and nested ErrorMessageYamlObject.
+    '''
+
+    transfer_cls = ErrorYamlObject
+    aggregate_cls = ErrorAggregate
+
+    sample_data = ERROR_SAMPLE_DATA
+
+    aggregate_sample_data = ERROR_SAMPLE_DATA
+
+    equality_fields = ERROR_EQUALITY_FIELDS
+
+    # *** domain-specific tests
+
+    # ** test: from_data
+    def test_from_data(self):
+        '''
+        Test that from_data() initializes scalar fields and nested ErrorMessageYamlObject instances.
+        '''
+
+        # Create a YAML object from sample data.
+        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+
+        # Assert scalar fields.
+        assert yaml_obj.name == 'TEST_ERROR'
+        assert yaml_obj.error_code == 'TEST_ERROR'
+
+        # Assert nested messages.
+        assert len(yaml_obj.message) == 1
+        assert isinstance(yaml_obj.message[0], ErrorMessageYamlObject)
+        assert yaml_obj.message[0].lang == 'en'
+        assert yaml_obj.message[0].text == 'Test error message.'
+
+    # ** test: to_primitive_to_data_yaml
+    def test_to_primitive_to_data_yaml(self):
+        '''
+        Test that to_primitive('to_data.yaml') excludes id and serializes messages correctly.
+        '''
+
+        # Create a YAML object and serialize.
+        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+        primitive = yaml_obj.to_primitive('to_data.yaml')
+
+        # Assert id is excluded.
+        assert isinstance(primitive, dict)
+        assert primitive.pop('id', None) is None
+
+        # Assert remaining fields.
+        assert primitive.get('name') == 'TEST_ERROR'
+        assert primitive.get('error_code') == 'TEST_ERROR'
+        assert len(primitive.get('message')) == 1
+        assert primitive.get('message')[0].get('lang') == 'en'
+        assert primitive.get('message')[0].get('text') == 'Test error message.'
+
+    # ** test: map_messages
+    def test_map_messages(self):
+        '''
+        Test that map() produces ErrorMessage domain objects in the message list.
+        '''
+
+        # Create YAML object and map.
+        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+        mapped = yaml_obj.map()
+
+        # Assert messages are ErrorMessage instances.
+        assert len(mapped.message) == 1
+        assert isinstance(mapped.message[0], ErrorMessage)
+        assert mapped.message[0].lang == 'en'
+        assert mapped.message[0].text == 'Test error message.'
+
+    # ** test: from_model_messages
+    def test_from_model_messages(self, aggregate):
+        '''
+        Test that from_model() converts messages to ErrorMessageYamlObject instances.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Convert aggregate to YAML object.
+        yaml_obj = ErrorYamlObject.from_model(aggregate)
+
+        # Assert messages are ErrorMessageYamlObject instances.
+        assert len(yaml_obj.message) == 1
+        assert all(isinstance(msg, ErrorMessageYamlObject) for msg in yaml_obj.message)
+
+    # ** test: round_trip_messages
+    def test_round_trip_messages(self, aggregate):
+        '''
+        Test that round-trip preserves message content field-by-field.
+
+        :param aggregate: The error aggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Round-trip: aggregate -> YAML object -> aggregate.
+        yaml_obj = ErrorYamlObject.from_model(aggregate)
+        round_tripped = yaml_obj.map()
+
+        # Assert message content preserved.
+        assert len(round_tripped.message) == len(aggregate.message)
+        for original, restored in zip(aggregate.message, round_tripped.message):
+            assert restored.lang == original.lang
+            assert restored.text == original.text
+
+    # ** test: from_model_via_error_new
+    def test_from_model_via_error_new(self):
+        '''
+        Test that from_model() works with an Error.new() factory-created model with multilingual messages.
+        '''
+
+        # Create an Error model via the domain factory.
+        error = Error.new(
+            id='test_error',
+            name='Test Error',
+            message=[
+                {'lang': 'en', 'text': 'Test message'},
+                {'lang': 'es', 'text': 'Mensaje de prueba'},
+            ],
+        )
+
+        # Convert to YAML object.
+        yaml_obj = ErrorYamlObject.from_model(error)
+
+        # Assert the YAML object is valid.
+        assert isinstance(yaml_obj, ErrorYamlObject)
+        assert yaml_obj.id == 'test_error'
+        assert yaml_obj.name == 'Test Error'
+        assert len(yaml_obj.message) == 2
+        assert all(isinstance(msg, ErrorMessageYamlObject) for msg in yaml_obj.message)
+
+
+# *** standalone tests
+
+# ** test: error_message_yaml_object_map
+def test_error_message_yaml_object_map():
+    '''
+    Test that ErrorMessageYamlObject maps to an ErrorMessage domain object.
+    '''
+
+    # Create from data and map.
+    yaml_obj = TransferObject.from_data(
+        ErrorMessageYamlObject,
+        lang='en',
+        text='Test message',
+    )
+    msg = yaml_obj.map()
+
+    # Assert the mapped domain object.
+    assert isinstance(msg, ErrorMessage)
+    assert msg.lang == 'en'
+    assert msg.text == 'Test message'
+
+
+# ** test: error_message_yaml_object_from_model
+def test_error_message_yaml_object_from_model():
+    '''
+    Test that ErrorMessageYamlObject can be created from an ErrorMessage domain object.
+    '''
+
+    # Create an ErrorMessage via DomainObject.new.
+    model = DomainObject.new(
+        ErrorMessage,
+        lang='es',
+        text='Mensaje de prueba',
     )
 
-# *** tests
+    # Convert to YAML object.
+    yaml_obj = ErrorMessageYamlObject.from_model(model)
 
-# ** test: error_data_from_data
-def test_error_data_from_data(error_yaml_object: ErrorYamlObject):
-    '''
-    Test the creation of error data from a dictionary.
-
-    :param error_yaml_object: The error YAML object.
-    :type error_yaml_object: ErrorYamlObject
-    '''
-
-    # Assert the error data is an instance of ErrorYamlObject.
-    assert error_yaml_object.name == 'TEST_ERROR'
-    assert error_yaml_object.error_code == 'TEST_ERROR'
-    assert len(error_yaml_object.message) == 1
-    assert error_yaml_object.message[0].lang == 'en'
-    assert error_yaml_object.message[0].text == 'Test error message.'
-
-# ** test: error_data_to_primitive_to_data_yaml
-def test_error_data_to_primitive_to_data_yaml(error_yaml_object: ErrorYamlObject):
-    '''
-    Test the conversion of error data to a primitive dictionary.
-
-    :param error_yaml_object: The error YAML object.
-    :type error_yaml_object: ErrorYamlObject
-    '''
-
-    # Convert the error data to a primitive.
-    primitive = error_yaml_object.to_primitive('to_data.yaml')
-
-    # Assert the primitive is a dictionary.
-    assert isinstance(primitive, dict)
-
-    # Assert the primitive values are correct.
-    assert primitive.pop('id', None) is None
-    assert primitive.get('name') == 'TEST_ERROR'
-    assert primitive.get('error_code') == 'TEST_ERROR'
-    assert len(primitive.get('message')) == 1
-    assert primitive.get('message')[0].get('lang') == 'en'
-    assert primitive.get('message')[0].get('text') == 'Test error message.'
-
-# ** test: error_data_map
-def test_error_data_map(error_yaml_object: ErrorYamlObject):
-    '''
-    Test the mapping of error YAML object to an error aggregate.
-
-    :param error_yaml_object: The error YAML object.
-    :type error_yaml_object: ErrorYamlObject
-    '''
-
-    # Map the error data to an error aggregate.
-    error = error_yaml_object.map()
-
-    # Assert the error is an instance of ErrorAggregate.
-    assert isinstance(error, ErrorAggregate)
-    assert error.id == error_yaml_object.id
-    assert error.name == error_yaml_object.name
-    assert error.error_code == error_yaml_object.error_code
-    assert len(error.message) == 1
-    assert isinstance(error.message[0], ErrorMessage)
-
-    # Assert the error message attributes.
-    error_message = error.message[0]
-    assert error_message.lang == 'en'
-    assert error_message.text == 'Test error message.'
-
-
-# ** test: error_yaml_object_from_model
-def test_error_yaml_object_from_model():
-    '''
-    Test creating an ErrorYamlObject from an Error model.
-    '''
-
-    # Create an error model.
-    error = Error.new(
-        id='test_error',
-        name='Test Error',
-        message=[
-            {'lang': 'en', 'text': 'Test message'},
-            {'lang': 'es', 'text': 'Mensaje de prueba'}
-        ]
-    )
-
-    # Create YAML object from model.
-    yaml_object = ErrorYamlObject.from_model(error)
-
-    # Assert the YAML object is valid.
-    assert isinstance(yaml_object, ErrorYamlObject)
-    assert yaml_object.id == 'test_error'
-    assert yaml_object.name == 'Test Error'
-    assert len(yaml_object.message) == 2
-    assert all(isinstance(msg, ErrorMessageYamlObject) for msg in yaml_object.message)
-
-
-# ** test: error_aggregate_new
-def test_error_aggregate_new():
-    '''
-    Test creating a new ErrorAggregate.
-    '''
-
-    # Create an error aggregate.
-    error_data = dict(
-        id='test_error',
-        name='Test Error',
-        error_code='TEST_ERROR',
-        message=[
-            {'lang': 'en', 'text': 'Test message'}
-        ]
-    )
-
-    aggregate = ErrorAggregate.new(**error_data)
-
-    # Assert the aggregate is valid.
-    assert isinstance(aggregate, ErrorAggregate)
-    assert aggregate.id == 'test_error'
-    assert aggregate.name == 'Test Error'
-    assert len(aggregate.message) == 1
-
-
-# ** test: error_aggregate_rename
-def test_error_aggregate_rename():
-    '''
-    Test renaming an error via ErrorAggregate.
-    '''
-
-    # Create an error aggregate.
-    aggregate = ErrorAggregate.new(
-        id='test_error',
-        name='Test Error',
-        error_code='TEST_ERROR',
-        message=[
-            {'lang': 'en', 'text': 'Test message'}
-        ]
-    )
-
-    # Rename the error.
-    aggregate.rename('Renamed Error')
-
-    # Assert the name was updated.
-    assert aggregate.name == 'Renamed Error'
-
-# ** test: error_aggregate_set_message
-def test_error_aggregate_set_message():
-    '''
-    Test setting a message on an ErrorAggregate.
-    '''
-
-    # Create an error aggregate.
-    error_data = dict(
-        id='test_error',
-        name='Test Error',
-        error_code='TEST_ERROR',
-        message=[]
-    )
-
-    aggregate = ErrorAggregate.new(**error_data)
-
-    # Set a message.
-    aggregate.set_message('en', 'New test message')
-
-    # Assert the message was set.
-    assert len(aggregate.message) == 1
-    assert aggregate.message[0].lang == 'en'
-    assert aggregate.message[0].text == 'New test message'
-
-    # Update the message.
-    aggregate.set_message('en', 'Updated message')
-
-    # Assert the message was updated (not added).
-    assert len(aggregate.message) == 1
-    assert aggregate.message[0].text == 'Updated message'
-
-
-# ** test: error_aggregate_remove_message
-def test_error_aggregate_remove_message():
-    '''
-    Test removing a message from an ErrorAggregate.
-    '''
-
-    # Create an error aggregate with messages.
-    error_data = dict(
-        id='test_error',
-        name='Test Error',
-        error_code='TEST_ERROR',
-        message=[
-            {'lang': 'en', 'text': 'English message'},
-            {'lang': 'es', 'text': 'Spanish message'}
-        ]
-    )
-
-    aggregate = ErrorAggregate.new(**error_data)
-
-    # Remove one message.
-    aggregate.remove_message('en')
-
-    # Assert only one message remains.
-    assert len(aggregate.message) == 1
-    assert aggregate.message[0].lang == 'es'
+    # Assert the YAML object fields.
+    assert isinstance(yaml_obj, ErrorMessageYamlObject)
+    assert yaml_obj.lang == 'es'
+    assert yaml_obj.text == 'Mensaje de prueba'

--- a/tiferet/mappers/tests/test_feature.py
+++ b/tiferet/mappers/tests/test_feature.py
@@ -2,406 +2,447 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
+from ...domain import DomainObject, FeatureEvent
+from ...events import a
+from ..settings import TransferObject
 from ..feature import (
     FeatureEventAggregate,
     FeatureEventYamlObject,
     FeatureAggregate,
     FeatureYamlObject,
 )
-from ...domain import (
-    Feature,
-    FeatureEvent,
-)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: feature_event_yaml_object
-@pytest.fixture
-def feature_event_yaml_object() -> FeatureEventYamlObject:
+# *** constants
+
+# ** constant: feature_event_aggregate_sample_data
+FEATURE_EVENT_AGGREGATE_SAMPLE_DATA = {
+    'name': 'Test Event',
+    'service_id': 'test_event_handler',
+    'parameters': {'key': 'value'},
+    'data_key': 'result',
+    'pass_on_error': True,
+}
+
+# ** constant: feature_event_equality_fields
+FEATURE_EVENT_EQUALITY_FIELDS = [
+    'name',
+    'service_id',
+    'parameters',
+    'data_key',
+    'pass_on_error',
+]
+
+# ** constant: feature_aggregate_sample_data
+FEATURE_AGGREGATE_SAMPLE_DATA = {
+    'name': 'Add Number',
+    'group_id': 'calc',
+    'feature_key': 'add_number',
+    'id': 'calc.add_number',
+    'description': 'Add Number',
+}
+
+# ** constant: feature_equality_fields
+FEATURE_EQUALITY_FIELDS = [
+    'id',
+    'name',
+    'group_id',
+    'feature_key',
+    'description',
+    'steps',
+]
+
+# ** constant: step_tuple
+def STEP_TUPLE(s):
     '''
-    Provides a feature event YAML object fixture with pass_on_error,
-    data_key, and params alias.
-
-    :return: The feature event YAML object instance.
-    :rtype: FeatureEventYamlObject
+    Normalize a single step (dict or domain object) into a comparable tuple.
     '''
 
-    # Create and return a feature event YAML object.
-    return TransferObject.from_data(
-        FeatureEventYamlObject,
-        name='Test Event',
-        attribute_id='test_event_handler',
-        params={'key': 'value'},
-        data_key='result',
-        pass_on_error=True,
+    if isinstance(s, dict):
+        return (
+            s.get('name', ''),
+            s.get('service_id', ''),
+            tuple(sorted(s.get('parameters', {}).items())),
+        )
+    return (
+        getattr(s, 'name', ''),
+        getattr(s, 'service_id', ''),
+        tuple(sorted((getattr(s, 'parameters', None) or {}).items())),
     )
 
+# ** constant: feature_field_normalizers
+FEATURE_FIELD_NORMALIZERS = {
+    'steps': lambda steps: tuple(sorted(STEP_TUPLE(s) for s in (steps or []))),
+}
 
-# ** fixture: feature_yaml_object
-@pytest.fixture
-def feature_yaml_object() -> FeatureYamlObject:
+
+# *** classes
+
+# ** class: TestFeatureEventAggregate
+class TestFeatureEventAggregate(AggregateTestBase):
     '''
-    Provides a feature YAML object fixture with one step containing params.
-
-    :return: The feature YAML object instance.
-    :rtype: FeatureYamlObject
+    Tests for FeatureEventAggregate construction, set_attribute, and domain-specific mutations.
     '''
 
-    # Create and return a feature YAML object.
-    return TransferObject.from_data(
-        FeatureYamlObject,
-        id='calc.add',
-        name='Add Number',
-        group_id='calc',
-        feature_key='add',
-        description='Adds one number to another',
-        steps=[{
+    aggregate_cls = FeatureEventAggregate
+
+    sample_data = FEATURE_EVENT_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FEATURE_EVENT_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Event', None),
+        ('service_id', 'updated_handler', None),
+        ('data_key', 'new_key', None),
+    ]
+
+    # *** domain-specific mutation tests
+
+    # ** test: set_pass_on_error
+    def test_set_pass_on_error(self, aggregate):
+        '''
+        Verifies string normalization ("false", "False", truthy).
+        '''
+
+        # String "false" should normalize to False.
+        aggregate.set_pass_on_error('false')
+        assert aggregate.pass_on_error is False
+
+        # String "False" should normalize to False.
+        aggregate.set_pass_on_error('False')
+        assert aggregate.pass_on_error is False
+
+        # Truthy string should normalize to True.
+        aggregate.set_pass_on_error('true')
+        assert aggregate.pass_on_error is True
+
+        # Boolean True should remain True.
+        aggregate.set_pass_on_error(True)
+        assert aggregate.pass_on_error is True
+
+    # ** test: set_parameters
+    def test_set_parameters(self, aggregate):
+        '''
+        Verifies merge, None-prune, and no-op on None.
+        '''
+
+        # Merge new parameters (new_key added, key updated).
+        aggregate.set_parameters({'key': '10', 'new_key': '3'})
+        assert aggregate.parameters == {'key': '10', 'new_key': '3'}
+
+        # Prune keys with None values.
+        aggregate.set_parameters({'new_key': None})
+        assert aggregate.parameters == {'key': '10'}
+
+        # None input is a no-op.
+        aggregate.set_parameters(None)
+        assert aggregate.parameters == {'key': '10'}
+
+    # ** test: set_attribute_delegation
+    def test_set_attribute_delegation(self, aggregate):
+        '''
+        Verifies delegation to specialized helpers.
+        '''
+
+        # set_attribute for parameters should delegate to set_parameters.
+        aggregate.set_attribute('parameters', {'y': '2'})
+        assert 'y' in aggregate.parameters
+
+        # set_attribute for pass_on_error should delegate to set_pass_on_error.
+        aggregate.set_attribute('pass_on_error', 'false')
+        assert aggregate.pass_on_error is False
+
+        # set_attribute for other attributes should use setattr.
+        aggregate.set_attribute('name', 'Renamed Event')
+        assert aggregate.name == 'Renamed Event'
+
+
+# ** class: TestFeatureAggregate
+class TestFeatureAggregate(AggregateTestBase):
+    '''
+    Tests for FeatureAggregate construction, set_attribute, and domain-specific mutations.
+    '''
+
+    aggregate_cls = FeatureAggregate
+
+    sample_data = FEATURE_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FEATURE_EQUALITY_FIELDS
+
+    field_normalizers = FEATURE_FIELD_NORMALIZERS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Feature', None),
+        ('description', 'Updated description', None),
+        # invalid
+        ('invalid_attr', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FeatureAggregate:
+        '''
+        Override to use FeatureAggregate.new() custom factory.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FeatureAggregate.new(**(data or self.sample_data))
+
+    # *** domain-specific tests
+
+    # ** test: smart_derivation
+    def test_smart_derivation(self, aggregate):
+        '''
+        Verifies smart derivation (name -> feature_key -> id).
+        '''
+
+        # Assert smart derivation of feature_key and id.
+        assert aggregate.feature_key == 'add_number'
+        assert aggregate.id == 'calc.add_number'
+        assert aggregate.description == 'Add Number'
+
+    # ** test: add_step
+    def test_add_step(self, aggregate):
+        '''
+        Verifies step append.
+        '''
+
+        # Add a step.
+        step = aggregate.add_step(
+            name='Step One',
+            service_id='step_one_event',
+        )
+
+        # Assert the step was appended.
+        assert len(aggregate.steps) == 1
+        assert aggregate.steps[0] is step
+        assert step.name == 'Step One'
+        assert step.service_id == 'step_one_event'
+
+    # ** test: add_step_position
+    def test_add_step_position(self, aggregate):
+        '''
+        Verifies step insertion at position 0.
+        '''
+
+        # Add two steps, inserting the second at position 0.
+        aggregate.add_step(name='Step One', service_id='step_one_event')
+        inserted = aggregate.add_step(
+            name='Step Zero',
+            service_id='step_zero_event',
+            position=0,
+        )
+
+        # Assert the step was inserted at position 0.
+        assert len(aggregate.steps) == 2
+        assert aggregate.steps[0] is inserted
+        assert aggregate.steps[0].name == 'Step Zero'
+        assert aggregate.steps[1].name == 'Step One'
+
+    # ** test: remove_step
+    def test_remove_step(self, aggregate):
+        '''
+        Verifies removal and invalid position handling.
+        '''
+
+        # Add two steps.
+        aggregate.add_step(name='Step One', service_id='step_one_event')
+        aggregate.add_step(name='Step Two', service_id='step_two_event')
+
+        # Remove the first step.
+        removed = aggregate.remove_step(0)
+        assert removed is not None
+        assert removed.name == 'Step One'
+        assert len(aggregate.steps) == 1
+
+        # Attempt to remove at invalid positions.
+        assert aggregate.remove_step(-1) is None
+        assert aggregate.remove_step(99) is None
+
+    # ** test: reorder_step
+    def test_reorder_step(self, aggregate):
+        '''
+        Verifies move with clamping.
+        '''
+
+        # Add three steps.
+        aggregate.add_step(name='A', service_id='a_event')
+        aggregate.add_step(name='B', service_id='b_event')
+        aggregate.add_step(name='C', service_id='c_event')
+
+        # Move step A (position 0) to position 2.
+        moved = aggregate.reorder_step(0, 2)
+        assert moved is not None
+        assert moved.name == 'A'
+        assert aggregate.steps[0].name == 'B'
+        assert aggregate.steps[1].name == 'C'
+        assert aggregate.steps[2].name == 'A'
+
+    # ** test: rename
+    def test_rename(self, aggregate):
+        '''
+        Verifies name update without id change.
+        '''
+
+        # Record original id and rename the feature.
+        original_id = aggregate.id
+        aggregate.rename('New Name')
+
+        # Assert the name was updated but the id was not.
+        assert aggregate.name == 'New Name'
+        assert aggregate.id == original_id
+
+    # ** test: set_description
+    def test_set_description(self, aggregate):
+        '''
+        Verifies set and clear.
+        '''
+
+        # Set a description.
+        aggregate.set_description('A custom description')
+        assert aggregate.description == 'A custom description'
+
+        # Clear the description.
+        aggregate.set_description(None)
+        assert aggregate.description is None
+
+
+# ** class: TestFeatureYamlObject
+class TestFeatureYamlObject(TransferObjectTestBase):
+    '''
+    Tests for FeatureYamlObject mapping, round-trip, and nested FeatureEventYamlObject.
+    '''
+
+    transfer_cls = FeatureYamlObject
+    aggregate_cls = FeatureAggregate
+
+    # YAML-format sample data (steps with params alias and service_id).
+    sample_data = {
+        'id': 'calc.add',
+        'name': 'Add Number',
+        'group_id': 'calc',
+        'feature_key': 'add',
+        'description': 'Adds one number to another',
+        'steps': [{
             'name': 'Add a and b',
-            'attribute_id': 'add_number_event',
+            'service_id': 'add_number_event',
             'params': {'precision': '2'},
         }],
-    )
-
-
-# *** tests
-
-# ** test: feature_event_data_init
-def test_feature_event_data_init(feature_event_yaml_object: FeatureEventYamlObject):
-    '''
-    Verifies from_data() initialization including params alias.
-
-    :param feature_event_yaml_object: The feature event YAML object.
-    :type feature_event_yaml_object: FeatureEventYamlObject
-    '''
-
-    # Assert basic attributes.
-    assert feature_event_yaml_object.name == 'Test Event'
-    assert feature_event_yaml_object.attribute_id == 'test_event_handler'
-    assert feature_event_yaml_object.data_key == 'result'
-    assert feature_event_yaml_object.pass_on_error is True
-
-    # Assert the params alias resolved correctly.
-    assert feature_event_yaml_object.parameters == {'key': 'value'}
-
-
-# ** test: feature_event_data_map
-def test_feature_event_data_map(feature_event_yaml_object: FeatureEventYamlObject):
-    '''
-    Verifies map() produces a FeatureEvent with correct fields.
-
-    :param feature_event_yaml_object: The feature event YAML object.
-    :type feature_event_yaml_object: FeatureEventYamlObject
-    '''
-
-    # Map the feature event data to a feature event aggregate.
-    event = feature_event_yaml_object.map()
-
-    # Assert the mapped object is a FeatureEventAggregate.
-    assert isinstance(event, FeatureEventAggregate)
-    assert event.name == 'Test Event'
-    assert event.attribute_id == 'test_event_handler'
-    assert event.parameters == {'key': 'value'}
-    assert event.data_key == 'result'
-    assert event.pass_on_error is True
-
-
-# ** test: feature_data_from_data
-def test_feature_data_from_data(feature_yaml_object: FeatureYamlObject):
-    '''
-    Verifies nested steps initialization.
-
-    :param feature_yaml_object: The feature YAML object.
-    :type feature_yaml_object: FeatureYamlObject
-    '''
-
-    # Assert basic attributes.
-    assert feature_yaml_object.id == 'calc.add'
-    assert feature_yaml_object.name == 'Add Number'
-    assert feature_yaml_object.group_id == 'calc'
-    assert feature_yaml_object.feature_key == 'add'
-    assert feature_yaml_object.description == 'Adds one number to another'
-
-    # Assert the steps were initialized as FeatureEventYamlObject instances.
-    assert len(feature_yaml_object.steps) == 1
-    step = feature_yaml_object.steps[0]
-    assert isinstance(step, FeatureEventYamlObject)
-    assert step.name == 'Add a and b'
-    assert step.attribute_id == 'add_number_event'
-    assert step.parameters == {'precision': '2'}
-
-
-# ** test: feature_data_map
-def test_feature_data_map(feature_yaml_object: FeatureYamlObject):
-    '''
-    Verifies map() produces a FeatureAggregate with nested steps.
-
-    :param feature_yaml_object: The feature YAML object.
-    :type feature_yaml_object: FeatureYamlObject
-    '''
-
-    # Map the feature data to a feature aggregate.
-    feature = feature_yaml_object.map()
-
-    # Assert the mapped object is a FeatureAggregate.
-    assert isinstance(feature, FeatureAggregate)
-    assert feature.id == 'calc.add'
-    assert feature.name == 'Add Number'
-    assert feature.group_id == 'calc'
-    assert feature.feature_key == 'add'
-
-    # Assert nested steps were mapped correctly.
-    assert len(feature.steps) == 1
-    step = feature.steps[0]
-    assert isinstance(step, FeatureEventAggregate)
-    assert step.name == 'Add a and b'
-    assert step.attribute_id == 'add_number_event'
-    assert step.parameters == {'precision': '2'}
-
-
-# ** test: feature_aggregate_new
-def test_feature_aggregate_new():
-    '''
-    Verifies smart derivation (name → feature_key → id).
-    '''
-
-    # Create a feature aggregate with only name and group_id.
-    feature = FeatureAggregate.new(
-        name='Add Number',
-        group_id='calc',
-    )
-
-    # Assert smart derivation of feature_key and id.
-    assert feature.feature_key == 'add_number'
-    assert feature.id == 'calc.add_number'
-    assert feature.description == 'Add Number'
-
-
-# ** test: feature_aggregate_add_step
-def test_feature_aggregate_add_step():
-    '''
-    Verifies step append.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-
-    # Add a step.
-    step = feature.add_step(
-        name='Step One',
-        attribute_id='step_one_event',
-    )
-
-    # Assert the step was appended.
-    assert len(feature.steps) == 1
-    assert feature.steps[0] is step
-    assert step.name == 'Step One'
-    assert step.attribute_id == 'step_one_event'
-
-
-# ** test: feature_aggregate_add_step_position
-def test_feature_aggregate_add_step_position():
-    '''
-    Verifies step insertion at position 0.
-    '''
-
-    # Create a feature aggregate with an existing step.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='Step One', attribute_id='step_one_event')
-
-    # Insert a new step at position 0.
-    inserted = feature.add_step(
-        name='Step Zero',
-        attribute_id='step_zero_event',
-        position=0,
-    )
-
-    # Assert the step was inserted at position 0.
-    assert len(feature.steps) == 2
-    assert feature.steps[0] is inserted
-    assert feature.steps[0].name == 'Step Zero'
-    assert feature.steps[1].name == 'Step One'
-
-
-# ** test: feature_aggregate_remove_step
-def test_feature_aggregate_remove_step():
-    '''
-    Verifies removal and invalid position handling.
-    '''
-
-    # Create a feature aggregate with steps.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='Step One', attribute_id='step_one_event')
-    feature.add_step(name='Step Two', attribute_id='step_two_event')
-
-    # Remove the first step.
-    removed = feature.remove_step(0)
-    assert removed is not None
-    assert removed.name == 'Step One'
-    assert len(feature.steps) == 1
-
-    # Attempt to remove at an invalid position.
-    assert feature.remove_step(-1) is None
-    assert feature.remove_step(99) is None
-
-
-# ** test: feature_aggregate_reorder_step
-def test_feature_aggregate_reorder_step():
-    '''
-    Verifies move with clamping.
-    '''
-
-    # Create a feature aggregate with steps.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-    feature.add_step(name='A', attribute_id='a_event')
-    feature.add_step(name='B', attribute_id='b_event')
-    feature.add_step(name='C', attribute_id='c_event')
-
-    # Move step A (position 0) to position 2.
-    moved = feature.reorder_step(0, 2)
-    assert moved is not None
-    assert moved.name == 'A'
-    assert feature.steps[0].name == 'B'
-    assert feature.steps[1].name == 'C'
-    assert feature.steps[2].name == 'A'
-
-
-# ** test: feature_aggregate_rename
-def test_feature_aggregate_rename():
-    '''
-    Verifies name update without id change.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Old Name',
-        group_id='test',
-    )
-    original_id = feature.id
-
-    # Rename the feature.
-    feature.rename('New Name')
-
-    # Assert the name was updated but the id was not.
-    assert feature.name == 'New Name'
-    assert feature.id == original_id
-
-
-# ** test: feature_aggregate_set_description
-def test_feature_aggregate_set_description():
-    '''
-    Verifies set and clear.
-    '''
-
-    # Create a feature aggregate.
-    feature = FeatureAggregate.new(
-        name='Test Feature',
-        group_id='test',
-    )
-
-    # Set a description.
-    feature.set_description('A custom description')
-    assert feature.description == 'A custom description'
-
-    # Clear the description.
-    feature.set_description(None)
-    assert feature.description is None
-
-
-# ** test: feature_event_aggregate_set_pass_on_error
-def test_feature_event_aggregate_set_pass_on_error():
-    '''
-    Verifies string normalization ("false", "False", truthy).
-    '''
-
-    # Create a feature event aggregate.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-    )
-
-    # String "false" should normalize to False.
-    event.set_pass_on_error('false')
-    assert event.pass_on_error is False
-
-    # String "False" should normalize to False.
-    event.set_pass_on_error('False')
-    assert event.pass_on_error is False
-
-    # Truthy string should normalize to True.
-    event.set_pass_on_error('true')
-    assert event.pass_on_error is True
-
-    # Boolean True should remain True.
-    event.set_pass_on_error(True)
-    assert event.pass_on_error is True
-
-
-# ** test: feature_event_aggregate_set_parameters
-def test_feature_event_aggregate_set_parameters():
-    '''
-    Verifies merge, None-prune, and no-op on None.
-    '''
-
-    # Create a feature event aggregate with initial parameters.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-        parameters={'a': '1', 'b': '2'},
-    )
-
-    # Merge new parameters (c added, a updated).
-    event.set_parameters({'a': '10', 'c': '3'})
-    assert event.parameters == {'a': '10', 'b': '2', 'c': '3'}
-
-    # Prune keys with None values.
-    event.set_parameters({'b': None})
-    assert event.parameters == {'a': '10', 'c': '3'}
-
-    # None input is a no-op.
-    event.set_parameters(None)
-    assert event.parameters == {'a': '10', 'c': '3'}
-
-
-# ** test: feature_event_aggregate_set_attribute
-def test_feature_event_aggregate_set_attribute():
-    '''
-    Verifies delegation to specialized helpers.
-    '''
-
-    # Create a feature event aggregate.
-    event = FeatureEventAggregate.new(
-        name='Test Event',
-        attribute_id='test_handler',
-        parameters={'x': '1'},
-    )
-
-    # set_attribute for parameters should delegate to set_parameters.
-    event.set_attribute('parameters', {'y': '2'})
-    assert event.parameters == {'x': '1', 'y': '2'}
-
-    # set_attribute for pass_on_error should delegate to set_pass_on_error.
-    event.set_attribute('pass_on_error', 'false')
-    assert event.pass_on_error is False
-
-    # set_attribute for other attributes should use setattr.
-    event.set_attribute('name', 'Renamed Event')
-    assert event.name == 'Renamed Event'
+    }
+
+    # Aggregate-format expected data (defaults filled in).
+    aggregate_sample_data = {
+        'id': 'calc.add',
+        'name': 'Add Number',
+        'group_id': 'calc',
+        'feature_key': 'add',
+        'description': 'Adds one number to another',
+        'steps': [{
+            'name': 'Add a and b',
+            'service_id': 'add_number_event',
+            'parameters': {'precision': '2'},
+        }],
+    }
+
+    equality_fields = FEATURE_EQUALITY_FIELDS
+
+    field_normalizers = FEATURE_FIELD_NORMALIZERS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FeatureAggregate:
+        '''
+        Override to use FeatureAggregate.new() custom factory.
+        '''
+
+        # Create an aggregate using the custom factory.
+        data = data or self.aggregate_sample_data
+
+        # Build steps as FeatureEventAggregate instances.
+        steps = [
+            FeatureEventAggregate.new(**step)
+            for step in data.get('steps', [])
+        ]
+
+        # Create the feature aggregate with mapped steps.
+        return FeatureAggregate.new(
+            **{k: v for k, v in data.items() if k != 'steps'},
+            steps=steps,
+        )
+
+    # *** child mapper: FeatureEventYamlObject
+
+    # ** constant: feature_event_sample_data
+    feature_event_sample_data = {
+        'name': 'Test Event',
+        'service_id': 'test_event_handler',
+        'params': {'key': 'value'},
+        'data_key': 'result',
+        'pass_on_error': True,
+    }
+
+    # ** test: feature_event_yaml_map_basic
+    def test_feature_event_yaml_map_basic(self):
+        '''
+        Test mapping a FeatureEventYamlObject to a FeatureEventAggregate.
+        '''
+
+        # Create a YAML object and map it.
+        yaml_obj = TransferObject.from_data(
+            FeatureEventYamlObject,
+            **self.feature_event_sample_data,
+        )
+        event = yaml_obj.map()
+
+        # Verify the mapped entity.
+        assert isinstance(event, FeatureEventAggregate)
+        assert event.name == 'Test Event'
+        assert event.service_id == 'test_event_handler'
+        assert event.parameters == {'key': 'value'}
+        assert event.data_key == 'result'
+        assert event.pass_on_error is True
+
+    # ** test: feature_event_yaml_params_alias
+    def test_feature_event_yaml_params_alias(self):
+        '''
+        Test that the "params" alias is correctly deserialized.
+        '''
+
+        # Create YAML object using the 'params' alias.
+        yaml_obj = TransferObject.from_data(
+            FeatureEventYamlObject,
+            name='Alias Event',
+            service_id='alias_handler',
+            params={'alias_key': 'value'},
+        )
+        event = yaml_obj.map()
+
+        # Verify aliased parameters were deserialized correctly.
+        assert event.parameters == {'alias_key': 'value'}
+
+    # ** test: feature_event_yaml_from_model
+    def test_feature_event_yaml_from_model(self):
+        '''
+        Test that FeatureEventYamlObject can be created from a FeatureEvent model.
+        '''
+
+        # Create a FeatureEvent model.
+        model = DomainObject.new(
+            FeatureEvent,
+            name='Test Event',
+            service_id='test_event_handler',
+            parameters={'key': 'value'},
+            data_key='result',
+            pass_on_error=True,
+        )
+
+        # Create a YAML object from the model.
+        yaml_obj = FeatureEventYamlObject.from_model(model)
+
+        # Verify the YAML object has the correct values.
+        assert isinstance(yaml_obj, FeatureEventYamlObject)
+        assert yaml_obj.name == model.name
+        assert yaml_obj.service_id == model.service_id
+        assert yaml_obj.parameters == model.parameters

--- a/tiferet/mappers/tests/test_logging.py
+++ b/tiferet/mappers/tests/test_logging.py
@@ -2,13 +2,9 @@
 
 # *** imports
 
-# ** infra
-import pytest
-
 # ** app
-from ..settings import (
-    TransferObject,
-)
+from ...events import a
+from ..settings import TransferObject
 from ..logging import (
     FormatterAggregate,
     FormatterYamlObject,
@@ -18,100 +14,327 @@ from ..logging import (
     LoggerYamlObject,
     LoggingSettingsYamlObject,
 )
-from ...domain import (
-    Formatter,
-    Handler,
-    Logger,
-)
+from .settings import AggregateTestBase, TransferObjectTestBase
 
-# *** fixtures
 
-# ** fixture: formatter_config_data
-@pytest.fixture
-def formatter_config_data() -> FormatterYamlObject:
+# *** constants
+
+# ** constant: formatter_aggregate_sample_data
+FORMATTER_AGGREGATE_SAMPLE_DATA = {
+    'id': 'simple',
+    'name': 'Simple Formatter',
+    'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    'datefmt': '%Y-%m-%d %H:%M:%S',
+}
+
+# ** constant: formatter_equality_fields
+FORMATTER_EQUALITY_FIELDS = ['id', 'name', 'format', 'datefmt']
+
+# ** constant: handler_aggregate_sample_data
+HANDLER_AGGREGATE_SAMPLE_DATA = {
+    'id': 'console',
+    'name': 'Console Handler',
+    'module_path': 'logging',
+    'class_name': 'StreamHandler',
+    'level': 'DEBUG',
+    'formatter': 'simple',
+    'stream': 'ext://sys.stdout',
+}
+
+# ** constant: handler_equality_fields
+HANDLER_EQUALITY_FIELDS = ['id', 'name', 'module_path', 'class_name', 'level', 'formatter', 'stream']
+
+# ** constant: logger_aggregate_sample_data
+LOGGER_AGGREGATE_SAMPLE_DATA = {
+    'id': 'app',
+    'name': 'App Logger',
+    'level': 'DEBUG',
+    'handlers': ['console'],
+}
+
+# ** constant: logger_equality_fields
+LOGGER_EQUALITY_FIELDS = ['id', 'name', 'level', 'handlers']
+
+
+# *** classes
+
+# ** class: TestFormatterAggregate
+class TestFormatterAggregate(AggregateTestBase):
     '''
-    Provides a formatter YAML object fixture.
-
-    :return: The formatter YAML object instance.
-    :rtype: FormatterYamlObject
-    '''
-
-    # Create and return a formatter YAML object.
-    return TransferObject.from_data(
-        FormatterYamlObject,
-        id='simple',
-        name='Simple Formatter',
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-    )
-
-
-# ** fixture: handler_config_data
-@pytest.fixture
-def handler_config_data() -> HandlerYamlObject:
-    '''
-    Provides a handler YAML object fixture.
-
-    :return: The handler YAML object instance.
-    :rtype: HandlerYamlObject
-    '''
-
-    # Create and return a handler YAML object.
-    return TransferObject.from_data(
-        HandlerYamlObject,
-        id='console',
-        name='Console Handler',
-        module_path='logging',
-        class_name='StreamHandler',
-        level='DEBUG',
-        formatter='simple',
-        stream='ext://sys.stdout',
-    )
-
-
-# ** fixture: logger_config_data
-@pytest.fixture
-def logger_config_data() -> LoggerYamlObject:
-    '''
-    Provides a logger YAML object fixture.
-
-    :return: The logger YAML object instance.
-    :rtype: LoggerYamlObject
+    Tests for FormatterAggregate construction, set_attribute, and domain-specific behavior.
     '''
 
-    # Create and return a logger YAML object.
-    return TransferObject.from_data(
-        LoggerYamlObject,
-        id='app',
-        name='App Logger',
-        level='DEBUG',
-        handlers=['console'],
-    )
+    aggregate_cls = FormatterAggregate
+
+    sample_data = FORMATTER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FORMATTER_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Formatter', None),
+        ('format', '%(message)s', None),
+        # invalid
+        ('invalid_attribute', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FormatterAggregate:
+        '''
+        Override to use FormatterAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FormatterAggregate.new(**(data or self.sample_data))
+
+    # *** domain-specific tests
+
+    # ** test: format_config
+    def test_format_config(self, aggregate):
+        '''
+        Test that format_config() returns the expected formatter configuration dict.
+
+        :param aggregate: The formatter aggregate fixture.
+        :type aggregate: FormatterAggregate
+        '''
+
+        # Get the format config.
+        config = aggregate.format_config()
+
+        # Assert the configuration contains the expected keys and values.
+        assert config['format'] == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        assert config['datefmt'] == '%Y-%m-%d %H:%M:%S'
 
 
-# ** fixture: logging_settings_config_data
-@pytest.fixture
-def logging_settings_config_data(
-    formatter_config_data: FormatterYamlObject,
-    handler_config_data: HandlerYamlObject,
-    logger_config_data: LoggerYamlObject,
-) -> LoggingSettingsYamlObject:
+# ** class: TestHandlerAggregate
+class TestHandlerAggregate(AggregateTestBase):
     '''
-    Provides a logging settings YAML object fixture assembled from
-    individual formatter, handler, and logger fixtures.
-
-    :param formatter_config_data: The formatter YAML object.
-    :type formatter_config_data: FormatterYamlObject
-    :param handler_config_data: The handler YAML object.
-    :type handler_config_data: HandlerYamlObject
-    :param logger_config_data: The logger YAML object.
-    :type logger_config_data: LoggerYamlObject
-    :return: The logging settings YAML object instance.
-    :rtype: LoggingSettingsYamlObject
+    Tests for HandlerAggregate construction, set_attribute, and domain-specific behavior.
     '''
 
-    # Create and return a logging settings YAML object.
-    return LoggingSettingsYamlObject.from_data(
+    aggregate_cls = HandlerAggregate
+
+    sample_data = HANDLER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = HANDLER_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Handler', None),
+        ('level', 'ERROR', None),
+        # invalid
+        ('invalid_attribute', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> HandlerAggregate:
+        '''
+        Override to use HandlerAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return HandlerAggregate.new(**(data or self.sample_data))
+
+    # *** domain-specific tests
+
+    # ** test: format_config
+    def test_format_config(self, aggregate):
+        '''
+        Test that format_config() returns the expected handler configuration dict with stream.
+
+        :param aggregate: The handler aggregate fixture.
+        :type aggregate: HandlerAggregate
+        '''
+
+        # Get the format config.
+        config = aggregate.format_config()
+
+        # Assert the configuration contains the expected keys and values.
+        assert config['class'] == 'logging.StreamHandler'
+        assert config['level'] == 'DEBUG'
+        assert config['formatter'] == 'simple'
+        assert config['stream'] == 'ext://sys.stdout'
+
+    # ** test: format_config_no_optional
+    def test_format_config_no_optional(self):
+        '''
+        Test that format_config() omits stream and filename when not set.
+        '''
+
+        # Create a handler without optional stream/filename.
+        handler = HandlerAggregate.new(
+            id='file_handler',
+            name='File Handler',
+            module_path='logging',
+            class_name='FileHandler',
+            level='INFO',
+            formatter='simple',
+        )
+
+        # Get the format config.
+        config = handler.format_config()
+
+        # Assert stream and filename are omitted.
+        assert 'stream' not in config
+        assert 'filename' not in config
+        assert config['class'] == 'logging.FileHandler'
+        assert config['level'] == 'INFO'
+
+
+# ** class: TestLoggerAggregate
+class TestLoggerAggregate(AggregateTestBase):
+    '''
+    Tests for LoggerAggregate construction, set_attribute, and domain-specific behavior.
+    '''
+
+    aggregate_cls = LoggerAggregate
+
+    sample_data = LOGGER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = LOGGER_EQUALITY_FIELDS
+
+    set_attribute_params = [
+        # valid
+        ('name', 'Updated Logger', None),
+        ('level', 'ERROR', None),
+        # invalid
+        ('invalid_attribute', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> LoggerAggregate:
+        '''
+        Override to use LoggerAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return LoggerAggregate.new(**(data or self.sample_data))
+
+    # *** domain-specific tests
+
+    # ** test: format_config
+    def test_format_config(self, aggregate):
+        '''
+        Test that format_config() returns the expected logger configuration dict.
+
+        :param aggregate: The logger aggregate fixture.
+        :type aggregate: LoggerAggregate
+        '''
+
+        # Get the format config.
+        config = aggregate.format_config()
+
+        # Assert the configuration contains the expected keys and values.
+        assert config['level'] == 'DEBUG'
+        assert config['handlers'] == ['console']
+        assert config['propagate'] is False
+
+    # ** test: empty_handlers_root
+    def test_empty_handlers_root(self):
+        '''
+        Test creating a logger with empty handlers and is_root=True.
+        '''
+
+        # Create a root logger with empty handlers.
+        logger = LoggerAggregate.new(
+            id='root',
+            name='Root Logger',
+            level='WARNING',
+            handlers=[],
+            is_root=True,
+        )
+
+        # Assert the logger attributes.
+        assert logger.is_root is True
+        assert logger.handlers == []
+        assert logger.level == 'WARNING'
+
+
+# ** class: TestFormatterYamlObject
+class TestFormatterYamlObject(TransferObjectTestBase):
+    '''
+    Tests for FormatterYamlObject mapping and round-trip.
+    '''
+
+    transfer_cls = FormatterYamlObject
+    aggregate_cls = FormatterAggregate
+
+    sample_data = FORMATTER_AGGREGATE_SAMPLE_DATA
+
+    aggregate_sample_data = FORMATTER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = FORMATTER_EQUALITY_FIELDS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> FormatterAggregate:
+        '''
+        Override to use FormatterAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return FormatterAggregate.new(**(data or self.aggregate_sample_data))
+
+
+# ** class: TestHandlerYamlObject
+class TestHandlerYamlObject(TransferObjectTestBase):
+    '''
+    Tests for HandlerYamlObject mapping and round-trip.
+    '''
+
+    transfer_cls = HandlerYamlObject
+    aggregate_cls = HandlerAggregate
+
+    sample_data = HANDLER_AGGREGATE_SAMPLE_DATA
+
+    aggregate_sample_data = HANDLER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = HANDLER_EQUALITY_FIELDS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> HandlerAggregate:
+        '''
+        Override to use HandlerAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return HandlerAggregate.new(**(data or self.aggregate_sample_data))
+
+
+# ** class: TestLoggerYamlObject
+class TestLoggerYamlObject(TransferObjectTestBase):
+    '''
+    Tests for LoggerYamlObject mapping and round-trip.
+    '''
+
+    transfer_cls = LoggerYamlObject
+    aggregate_cls = LoggerAggregate
+
+    sample_data = LOGGER_AGGREGATE_SAMPLE_DATA
+
+    aggregate_sample_data = LOGGER_AGGREGATE_SAMPLE_DATA
+
+    equality_fields = LOGGER_EQUALITY_FIELDS
+
+    # * method: make_aggregate
+    def make_aggregate(self, data: dict = None) -> LoggerAggregate:
+        '''
+        Override to use LoggerAggregate.new() which defaults to strict=False.
+        '''
+
+        # Create an aggregate using the custom factory.
+        return LoggerAggregate.new(**(data or self.aggregate_sample_data))
+
+
+# *** standalone tests
+
+# ** test: logging_settings_from_data_success
+def test_logging_settings_from_data_success():
+    '''
+    Test LoggingSettingsYamlObject.from_data() with full YAML data and id injection.
+    '''
+
+    # Create a logging settings YAML object with full data.
+    settings = LoggingSettingsYamlObject.from_data(
         formatters={
             'simple': {
                 'name': 'Simple Formatter',
@@ -138,171 +361,32 @@ def logging_settings_config_data(
         },
     )
 
-
-# *** tests
-
-# ** test: test_formatter_data_map_success
-def test_formatter_data_map_success(formatter_config_data: FormatterYamlObject):
-    '''
-    Test mapping a FormatterYamlObject to a Formatter and verifying format_config() output.
-
-    :param formatter_config_data: The formatter YAML object fixture.
-    :type formatter_config_data: FormatterYamlObject
-    '''
-
-    # Map the formatter data to a formatter aggregate.
-    formatter = formatter_config_data.map()
-
-    # Assert the formatter is mapped correctly.
-    assert isinstance(formatter, Formatter)
-    assert formatter.id == 'simple'
-    assert formatter.name == 'Simple Formatter'
-
-    # Verify format_config() output.
-    config = formatter.format_config()
-    assert config['format'] == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    assert config['datefmt'] == '%Y-%m-%d %H:%M:%S'
-
-
-# ** test: test_handler_data_map_success
-def test_handler_data_map_success(handler_config_data: HandlerYamlObject):
-    '''
-    Test mapping a HandlerYamlObject to a Handler and verifying format_config() with stream.
-
-    :param handler_config_data: The handler YAML object fixture.
-    :type handler_config_data: HandlerYamlObject
-    '''
-
-    # Map the handler data to a handler aggregate.
-    handler = handler_config_data.map()
-
-    # Assert the handler is mapped correctly.
-    assert isinstance(handler, Handler)
-    assert handler.id == 'console'
-    assert handler.name == 'Console Handler'
-
-    # Verify format_config() includes stream.
-    config = handler.format_config()
-    assert config['class'] == 'logging.StreamHandler'
-    assert config['level'] == 'DEBUG'
-    assert config['formatter'] == 'simple'
-    assert config['stream'] == 'ext://sys.stdout'
-
-
-# ** test: test_handler_data_map_no_optional
-def test_handler_data_map_no_optional():
-    '''
-    Test mapping a handler without stream/filename and verifying they are omitted from format_config().
-    '''
-
-    # Create a handler YAML object without optional stream/filename.
-    handler_yaml = TransferObject.from_data(
-        HandlerYamlObject,
-        id='file_handler',
-        name='File Handler',
-        module_path='logging',
-        class_name='FileHandler',
-        level='INFO',
-        formatter='simple',
-    )
-
-    # Map to handler aggregate.
-    handler = handler_yaml.map()
-
-    # Verify format_config() omits stream and filename.
-    config = handler.format_config()
-    assert 'stream' not in config
-    assert 'filename' not in config
-    assert config['class'] == 'logging.FileHandler'
-    assert config['level'] == 'INFO'
-
-
-# ** test: test_logger_data_map_success
-def test_logger_data_map_success(logger_config_data: LoggerYamlObject):
-    '''
-    Test mapping a LoggerYamlObject to a Logger and verifying format_config() output.
-
-    :param logger_config_data: The logger YAML object fixture.
-    :type logger_config_data: LoggerYamlObject
-    '''
-
-    # Map the logger data to a logger aggregate.
-    logger = logger_config_data.map()
-
-    # Assert the logger is mapped correctly.
-    assert isinstance(logger, Logger)
-    assert logger.id == 'app'
-    assert logger.name == 'App Logger'
-
-    # Verify format_config() output.
-    config = logger.format_config()
-    assert config['level'] == 'DEBUG'
-    assert config['handlers'] == ['console']
-    assert config['propagate'] is False
-
-
-# ** test: test_logger_data_map_empty_handlers
-def test_logger_data_map_empty_handlers():
-    '''
-    Test mapping a logger with empty handlers and is_root=True.
-    '''
-
-    # Create a logger YAML object with empty handlers and is_root=True.
-    logger_yaml = TransferObject.from_data(
-        LoggerYamlObject,
-        id='root',
-        name='Root Logger',
-        level='WARNING',
-        handlers=[],
-        is_root=True,
-    )
-
-    # Map to logger aggregate.
-    logger = logger_yaml.map()
-
-    # Verify the logger attributes.
-    assert logger.is_root is True
-    assert logger.handlers == []
-    assert logger.level == 'WARNING'
-
-
-# ** test: test_logging_settings_data_from_data_success
-def test_logging_settings_data_from_data_success(
-    logging_settings_config_data: LoggingSettingsYamlObject,
-):
-    '''
-    Test from_data() with full YAML data, verifying id injection.
-
-    :param logging_settings_config_data: The logging settings YAML object fixture.
-    :type logging_settings_config_data: LoggingSettingsYamlObject
-    '''
-
     # Assert formatters were created with id injection.
-    assert 'simple' in logging_settings_config_data.formatters
-    formatter = logging_settings_config_data.formatters['simple']
+    assert 'simple' in settings.formatters
+    formatter = settings.formatters['simple']
     assert isinstance(formatter, FormatterYamlObject)
     assert formatter.id == 'simple'
     assert formatter.name == 'Simple Formatter'
 
     # Assert handlers were created with id injection.
-    assert 'console' in logging_settings_config_data.handlers
-    handler = logging_settings_config_data.handlers['console']
+    assert 'console' in settings.handlers
+    handler = settings.handlers['console']
     assert isinstance(handler, HandlerYamlObject)
     assert handler.id == 'console'
     assert handler.name == 'Console Handler'
 
     # Assert loggers were created with id injection.
-    assert 'app' in logging_settings_config_data.loggers
-    logger = logging_settings_config_data.loggers['app']
+    assert 'app' in settings.loggers
+    logger = settings.loggers['app']
     assert isinstance(logger, LoggerYamlObject)
     assert logger.id == 'app'
     assert logger.name == 'App Logger'
 
 
-# ** test: test_logging_settings_data_from_data_empty
-def test_logging_settings_data_from_data_empty():
+# ** test: logging_settings_from_data_empty
+def test_logging_settings_from_data_empty():
     '''
-    Test from_data() with empty data returns empty dicts.
+    Test LoggingSettingsYamlObject.from_data() with empty dicts.
     '''
 
     # Create a logging settings YAML object with empty data.
@@ -316,114 +400,3 @@ def test_logging_settings_data_from_data_empty():
     assert settings.formatters == {}
     assert settings.handlers == {}
     assert settings.loggers == {}
-
-
-# ** test: test_formatter_aggregate_new_success
-def test_formatter_aggregate_new_success():
-    '''
-    Test creating a FormatterAggregate via Aggregate.new().
-    '''
-
-    # Create a formatter aggregate.
-    formatter = FormatterAggregate.new(
-        id='detailed',
-        name='Detailed Formatter',
-        format='%(asctime)s %(levelname)s %(name)s %(message)s',
-        datefmt='%Y-%m-%d',
-    )
-
-    # Assert the aggregate is valid.
-    assert isinstance(formatter, FormatterAggregate)
-    assert formatter.id == 'detailed'
-    assert formatter.name == 'Detailed Formatter'
-    assert formatter.format == '%(asctime)s %(levelname)s %(name)s %(message)s'
-
-
-# ** test: test_handler_aggregate_new_success
-def test_handler_aggregate_new_success():
-    '''
-    Test creating a HandlerAggregate via Aggregate.new().
-    '''
-
-    # Create a handler aggregate.
-    handler = HandlerAggregate.new(
-        id='file',
-        name='File Handler',
-        module_path='logging',
-        class_name='FileHandler',
-        level='ERROR',
-        formatter='detailed',
-        filename='error.log',
-    )
-
-    # Assert the aggregate is valid.
-    assert isinstance(handler, HandlerAggregate)
-    assert handler.id == 'file'
-    assert handler.name == 'File Handler'
-    assert handler.filename == 'error.log'
-
-
-# ** test: test_logger_aggregate_new_success
-def test_logger_aggregate_new_success():
-    '''
-    Test creating a LoggerAggregate via Aggregate.new().
-    '''
-
-    # Create a logger aggregate.
-    logger = LoggerAggregate.new(
-        id='main',
-        name='Main Logger',
-        level='INFO',
-        handlers=['console', 'file'],
-        propagate=True,
-    )
-
-    # Assert the aggregate is valid.
-    assert isinstance(logger, LoggerAggregate)
-    assert logger.id == 'main'
-    assert logger.name == 'Main Logger'
-    assert logger.level == 'INFO'
-    assert logger.handlers == ['console', 'file']
-    assert logger.propagate is True
-
-
-# ** test: test_formatter_yaml_object_map_returns_aggregate
-def test_formatter_yaml_object_map_returns_aggregate(formatter_config_data: FormatterYamlObject):
-    '''
-    Test that FormatterYamlObject.map() returns a FormatterAggregate instance.
-
-    :param formatter_config_data: The formatter YAML object fixture.
-    :type formatter_config_data: FormatterYamlObject
-    '''
-
-    # Map and verify the return type.
-    result = formatter_config_data.map()
-    assert isinstance(result, FormatterAggregate)
-
-
-# ** test: test_handler_yaml_object_map_returns_aggregate
-def test_handler_yaml_object_map_returns_aggregate(handler_config_data: HandlerYamlObject):
-    '''
-    Test that HandlerYamlObject.map() returns a HandlerAggregate instance.
-
-    :param handler_config_data: The handler YAML object fixture.
-    :type handler_config_data: HandlerYamlObject
-    '''
-
-    # Map and verify the return type.
-    result = handler_config_data.map()
-    assert isinstance(result, HandlerAggregate)
-
-
-# ** test: test_logger_yaml_object_map_returns_aggregate
-def test_logger_yaml_object_map_returns_aggregate(logger_config_data: LoggerYamlObject):
-    '''
-    Test that LoggerYamlObject.map() returns a LoggerAggregate instance.
-
-    :param logger_config_data: The logger YAML object fixture.
-    :type logger_config_data: LoggerYamlObject
-    '''
-
-    # Map and verify the return type.
-    result = logger_config_data.map()
-    assert isinstance(result, LoggerAggregate)


### PR DESCRIPTION
## Rebase v2.0a5-release into main

Brings all milestone 19 (2.0.0a5 — Domain & Repo Cleanup) work into `main`.

### Commits (10)

- `52006de` Domain – App: Introduce service_id on AppServiceDependency; deprecate attribute_id (#648)
- `aaf5b53` Mappers – Mapper Test Harness (AggregateTestBase & TransferObjectTestBase) (#649)
- `39d3fc3` Domain – Feature: Introduce service_id on FeatureEvent; deprecate attribute_id (#654)
- `c09e3cb` Mappers – App: Migrate attribute_id to service_id and remove JSON serialization roles (#655)
- `ce89844` Mappers – CLI: migrate tests to shared test harness (#656)
- `938f56d` Mappers – DI: Remove JSON serialization roles and migrate tests to shared test harness (#657)
- `f62c1c9` Mappers – Error: Remove JSON serialization roles and migrate tests to shared test harness (#658)
- `27bd007` Mappers – migrate test_feature.py to harness pattern, swap attribute_id to service_id, remove to_data.json roles (#659)
- `caf8d4c` Tests – migrate test_logging.py to harness-based mapper test style (#661)
- `8b44dfc` Release – v2.0.0a5 Version Bump and Documentation Update (#662)

Tag: `v2.0.0a5`  
Release: https://github.com/greatstrength/tiferet/releases/tag/v2.0.0a5

Co-Authored-By: Oz <oz-agent@warp.dev>