### PR TITLE
Events – Add App Events (#635)

### DIFF
--- a/docs/guides/events/app.md
+++ b/docs/guides/events/app.md
@@ -1,0 +1,277 @@
+# Events – App Interface Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/app.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The app event module provides the full CRUD surface for `AppInterface` configurations — the blueprints that define how a Tiferet application is assembled at runtime. Every event in this module depends on an injected `AppService` and operates on `AppInterface` domain objects through the `AppInterfaceAggregate` mapper.
+
+These events are consumed by `AppManagerContext` during bootstrapping and by management tooling that creates, updates, and removes interface configurations.
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `AddAppInterface` | Create | `id`, `name`, `module_path`, `class_name` | `AppInterface` |
+| `GetAppInterface` | Read | `interface_id` | `AppInterface` |
+| `ListAppInterfaces` | Read (all) | *(none)* | `List[AppInterface]` |
+| `UpdateAppInterface` | Update (scalar) | `id`, `attribute` | `str` (ID) |
+| `SetAppConstants` | Update (constants) | `id` | `str` (ID) |
+| `SetServiceDependency` | Update (service dep) | `id`, `service_id`, `module_path`, `class_name` | `str` (ID) |
+| `RemoveServiceDependency` | Delete (service dep) | `id`, `service_id` | `str` (ID) |
+| `RemoveAppInterface` | Delete | `id` | `str` (ID) |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`app_service: AppService`** — the service interface for persisting and retrieving `AppInterface` configurations.
+
+## Event Details
+
+### AddAppInterface
+
+Creates a new `AppInterface` and persists it via `AppService.save()`.
+
+**Required:** `id`, `name`, `module_path`, `class_name`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `description` | `str \| None` | `None` | Human-readable description |
+| `logger_id` | `str` | `'default'` | Logger configuration identifier |
+| `flags` | `List[str]` | `['default']` | Flags for dependency resolution |
+| `services` | `List[Dict]` | `[]` | Service dependency definitions (each dict has `service_id`, `module_path`, `class_name`, optional `parameters`) |
+| `constants` | `Dict[str, str]` | `{}` | Constant values for the DI injector |
+
+**Returns:** The created `AppInterface` instance.
+
+**Behavior:**
+1. Collects all parameters into a data dict.
+2. Delegates to `AppInterfaceAggregate.new(app_interface_data=...)` for creation and validation.
+3. Saves via `app_service.save(interface)`.
+
+```python
+result = DomainEvent.handle(
+    AddAppInterface,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    name='My Application',
+    module_path='myapp.contexts.main',
+    class_name='MainContext',
+    services=[{
+        'service_id': 'db_service',
+        'module_path': 'myapp.repos.db',
+        'class_name': 'DbRepository',
+        'parameters': {'connection_string': 'sqlite:///app.db'},
+    }],
+)
+```
+
+### GetAppInterface
+
+Retrieves an `AppInterface` by ID. Optionally merges default services into the result for any `service_id` not already present on the interface.
+
+**Required:** `interface_id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `default_services` | `List[AppServiceDependency]` | `[]` | Default service dependencies to merge if their `service_id` is missing |
+
+**Returns:** The loaded `AppInterface` instance.
+
+**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+
+**Behavior:**
+1. Retrieves the interface via `app_service.get(interface_id)`.
+2. Raises a structured error if `None`.
+3. If `default_services` is provided, iterates them and adds any whose `service_id` is not already present on the interface.
+
+```python
+interface = DomainEvent.handle(
+    GetAppInterface,
+    dependencies={'app_service': app_service},
+    interface_id='my_app',
+    default_services=[default_error_repo, default_feature_repo],
+)
+```
+
+### ListAppInterfaces
+
+Lists all configured app interfaces. No required parameters.
+
+**Returns:** `List[AppInterface]` — may be empty.
+
+```python
+interfaces = DomainEvent.handle(
+    ListAppInterfaces,
+    dependencies={'app_service': app_service},
+)
+```
+
+### UpdateAppInterface
+
+Updates a single scalar attribute on an existing app interface. The attribute is updated via `AppInterfaceAggregate.set_attribute()`, which enforces a gated allowlist of mutable fields.
+
+**Required:** `id`, `attribute`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `value` | `Any` | — | The new value for the attribute |
+
+**Returns:** `str` — the interface ID.
+
+**Errors:**
+- `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+- `INVALID_MODEL_ATTRIBUTE` if the attribute name is not in the supported set.
+- `INVALID_APP_INTERFACE_TYPE` if `module_path` or `class_name` is set to an empty string.
+
+**Supported attributes:** `name`, `description`, `module_path`, `class_name`, `logger_id`, `flags`.
+
+```python
+DomainEvent.handle(
+    UpdateAppInterface,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    attribute='description',
+    value='Updated description',
+)
+```
+
+### SetAppConstants
+
+Sets, merges, or clears constants on an app interface.
+
+**Required:** `id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `constants` | `dict[str, Any] \| None` | `None` | Constants to apply. `None` clears all constants. Dict keys with `None` values are removed; others are merged. |
+
+**Returns:** `str` — the interface ID.
+
+**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+
+**Merge semantics** (delegated to `AppInterfaceAggregate.set_constants`):
+- `constants=None` → clears all constants.
+- `constants={'KEY': 'val'}` → merges into existing; existing keys are overwritten.
+- `constants={'KEY': None}` → removes `KEY` from the constants dict.
+
+```python
+# Merge new constants
+DomainEvent.handle(
+    SetAppConstants,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    constants={'DB_HOST': 'localhost', 'DB_PORT': '5432'},
+)
+
+# Clear all constants
+DomainEvent.handle(
+    SetAppConstants,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    constants=None,
+)
+```
+
+### SetServiceDependency
+
+Adds or updates a service dependency on an app interface. Uses PUT semantics — if the `service_id` already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
+
+**Required:** `id`, `service_id`, `module_path`, `class_name`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `parameters` | `dict[str, Any] \| None` | `None` | Parameters for the service dependency. `None` clears existing parameters. Dict keys with `None` values are pruned. |
+
+**Returns:** `str` — the interface ID.
+
+**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+
+```python
+DomainEvent.handle(
+    SetServiceDependency,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    service_id='cache_service',
+    module_path='myapp.services.cache',
+    class_name='RedisCacheService',
+    parameters={'host': 'localhost', 'port': '6379'},
+)
+```
+
+### RemoveServiceDependency
+
+Removes a service dependency from an app interface by `service_id`. The operation is **idempotent** — removing a non-existent service does not raise an error.
+
+**Required:** `id`, `service_id`
+
+**Returns:** `str` — the interface ID.
+
+**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+
+```python
+DomainEvent.handle(
+    RemoveServiceDependency,
+    dependencies={'app_service': app_service},
+    id='my_app',
+    service_id='cache_service',
+)
+```
+
+### RemoveAppInterface
+
+Deletes an entire app interface configuration by ID. The operation is **idempotent** — removing a non-existent interface does not raise an error.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed interface ID.
+
+```python
+DomainEvent.handle(
+    RemoveAppInterface,
+    dependencies={'app_service': app_service},
+    id='my_app',
+)
+```
+
+## Common Patterns
+
+### Retrieve → Verify → Mutate → Save
+
+Most mutation events follow the same four-step pattern:
+
+1. **Retrieve** the `AppInterface` via `app_service.get(id)`.
+2. **Verify** it exists using `self.verify()` or `self.raise_error()`.
+3. **Mutate** the aggregate via its domain methods (`set_attribute`, `set_service`, `set_constants`, etc.).
+4. **Save** the updated aggregate via `app_service.save(interface)`.
+
+This pattern ensures that domain rules are enforced by the aggregate, not the event, and that persistence is always explicit.
+
+### Idempotent Deletes
+
+Both `RemoveServiceDependency` and `RemoveAppInterface` are idempotent — they succeed silently if the target does not exist. This simplifies orchestration workflows where deletions may be retried.
+
+### Default Service Merging
+
+`GetAppInterface` supports a `default_services` list that is merged into the loaded interface. This is used by `AppManagerContext` to inject framework-level defaults (error repository, feature repository, etc.) that the user doesn't need to declare explicitly.
+
+## Related Documentation
+
+- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain objects
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and test harness
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions
+- [docs/guides/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/mappers.md) — Mapper strategies

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -1,0 +1,500 @@
+# *** imports
+
+# ** core
+from typing import List, Dict, Any
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import AppInterface, AppServiceDependency
+from ..interfaces import AppService
+from ..mappers import AppInterfaceAggregate
+
+# *** events
+
+# ** event: add_app_interface
+class AddAppInterface(DomainEvent):
+    '''
+    A domain event to add a new application interface configuration via the AppService.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService):
+        '''
+        Initialize the AddAppInterface command.
+
+        :param app_service: The application service used to persist app interfaces.
+        :type app_service: AppService
+        '''
+
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'module_path', 'class_name'])
+    def execute(
+        self,
+        id: str,
+        name: str,
+        module_path: str,
+        class_name: str,
+        description: str | None = None,
+        logger_id: str = 'default',
+        flags: List[str] = ['default'],
+        services: List[Dict[str, Any]] = [],
+        constants: Dict[str, str] = {},
+        **kwargs,
+    ) -> AppInterface:
+        '''
+        Create and save a new AppInterface using the injected AppService.
+
+        Required parameters: ``id``, ``name``, ``module_path``, ``class_name``.
+
+        :param id: Unique identifier for the app interface.
+        :type id: str
+        :param name: Human readable name of the interface.
+        :type name: str
+        :param module_path: Python module path of the app context class.
+        :type module_path: str
+        :param class_name: Name of the app context class.
+        :type class_name: str
+        :param description: Optional description.
+        :type description: str | None
+        :param logger_id: Optional logger identifier, defaults to ``'default'``.
+        :type logger_id: str | None
+        :param flags: Optional list of flags, defaults to ``['default']``.
+        :type flags: List[str]
+        :param services: Optional list of service dependency definitions; each item is a
+            dict with keys ``service_id``, ``module_path``, ``class_name`` and
+            optional ``parameters``.
+        :type services: List[Dict[str, Any]] | None
+        :param constants: Optional dictionary of constant values.
+        :type constants: Dict[str, str] | None
+        :return: The created AppInterface.
+        :rtype: AppInterface
+        '''
+
+        # Collect the app interface data.
+        app_interface_data = {
+            'id': id,
+            'name': name,
+            'module_path': module_path,
+            'class_name': class_name,
+            'description': description,
+            'logger_id': logger_id,
+            'flags': flags,
+            'services': services,
+            'constants': constants,
+        }
+
+        # Create the AppInterface model; flags defaults to ['default'].
+        interface = AppInterfaceAggregate.new(
+            app_interface_data=app_interface_data
+        )
+
+        # Persist the new interface via the app service.
+        self.app_service.save(interface)
+
+        # Return the created AppInterface instance.
+        return interface
+
+# ** event: get_app_interface
+class GetAppInterface(DomainEvent):
+    '''
+    A domain event to retrieve an app interface using the ``AppService`` abstraction.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the GetAppInterface command.
+
+        :param app_service: The app service used to retrieve interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['interface_id'])
+    def execute(self, interface_id: str, default_services: List[AppServiceDependency] = [], **kwargs) -> AppInterface:
+        '''
+        Execute the command to load the application interface.
+
+        :param interface_id: The ID of the application interface to load.
+        :type interface_id: str
+        :param default_services: A list of AppServiceDependency objects to merge
+            into the interface for any service_id not already present.
+        :type default_services: List[AppServiceDependency]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The loaded application interface.
+        :rtype: AppInterface
+        :raises TiferetError: If the interface cannot be found.
+        '''
+
+        # Retrieve the app interface via the app service.
+        interface = self.app_service.get(interface_id)
+
+        # Raise an error if the interface is not found.
+        if not interface:
+            self.raise_error(
+                a.const.APP_INTERFACE_NOT_FOUND_ID,
+                f'App interface with ID {interface_id} not found.',
+                interface_id=interface_id,
+            )
+
+        # Merge default services into the interface for any service_id not already present.
+        if default_services:
+
+            # Build a set of existing service_ids for lookup.
+            existing_ids = {dep.service_id for dep in interface.services}
+
+            # Add any default service whose service_id is not already present.
+            for dep in default_services:
+                if dep.service_id not in existing_ids:
+                    interface.add_service(
+                        service_id=dep.service_id,
+                        module_path=dep.module_path,
+                        class_name=dep.class_name,
+                        parameters=dep.parameters,
+                    )
+
+        # Return the loaded application interface.
+        return interface
+
+# ** event: update_app_interface
+class UpdateAppInterface(DomainEvent):
+    '''
+    A domain event to update scalar attributes of an existing app interface.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the UpdateAppInterface command.
+
+        :param app_service: The app service used to manage app interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'attribute'])
+    def execute(self, id: str, attribute: str, value: Any, **kwargs) -> str:
+        '''
+        Update a scalar attribute on an existing app interface.
+
+        :param id: The unique identifier for the app interface to update.
+        :type id: str
+        :param attribute: The attribute name to update.
+        :type attribute: str
+        :param value: The new value for the attribute.
+        :type value: Any
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The ID of the updated app interface.
+        :rtype: str
+        '''
+
+        # Retrieve the app interface via the app service.
+        interface = self.app_service.get(id)
+
+        # Verify that the interface exists.
+        self.verify(
+            expression=interface is not None,
+            error_code=a.const.APP_INTERFACE_NOT_FOUND_ID,
+            message=f'App interface with ID {id} not found.',
+            interface_id=id,
+        )
+
+        # Update the attribute via the model method.
+        interface.set_attribute(attribute, value)
+
+        # Persist the updated interface.
+        self.app_service.save(interface)
+
+        # Return the interface ID.
+        return id
+
+# ** event: set_app_constants
+class SetAppConstants(DomainEvent):
+    '''
+    A domain event to set or clear constants on an app interface.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the SetAppConstants command.
+
+        :param app_service: The app service used to manage app interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(
+            self,
+            id: str,
+            constants: dict[str, Any] | None = None,
+            **kwargs,
+        ) -> str:
+        '''
+        Set constants on an app interface.
+
+        :param id: The unique identifier for the app interface.
+        :type id: str
+        :param constants: A mapping of constants to apply. ``None`` clears all constants.
+        :type constants: dict[str, Any] | None
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The ID of the app interface whose constants were updated.
+        :rtype: str
+        '''
+
+        # Retrieve the app interface via the app service.
+        interface = self.app_service.get(id)
+
+        # Verify that the interface exists.
+        self.verify(
+            expression=interface is not None,
+            error_code=a.const.APP_INTERFACE_NOT_FOUND_ID,
+            message=f'App interface with ID {id} not found.',
+            interface_id=id,
+        )
+
+        # Update constants via the model method.
+        interface.set_constants(constants)
+
+        # Persist the updated interface.
+        self.app_service.save(interface)
+
+        # Return the interface ID.
+        return id
+
+# ** event: list_app_interfaces
+class ListAppInterfaces(DomainEvent):
+    '''
+    A domain event to list all configured app interfaces.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the ListAppInterfaces command.
+
+        :param app_service: The app service to use.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    def execute(self, **kwargs) -> List[AppInterface]:
+        '''
+        List all app interfaces.
+
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: List of AppInterface models.
+        :rtype: List[AppInterface]
+        '''
+
+        # Delegate to the app service to retrieve all interfaces.
+        return self.app_service.list()
+
+
+# ** event: set_service_dependency
+class SetServiceDependency(DomainEvent):
+    '''
+    A domain event to set or update a service dependency on an app interface.
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the SetServiceDependency command.
+
+        :param app_service: The app service used to manage app interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'service_id', 'module_path', 'class_name'])
+    def execute(
+            self,
+            id: str,
+            service_id: str,
+            module_path: str,
+            class_name: str,
+            parameters: dict[str, Any] | None = None,
+            **kwargs,
+        ) -> str:
+        '''
+        Set or update a service dependency on an app interface.
+
+        :param id: The unique identifier for the app interface.
+        :type id: str
+        :param service_id: The service dependency identifier.
+        :type service_id: str
+        :param module_path: The module path for the service dependency implementation.
+        :type module_path: str
+        :param class_name: The class name for the service dependency implementation.
+        :type class_name: str
+        :param parameters: Optional parameters for the service dependency. ``None`` clears parameters.
+        :type parameters: dict[str, Any] | None
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The ID of the app interface whose service dependency was set.
+        :rtype: str
+        '''
+
+        # Retrieve the app interface via the app service.
+        interface = self.app_service.get(id)
+
+        # Verify that the interface exists.
+        self.verify(
+            expression=interface is not None,
+            error_code=a.const.APP_INTERFACE_NOT_FOUND_ID,
+            message=f'App interface with ID {id} not found.',
+            interface_id=id,
+        )
+
+        # Set or update the service dependency on the interface.
+        interface.set_service(
+            service_id=service_id,
+            module_path=module_path,
+            class_name=class_name,
+            parameters=parameters,
+        )
+
+        # Persist the updated interface.
+        self.app_service.save(interface)
+
+        # Return the interface ID.
+        return id
+
+# ** event: remove_service_dependency
+class RemoveServiceDependency(DomainEvent):
+    '''
+    A domain event to remove a service dependency from an app interface (idempotent).
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the RemoveServiceDependency command.
+
+        :param app_service: The app service used to manage app interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'service_id'])
+    def execute(self, id: str, service_id: str, **kwargs) -> str:
+        '''
+        Remove a service dependency by service_id.
+
+        :param id: The unique identifier for the app interface.
+        :type id: str
+        :param service_id: The service dependency identifier to remove.
+        :type service_id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The ID of the app interface whose service dependency was removed.
+        :rtype: str
+        '''
+
+        # Retrieve the app interface via the app service.
+        interface = self.app_service.get(id)
+
+        # Verify that the interface exists.
+        self.verify(
+            expression=interface is not None,
+            error_code=a.const.APP_INTERFACE_NOT_FOUND_ID,
+            message=f'App interface with ID {id} not found.',
+            interface_id=id,
+        )
+
+        # Remove the service dependency idempotently from the interface.
+        interface.remove_service(service_id=service_id)
+
+        # Persist the updated interface.
+        self.app_service.save(interface)
+
+        # Return the interface ID.
+        return id
+
+# ** event: remove_app_interface
+class RemoveAppInterface(DomainEvent):
+    '''
+    A domain event to remove an entire app interface configuration by ID (idempotent).
+    '''
+
+    # * attribute: app_service
+    app_service: AppService
+
+    # * init
+    def __init__(self, app_service: AppService) -> None:
+        '''
+        Initialize the RemoveAppInterface command.
+
+        :param app_service: The app service used to manage app interfaces.
+        :type app_service: AppService
+        '''
+
+        # Set the app service dependency.
+        self.app_service = app_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove an app interface by ID.
+
+        :param id: The interface ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The removed interface ID.
+        :rtype: str
+        '''
+
+        # Delegate deletion to the app service (idempotent operation).
+        self.app_service.delete(id)
+
+        # Return the interface ID.
+        return id

--- a/tiferet/events/tests/test_app.py
+++ b/tiferet/events/tests/test_app.py
@@ -1,0 +1,787 @@
+"""Tiferet App Commands Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..app import (
+    GetAppInterface,
+    AddAppInterface,
+    ListAppInterfaces,
+    UpdateAppInterface,
+    SetAppConstants,
+    SetServiceDependency,
+    RemoveServiceDependency,
+    RemoveAppInterface,
+)
+from ..settings import TiferetError, DomainEvent, a
+from ...domain import (
+    AppInterface,
+    AppServiceDependency,
+    DomainObject,
+)
+from ...interfaces import AppService
+from ...mappers import Aggregate, AppInterfaceAggregate
+from .settings import DomainEventTestBase, ServiceEventTestBase
+
+# *** fixtures
+
+# ** fixture: app_interface
+@pytest.fixture
+def app_interface():
+    '''
+    Fixture to create an AppInterface aggregate for testing.
+
+    :return: An AppInterfaceAggregate instance.
+    :rtype: AppInterfaceAggregate
+    '''
+
+    # Create a test AppInterface instance.
+    return Aggregate.new(
+        AppInterfaceAggregate,
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+        description='The test app.',
+        flags=['test'],
+        services=[
+            DomainObject.new(
+                AppServiceDependency,
+                service_id='test_service',
+                module_path='test_module_path',
+                class_name='test_class_name',
+            ),
+        ],
+    )
+
+# *** tests
+
+# ** test: TestAddAppInterface
+class TestAddAppInterface(DomainEventTestBase):
+    '''
+    Tests for AddAppInterface using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddAppInterface
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test.interface',
+        name='Test Interface',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'module_path', 'class_name']
+
+    # * method: test_minimal_success
+    def test_minimal_success(self, mock_dependencies):
+        '''
+        Test creating a minimal app interface with only required parameters.
+        '''
+
+        # Execute via the harness handle helper.
+        interface = self.handle(mock_dependencies)
+
+        # Assert the result is an AppInterface instance with expected defaults.
+        assert isinstance(interface, AppInterface)
+        assert interface.id == 'test.interface'
+        assert interface.name == 'Test Interface'
+        assert interface.module_path == 'tiferet.contexts.app'
+        assert interface.class_name == 'AppContext'
+        assert interface.description is None
+        assert interface.logger_id == 'default'
+        assert interface.flags == ['default']
+        assert interface.services == []
+        assert interface.constants == {}
+
+        # Assert the interface is saved via the app service.
+        mock_dependencies['app_service'].save.assert_called_once_with(interface)
+
+    # * method: test_full_parameters
+    def test_full_parameters(self, mock_dependencies):
+        '''
+        Test creating an app interface with all parameters populated.
+        '''
+
+        # Execute via the harness handle helper with full parameters.
+        interface = self.handle(
+            mock_dependencies,
+            description='A test app interface.',
+            logger_id='test_logger',
+            flags=['test_feature', 'test_data'],
+            services=[
+                {
+                    'service_id': 'svc1',
+                    'module_path': 'test.module',
+                    'class_name': 'TestClass',
+                    'parameters': {'foo': 'bar'},
+                }
+            ],
+            constants={'CONST_KEY': 'VALUE'},
+        )
+
+        # Assert core fields.
+        assert isinstance(interface, AppInterface)
+        assert interface.id == 'test.interface'
+        assert interface.description == 'A test app interface.'
+        assert interface.logger_id == 'test_logger'
+        assert interface.flags == ['test_feature', 'test_data']
+        assert interface.constants == {'CONST_KEY': 'VALUE'}
+
+        # Assert services are materialized as AppServiceDependency models.
+        assert len(interface.services) == 1
+        svc = interface.services[0]
+        assert isinstance(svc, AppServiceDependency)
+        assert svc.service_id == 'svc1'
+        assert svc.module_path == 'test.module'
+        assert svc.class_name == 'TestClass'
+        assert svc.parameters == {'foo': 'bar'}
+
+        # Assert the interface is saved.
+        mock_dependencies['app_service'].save.assert_called_once()
+
+    # * method: test_default_fallbacks
+    def test_default_fallbacks(self, mock_dependencies):
+        '''
+        Test that logger_id and flags fall back to defaults.
+        '''
+
+        # Execute via the harness handle helper with defaults.
+        interface = self.handle(mock_dependencies)
+
+        # All flags should be normalized to 'default'.
+        assert interface.logger_id == 'default'
+        assert interface.flags == ['default']
+
+        # Assert the interface is saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(interface)
+
+
+# ** test: TestGetAppInterface
+class TestGetAppInterface(ServiceEventTestBase):
+    '''
+    Tests for GetAppInterface using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = GetAppInterface
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: service_attr
+    service_attr = 'app_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(interface_id='test')
+
+    # * attribute: required_params
+    required_params = ['interface_id']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.APP_INTERFACE_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(interface_id='non_existent_id')
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, app_interface):
+        '''
+        Test successful retrieval of an app interface.
+        '''
+
+        # Configure the service mock to return the app interface.
+        mock_dependencies['app_service'].get.return_value = app_interface
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert that the returned interface matches the expected app interface.
+        assert result == app_interface
+
+
+# ** test: TestListAppInterfaces
+class TestListAppInterfaces(DomainEventTestBase):
+    '''
+    Tests for ListAppInterfaces using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListAppInterfaces
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict()
+
+    # * method: test_empty
+    def test_empty(self, mock_dependencies):
+        '''
+        Test that ListAppInterfaces returns an empty list when no interfaces are configured.
+        '''
+
+        # Configure the service to return an empty list.
+        mock_dependencies['app_service'].list.return_value = []
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert that an empty list is returned and the service was called.
+        assert result == []
+        mock_dependencies['app_service'].list.assert_called_once_with()
+
+    # * method: test_multiple
+    def test_multiple(self, mock_dependencies, app_interface):
+        '''
+        Test that ListAppInterfaces returns multiple interfaces when configured.
+        '''
+
+        # Configure the service to return multiple interfaces.
+        another_interface = Aggregate.new(
+            AppInterfaceAggregate,
+            id='other',
+            name='Other App',
+            module_path='tiferet.contexts.app',
+            class_name='OtherAppContext',
+        )
+        mock_dependencies['app_service'].list.return_value = [app_interface, another_interface]
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert that the returned list matches the configured interfaces.
+        assert result == [app_interface, another_interface]
+        mock_dependencies['app_service'].list.assert_called_once_with()
+
+
+# ** test: TestSetServiceDependency
+class TestSetServiceDependency(ServiceEventTestBase):
+    '''
+    Tests for SetServiceDependency using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetServiceDependency
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: service_attr
+    service_attr = 'app_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test',
+        service_id='new_dependency',
+        module_path='new.module.path',
+        class_name='NewClass',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'service_id', 'module_path', 'class_name']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.APP_INTERFACE_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.interface',
+        service_id='dep',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, app_interface):
+        '''
+        Override to provide a service mock pre-configured with an app_interface.
+        '''
+
+        # Create a mock AppService that returns the app_interface on get.
+        service = mock.Mock(spec=AppService)
+        service.get.return_value = app_interface
+        return {'app_service': service}
+
+    # * method: test_creates_new_service
+    def test_creates_new_service(self, mock_dependencies, app_interface):
+        '''
+        Test that SetServiceDependency creates a new dependency when it does not exist.
+        '''
+
+        # Ensure no service with the target id exists initially.
+        assert app_interface.get_service('new_dependency') is None
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies, parameters={'param1': 'value1'})
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # A new service dependency should be created with the provided values.
+        new_svc = app_interface.get_service('new_dependency')
+        assert new_svc is not None
+        assert new_svc.module_path == 'new.module.path'
+        assert new_svc.class_name == 'NewClass'
+        assert new_svc.parameters == {'param1': 'value1'}
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_updates_existing_and_merges_parameters
+    def test_updates_existing_and_merges_parameters(self, mock_dependencies, app_interface):
+        '''
+        Test that SetServiceDependency updates an existing dependency and merges parameters.
+        '''
+
+        # Precondition: existing service from fixture.
+        existing_svc = app_interface.get_service('test_service')
+        existing_svc.parameters = {'keep': 'value', 'override': 'old', 'remove': 'to_be_removed'}
+
+        # Execute via the harness handle helper with updated fields.
+        result = self.handle(
+            mock_dependencies,
+            service_id='test_service',
+            module_path='updated.module.path',
+            class_name='UpdatedClass',
+            parameters={
+                'override': 'new',
+                'remove': None,
+                'new_param': 'new_value',
+            },
+        )
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # Service dependency should be updated.
+        updated_svc = app_interface.get_service('test_service')
+        assert updated_svc.module_path == 'updated.module.path'
+        assert updated_svc.class_name == 'UpdatedClass'
+        assert updated_svc.parameters == {
+            'keep': 'value',
+            'override': 'new',
+            'new_param': 'new_value',
+        }
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_parameters_none_clears_existing
+    def test_parameters_none_clears_existing(self, mock_dependencies, app_interface):
+        '''
+        Test that passing parameters=None clears existing parameters.
+        '''
+
+        # Precondition: existing service has parameters.
+        existing_svc = app_interface.get_service('test_service')
+        existing_svc.parameters = {'key': 'value'}
+
+        # Execute via the harness handle helper with parameters=None.
+        result = self.handle(
+            mock_dependencies,
+            service_id='test_service',
+            module_path='tiferet.contexts.app',
+            class_name='AppContext',
+            parameters=None,
+        )
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # Parameters should be cleared.
+        cleared_svc = app_interface.get_service('test_service')
+        assert cleared_svc.parameters == {}
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+# ** test: TestUpdateAppInterface
+class TestUpdateAppInterface(ServiceEventTestBase):
+    '''
+    Tests for UpdateAppInterface using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = UpdateAppInterface
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: service_attr
+    service_attr = 'app_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test',
+        attribute='name',
+        value='Updated Name',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'attribute']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.APP_INTERFACE_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.interface',
+        attribute='name',
+        value='Updated Name',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, app_interface):
+        '''
+        Override to provide a service mock pre-configured with an app_interface.
+        '''
+
+        # Create a mock AppService that returns the app_interface on get.
+        service = mock.Mock(spec=AppService)
+        service.get.return_value = app_interface
+        return {'app_service': service}
+
+    # * method: test_success_supported_attributes
+    @pytest.mark.parametrize(
+        'attribute,new_value',
+        [
+            ('name', 'Updated Name'),
+            ('description', 'Updated description'),
+            ('module_path', 'updated.module.path'),
+            ('class_name', 'UpdatedClass'),
+            ('logger_id', 'updated_logger'),
+            ('flags', ['updated_flags']),
+        ],
+    )
+    def test_success_supported_attributes(
+        self, mock_dependencies, app_interface, attribute, new_value
+    ):
+        '''
+        Test updating each supported scalar attribute via UpdateAppInterface.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies, id=app_interface.id, attribute=attribute, value=new_value)
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # The attribute on the interface should be updated.
+        assert getattr(app_interface, attribute) == new_value
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_invalid_attribute_raises_model_error
+    def test_invalid_attribute_raises_model_error(self, mock_dependencies, app_interface):
+        '''
+        Test that an invalid attribute name raises INVALID_MODEL_ATTRIBUTE.
+        '''
+
+        # Execute the command with an unsupported attribute name.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, id=app_interface.id, attribute='invalid_attribute', value='value')
+
+        # The underlying model validation should raise INVALID_MODEL_ATTRIBUTE.
+        assert exc_info.value.error_code == a.const.INVALID_MODEL_ATTRIBUTE_ID
+        mock_dependencies['app_service'].save.assert_not_called()
+
+    # * method: test_invalid_type_attributes_empty_value
+    @pytest.mark.parametrize('attribute', ['module_path', 'class_name'])
+    def test_invalid_type_attributes_empty_value(self, mock_dependencies, app_interface, attribute):
+        '''
+        Test that empty values for module_path or class_name are rejected by the model.
+        '''
+
+        # Execute the command with an empty value for a type-constrained attribute.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, id=app_interface.id, attribute=attribute, value='')
+
+        # The underlying model validation should raise INVALID_APP_INTERFACE_TYPE.
+        assert exc_info.value.error_code == a.const.INVALID_APP_INTERFACE_TYPE_ID
+        mock_dependencies['app_service'].save.assert_not_called()
+
+# ** test: TestSetAppConstants
+class TestSetAppConstants(ServiceEventTestBase):
+    '''
+    Tests for SetAppConstants using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetAppConstants
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: service_attr
+    service_attr = 'app_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test',
+        constants={'KEY': 'VALUE'},
+    )
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.APP_INTERFACE_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.interface',
+        constants={'KEY': 'VALUE'},
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, app_interface):
+        '''
+        Override to provide a service mock pre-configured with an app_interface.
+        '''
+
+        # Create a mock AppService that returns the app_interface on get.
+        service = mock.Mock(spec=AppService)
+        service.get.return_value = app_interface
+        return {'app_service': service}
+
+    # * method: test_full_clear
+    def test_full_clear(self, mock_dependencies, app_interface):
+        '''
+        Test that SetAppConstants clears all constants when constants=None.
+        '''
+
+        # Seed existing constants on the interface.
+        app_interface.constants = {
+            'EXISTING': 'value',
+            'OTHER': 'other_value',
+        }
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies, constants=None)
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # All constants should be cleared.
+        assert app_interface.constants == {}
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_merge_override_and_remove
+    def test_merge_override_and_remove(self, mock_dependencies, app_interface):
+        '''
+        Test that SetAppConstants merges, overrides, and removes None-valued keys.
+        '''
+
+        # Seed existing constants.
+        app_interface.constants = {
+            'KEEP': 'keep_value',
+            'OVERRIDE': 'old',
+            'REMOVE': 'to_be_removed',
+        }
+
+        # Execute via the harness handle helper with mixed updates.
+        result = self.handle(
+            mock_dependencies,
+            constants={
+                'OVERRIDE': 'new',
+                'REMOVE': None,
+                'ADD': 'added',
+            },
+        )
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # Constants should be merged/updated with None-valued keys removed.
+        assert app_interface.constants == {
+            'KEEP': 'keep_value',
+            'OVERRIDE': 'new',
+            'ADD': 'added',
+        }
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_add_new_constants
+    def test_add_new_constants(self, mock_dependencies, app_interface):
+        '''
+        Test that SetAppConstants adds new constants when none exist.
+        '''
+
+        # Precondition: no constants defined.
+        assert app_interface.constants == {}
+
+        # Execute via the harness handle helper with new constants.
+        result = self.handle(
+            mock_dependencies,
+            constants={
+                'NEW_ONE': 'one',
+                'NEW_TWO': 'two',
+            },
+        )
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # All new constants should be present.
+        assert app_interface.constants == {
+            'NEW_ONE': 'one',
+            'NEW_TWO': 'two',
+        }
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+
+# ** test: TestRemoveServiceDependency
+class TestRemoveServiceDependency(ServiceEventTestBase):
+    '''
+    Tests for RemoveServiceDependency using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveServiceDependency
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: service_attr
+    service_attr = 'app_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test',
+        service_id='test_service',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'service_id']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.APP_INTERFACE_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.interface',
+        service_id='dep',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, app_interface):
+        '''
+        Override to provide a service mock pre-configured with an app_interface.
+        '''
+
+        # Create a mock AppService that returns the app_interface on get.
+        service = mock.Mock(spec=AppService)
+        service.get.return_value = app_interface
+        return {'app_service': service}
+
+    # * method: test_removes_existing
+    def test_removes_existing(self, mock_dependencies, app_interface):
+        '''
+        Test that RemoveServiceDependency removes an existing service dependency.
+        '''
+
+        # Precondition: the service dependency exists on the interface.
+        existing_svc = app_interface.get_service('test_service')
+        assert existing_svc is not None
+        initial_count = len(app_interface.services)
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # The service dependency should be removed.
+        assert app_interface.get_service('test_service') is None
+        assert len(app_interface.services) == initial_count - 1
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+    # * method: test_missing_service_is_idempotent
+    def test_missing_service_is_idempotent(self, mock_dependencies, app_interface):
+        '''
+        Test that removing a non-existent service dependency is idempotent.
+        '''
+
+        # Precondition: no service dependency with the given id exists.
+        assert app_interface.get_service('missing_service') is None
+        initial_count = len(app_interface.services)
+
+        # Execute via the harness handle helper with a non-existent service id.
+        result = self.handle(mock_dependencies, service_id='missing_service')
+
+        # Command should return the interface id.
+        assert result == app_interface.id
+
+        # Services list should remain unchanged.
+        assert app_interface.get_service('missing_service') is None
+        assert len(app_interface.services) == initial_count
+
+        # The updated interface should be saved.
+        mock_dependencies['app_service'].save.assert_called_once_with(app_interface)
+
+# ** test: TestRemoveAppInterface
+class TestRemoveAppInterface(DomainEventTestBase):
+    '''
+    Tests for RemoveAppInterface using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveAppInterface
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='existing.interface')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success_existing
+    def test_success_existing(self, mock_dependencies):
+        '''
+        Test that RemoveAppInterface deletes an existing app interface and returns the ID.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Command should return the interface id and delegate deletion to the service.
+        assert result == 'existing.interface'
+        mock_dependencies['app_service'].delete.assert_called_once_with('existing.interface')
+
+    # * method: test_success_missing_is_idempotent
+    def test_success_missing_is_idempotent(self, mock_dependencies):
+        '''
+        Test that removing a non-existent interface is idempotent and still succeeds.
+        '''
+
+        # Execute via the harness handle helper with a different id.
+        result = self.handle(mock_dependencies, id='missing.interface')
+
+        # Command should return the interface id and still call delete exactly once.
+        assert result == 'missing.interface'
+        mock_dependencies['app_service'].delete.assert_called_once_with('missing.interface')


### PR DESCRIPTION
Add 8 domain events for `AppInterface` CRUD, full test suite using the domain event test harness, and user-facing guide.

## Changes
- **`tiferet/events/app.py`** — 8 domain events: `AddAppInterface`, `GetAppInterface`, `ListAppInterfaces`, `UpdateAppInterface`, `SetAppConstants`, `SetServiceDependency`, `RemoveServiceDependency`, `RemoveAppInterface`.
- **`tiferet/events/tests/test_app.py`** — 8 test harness classes (45 tests pass, 1 expected skip).
- **`docs/guides/events/app.md`** — User-facing event guide.

Closes #635

Co-Authored-By: Oz <oz-agent@warp.dev>