### PR TITLE
Events – Add CLI Events (#638)

### DIFF
--- a/docs/guides/events/cli.md
+++ b/docs/guides/events/cli.md
@@ -1,0 +1,156 @@
+# Events – CLI Command Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/cli.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The CLI event module provides domain events for managing `CliCommand` configurations — the definitions that drive Tiferet's command-line interface. Every event depends on an injected `CliService` and operates on `CliCommand` domain objects through the `CliCommandAggregate` mapper.
+
+These events are consumed by CLI management tooling and by contexts that need to inspect or modify the CLI command tree at runtime.
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `AddCliCommand` | Create | `id` | `CliCommand` |
+| `AddCliArgument` | Update (add arg) | `command_id` | `str` (ID) |
+| `ListCliCommands` | Read (all) | *(none)* | `List[CliCommand]` |
+| `GetParentArguments` | Read (parent args) | *(none)* | `List` |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`cli_service: CliService`** — the service interface for persisting, retrieving, and querying `CliCommand` configurations.
+
+## Event Details
+
+### AddCliCommand
+
+Creates a new `CliCommand` and persists it via `CliService.save()`. Verifies the command ID does not already exist before creation.
+
+**Required:** `id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | — | The command name |
+| `key` | `str` | — | The command key (used in CLI parsing) |
+| `group_key` | `str` | — | The group key for command grouping |
+| `description` | `str \| None` | `None` | Human-readable description |
+| `arguments` | `list` | `[]` | Initial list of argument definitions |
+
+**Returns:** The created `CliCommand` instance.
+
+**Errors:**
+- `CLI_COMMAND_ALREADY_EXISTS` if a command with the given ID already exists.
+
+**Behavior:**
+1. Verifies the ID is not already in use via `cli_service.exists(id)`.
+2. Creates the command via `CliCommandAggregate.new(...)`.
+3. Saves via `cli_service.save(command)`.
+
+```python
+result = DomainEvent.handle(
+    AddCliCommand,
+    dependencies={'cli_service': cli_service},
+    id='calc.add',
+    name='Add Number Command',
+    key='add',
+    group_key='calc',
+    description='Adds two numbers.',
+    arguments=[
+        {
+            'name_or_flags': ['a'],
+            'description': 'The first number.',
+        },
+        {
+            'name_or_flags': ['b'],
+            'description': 'The second number.',
+        },
+    ],
+)
+```
+
+### AddCliArgument
+
+Adds an argument to an existing CLI command. Retrieves the command, delegates to `CliCommandAggregate.add_argument()`, and persists the result.
+
+**Required:** `command_id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name_or_flags` | `list` | — | The argument name or flags (e.g., `['a']` or `['-v', '--verbose']`) |
+| `description` | `str \| None` | `None` | Argument description |
+
+Additional kwargs (`type`, `required`, `default`, `choices`, `nargs`, `action`) are forwarded to `CliCommandAggregate.add_argument()`.
+
+**Returns:** `str` — the command ID.
+
+**Errors:**
+- `CLI_COMMAND_NOT_FOUND` if the command does not exist.
+
+```python
+DomainEvent.handle(
+    AddCliArgument,
+    dependencies={'cli_service': cli_service},
+    command_id='calc.add',
+    name_or_flags=['-p', '--precision'],
+    description='Decimal precision for the result.',
+    type='int',
+    default='2',
+)
+```
+
+### ListCliCommands
+
+Lists all configured CLI commands. No required parameters.
+
+**Returns:** `List[CliCommand]` — may be empty.
+
+```python
+commands = DomainEvent.handle(
+    ListCliCommands,
+    dependencies={'cli_service': cli_service},
+)
+```
+
+### GetParentArguments
+
+Retrieves parent-level CLI arguments — arguments that apply globally across all commands (e.g., `--verbose`, `--config`). Delegates to `CliService.get_parent_arguments()`.
+
+**Returns:** `List` — list of `CliArgument` instances; may be empty.
+
+```python
+parent_args = DomainEvent.handle(
+    GetParentArguments,
+    dependencies={'cli_service': cli_service},
+)
+```
+
+## Common Patterns
+
+### Existence Check Before Creation
+
+`AddCliCommand` uses `self.verify(not cli_service.exists(id), ...)` to prevent duplicate commands. This differs from the retrieve→verify→mutate→save pattern used in most other events because creation only needs an existence check, not a full retrieval.
+
+### Retrieve → Verify → Mutate → Save
+
+`AddCliArgument` follows the standard four-step pattern: retrieve the command, verify it exists, mutate it via the aggregate method, and save the updated aggregate.
+
+### Kwargs Forwarding
+
+`AddCliArgument` forwards additional `**kwargs` to `CliCommandAggregate.add_argument()`, allowing callers to pass argument metadata (`type`, `required`, `default`, `choices`, `nargs`, `action`) without the event needing to enumerate every field.
+
+## Related Documentation
+
+- [docs/guides/domain/cli.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/cli.md) — CLI domain objects
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and test harness
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions
+- [docs/guides/events/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/events/app.md) — App event guide

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -195,6 +195,12 @@ UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
 # ** constant: app_interface_not_found_id
 APP_INTERFACE_NOT_FOUND_ID = 'APP_INTERFACE_NOT_FOUND'
 
+# ** constant: cli_command_not_found_id
+CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
+
+# ** constant: cli_command_already_exists_id
+CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
+
 # ** constant: invalid_service_configuration_id
 INVALID_SERVICE_CONFIGURATION_ID = 'INVALID_SERVICE_CONFIGURATION'
 
@@ -752,11 +758,20 @@ DEFAULT_ERRORS = {
     },
 
     # * error: CLI_COMMAND_NOT_FOUND
-    'CLI_COMMAND_NOT_FOUND': {
-        'id': 'CLI_COMMAND_NOT_FOUND',
+    CLI_COMMAND_NOT_FOUND_ID: {
+        'id': CLI_COMMAND_NOT_FOUND_ID,
         'name': 'CLI Command Not Found',
         'message': [
-            {'lang': 'en_US', 'text': 'Command {command} not found.'}
+            {'lang': 'en_US', 'text': 'CLI command {command_id} not found.'}
+        ]
+    },
+
+    # * error: CLI_COMMAND_ALREADY_EXISTS
+    CLI_COMMAND_ALREADY_EXISTS_ID: {
+        'id': CLI_COMMAND_ALREADY_EXISTS_ID,
+        'name': 'CLI Command Already Exists',
+        'message': [
+            {'lang': 'en_US', 'text': 'CLI command with ID {id} already exists.'}
         ]
     },
 

--- a/tiferet/events/cli.py
+++ b/tiferet/events/cli.py
@@ -1,0 +1,225 @@
+"""Tiferet CLI Domain Events"""
+
+# *** imports
+
+# ** core
+from typing import Optional, List
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import CliCommand
+from ..interfaces import CliService
+from ..mappers import CliCommandAggregate
+
+# *** events
+
+# ** event: list_cli_commands
+class ListCliCommands(DomainEvent):
+    '''
+    A domain event to list all CLI commands.
+    '''
+
+    # * attribute: cli_service
+    cli_service: CliService
+
+    # * init
+    def __init__(self, cli_service: CliService):
+        '''
+        Initialize the ListCliCommands event.
+
+        :param cli_service: The CLI service.
+        :type cli_service: CliService
+        '''
+
+        # Set the CLI service dependency.
+        self.cli_service = cli_service
+
+    # * method: execute
+    def execute(self, **kwargs) -> List[CliCommand]:
+        '''
+        List all CLI commands.
+
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: List of CLI commands.
+        :rtype: List[CliCommand]
+        '''
+
+        # Delegate to the CLI service.
+        return self.cli_service.list()
+
+
+# ** event: get_parent_arguments
+class GetParentArguments(DomainEvent):
+    '''
+    A domain event to retrieve parent-level CLI arguments.
+    '''
+
+    # * attribute: cli_service
+    cli_service: CliService
+
+    # * init
+    def __init__(self, cli_service: CliService):
+        '''
+        Initialize the GetParentArguments event.
+
+        :param cli_service: The CLI service.
+        :type cli_service: CliService
+        '''
+
+        # Set the CLI service dependency.
+        self.cli_service = cli_service
+
+    # * method: execute
+    def execute(self, **kwargs) -> List:
+        '''
+        Get parent-level CLI arguments.
+
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: List of parent CLI arguments.
+        :rtype: List
+        '''
+
+        # Delegate to the CLI service.
+        return self.cli_service.get_parent_arguments()
+
+# ** event: add_cli_command
+class AddCliCommand(DomainEvent):
+    '''
+    A domain event to add a new CLI command.
+    '''
+
+    # * attribute: cli_service
+    cli_service: CliService
+
+    # * init
+    def __init__(self, cli_service: CliService):
+        '''
+        Initialize the AddCliCommand event.
+
+        :param cli_service: The CLI service.
+        :type cli_service: CliService
+        '''
+
+        # Set the CLI service dependency.
+        self.cli_service = cli_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(
+        self,
+        id: str,
+        name: str,
+        key: str,
+        group_key: str,
+        description: Optional[str] = None,
+        arguments: Optional[list] = [],
+        **kwargs,
+    ) -> CliCommand:
+        '''
+        Add a new CLI command.
+
+        :param id: Required unique identifier.
+        :type id: str
+        :param name: The command name.
+        :type name: str
+        :param key: The command key.
+        :type key: str
+        :param group_key: The group key.
+        :type group_key: str
+        :param description: Optional command description.
+        :type description: str | None
+        :param arguments: Optional list of arguments.
+        :type arguments: list | None
+        :return: Created CliCommand model.
+        :rtype: CliCommand
+        '''
+
+        # Check for existing command id.
+        self.verify(
+            not self.cli_service.exists(id),
+            a.const.CLI_COMMAND_ALREADY_EXISTS_ID,
+            id=id,
+        )
+
+        # Create CLI command aggregate.
+        command = CliCommandAggregate.new(
+            id=id,
+            name=name,
+            key=key,
+            group_key=group_key,
+            description=description,
+            arguments=arguments,
+        )
+
+        # Save the new command and return it.
+        self.cli_service.save(command)
+        return command
+
+
+# ** event: add_cli_argument
+class AddCliArgument(DomainEvent):
+    '''
+    A domain event to add an argument to an existing CLI command.
+    '''
+
+    # * attribute: cli_service
+    cli_service: CliService
+
+    # * init
+    def __init__(self, cli_service: CliService):
+        '''
+        Initialize the AddCliArgument event.
+
+        :param cli_service: The CLI service.
+        :type cli_service: CliService
+        '''
+
+        # Set the CLI service dependency.
+        self.cli_service = cli_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['command_id'])
+    def execute(
+        self,
+        command_id: str,
+        name_or_flags: list,
+        description: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        '''
+        Add an argument to an existing CLI command.
+
+        :param command_id: The CLI command identifier.
+        :type command_id: str
+        :param name_or_flags: The argument name or flags.
+        :type name_or_flags: list
+        :param description: Optional argument description.
+        :type description: str | None
+        :return: The CLI command id.
+        :rtype: str
+        '''
+
+        # Retrieve the existing CLI command.
+        command = self.cli_service.get(command_id)
+
+        # Verify that the command exists.
+        self.verify(
+            command is not None,
+            a.const.CLI_COMMAND_NOT_FOUND_ID,
+            command_id=command_id,
+        )
+
+        # Add the argument via the aggregate's method.
+        command.add_argument(
+            name_or_flags=name_or_flags,
+            description=description,
+            **kwargs,
+        )
+
+        # Persist the updated command.
+        self.cli_service.save(command)
+
+        # Return the id for confirmation.
+        return command_id

--- a/tiferet/events/tests/test_cli.py
+++ b/tiferet/events/tests/test_cli.py
@@ -1,0 +1,382 @@
+"""Tiferet CLI Domain Event Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..cli import (
+    AddCliCommand,
+    AddCliArgument,
+    ListCliCommands,
+    GetParentArguments,
+)
+from ..settings import DomainEvent, a
+from ...domain import CliCommand, CliArgument, DomainObject
+from ...interfaces import CliService
+from ...mappers import CliCommandAggregate
+from .settings import DomainEventTestBase, ServiceEventTestBase
+
+# *** fixtures
+
+# ** fixture: cli_command
+@pytest.fixture
+def cli_command():
+    '''
+    Fixture to create a CliCommand aggregate for testing.
+
+    :return: A CliCommandAggregate instance.
+    :rtype: CliCommandAggregate
+    '''
+
+    # Create a test CliCommand instance.
+    return CliCommandAggregate.new(
+        id='test.command',
+        name='Test Command',
+        key='command',
+        group_key='test',
+        description='A test command',
+        arguments=[],
+    )
+
+# *** tests
+
+# ** test: TestAddCliCommand
+class TestAddCliCommand(DomainEventTestBase):
+    '''
+    Tests for AddCliCommand using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddCliCommand
+
+    # * attribute: dependencies
+    dependencies = {'cli_service': CliService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test.new_command',
+        name='New Command',
+        key='new_command',
+        group_key='test',
+    )
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self):
+        '''
+        Override to provide a CLI service mock pre-configured with exists=False.
+        '''
+
+        # Create a mock CliService that returns False for exists.
+        service = mock.Mock(spec=CliService)
+        service.exists.return_value = False
+        return {'cli_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test that AddCliCommand successfully creates a new CLI command.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result is a CliCommand instance with expected fields.
+        assert isinstance(result, CliCommand)
+        assert result.id == 'test.new_command'
+        assert result.name == 'New Command'
+        assert result.key == 'new_command'
+        assert result.group_key == 'test'
+        assert result.arguments == []
+
+        # Assert the service was called to check existence and to save.
+        mock_dependencies['cli_service'].exists.assert_called_once_with('test.new_command')
+        mock_dependencies['cli_service'].save.assert_called_once_with(result)
+
+    # * method: test_with_arguments
+    def test_with_arguments(self, mock_dependencies):
+        '''
+        Test that AddCliCommand can create a command with initial arguments.
+        '''
+
+        # Execute via the harness handle helper with arguments.
+        result = self.handle(
+            mock_dependencies,
+            id='test.verbose_command',
+            name='Verbose Command',
+            key='verbose_command',
+            description='A command with arguments',
+            arguments=[
+                {
+                    'name_or_flags': ['-v', '--verbose'],
+                    'description': 'Enable verbose output',
+                    'type': 'str',
+                }
+            ],
+        )
+
+        # Assert the result has arguments.
+        assert isinstance(result, CliCommand)
+        assert result.id == 'test.verbose_command'
+        assert len(result.arguments) == 1
+
+        # Assert the service interactions.
+        mock_dependencies['cli_service'].exists.assert_called_once_with('test.verbose_command')
+        mock_dependencies['cli_service'].save.assert_called_once_with(result)
+
+    # * method: test_duplicate_id
+    def test_duplicate_id(self, mock_dependencies):
+        '''
+        Test that AddCliCommand fails when the command id already exists.
+        '''
+
+        # Configure the service to report the id exists.
+        mock_dependencies['cli_service'].exists.return_value = True
+
+        # Execute and expect a CLI_COMMAND_ALREADY_EXISTS error.
+        with pytest.raises(Exception) as exc_info:
+            self.handle(mock_dependencies)
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.CLI_COMMAND_ALREADY_EXISTS_ID
+
+
+# ** test: TestAddCliArgument
+class TestAddCliArgument(ServiceEventTestBase):
+    '''
+    Tests for AddCliArgument using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddCliArgument
+
+    # * attribute: dependencies
+    dependencies = {'cli_service': CliService}
+
+    # * attribute: service_attr
+    service_attr = 'cli_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        command_id='test.command',
+        name_or_flags=['-v', '--verbose'],
+        description='Enable verbose output',
+    )
+
+    # * attribute: required_params
+    required_params = ['command_id']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.CLI_COMMAND_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        command_id='test.missing',
+        name_or_flags=['-v'],
+        description='Verbose',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, cli_command):
+        '''
+        Override to provide a CLI service mock pre-configured with a cli_command.
+        '''
+
+        # Create a mock CliService that returns the cli_command on get.
+        service = mock.Mock(spec=CliService)
+        service.get.return_value = cli_command
+        return {'cli_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, cli_command):
+        '''
+        Test that AddCliArgument successfully adds an argument to a command.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result is the command id and argument was added.
+        assert result == 'test.command'
+        assert len(cli_command.arguments) == 1
+
+        # Assert service interactions.
+        mock_dependencies['cli_service'].get.assert_called_once_with('test.command')
+        mock_dependencies['cli_service'].save.assert_called_once_with(cli_command)
+
+    # * method: test_with_kwargs
+    def test_with_kwargs(self, mock_dependencies, cli_command):
+        '''
+        Test that AddCliArgument handles additional kwargs for arguments.
+        '''
+
+        # Execute via the harness handle helper with additional kwargs.
+        result = self.handle(
+            mock_dependencies,
+            name_or_flags=['--count'],
+            description='Number of items',
+            type='int',
+            required=True,
+            default='5',
+        )
+
+        # Assert the result and argument was added.
+        assert result == 'test.command'
+        assert len(cli_command.arguments) == 1
+
+        # Assert service interactions.
+        mock_dependencies['cli_service'].get.assert_called_once_with('test.command')
+        mock_dependencies['cli_service'].save.assert_called_once_with(cli_command)
+
+    # * method: test_multiple_arguments
+    def test_multiple_arguments(self, mock_dependencies, cli_command):
+        '''
+        Test adding multiple arguments to the same command sequentially.
+        '''
+
+        # Add first argument.
+        self.handle(mock_dependencies)
+
+        # Add second argument.
+        self.handle(
+            mock_dependencies,
+            name_or_flags=['-q', '--quiet'],
+            description='Quiet mode',
+        )
+
+        # Assert both arguments were added.
+        assert len(cli_command.arguments) == 2
+        assert mock_dependencies['cli_service'].save.call_count == 2
+
+
+# ** test: TestListCliCommands
+class TestListCliCommands(DomainEventTestBase):
+    '''
+    Tests for ListCliCommands using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListCliCommands
+
+    # * attribute: dependencies
+    dependencies = {'cli_service': CliService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict()
+
+    # * method: test_empty
+    def test_empty(self, mock_dependencies):
+        '''
+        Test that ListCliCommands returns an empty list when no commands exist.
+        '''
+
+        # Configure the service to return an empty list.
+        mock_dependencies['cli_service'].list.return_value = []
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert an empty list is returned.
+        assert result == []
+        mock_dependencies['cli_service'].list.assert_called_once()
+
+    # * method: test_multiple
+    def test_multiple(self, mock_dependencies, cli_command):
+        '''
+        Test that ListCliCommands returns multiple commands.
+        '''
+
+        # Create another command for the list.
+        another = CliCommandAggregate.new(
+            id='test.another',
+            name='Another Command',
+            key='another',
+            group_key='test',
+        )
+
+        # Configure the service to return multiple commands.
+        mock_dependencies['cli_service'].list.return_value = [cli_command, another]
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert both commands are returned.
+        assert len(result) == 2
+        assert result[0].id == 'test.command'
+        assert result[1].id == 'test.another'
+        mock_dependencies['cli_service'].list.assert_called_once()
+
+
+# ** test: TestGetParentArguments
+class TestGetParentArguments(DomainEventTestBase):
+    '''
+    Tests for GetParentArguments using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = GetParentArguments
+
+    # * attribute: dependencies
+    dependencies = {'cli_service': CliService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict()
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test that GetParentArguments returns parent arguments.
+        '''
+
+        # Create sample parent arguments.
+        parent_args = [
+            DomainObject.new(
+                CliArgument,
+                name_or_flags=['--verbose', '-v'],
+                description='Enable verbose output',
+                type='str',
+                required=False,
+            ),
+            DomainObject.new(
+                CliArgument,
+                name_or_flags=['--debug'],
+                description='Enable debug mode',
+                type='str',
+                required=False,
+            ),
+        ]
+
+        # Configure the service to return parent arguments.
+        mock_dependencies['cli_service'].get_parent_arguments.return_value = parent_args
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the results.
+        assert len(result) == 2
+        assert '--verbose' in result[0].name_or_flags
+        assert '--debug' in result[1].name_or_flags
+        mock_dependencies['cli_service'].get_parent_arguments.assert_called_once()
+
+    # * method: test_empty
+    def test_empty(self, mock_dependencies):
+        '''
+        Test that GetParentArguments handles empty parent argument lists.
+        '''
+
+        # Configure the service to return an empty list.
+        mock_dependencies['cli_service'].get_parent_arguments.return_value = []
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert an empty list is returned.
+        assert result == []
+        mock_dependencies['cli_service'].get_parent_arguments.assert_called_once()


### PR DESCRIPTION
Add 4 CLI domain events with full test harness coverage, error constants, and user-facing guide.

## Changes
- **`tiferet/events/cli.py`** — New file. `ListCliCommands`, `GetParentArguments`, `AddCliCommand`, `AddCliArgument` — all injecting `CliService`.
- **`tiferet/events/tests/test_cli.py`** — New file. 4 harness-based test classes (13 passed, 2 skipped). Auto-parametrized required-param and not-found tests.
- **`tiferet/assets/constants.py`** — Add `CLI_COMMAND_NOT_FOUND_ID` and `CLI_COMMAND_ALREADY_EXISTS_ID` constants; add `CLI_COMMAND_ALREADY_EXISTS` to `DEFAULT_ERRORS`; update existing `CLI_COMMAND_NOT_FOUND` entry to use constant.
- **`docs/guides/events/cli.md`** — New file. User-facing event guide.

Closes #638

Co-Authored-By: Oz <oz-agent@warp.dev>