### PR TITLE
Events – Add DI Events (#636)

### DIFF
--- a/docs/guides/events/di.md
+++ b/docs/guides/events/di.md
@@ -1,0 +1,269 @@
+# Events – DI Service Configuration Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/di.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The DI event module provides the full CRUD surface for `ServiceConfiguration` objects — the dependency injection blueprints that define how services are resolved and wired at runtime. Every event in this module depends on an injected `DIService` and operates on `ServiceConfiguration` domain objects through the `ServiceConfigurationAggregate` mapper.
+
+These events are the forward-compatible successors to the container events in `tiferet/events/container.py`, using DI-specific terminology (`ServiceConfiguration`, `DIService`, `configuration_exists`, etc.) instead of container-centric naming (`ContainerAttribute`, `ContainerService`, `attribute_exists`).
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `AddServiceConfiguration` | Create | `id` | `ServiceConfiguration` |
+| `SetDefaultServiceConfiguration` | Update (default type) | *(none — `id` is positional)* | `ServiceConfiguration` |
+| `SetServiceDependency` | Update (flagged dep) | `flag` | `str` (ID) |
+| `RemoveServiceDependency` | Delete (flagged dep) | `flag` | `str` (ID) |
+| `RemoveServiceConfiguration` | Delete | `id` | `str` (ID) |
+| `SetServiceConstants` | Update (constants) | *(none)* | `Dict[str, Any]` |
+| `ListAllSettings` | Read (all) | *(none)* | `Tuple[List[ServiceConfiguration], Dict]` |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`di_service: DIService`** — the service interface for persisting and retrieving `ServiceConfiguration` objects and constants.
+
+## Event Details
+
+### AddServiceConfiguration
+
+Creates a new `ServiceConfiguration` and persists it via `DIService.save_configuration()`. A configuration must define at least one type source: either a default type (`module_path` + `class_name`) or one or more flagged dependencies.
+
+**Required:** `id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `module_path` | `str \| None` | `None` | Default module path for the service class |
+| `class_name` | `str \| None` | `None` | Default class name for the service class |
+| `parameters` | `Dict[str, Any]` | `{}` | Default configuration parameters |
+|| `flagged_dependencies` | `List[Dict[str, Any]]` | `[]` | List of flagged dependency dicts (each with `flag`, `module_path`, `class_name`, optional `parameters`) |
+
+**Returns:** The created `ServiceConfiguration` instance.
+
+**Errors:**
+- `CONFIGURATION_ALREADY_EXISTS` if a configuration with the given ID already exists.
+- `INVALID_SERVICE_CONFIGURATION` if neither a default type nor dependencies are provided.
+
+**Behavior:**
+1. Verifies the ID does not already exist via `di_service.configuration_exists(id)`.
+2. Validates that at least one type source is provided.
+3. Creates a `ServiceConfigurationAggregate` via its `new()` factory.
+4. Saves via `di_service.save_configuration(configuration)`.
+
+```python
+result = DomainEvent.handle(
+    AddServiceConfiguration,
+    dependencies={'di_service': di_service},
+    id='error_repo',
+    module_path='myapp.repos.error',
+    class_name='ErrorYamlRepository',
+    parameters={'error_yaml_file': 'app/configs/error.yml'},
+)
+```
+
+### SetDefaultServiceConfiguration
+
+Sets or updates the default module/class and parameters for an existing service configuration.
+
+**Required:** `id` (positional)
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `module_path` | `str \| None` | `None` | New default module path |
+| `class_name` | `str \| None` | `None` | New default class name |
+| `parameters` | `Dict[str, Any] \| None` | `None` | New parameters. `None` clears all parameters. |
+
+**Returns:** The updated `ServiceConfiguration` instance.
+
+**Errors:**
+- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
+- `INVALID_SERVICE_CONFIGURATION` if only one of `module_path` or `class_name` is provided (both must be provided for an atomic type update).
+
+**Behavior:**
+- If both `module_path` and `class_name` are provided, updates the default type and parameters.
+- If neither is provided, only parameters are updated (or cleared) while keeping the existing type.
+- Parameters with `None` values are removed from the dict.
+
+```python
+DomainEvent.handle(
+    SetDefaultServiceConfiguration,
+    dependencies={'di_service': di_service},
+    id='error_repo',
+    module_path='myapp.repos.error_v2',
+    class_name='ErrorJsonRepository',
+    parameters={'error_json_file': 'app/configs/error.json'},
+)
+```
+
+### SetServiceDependency
+
+Adds or updates a flagged dependency on an existing service configuration. Uses PUT semantics — if the flag already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
+
+**Required:** `flag`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The service configuration identifier |
+| `module_path` | `str` | — | The module path for the dependency |
+| `class_name` | `str` | — | The class name for the dependency |
+| `parameters` | `Dict[str, Any]` | `{}` | Parameters for the dependency. Keys with `None` values are pruned during merge. |
+
+**Returns:** `str` — the service configuration ID.
+
+**Errors:**
+- `INVALID_FLAGGED_DEPENDENCY` if either `module_path` or `class_name` is empty.
+- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
+
+```python
+DomainEvent.handle(
+    SetServiceDependency,
+    dependencies={'di_service': di_service},
+    id='error_repo',
+    flag='json',
+    module_path='myapp.repos.error',
+    class_name='ErrorJsonRepository',
+    parameters={'error_json_file': 'app/configs/error.json'},
+)
+```
+
+### RemoveServiceDependency
+
+Removes a flagged dependency from an existing service configuration by flag. The removal is **idempotent** at the model level — removing a non-existent flag does not raise an error. However, post-removal validation ensures at least one type source remains.
+
+**Required:** `flag`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The service configuration identifier |
+
+**Returns:** `str` — the service configuration ID.
+
+**Errors:**
+- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
+- `INVALID_SERVICE_CONFIGURATION` if removing the dependency would leave no type source (no default type and no remaining dependencies).
+
+```python
+DomainEvent.handle(
+    RemoveServiceDependency,
+    dependencies={'di_service': di_service},
+    id='error_repo',
+    flag='json',
+)
+```
+
+### RemoveServiceConfiguration
+
+Deletes an entire service configuration by ID. The operation is **idempotent** — the underlying service handles non-existent IDs gracefully.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed configuration ID.
+
+```python
+DomainEvent.handle(
+    RemoveServiceConfiguration,
+    dependencies={'di_service': di_service},
+    id='error_repo',
+)
+```
+
+### SetServiceConstants
+
+Sets, merges, or clears service-level constants. Constants are global key-value pairs stored alongside service configurations.
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `constants` | `Dict[str, Any] \| None` | `{}` | Constants to apply. `None` clears all. Dict keys with `None` values are removed; others are merged. |
+
+**Returns:** `Dict[str, Any]` — the updated constants dictionary.
+
+**Merge semantics:**
+- `constants=None` → clears all constants.
+- `constants={'KEY': 'val'}` → merges into existing; existing keys are overwritten.
+- `constants={'KEY': None}` → removes `KEY` from the constants dict.
+- `constants={}` → no-op; existing constants are preserved.
+
+```python
+# Merge new constants
+DomainEvent.handle(
+    SetServiceConstants,
+    dependencies={'di_service': di_service},
+    constants={'APP_DIR': 'app', 'DEBUG': 'true'},
+)
+
+# Clear all constants
+DomainEvent.handle(
+    SetServiceConstants,
+    dependencies={'di_service': di_service},
+    constants=None,
+)
+```
+
+### ListAllSettings
+
+Lists all service configurations and constants. No required parameters.
+
+**Returns:** `Tuple[List[ServiceConfiguration], Dict[str, Any]]` — the list of configurations and the constants dictionary.
+
+```python
+configurations, constants = DomainEvent.handle(
+    ListAllSettings,
+    dependencies={'di_service': di_service},
+)
+```
+
+## Common Patterns
+
+### Retrieve → Verify → Mutate → Save
+
+Most mutation events (`SetDefaultServiceConfiguration`, `SetServiceDependency`, `RemoveServiceDependency`) follow a four-step pattern:
+
+1. **Retrieve** the configuration via `di_service.get_configuration(id)`.
+2. **Verify** it exists using `self.verify()`.
+3. **Mutate** the aggregate via its domain methods (`set_default_type`, `set_dependency`, `remove_dependency`).
+4. **Save** the updated aggregate via `di_service.save_configuration(configuration)`.
+
+### Type Source Invariant
+
+A service configuration must always have at least one type source — either a default type (`module_path` + `class_name`) or at least one flagged dependency. This invariant is enforced during creation (`AddServiceConfiguration`) and after dependency removal (`RemoveServiceDependency`).
+
+### Idempotent Deletes
+
+Both `RemoveServiceDependency` (at the model level) and `RemoveServiceConfiguration` are idempotent — they succeed silently if the target does not exist.
+
+### Container vs DI Events
+
+The DI events mirror the container events but use forward-compatible DI terminology:
+
+| Container (legacy) | DI (forward) |
+|---|---|
+| `ContainerService` | `DIService` |
+| `ContainerAttribute` | `ServiceConfiguration` |
+| `attribute_exists()` | `configuration_exists()` |
+| `get_attribute()` | `get_configuration()` |
+| `save_attribute()` | `save_configuration()` |
+| `delete_attribute()` | `delete_configuration()` |
+| `ATTRIBUTE_ALREADY_EXISTS` | `CONFIGURATION_ALREADY_EXISTS` |
+
+## Related Documentation
+
+- [docs/guides/domain/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/di.md) — DI domain objects
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and test harness
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions
+- [docs/guides/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/mappers.md) — Mapper strategies

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -213,6 +213,9 @@ SERVICE_CONFIGURATION_NOT_FOUND_ID = 'SERVICE_CONFIGURATION_NOT_FOUND'
 # ** constant: invalid_flagged_dependency_id
 INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
 
+# ** constant: configuration_already_exists_id
+CONFIGURATION_ALREADY_EXISTS_ID = 'CONFIGURATION_ALREADY_EXISTS'
+
 # ** constant: invalid_model_attribute_id
 INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
 
@@ -603,6 +606,18 @@ DEFAULT_ERRORS = {
             {
                 'lang': 'en_US',
                 'text': 'A flagged dependency must define both module_path and class_name.',
+            }
+        ],
+    },
+
+    # * error: CONFIGURATION_ALREADY_EXISTS
+    CONFIGURATION_ALREADY_EXISTS_ID: {
+        'id': CONFIGURATION_ALREADY_EXISTS_ID,
+        'name': 'Configuration Already Exists',
+        'message': [
+            {
+                'lang': 'en_US',
+                'text': 'A service configuration with ID {id} already exists.',
             }
         ],
     },

--- a/tiferet/events/di.py
+++ b/tiferet/events/di.py
@@ -1,0 +1,467 @@
+"""Tiferet DI Domain Events"""
+
+# *** imports
+
+# ** core
+from typing import Tuple, List, Dict, Any, Optional
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain.di import ServiceConfiguration
+from ..interfaces.di import DIService
+from ..mappers.di import ServiceConfigurationAggregate
+
+# *** events
+
+# ** event: add_service_configuration
+class AddServiceConfiguration(DomainEvent):
+    '''
+    A domain event to add a new service configuration.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the AddServiceConfiguration event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(
+        self,
+        id: str,
+        module_path: Optional[str] = None,
+        class_name: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = {},
+        flagged_dependencies: Optional[List[Dict[str, Any]]] = [],
+        **kwargs,
+    ) -> ServiceConfiguration:
+        '''
+        Add a new service configuration.
+
+        :param id: Required unique identifier.
+        :type id: str
+        :param module_path: Optional default module path.
+        :type module_path: str | None
+        :param class_name: Optional default class name.
+        :type class_name: str | None
+        :param parameters: Optional configuration parameters (default {}).
+        :type parameters: Dict[str, Any] | None
+        :param flagged_dependencies: Optional list of flagged dependencies (default []).
+        :type flagged_dependencies: List[Dict[str, Any]] | None
+        :return: Created ServiceConfiguration model.
+        :rtype: ServiceConfiguration
+        '''
+
+        # Check for existing configuration id.
+        self.verify(
+            not self.di_service.configuration_exists(id),
+            a.const.CONFIGURATION_ALREADY_EXISTS_ID,
+            id=id,
+        )
+
+        # Validate at least one type source (default type or flagged dependencies).
+        has_default = bool(module_path and class_name)
+        has_deps = bool(flagged_dependencies)
+        self.verify(
+            has_default or has_deps,
+            a.const.INVALID_SERVICE_CONFIGURATION_ID,
+        )
+
+        # Create service configuration aggregate from dependency dicts.
+        configuration = ServiceConfigurationAggregate.new(
+            service_configuration_data=dict(
+                id=id,
+                module_path=module_path,
+                class_name=class_name,
+                parameters=parameters,
+                dependencies=flagged_dependencies,
+            ),
+        )
+
+        # Save the new configuration and return it.
+        self.di_service.save_configuration(configuration)
+        return configuration
+
+# ** event: set_default_service_configuration
+class SetDefaultServiceConfiguration(DomainEvent):
+    '''
+    A domain event to set or update the default service configuration for an
+    existing service configuration.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the SetDefaultServiceConfiguration event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    def execute(
+        self,
+        id: str,
+        module_path: Optional[str] = None,
+        class_name: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> ServiceConfiguration:
+        '''
+        Set or update the default module/class and parameters for an
+        existing service configuration.
+
+        :param id: The unique service configuration identifier.
+        :type id: str
+        :param module_path: Optional default module path.
+        :type module_path: str | None
+        :param class_name: Optional default class name.
+        :type class_name: str | None
+        :param parameters: Optional configuration parameters. When None,
+            existing parameters are cleared.
+        :type parameters: Dict[str, Any] | None
+        :return: The updated service configuration.
+        :rtype: ServiceConfiguration
+        '''
+
+        # Retrieve the existing configuration.
+        configuration = self.di_service.get_configuration(id)
+
+        # Verify that the configuration exists.
+        self.verify(
+            configuration is not None,
+            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            id=id,
+        )
+
+        # If either module_path or class_name is provided, both must be
+        # non-None to ensure an atomic default type update.
+        if module_path is not None or class_name is not None:
+            self.verify(
+                module_path is not None and class_name is not None,
+                a.const.INVALID_SERVICE_CONFIGURATION_ID,
+            )
+
+            # Update both type and parameters via the model helper.
+            configuration.set_default_type(
+                module_path,
+                class_name,
+                parameters,
+            )
+        else:
+            # Only parameters are being updated (or cleared). Keep the
+            # existing module_path and class_name but delegate parameter
+            # handling/cleanup to the model helper.
+            configuration.set_default_type(
+                configuration.module_path,
+                configuration.class_name,
+                parameters,
+            )
+
+        # Persist the updated configuration and return it.
+        self.di_service.save_configuration(configuration)
+        return configuration
+
+# ** event: set_service_dependency
+class SetServiceDependency(DomainEvent):
+    '''
+    A domain event to set or update a flagged dependency on an existing
+    service configuration.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the SetServiceDependency event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['flag'])
+    def execute(
+        self,
+        id: str,
+        flag: str,
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = {},
+        **kwargs,
+    ) -> str:
+        '''
+        Set or update a flagged dependency for the given service
+        configuration.
+
+        :param id: The service configuration identifier.
+        :type id: str
+        :param flag: The flag that identifies the dependency.
+        :type flag: str
+        :param module_path: The module path for the dependency.
+        :type module_path: str
+        :param class_name: The class name for the dependency.
+        :type class_name: str
+        :param parameters: Parameters for the dependency.
+        :type parameters: Dict[str, Any]
+        :return: The service configuration id.
+        :rtype: str
+        '''
+
+        # Ensure module_path and class_name are both provided for a valid
+        # flagged dependency.
+        self.verify(
+            bool(module_path) and bool(class_name),
+            a.const.INVALID_FLAGGED_DEPENDENCY_ID,
+        )
+
+        # Retrieve the existing configuration.
+        configuration = self.di_service.get_configuration(id)
+
+        # Verify that the configuration exists.
+        self.verify(
+            configuration is not None,
+            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            id=id,
+        )
+
+        # Delegate to the model to set/update the flagged dependency.
+        configuration.set_dependency(
+            flag=flag,
+            module_path=module_path,
+            class_name=class_name,
+            parameters=parameters,
+        )
+
+        # Persist the updated configuration.
+        self.di_service.save_configuration(configuration)
+
+        # Return the id for convenience/confirmation.
+        return id
+
+
+# ** event: remove_service_dependency
+class RemoveServiceDependency(DomainEvent):
+    '''
+    A domain event to remove a flagged dependency from an existing service
+    configuration.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the RemoveServiceDependency event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['flag'])
+    def execute(
+        self,
+        id: str,
+        flag: str,
+        **kwargs,
+    ) -> str:
+        '''
+        Remove a flagged dependency from the given service configuration.
+
+        :param id: The service configuration identifier.
+        :type id: str
+        :param flag: The flag that identifies the dependency to remove.
+        :type flag: str
+        :return: The service configuration id.
+        :rtype: str
+        '''
+
+        # Retrieve the existing configuration.
+        configuration = self.di_service.get_configuration(id)
+
+        # Verify that the configuration exists.
+        self.verify(
+            configuration is not None,
+            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            id=id,
+        )
+
+        # Remove the dependency by flag (idempotent at the model level).
+        configuration.remove_dependency(flag)
+
+        # Post-removal validation: ensure a remaining type source.
+        has_default = bool(configuration.module_path and configuration.class_name)
+        has_deps = bool(configuration.dependencies)
+        self.verify(
+            has_default or has_deps,
+            a.const.INVALID_SERVICE_CONFIGURATION_ID,
+        )
+
+        # Persist the updated configuration.
+        self.di_service.save_configuration(configuration)
+
+        # Return the id for convenience/confirmation.
+        return id
+
+# ** event: remove_service_configuration
+class RemoveServiceConfiguration(DomainEvent):
+    '''
+    A domain event to remove a service configuration by ID.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the RemoveServiceConfiguration event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove a service configuration.
+
+        :param id: The unique identifier of the configuration to remove.
+        :type id: str
+        :param kwargs: Additional context.
+        :type kwargs: dict
+        :return: The removed configuration ID.
+        :rtype: str
+        '''
+
+        # Delete (idempotent; underlying service handles non-existent IDs).
+        self.di_service.delete_configuration(id)
+
+        # Return id for confirmation.
+        return id
+
+
+# ** event: set_service_constants
+class SetServiceConstants(DomainEvent):
+    '''
+    A domain event to set or clear service-level constants.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the SetServiceConstants event.
+
+        :param di_service: The DI service to use.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    def execute(
+        self,
+        constants: Optional[Dict[str, Any]] = {},
+        **kwargs,
+    ) -> Dict[str, Any]:
+        '''
+        Set service constants.
+
+        :param constants: New constants dictionary, or None to clear all.
+            Keys with None value are removed using pop-style semantics.
+        :type constants: Dict[str, Any] | None
+        :param kwargs: Additional context.
+        :type kwargs: dict
+        :return: The updated constants dictionary.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Retrieve current constants from the DI service.
+        _, current_constants = self.di_service.list_all()
+
+        if constants is None:
+            # Clear all constants.
+            updated = {}
+        else:
+            # Start from existing constants, then apply updates/removals.
+            updated = dict(current_constants or {})
+
+            # Update the current constants giving preference to the added ones.
+            updated.update(constants)
+
+            # Remove any constants with a value of None.
+            updated = {k: v for k, v in updated.items() if v != None}
+
+        # Persist the updated constants.
+        self.di_service.save_constants(updated)
+
+        # Return the updated constants dictionary.
+        return updated
+
+
+# ** event: list_all_settings
+class ListAllSettings(DomainEvent):
+    '''
+    A domain event to list all service configurations and constants.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * init
+    def __init__(self, di_service: DIService):
+        '''
+        Initialize the ListAllSettings event.
+
+        :param di_service: The DI service.
+        :type di_service: DIService
+        '''
+
+        # Set the event attributes.
+        self.di_service = di_service
+
+    # * method: execute
+    def execute(self) -> Tuple[List[ServiceConfiguration], Dict[str, Any]]:
+        '''
+        Execute the list all settings event.
+
+        :return: The list of all service configurations and constants.
+        :rtype: Tuple[List[ServiceConfiguration], Dict[str, Any]]
+        '''
+
+        # Return the list of all service configurations from the DI service.
+        return self.di_service.list_all()

--- a/tiferet/events/tests/test_di.py
+++ b/tiferet/events/tests/test_di.py
@@ -1,0 +1,817 @@
+"""Tests for Tiferet DI Domain Events"""
+
+# *** imports
+
+# ** core
+from typing import Tuple, Dict, Any, List
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..di import (
+    AddServiceConfiguration,
+    SetDefaultServiceConfiguration,
+    SetServiceDependency,
+    RemoveServiceDependency,
+    RemoveServiceConfiguration,
+    SetServiceConstants,
+    ListAllSettings,
+)
+from ..settings import DomainEvent, TiferetError, a
+from ...domain.di import ServiceConfiguration, FlaggedDependency
+from ...mappers.di import (
+    ServiceConfigurationAggregate,
+    FlaggedDependencyAggregate,
+)
+from ...mappers.settings import Aggregate
+from ...interfaces.di import DIService
+from .settings import DomainEventTestBase, ServiceEventTestBase
+
+# *** fixtures
+
+# ** fixture: flagged_dependency_for_di
+@pytest.fixture
+def flagged_dependency_for_di() -> FlaggedDependency:
+    '''
+    A flagged dependency instance for DI event tests.
+
+    :return: A FlaggedDependencyAggregate instance.
+    :rtype: FlaggedDependencyAggregate
+    '''
+
+    # Create a flagged dependency aggregate.
+    return Aggregate.new(
+        FlaggedDependencyAggregate,
+        module_path='tiferet.repos.example',
+        class_name='ExampleRepository',
+        flag='test_alpha',
+        parameters={
+            'test_param': 'test_value',
+            'param': 'value1',
+        },
+    )
+
+# ** fixture: service_configuration_aggregate
+@pytest.fixture
+def service_configuration_aggregate(flagged_dependency_for_di) -> ServiceConfigurationAggregate:
+    '''
+    A service configuration aggregate for DI event tests.
+
+    :param flagged_dependency_for_di: The flagged dependency fixture.
+    :type flagged_dependency_for_di: FlaggedDependency
+    :return: A ServiceConfigurationAggregate instance.
+    :rtype: ServiceConfigurationAggregate
+    '''
+
+    # Create a service configuration aggregate with a default type and one dependency.
+    return ServiceConfigurationAggregate.new(
+        service_configuration_data=dict(
+            id='svc_test',
+            module_path='tiferet.repos.example',
+            class_name='ExampleRepository',
+            parameters={'param_1': 'value_1'},
+            dependencies=[flagged_dependency_for_di],
+        ),
+    )
+
+# *** tests
+
+# ** test: TestAddServiceConfiguration
+class TestAddServiceConfiguration(DomainEventTestBase):
+    '''
+    Tests for AddServiceConfiguration using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddServiceConfiguration
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='svc_new',
+        module_path='tiferet.repos.example',
+        class_name='ExampleRepository',
+        parameters={'param': 'value'},
+        flagged_dependencies=[],
+    )
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self) -> dict:
+        '''
+        Override to pre-configure configuration_exists to return False.
+        '''
+
+        # Create the mock DI service.
+        service = mock.Mock(spec=DIService)
+        service.configuration_exists.return_value = False
+        return {'di_service': service}
+
+    # * method: test_default_type_only
+    def test_default_type_only(self, mock_dependencies):
+        '''
+        Test adding a configuration with only a default type.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result is a ServiceConfiguration instance.
+        assert isinstance(result, ServiceConfiguration)
+        assert result.id == 'svc_new'
+        assert result.module_path == 'tiferet.repos.example'
+        assert result.class_name == 'ExampleRepository'
+        assert result.parameters == {'param': 'value'}
+        assert result.dependencies == []
+
+        # Assert the service was called to check existence and save.
+        mock_dependencies['di_service'].configuration_exists.assert_called_once_with('svc_new')
+        mock_dependencies['di_service'].save_configuration.assert_called_once_with(result)
+
+    # * method: test_dependencies_only
+    def test_dependencies_only(self, mock_dependencies):
+        '''
+        Test adding a configuration with only flagged dependencies.
+        '''
+
+        # Execute via the harness with flagged_dependencies and no default type.
+        result = self.handle(
+            mock_dependencies,
+            module_path=None,
+            class_name=None,
+            parameters={},
+            flagged_dependencies=[
+                dict(
+                    module_path='tiferet.repos.example',
+                    class_name='ExampleRepository',
+                    flag='alpha',
+                    parameters={'flag_param': 'x'},
+                )
+            ],
+        )
+
+        # Assert the configuration was created with dependencies.
+        assert isinstance(result, ServiceConfiguration)
+        assert result.id == 'svc_new'
+        assert result.module_path is None
+        assert result.class_name is None
+        assert len(result.dependencies) == 1
+
+        # Assert the dependency was materialized correctly.
+        dep = result.dependencies[0]
+        assert dep.flag == 'alpha'
+        assert dep.module_path == 'tiferet.repos.example'
+
+    # * method: test_default_and_dependencies
+    def test_default_and_dependencies(self, mock_dependencies):
+        '''
+        Test adding a configuration with both a default type and dependencies.
+        '''
+
+        # Execute via the harness with both default type and flagged_dependencies.
+        result = self.handle(
+            mock_dependencies,
+            flagged_dependencies=[
+                dict(
+                    module_path='tiferet.repos.other',
+                    class_name='OtherRepository',
+                    flag='beta',
+                    parameters={},
+                )
+            ],
+        )
+
+        # Assert both default type and dependencies are present.
+        assert result.module_path == 'tiferet.repos.example'
+        assert result.class_name == 'ExampleRepository'
+        assert len(result.dependencies) == 1
+        assert result.dependencies[0].flag == 'beta'
+
+    # * method: test_duplicate_id
+    def test_duplicate_id(self, mock_dependencies):
+        '''
+        Test that adding a configuration with an existing ID raises an error.
+        '''
+
+        # Configure the service to report the ID already exists.
+        mock_dependencies['di_service'].configuration_exists.return_value = True
+
+        # Execute and expect a CONFIGURATION_ALREADY_EXISTS error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies)
+
+        assert exc_info.value.error_code == a.const.CONFIGURATION_ALREADY_EXISTS_ID
+
+    # * method: test_no_type_source
+    def test_no_type_source(self, mock_dependencies):
+        '''
+        Test that adding a configuration with no default type and no dependencies fails.
+        '''
+
+        # Execute with neither default type nor flagged dependencies.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(
+                mock_dependencies,
+                module_path=None,
+                class_name=None,
+                flagged_dependencies=[],
+            )
+
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+
+
+# ** test: TestSetDefaultServiceConfiguration
+class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
+    '''
+    Tests for SetDefaultServiceConfiguration using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetDefaultServiceConfiguration
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: service_attr
+    service_attr = 'di_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='svc_test',
+        module_path='new.module',
+        class_name='NewClass',
+        parameters={'param': 'value'},
+    )
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing',
+        module_path='mod',
+        class_name='Cls',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+        '''
+        Override to pre-configure get_configuration to return the fixture.
+        '''
+
+        # Create the mock DI service.
+        service = mock.Mock(spec=DIService)
+        service.get_configuration.return_value = service_configuration_aggregate
+        return {'di_service': service}
+
+    # * method: test_full_update
+    def test_full_update(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test updating both default type and parameters.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the configuration was updated.
+        assert result is service_configuration_aggregate
+        assert result.module_path == 'new.module'
+        assert result.class_name == 'NewClass'
+        assert result.parameters == {'param': 'value'}
+
+        # Assert the service was called to save.
+        mock_dependencies['di_service'].save_configuration.assert_called_once_with(result)
+
+    # * method: test_parameters_only
+    def test_parameters_only(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test updating only parameters when module_path and class_name are not provided.
+        '''
+
+        # Execute with no type update, just parameters.
+        result = self.handle(
+            mock_dependencies,
+            module_path=None,
+            class_name=None,
+            parameters={'param_1': 'updated', 'drop': None},
+        )
+
+        # Default type should remain unchanged.
+        assert result.module_path == 'tiferet.repos.example'
+        assert result.class_name == 'ExampleRepository'
+        # Parameters should be cleaned via set_default_type.
+        assert result.parameters == {'param_1': 'updated'}
+
+    # * method: test_clear_parameters
+    def test_clear_parameters(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test clearing parameters when parameters is None.
+        '''
+
+        # Execute with parameters=None to clear.
+        result = self.handle(
+            mock_dependencies,
+            module_path=None,
+            class_name=None,
+            parameters=None,
+        )
+
+        # Parameters should be cleared.
+        assert result.parameters == {}
+        assert result.module_path == 'tiferet.repos.example'
+
+    # * method: test_incomplete_type
+    def test_incomplete_type(self, mock_dependencies):
+        '''
+        Test that providing only one of module_path or class_name raises an error.
+        '''
+
+        # Execute with only module_path (no class_name).
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(
+                mock_dependencies,
+                module_path='new.module',
+                class_name=None,
+                parameters={'param': 'value'},
+            )
+
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+
+    # * method: test_not_found
+    def test_not_found(self, mock_dependencies):
+        '''
+        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        the DI service returns None.
+        '''
+
+        # Configure the service mock to return None.
+        mock_dependencies['di_service'].get_configuration.return_value = None
+
+        # Execute and expect the not-found error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, **self.not_found_kwargs)
+
+        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+
+# ** test: TestSetServiceDependency
+class TestSetServiceDependency(ServiceEventTestBase):
+    '''
+    Tests for SetServiceDependency using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetServiceDependency
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: service_attr
+    service_attr = 'di_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='svc_test',
+        flag='alpha',
+        module_path='tiferet.repos.example',
+        class_name='ExampleAlpha',
+        parameters={'param': 'value'},
+    )
+
+    # * attribute: required_params
+    required_params = ['flag']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing',
+        flag='alpha',
+        module_path='tiferet.repos.example',
+        class_name='ExampleAlpha',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+        '''
+        Override to pre-configure get_configuration to return the fixture.
+        '''
+
+        # Create the mock DI service.
+        service = mock.Mock(spec=DIService)
+        service.get_configuration.return_value = service_configuration_aggregate
+        return {'di_service': service}
+
+    # * method: test_add_new
+    def test_add_new(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test adding a new flagged dependency when the flag does not yet exist.
+        '''
+
+        # Remove existing dependencies to test adding a fresh one.
+        service_configuration_aggregate.dependencies = []
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the dependency was added.
+        assert result == 'svc_test'
+        dep = service_configuration_aggregate.get_dependency('alpha')
+        assert dep is not None
+        assert dep.module_path == 'tiferet.repos.example'
+        assert dep.class_name == 'ExampleAlpha'
+        assert dep.parameters == {'param': 'value'}
+
+        # Assert save was called.
+        mock_dependencies['di_service'].save_configuration.assert_called_once()
+
+    # * method: test_update_existing
+    def test_update_existing(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test updating an existing flagged dependency.
+        '''
+
+        # Execute with the same flag as the fixture dependency.
+        result = self.handle(
+            mock_dependencies,
+            flag='test_alpha',
+            module_path='tiferet.repos.updated',
+            class_name='UpdatedAlpha',
+            parameters={'test_param': 'updated', 'extra': None},
+        )
+
+        # Assert the dependency was updated.
+        assert result == 'svc_test'
+        dep = service_configuration_aggregate.get_dependency('test_alpha')
+        assert dep.module_path == 'tiferet.repos.updated'
+        assert dep.class_name == 'UpdatedAlpha'
+        # Parameters should be cleaned (None removed) and merged.
+        assert dep.parameters == {
+            'test_param': 'updated',
+            'param': 'value1',
+        }
+
+    # * method: test_incomplete_type
+    def test_incomplete_type(self, mock_dependencies):
+        '''
+        Test that providing an empty class_name raises INVALID_FLAGGED_DEPENDENCY.
+        '''
+
+        # Execute with an empty class_name.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(
+                mock_dependencies,
+                flag='alpha',
+                module_path='tiferet.repos.example',
+                class_name='',
+            )
+
+        assert exc_info.value.error_code == a.const.INVALID_FLAGGED_DEPENDENCY_ID
+
+    # * method: test_not_found
+    def test_not_found(self, mock_dependencies):
+        '''
+        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        the DI service returns None.
+        '''
+
+        # Configure the service mock to return None.
+        mock_dependencies['di_service'].get_configuration.return_value = None
+
+        # Execute and expect the not-found error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, **self.not_found_kwargs)
+
+        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+
+# ** test: TestRemoveServiceDependency
+class TestRemoveServiceDependency(ServiceEventTestBase):
+    '''
+    Tests for RemoveServiceDependency using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveServiceDependency
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: service_attr
+    service_attr = 'di_service'
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='svc_test',
+        flag='test_alpha',
+    )
+
+    # * attribute: required_params
+    required_params = ['flag']
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing_attr',
+        flag='alpha',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+        '''
+        Override to pre-configure get_configuration to return the fixture.
+        '''
+
+        # Create the mock DI service.
+        service = mock.Mock(spec=DIService)
+        service.get_configuration.return_value = service_configuration_aggregate
+        return {'di_service': service}
+
+    # * method: test_success_with_remaining_default
+    def test_success_with_remaining_default(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test removing a dependency while a default type remains configured.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the dependency was removed but default type remains.
+        assert result == 'svc_test'
+        assert service_configuration_aggregate.get_dependency('test_alpha') is None
+        assert service_configuration_aggregate.module_path == 'tiferet.repos.example'
+        assert service_configuration_aggregate.class_name == 'ExampleRepository'
+
+        # Assert save was called.
+        mock_dependencies['di_service'].save_configuration.assert_called_once()
+
+    # * method: test_nonexistent_flag
+    def test_nonexistent_flag(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test removing a non-existent flag is idempotent when type sources remain.
+        '''
+
+        # Execute with a flag that doesn't exist.
+        result = self.handle(mock_dependencies, flag='non_existent_flag')
+
+        # Dependencies and default type remain unchanged.
+        assert result == 'svc_test'
+        assert service_configuration_aggregate.get_dependency('test_alpha') is not None
+        assert service_configuration_aggregate.module_path == 'tiferet.repos.example'
+
+    # * method: test_invalid_after_removal
+    def test_invalid_after_removal(self, mock_dependencies, flagged_dependency_for_di):
+        '''
+        Test that removing the last type source raises INVALID_SERVICE_CONFIGURATION.
+        '''
+
+        # Create a configuration with only a dependency and no default type.
+        config = ServiceConfigurationAggregate.new(
+            service_configuration_data=dict(
+                id='svc_only_deps',
+                dependencies=[flagged_dependency_for_di],
+                parameters={},
+            ),
+        )
+        mock_dependencies['di_service'].get_configuration.return_value = config
+
+        # Execute and expect INVALID_SERVICE_CONFIGURATION.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, id='svc_only_deps', flag='test_alpha')
+
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+
+    # * method: test_not_found
+    def test_not_found(self, mock_dependencies):
+        '''
+        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        the DI service returns None.
+        '''
+
+        # Configure the service mock to return None.
+        mock_dependencies['di_service'].get_configuration.return_value = None
+
+        # Execute and expect the not-found error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, **self.not_found_kwargs)
+
+        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+
+
+# ** test: TestRemoveServiceConfiguration
+class TestRemoveServiceConfiguration(DomainEventTestBase):
+    '''
+    Tests for RemoveServiceConfiguration using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveServiceConfiguration
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='svc_to_delete')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_existing
+    def test_existing(self, mock_dependencies):
+        '''
+        Test removing an existing service configuration.
+        '''
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result is the deleted ID.
+        assert result == 'svc_to_delete'
+        mock_dependencies['di_service'].delete_configuration.assert_called_once_with('svc_to_delete')
+
+    # * method: test_nonexistent_is_idempotent
+    def test_nonexistent_is_idempotent(self, mock_dependencies):
+        '''
+        Test that removing a non-existent configuration is idempotent.
+        '''
+
+        # Execute with a non-existent ID.
+        result = self.handle(mock_dependencies, id='missing_id')
+
+        # Assert the result is the ID and delete was called.
+        assert result == 'missing_id'
+        mock_dependencies['di_service'].delete_configuration.assert_called_once_with('missing_id')
+
+
+# ** test: TestSetServiceConstants
+class TestSetServiceConstants(DomainEventTestBase):
+    '''
+    Tests for SetServiceConstants using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetServiceConstants
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(constants={'key': 'value'})
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self) -> dict:
+        '''
+        Override to pre-configure list_all to return existing constants.
+        '''
+
+        # Create the mock DI service with existing constants.
+        service = mock.Mock(spec=DIService)
+        service.list_all.return_value = ([], {'existing': 'old'})
+        return {'di_service': service}
+
+    # * method: test_clear_all_with_none
+    def test_clear_all_with_none(self, mock_dependencies):
+        '''
+        Test clearing all constants when None is passed.
+        '''
+
+        # Execute with constants=None.
+        result = self.handle(mock_dependencies, constants=None)
+
+        # Assert all constants were cleared.
+        assert result == {}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with({})
+
+    # * method: test_partial_removal
+    def test_partial_removal(self, mock_dependencies):
+        '''
+        Test removing keys with None values while preserving others.
+        '''
+
+        # Configure existing constants with a key to remove.
+        mock_dependencies['di_service'].list_all.return_value = (
+            [],
+            {'keep': 'value', 'remove': 'to_delete'},
+        )
+
+        # Execute with a removal.
+        result = self.handle(mock_dependencies, constants={'remove': None})
+
+        # Assert only the kept key remains.
+        assert result == {'keep': 'value'}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with({'keep': 'value'})
+
+    # * method: test_add_new
+    def test_add_new(self, mock_dependencies):
+        '''
+        Test adding new constants on top of existing ones.
+        '''
+
+        # Execute with a new constant.
+        result = self.handle(mock_dependencies, constants={'new': 'value'})
+
+        # Assert both existing and new constants are present.
+        assert result == {'existing': 'old', 'new': 'value'}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with(
+            {'existing': 'old', 'new': 'value'}
+        )
+
+    # * method: test_update_existing
+    def test_update_existing(self, mock_dependencies):
+        '''
+        Test updating existing constant values.
+        '''
+
+        # Execute with an updated constant.
+        result = self.handle(mock_dependencies, constants={'existing': 'new'})
+
+        # Assert the constant was updated.
+        assert result == {'existing': 'new'}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with({'existing': 'new'})
+
+    # * method: test_mixed_operations
+    def test_mixed_operations(self, mock_dependencies):
+        '''
+        Test adding, updating, and removing constants in a single call.
+        '''
+
+        # Configure multiple existing constants.
+        mock_dependencies['di_service'].list_all.return_value = (
+            [],
+            {'keep': 'value', 'remove': 'to_delete', 'update': 'old'},
+        )
+
+        # Execute with mixed operations.
+        result = self.handle(
+            mock_dependencies,
+            constants={
+                'remove': None,
+                'update': 'new',
+                'add': 'added',
+            },
+        )
+
+        # Assert the expected result.
+        expected = {'keep': 'value', 'update': 'new', 'add': 'added'}
+        assert result == expected
+        mock_dependencies['di_service'].save_constants.assert_called_once_with(expected)
+
+    # * method: test_empty_dict
+    def test_empty_dict(self, mock_dependencies):
+        '''
+        Test that an empty dict is idempotent (no changes).
+        '''
+
+        # Execute with an empty dict.
+        result = self.handle(mock_dependencies, constants={})
+
+        # Assert existing constants remain unchanged.
+        assert result == {'existing': 'old'}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with({'existing': 'old'})
+
+
+# ** test: TestListAllSettings
+class TestListAllSettings(DomainEventTestBase):
+    '''
+    Tests for ListAllSettings using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListAllSettings
+
+    # * attribute: dependencies
+    dependencies = {'di_service': DIService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict()
+
+    # * method: test_calls_list_all
+    def test_calls_list_all(self, mock_dependencies, service_configuration_aggregate):
+        '''
+        Test that ListAllSettings delegates to the DI service list_all method.
+        '''
+
+        # Configure the service to return a configuration and constants.
+        expected = ([service_configuration_aggregate], {'constant_1': 'value'})
+        mock_dependencies['di_service'].list_all.return_value = expected
+
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result matches the expected tuple.
+        assert result == expected
+        mock_dependencies['di_service'].list_all.assert_called_once()


### PR DESCRIPTION
Add the full CRUD event surface for `ServiceConfiguration` objects — 7 domain events for dependency injection management.

## Changes
- **`tiferet/events/di.py`** — New file. 7 domain events: `AddServiceConfiguration`, `SetDefaultServiceConfiguration`, `SetServiceDependency`, `RemoveServiceDependency`, `RemoveServiceConfiguration`, `SetServiceConstants`, `ListAllSettings`.
- **`tiferet/events/tests/test_di.py`** — New file. Complete test suite (31 tests) using the domain event test harness.
- **`docs/guides/events/di.md`** — New file. User-facing guide with per-event details, patterns, and examples.
- **`tiferet/assets/constants.py`** — Added `CONFIGURATION_ALREADY_EXISTS_ID` constant and `DEFAULT_ERRORS` entry.

Closes #636

Co-Authored-By: Oz <oz-agent@warp.dev>