### PR TITLE
Events – Add Error Events (#639)

### DIFF
--- a/docs/guides/events/error.md
+++ b/docs/guides/events/error.md
@@ -1,0 +1,251 @@
+# Events – Error Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/error.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The error event module provides the full CRUD surface for `Error` domain objects — the structured error definitions that power Tiferet's multilingual error handling. Every event in this module depends on an injected `ErrorService` and operates on `Error` domain objects through the `ErrorAggregate` mapper.
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `AddError` | Create | `id`, `name`, `message` | `Error` |
+| `GetError` | Read (single) | *(none)* | `Error` |
+| `ListErrors` | Read (all) | *(none)* | `List[Error]` |
+| `RenameError` | Update (name) | `new_name` | `Error` |
+| `SetErrorMessage` | Update (message) | `message` | `str` (ID) |
+| `RemoveErrorMessage` | Delete (message) | *(none)* | `str` (ID) |
+| `RemoveError` | Delete | `id` | `str` (ID) |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`error_service: ErrorService`** — the service interface for persisting and retrieving `Error` objects.
+
+## Event Details
+
+### AddError
+
+Creates a new `Error` with a primary message and optional additional language messages, then persists it via `ErrorService.save()`.
+
+**Required:** `id`, `name`, `message`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `lang` | `str` | `'en_US'` | Language code for the primary message |
+| `additional_messages` | `List[Dict[str, Any]]` | `[]` | Additional messages (each with `lang` and `text`) |
+
+**Returns:** The created `Error` instance.
+
+**Errors:**
+- `ERROR_ALREADY_EXISTS` if an error with the given ID already exists.
+
+```python
+result = DomainEvent.handle(
+    AddError,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+    name='Custom Validation Error',
+    message='Input validation failed for field {field}.',
+    additional_messages=[
+        {'lang': 'es_ES', 'text': 'La validación falló para el campo {field}.'}
+    ],
+)
+```
+
+### GetError
+
+Retrieves an `Error` by ID from the repository. Optionally falls back to built-in default errors defined in `assets/constants.py`.
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The error identifier |
+| `include_defaults` | `bool` | `False` | If `True`, search `DEFAULT_ERRORS` when not found in repository |
+
+**Returns:** The `Error` instance.
+
+**Errors:**
+- `ERROR_NOT_FOUND` if the error is not found in the repository (and not in defaults when `include_defaults=True`).
+
+**Behavior:**
+1. Attempts to retrieve from the repository via `error_service.get(id)`.
+2. If not found and `include_defaults=True`, checks `DEFAULT_ERRORS`.
+3. If still not found, raises `ERROR_NOT_FOUND`.
+
+```python
+# From repository only
+error = DomainEvent.handle(
+    GetError,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+)
+
+# With default fallback
+error = DomainEvent.handle(
+    GetError,
+    dependencies={'error_service': error_service},
+    id='COMMAND_PARAMETER_REQUIRED',
+    include_defaults=True,
+)
+```
+
+### ListErrors
+
+Lists all `Error` objects from the repository. Optionally merges with built-in defaults, where repository errors override defaults with the same ID.
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `include_defaults` | `bool` | `False` | If `True`, merge repository errors with `DEFAULT_ERRORS` |
+
+**Returns:** `List[Error]` — the list of error objects.
+
+**Merge semantics:**
+- Defaults are loaded first as a base dict keyed by ID.
+- Repository errors are merged on top, overriding any defaults with matching IDs.
+
+```python
+# Repository only
+errors = DomainEvent.handle(
+    ListErrors,
+    dependencies={'error_service': error_service},
+)
+
+# Including defaults
+errors = DomainEvent.handle(
+    ListErrors,
+    dependencies={'error_service': error_service},
+    include_defaults=True,
+)
+```
+
+### RenameError
+
+Renames an existing error by updating its `name` attribute.
+
+**Required:** `new_name`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The error identifier |
+
+**Returns:** The updated `Error` instance.
+
+**Errors:**
+- `ERROR_NOT_FOUND` if the error does not exist.
+
+```python
+DomainEvent.handle(
+    RenameError,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+    new_name='Field Validation Error',
+)
+```
+
+### SetErrorMessage
+
+Sets or updates the message text for a specific language on an existing error. If the language already exists, the text is replaced; otherwise a new message is added.
+
+**Required:** `message`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The error identifier |
+| `lang` | `str` | `'en_US'` | The language code for the message |
+
+**Returns:** `str` — the error ID.
+
+**Errors:**
+- `ERROR_NOT_FOUND` if the error does not exist.
+
+```python
+DomainEvent.handle(
+    SetErrorMessage,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+    message='Validation failed for {field}.',
+    lang='en_US',
+)
+```
+
+### RemoveErrorMessage
+
+Removes a message for a specific language from an existing error. Post-removal validation ensures at least one message remains.
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | — | The error identifier |
+| `lang` | `str` | `'en_US'` | The language code of the message to remove |
+
+**Returns:** `str` — the error ID.
+
+**Errors:**
+- `ERROR_NOT_FOUND` if the error does not exist.
+- `NO_ERROR_MESSAGES` if removing the message would leave the error with no messages.
+
+```python
+DomainEvent.handle(
+    RemoveErrorMessage,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+    lang='es_ES',
+)
+```
+
+### RemoveError
+
+Deletes an entire error by ID. The operation is **idempotent** — the underlying service handles non-existent IDs gracefully.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed error ID.
+
+```python
+DomainEvent.handle(
+    RemoveError,
+    dependencies={'error_service': error_service},
+    id='CUSTOM_VALIDATION_ERROR',
+)
+```
+
+## Common Patterns
+
+### Retrieve → Verify → Mutate → Save
+
+Most mutation events (`RenameError`, `SetErrorMessage`, `RemoveErrorMessage`) follow a four-step pattern:
+
+1. **Retrieve** the error via `error_service.get(id)`.
+2. **Verify** it exists using `self.verify()`.
+3. **Mutate** the aggregate via its domain methods (`rename`, `set_message`, `remove_message`).
+4. **Save** the updated aggregate via `error_service.save(error)`.
+
+### Message Invariant
+
+An error must always have at least one message. This invariant is enforced after message removal (`RemoveErrorMessage`) via a `verify` check on `len(error.message) > 0`.
+
+### Default Error Fallback
+
+`GetError` and `ListErrors` support an `include_defaults` flag that incorporates the built-in `DEFAULT_ERRORS` dict from `tiferet/assets/constants.py`. Repository errors always take precedence over defaults with the same ID.
+
+## Related Documentation
+
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and test harness
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions
+- [docs/guides/mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/mappers.md) — Mapper strategies

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -1,0 +1,405 @@
+"""Tiferet Error Events"""
+
+# *** imports
+
+# ** core
+from typing import (
+    List,
+    Dict,
+    Any
+)
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..interfaces import ErrorService
+from ..mappers import ErrorAggregate
+
+# *** events
+
+# ** event: add_error
+class AddError(DomainEvent):
+    '''
+    Event to add a new Error domain object to the repository.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the AddError event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'message'])
+    def execute(self,
+            id: str,
+            name: str,
+            message: str,
+            lang: str = 'en_US',
+            additional_messages: List[Dict[str, Any]] = []
+        ) -> None:
+        '''
+        Add a new Error to the app.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param name: The name of the error.
+        :type name: str
+        :param message: The primary error message text.
+        :type message: str
+        :param lang: The language of the primary error message (default is 'en_US').
+        :type lang: str
+        :param additional_messages: Additional error messages in different languages.
+        :type additional_messages: List[Dict[str, Any]]
+        '''
+
+        # Check if an error with the same ID already exists.
+        exists = self.error_service.exists(id)
+        self.verify(
+            expression=exists is False,
+            error_code=a.const.ERROR_ALREADY_EXISTS_ID,
+            message=f'An error with ID {id} already exists.',
+            id=id
+        )
+
+        # Create the Error aggregate.
+        error_messages = [{'lang': lang, 'text': message}] + additional_messages
+        new_error = ErrorAggregate.new(
+            id=id,
+            name=name,
+            message=error_messages
+        )
+
+        # Save the new error.
+        self.error_service.save(new_error)
+
+        # Return the new error.
+        return new_error
+
+# ** event: get_error
+class GetError(DomainEvent):
+    '''
+    Event to retrieve an Error domain object by its ID.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the GetError event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, id: str, include_defaults: bool = False, **kwargs) -> Error:
+        '''
+        Retrieve an Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param include_defaults: If True, search DEFAULT_ERRORS if not found in repository.
+        :type include_defaults: bool
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The Error domain model instance.
+        :rtype: Error
+        '''
+
+        # Attempt to retrieve from configured repository.
+        error = self.error_service.get(id)
+
+        # If found, return immediately.
+        if error:
+            return error
+
+        # If requested, check built-in defaults and return as error aggregate if found.
+        if include_defaults:
+            error_data = a.DEFAULT_ERRORS.get(id)
+            if error_data:
+                return ErrorAggregate.new(**error_data)
+
+        # If still not found and defaults not included, raise structured error.
+        self.raise_error(
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id,
+        )
+
+# ** event: list_errors
+class ListErrors(DomainEvent):
+    '''
+    Event to list all Error domain objects.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the ListErrors event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, include_defaults: bool = False, **kwargs) -> List[Error]:
+        '''
+        List all Errors.
+
+        :param include_defaults: If True, include DEFAULT_ERRORS in the list.
+        :type include_defaults: bool
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The list of Error domain model instances.
+        :rtype: List[Error]
+        '''
+
+        # If defaults are not included, retrieve from repository only.
+        if not include_defaults:
+            return self.error_service.list()
+
+        # If defaults are included, merge repository and default errors.
+        errors = {id: ErrorAggregate.new(**data) for id, data in a.const.DEFAULT_ERRORS.items()}
+        repo_errors = self.error_service.list()
+        errors.update({error.id: error for error in repo_errors})
+
+        # Return the merged list of errors.
+        return list(errors.values())
+
+# ** event: rename_error
+class RenameError(DomainEvent):
+    '''
+    Event to rename an existing Error domain object.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the RenameError event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['new_name'])
+    def execute(self, id: str, new_name: str, **kwargs) -> Error:
+        '''
+        Rename an existing Error by its ID.
+
+        :param id: The unique identifier of the error to rename.
+        :type id: str
+        :param new_name: The new name for the error.
+        :type new_name: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The updated Error domain model instance.
+        :rtype: Error
+        '''
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+
+        # Verify that the error exists.
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Update the name.
+        error.rename(new_name)
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error.
+        return error
+
+# ** event: set_error_message
+class SetErrorMessage(DomainEvent):
+    '''
+    Event to set the message of an existing Error domain object.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the SetErrorMessage event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['message'])
+    def execute(self, id: str, message: str, lang: str = 'en_US', **kwargs) -> str:
+        '''
+        Set the message of an existing Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param message: The new message text.
+        :type message: str
+        :param lang: The language of the message (default is 'en_US').
+        :type lang: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The unique identifier of the updated error.
+        :rtype: str
+        '''
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+
+        # Verify that the error exists.
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Update the message.
+        error.set_message(lang, message)
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error id.
+        return id
+
+# ** event: remove_error_message
+class RemoveErrorMessage(DomainEvent):
+    '''
+    Event to remove a message from an existing Error domain object.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the RemoveErrorMessage event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, id: str, lang: str = 'en_US', **kwargs) -> str:
+        '''
+        Remove a message from an existing Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param lang: The language of the message to remove (default is 'en_US').
+        :type lang: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The unique identifier of the updated error.
+        :rtype: str
+        '''
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Remove the message.
+        error.remove_message(lang)
+
+        # Verify that at least one message remains.
+        self.verify(
+            expression=len(error.message) > 0,
+            error_code=a.const.NO_ERROR_MESSAGES_ID,
+            message=f'No error messages are defined for error ID {id}.',
+            id=id
+        )
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error id.
+        return id
+
+# ** event: remove_error
+class RemoveError(DomainEvent):
+    '''
+    Event to remove an existing Error domain object by its ID.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the RemoveError event.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> None:
+        '''
+        Remove an existing Error by its ID.
+
+        :param id: The unique identifier of the error to remove.
+        :type id: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        '''
+
+        # Remove the error.
+        self.error_service.delete(id)
+
+        # Return the removed error id.
+        return id

--- a/tiferet/events/tests/test_error.py
+++ b/tiferet/events/tests/test_error.py
@@ -1,0 +1,542 @@
+"""Tiferet Tests for Error Events"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..error import (
+    AddError,
+    GetError,
+    ListErrors,
+    RenameError,
+    SetErrorMessage,
+    RemoveErrorMessage,
+    RemoveError,
+)
+from ..settings import DomainEvent, TiferetError, a
+from ...domain import Error
+from ...interfaces import ErrorService
+from ...mappers import ErrorAggregate
+from .settings import DomainEventTestBase, ServiceEventTestBase
+
+# *** fixtures
+
+# ** fixture: error
+@pytest.fixture
+def error() -> ErrorAggregate:
+    '''
+    A sample Error aggregate for event tests.
+
+    :return: An ErrorAggregate instance.
+    :rtype: ErrorAggregate
+    '''
+
+    # Create a sample error aggregate.
+    return ErrorAggregate.new(
+        id='TEST_ERROR',
+        name='Test Error',
+        message=[{
+            'lang': 'en_US',
+            'text': 'This is a test error message.'
+        }]
+    )
+
+# ** fixture: default_errors
+@pytest.fixture
+def default_errors() -> List[Error]:
+    '''
+    A list of default Error instances from constants.
+
+    :return: A list of default Error instances.
+    :rtype: List[Error]
+    '''
+
+    # Return a list of default Error aggregates.
+    return [
+        ErrorAggregate.new(**data) for data in a.DEFAULT_ERRORS.values()
+    ]
+
+# *** tests
+
+# ** test: TestAddError
+class TestAddError(DomainEventTestBase):
+    '''
+    Tests for AddError using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddError
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='NEW_ERROR',
+        name='New Error',
+        message='This is a new error message.',
+        lang='en_US',
+        additional_messages=[],
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'message']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self) -> dict:
+        '''
+        Override to pre-configure exists to return False.
+        '''
+
+        # Create the mock error service.
+        service = mock.Mock(spec=ErrorService)
+        service.exists.return_value = False
+        return {'error_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test adding a new error successfully.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the error was created correctly.
+        assert isinstance(result, Error)
+        assert result.id == 'NEW_ERROR'
+        assert result.name == 'New Error'
+        assert any(msg.text == 'This is a new error message.' and msg.lang == 'en_US' for msg in result.message)
+
+        # Assert the service was called correctly.
+        mock_dependencies['error_service'].exists.assert_called_once_with('NEW_ERROR')
+        mock_dependencies['error_service'].save.assert_called_once_with(result)
+
+    # * method: test_with_additional_messages
+    def test_with_additional_messages(self, mock_dependencies):
+        '''
+        Test adding a new error with additional language messages.
+        '''
+
+        # Execute with additional messages.
+        result = self.handle(
+            mock_dependencies,
+            additional_messages=[{'lang': 'es_ES', 'text': 'Este es un nuevo error.'}],
+        )
+
+        # Assert both messages are present.
+        assert len(result.message) == 2
+        assert any(msg.text == 'This is a new error message.' and msg.lang == 'en_US' for msg in result.message)
+        assert any(msg.text == 'Este es un nuevo error.' and msg.lang == 'es_ES' for msg in result.message)
+
+    # * method: test_already_exists
+    def test_already_exists(self, mock_dependencies):
+        '''
+        Test that adding an error with an existing ID raises an error.
+        '''
+
+        # Configure the service to report the ID already exists.
+        mock_dependencies['error_service'].exists.return_value = True
+
+        # Execute and expect an ERROR_ALREADY_EXISTS error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies)
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.ERROR_ALREADY_EXISTS_ID
+
+
+# ** test: TestGetError
+class TestGetError(ServiceEventTestBase):
+    '''
+    Tests for GetError using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = GetError
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: service_attr
+    service_attr = 'error_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.ERROR_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='TEST_ERROR')
+
+    # * attribute: required_params
+    required_params = []
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, error) -> dict:
+        '''
+        Override to pre-configure get to return the error fixture.
+        '''
+
+        # Create the mock error service.
+        service = mock.Mock(spec=ErrorService)
+        service.get.return_value = error
+        return {'error_service': service}
+
+    # * method: test_found_in_repo
+    def test_found_in_repo(self, mock_dependencies, error):
+        '''
+        Test retrieving an error found in the repository.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result matches the fixture.
+        assert result == error
+        mock_dependencies['error_service'].get.assert_called_once_with('TEST_ERROR')
+
+    # * method: test_found_in_defaults
+    def test_found_in_defaults(self, mock_dependencies):
+        '''
+        Test retrieving an error from built-in defaults when not in repository.
+        '''
+
+        # Configure the service to return None (not in repo).
+        mock_dependencies['error_service'].get.return_value = None
+
+        # Execute with include_defaults and a known default error ID.
+        error_id = a.const.ERROR_NOT_FOUND_ID
+        result = self.handle(
+            mock_dependencies,
+            id=error_id,
+            include_defaults=True,
+        )
+
+        # Assert the result matches the expected default error.
+        expected = ErrorAggregate.new(**a.DEFAULT_ERRORS.get(error_id))
+        assert result == expected
+        mock_dependencies['error_service'].get.assert_called_once_with(error_id)
+
+
+# ** test: TestListErrors
+class TestListErrors(DomainEventTestBase):
+    '''
+    Tests for ListErrors using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListErrors
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict()
+
+    # * attribute: required_params
+    required_params = []
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, error):
+        '''
+        Test listing errors from the repository.
+        '''
+
+        # Configure the mock to return a list with the error fixture.
+        mock_dependencies['error_service'].list.return_value = [error]
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result matches.
+        assert result == [error]
+        mock_dependencies['error_service'].list.assert_called_once()
+
+    # * method: test_with_defaults
+    def test_with_defaults(self, mock_dependencies, default_errors):
+        '''
+        Test listing errors including default errors.
+        '''
+
+        # Configure the mock to return a list with an additional error.
+        existing_error = ErrorAggregate.new(
+            id='EXISTING_ERROR',
+            name='Existing Error',
+            message=[{
+                'lang': 'en_US',
+                'text': 'This is an existing error message.'
+            }]
+        )
+        mock_dependencies['error_service'].list.return_value = [existing_error]
+
+        # Execute with include_defaults.
+        result = self.handle(mock_dependencies, include_defaults=True)
+
+        # Assert the result includes both existing and default errors.
+        expected_errors = [existing_error] + default_errors
+        assert len(result) == len(expected_errors)
+        for err in expected_errors:
+            assert err in result
+
+    # * method: test_with_defaults_and_override
+    def test_with_defaults_and_override(self, mock_dependencies, default_errors):
+        '''
+        Test listing errors with a repository error that overrides a default.
+        '''
+
+        # Create a repo error that overrides the default ERROR_NOT_FOUND.
+        overriding_error = ErrorAggregate.new(
+            id=a.const.ERROR_NOT_FOUND_ID,
+            name='Overriding Not Found Error',
+            message=[{
+                'lang': 'en_US',
+                'text': 'This is an overridden not found error message.'
+            }]
+        )
+        mock_dependencies['error_service'].list.return_value = [overriding_error]
+
+        # Execute with include_defaults.
+        result = self.handle(mock_dependencies, include_defaults=True)
+
+        # Assert the override replaces the default.
+        expected_errors = [overriding_error] + [
+            err for err in default_errors if err.id != a.const.ERROR_NOT_FOUND_ID
+        ]
+        assert len(result) == len(expected_errors)
+        for err in expected_errors:
+            assert err in result
+
+    # * method: test_no_errors_with_defaults
+    def test_no_errors_with_defaults(self, mock_dependencies, default_errors):
+        '''
+        Test listing errors when repository is empty and only defaults exist.
+        '''
+
+        # Configure the mock to return an empty list.
+        mock_dependencies['error_service'].list.return_value = []
+
+        # Execute with include_defaults.
+        result = self.handle(mock_dependencies, include_defaults=True)
+
+        # Assert only default errors are returned.
+        assert len(result) == len(default_errors)
+        for err in default_errors:
+            assert err in result
+
+
+# ** test: TestRenameError
+class TestRenameError(ServiceEventTestBase):
+    '''
+    Tests for RenameError using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RenameError
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: service_attr
+    service_attr = 'error_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.ERROR_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='TEST_ERROR', new_name='Renamed Error')
+
+    # * attribute: required_params
+    required_params = ['new_name']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, error) -> dict:
+        '''
+        Override to pre-configure get to return the error fixture.
+        '''
+
+        # Create the mock error service.
+        service = mock.Mock(spec=ErrorService)
+        service.get.return_value = error
+        return {'error_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, error):
+        '''
+        Test renaming an existing error successfully.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the error was renamed.
+        assert result == error
+        assert error.name == 'Renamed Error'
+        mock_dependencies['error_service'].get.assert_called_once_with('TEST_ERROR')
+        mock_dependencies['error_service'].save.assert_called_once_with(error)
+
+
+# ** test: TestSetErrorMessage
+class TestSetErrorMessage(ServiceEventTestBase):
+    '''
+    Tests for SetErrorMessage using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = SetErrorMessage
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: service_attr
+    service_attr = 'error_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.ERROR_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='TEST_ERROR',
+        message='Updated error message.',
+        lang='en_US',
+    )
+
+    # * attribute: required_params
+    required_params = ['message']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, error) -> dict:
+        '''
+        Override to pre-configure get to return the error fixture.
+        '''
+
+        # Create the mock error service.
+        service = mock.Mock(spec=ErrorService)
+        service.get.return_value = error
+        return {'error_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, error):
+        '''
+        Test setting a message for an existing error successfully.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the ID is returned and the message was updated.
+        assert result == 'TEST_ERROR'
+        assert any(msg.text == 'Updated error message.' and msg.lang == 'en_US' for msg in error.message)
+        mock_dependencies['error_service'].get.assert_called_once_with('TEST_ERROR')
+        mock_dependencies['error_service'].save.assert_called_once_with(error)
+
+
+# ** test: TestRemoveErrorMessage
+class TestRemoveErrorMessage(ServiceEventTestBase):
+    '''
+    Tests for RemoveErrorMessage using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveErrorMessage
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: service_attr
+    service_attr = 'error_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.ERROR_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='TEST_ERROR', lang='es_ES')
+
+    # * attribute: required_params
+    required_params = []
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, error) -> dict:
+        '''
+        Override to pre-configure get with an error that has two messages.
+        '''
+
+        # Add a second message so the remove succeeds.
+        error.set_message('es_ES', 'Este es un mensaje de error de prueba.')
+
+        # Create the mock error service.
+        service = mock.Mock(spec=ErrorService)
+        service.get.return_value = error
+        return {'error_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, error):
+        '''
+        Test removing a message from an existing error successfully.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the ID is returned and the message was removed.
+        assert result == 'TEST_ERROR'
+        assert all(msg.lang != 'es_ES' for msg in error.message)
+        mock_dependencies['error_service'].get.assert_called_once_with('TEST_ERROR')
+        mock_dependencies['error_service'].save.assert_called_once_with(error)
+
+    # * method: test_no_messages_left
+    def test_no_messages_left(self, mock_dependencies, error):
+        '''
+        Test that removing the last message raises NO_ERROR_MESSAGES.
+        '''
+
+        # Remove the es_ES message added by mock_dependencies so only en_US remains.
+        error.remove_message('es_ES')
+
+        # Execute removing the only remaining message (en_US).
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, lang='en_US')
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.NO_ERROR_MESSAGES_ID
+
+
+# ** test: TestRemoveError
+class TestRemoveError(DomainEventTestBase):
+    '''
+    Tests for RemoveError using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveError
+
+    # * attribute: dependencies
+    dependencies = {'error_service': ErrorService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='TEST_ERROR')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test removing an existing error successfully.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the ID is returned and delete was called.
+        assert result == 'TEST_ERROR'
+        mock_dependencies['error_service'].delete.assert_called_once_with('TEST_ERROR')


### PR DESCRIPTION
Add 7 error domain events, test suite using domain event test harness, and user-facing guide.

## Changes
- **`tiferet/events/error.py`** — New file. 7 domain events: `AddError`, `GetError`, `ListErrors`, `RenameError`, `SetErrorMessage`, `RemoveErrorMessage`, `RemoveError`. All inject `ErrorService` and operate through `ErrorAggregate`.
- **`tiferet/events/tests/test_error.py`** — New file. 7 test harness classes (24 pass, 3 skip). Auto-parametrized `test_missing_required_params` and `test_not_found` all work.
- **`docs/guides/events/error.md`** — New file. User-facing guide with event details, invocation examples, and common patterns.

Closes #639

Co-Authored-By: Oz <oz-agent@warp.dev>