### PR TITLE
Events – Add Feature Events (#640)

### DIFF
--- a/docs/guides/events/feature.md
+++ b/docs/guides/events/feature.md
@@ -1,0 +1,273 @@
+# Events – Feature Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/feature.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The feature event module provides the full CRUD surface for `Feature` domain objects — the configuration-driven workflow definitions that power Tiferet's feature execution engine. Every event in this module depends on an injected `FeatureService` and operates on `Feature` domain objects through the `FeatureAggregate` mapper.
+
+Features are composed of ordered **steps** (`FeatureEvent` instances), each referencing a `service_id` that maps to a service configuration in the dependency injection container.
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `AddFeature` | Create | `name`, `group_id` | `Feature` |
+| `GetFeature` | Read (single) | `id` | `Feature` |
+| `ListFeatures` | Read (all/filtered) | *(none)* | `List[Feature]` |
+| `RemoveFeature` | Delete | `id` | `str` (ID) |
+| `UpdateFeature` | Update (metadata) | `id`, `attribute` | `Feature` |
+| `AddFeatureStep` | Add step | `id`, `name`, `service_id` | `str` (ID) |
+| `UpdateFeatureStep` | Update step | `id`, `position`, `attribute` | `str` (ID) |
+| `RemoveFeatureStep` | Remove step | `id`, `position` | `str` (ID) |
+| `ReorderFeatureStep` | Reorder step | `id`, `start_position`, `end_position` | `str` (ID) |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`feature_service: FeatureService`** — the service interface for persisting and retrieving `Feature` objects.
+
+## Event Details
+
+### AddFeature
+
+Creates a new `Feature` with derived defaults, then persists it via `FeatureService.save()`.
+
+**Required:** `name`, `group_id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `feature_key` | `str` | snake_case of `name` | Explicit feature key |
+| `id` | `str` | `{group_id}.{feature_key}` | Explicit full feature ID |
+| `description` | `str` | same as `name` | Feature description |
+| `steps` | `list` | `[]` | Initial feature steps |
+| `log_params` | `dict` | `{}` | Logging parameters |
+
+**Returns:** The created `Feature` instance.
+
+**Errors:**
+- `FEATURE_ALREADY_EXISTS` if a feature with the derived/explicit ID already exists.
+
+```python
+result = DomainEvent.handle(
+    AddFeature,
+    dependencies={'feature_service': feature_service},
+    name='Calculate Sum',
+    group_id='calc',
+)
+```
+
+### GetFeature
+
+Retrieves a `Feature` by ID from the repository.
+
+**Required:** `id`
+
+**Returns:** The `Feature` instance.
+
+**Errors:**
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+
+```python
+feature = DomainEvent.handle(
+    GetFeature,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+)
+```
+
+### ListFeatures
+
+Lists `Feature` objects, optionally filtered by `group_id`.
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `group_id` | `str` | `None` | Filter by group identifier |
+
+**Returns:** `List[Feature]` — the list of feature objects.
+
+```python
+# All features
+features = DomainEvent.handle(
+    ListFeatures,
+    dependencies={'feature_service': feature_service},
+)
+
+# Filtered by group
+features = DomainEvent.handle(
+    ListFeatures,
+    dependencies={'feature_service': feature_service},
+    group_id='calc',
+)
+```
+
+### RemoveFeature
+
+Removes a feature by ID. Delegates to `FeatureService.delete()`, which is expected to be idempotent.
+
+**Required:** `id`
+
+**Returns:** `str` — the feature ID.
+
+```python
+DomainEvent.handle(
+    RemoveFeature,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+)
+```
+
+### UpdateFeature
+
+Updates basic metadata (`name` or `description`) on an existing feature.
+
+**Required:** `id`, `attribute`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `value` | `Any` | — | The new value for the attribute |
+
+**Supported attributes:** `name`, `description`
+
+**Returns:** The updated `Feature` instance.
+
+**Errors:**
+- `INVALID_FEATURE_ATTRIBUTE` if the attribute is not `name` or `description`.
+- `FEATURE_NAME_REQUIRED` if updating `name` with an empty value.
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+
+```python
+DomainEvent.handle(
+    UpdateFeature,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+    attribute='name',
+    value='Calculate Total',
+)
+```
+
+### AddFeatureStep
+
+Adds a step to an existing feature's workflow. Steps reference a `service_id` that maps to a service configuration in the DI container.
+
+**Required:** `id`, `name`, `service_id`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `parameters` | `dict` | `{}` | Step parameters |
+| `data_key` | `str` | `None` | Result data key |
+| `pass_on_error` | `bool` | `False` | Whether to continue on error |
+| `position` | `int` | `None` | Insertion position (None to append) |
+
+**Returns:** `str` — the feature ID.
+
+**Errors:**
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+
+```python
+DomainEvent.handle(
+    AddFeatureStep,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+    name='Add Numbers',
+    service_id='add_number_event',
+    parameters={'precision': '2'},
+    data_key='sum_result',
+)
+```
+
+### UpdateFeatureStep
+
+Updates an attribute on a feature step at a given position.
+
+**Required:** `id`, `position`, `attribute`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `value` | `Any` | `None` | The new value for the attribute |
+
+**Supported attributes:** `name`, `service_id`, `data_key`, `pass_on_error`, `parameters`
+
+**Returns:** `str` — the feature ID.
+
+**Errors:**
+- `INVALID_FEATURE_COMMAND_ATTRIBUTE` if the attribute is not supported.
+- `COMMAND_PARAMETER_REQUIRED` if updating `name` or `service_id` with an empty value.
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+- `FEATURE_COMMAND_NOT_FOUND` if no step exists at the given position.
+
+```python
+DomainEvent.handle(
+    UpdateFeatureStep,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+    position=0,
+    attribute='service_id',
+    value='updated_service',
+)
+```
+
+### RemoveFeatureStep
+
+Removes a step from a feature by position. Idempotent — invalid positions result in a no-op.
+
+**Required:** `id`, `position`
+
+**Returns:** `str` — the feature ID.
+
+**Errors:**
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+
+```python
+DomainEvent.handle(
+    RemoveFeatureStep,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+    position=0,
+)
+```
+
+### ReorderFeatureStep
+
+Moves a feature step from one position to another. The target position is clamped to the valid range. Idempotent for invalid start positions.
+
+**Required:** `id`, `start_position`, `end_position`
+
+**Returns:** `str` — the feature ID.
+
+**Errors:**
+- `FEATURE_NOT_FOUND` if the feature does not exist.
+
+```python
+DomainEvent.handle(
+    ReorderFeatureStep,
+    dependencies={'feature_service': feature_service},
+    id='calc.calculate_sum',
+    start_position=0,
+    end_position=2,
+)
+```
+
+## Migration Notes
+
+### v2.0.0a6 Changes
+
+- **Class renames:** `AddFeatureCommand` → `AddFeatureStep`, `UpdateFeatureCommand` → `UpdateFeatureStep`, `RemoveFeatureCommand` → `RemoveFeatureStep`, `ReorderFeatureCommand` → `ReorderFeatureStep`.
+- **Parameter renames:** `attribute_id` → `service_id` in `AddFeatureStep.execute()` and `UpdateFeatureStep` valid attributes.
+- **Parameter renames:** `commands` → `steps` in `AddFeature.execute()`.
+- **Artifact comments:** Updated from `# *** commands` / `# ** command:` to `# *** events` / `# ** event:`.
+- **Unused imports removed:** `Aggregate` and `FeatureEventAggregate` no longer imported.

--- a/tiferet/events/feature.py
+++ b/tiferet/events/feature.py
@@ -1,0 +1,668 @@
+"""Tiferet Feature Events"""
+
+# *** imports
+
+# ** core
+from typing import List, Any
+
+# ** app
+from ..domain import Feature
+from ..interfaces import FeatureService
+from ..mappers import FeatureAggregate
+from .settings import DomainEvent, a
+
+# *** events
+
+# ** event: add_feature
+class AddFeature(DomainEvent):
+    '''
+    Event to add a new feature configuration.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        '''
+        Initialize the AddFeature event.
+
+        :param feature_service: The feature service to use for managing feature configurations.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['name', 'group_id'])
+    def execute(
+            self,
+            name: str,
+            group_id: str,
+            feature_key: str | None = None,
+            id: str | None = None,
+            description: str | None = None,
+            steps: list | None = None,
+            log_params: dict | None = None,
+            **kwargs,
+        ) -> Feature:
+        '''
+        Add a new feature.
+
+        :param name: Required feature name.
+        :type name: str
+        :param group_id: Required group identifier.
+        :type group_id: str
+        :param feature_key: Optional explicit key (defaults to snake_case of name).
+        :type feature_key: str | None
+        :param id: Optional explicit full ID (defaults to f'{group_id}.{feature_key}').
+        :type id: str | None
+        :param description: Optional description (defaults to name).
+        :type description: str | None
+        :param steps: Optional list of initial feature steps.
+        :type steps: list | None
+        :param log_params: Optional logging parameters.
+        :type log_params: dict | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The created Feature model.
+        :rtype: Feature
+        '''
+
+        # Create feature using the aggregate factory.
+        feature = FeatureAggregate.new(
+            name=name,
+            group_id=group_id,
+            feature_key=feature_key,
+            id=id,
+            description=description,
+            steps=steps or [],
+            log_params=log_params or {},
+            **kwargs,
+        )
+
+        # Check for duplicate feature identifier.
+        self.verify(
+            expression=not self.feature_service.exists(feature.id),
+            error_code=a.const.FEATURE_ALREADY_EXISTS_ID,
+            message=f'Feature with ID {feature.id} already exists.',
+            id=feature.id,
+        )
+
+        # Persist the new feature.
+        self.feature_service.save(feature)
+
+        # Return the created feature.
+        return feature
+
+# ** event: get_feature
+class GetFeature(DomainEvent):
+    '''
+    Event to retrieve a feature by its identifier.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        '''
+        Initialize the GetFeature event.
+
+        :param feature_service: The feature service to use for retrieving features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> Feature:
+        '''
+        Retrieve a feature by ID.
+
+        :param id: The feature identifier.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The retrieved feature.
+        :rtype: Feature
+        '''
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists; raise FEATURE_NOT_FOUND if it does not.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            feature_id=id,
+        )
+
+        # Return the retrieved feature.
+        return feature
+
+# ** event: list_features
+class ListFeatures(DomainEvent):
+    '''
+    Event to list feature configurations.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        '''
+        Initialize the ListFeatures event.
+
+        :param feature_service: The feature service to use for listing features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    def execute(self, group_id: str | None = None, **kwargs) -> List[Feature]:
+        '''
+        List features, optionally filtered by group_id.
+
+        :param group_id: Optional group identifier to filter results.
+        :type group_id: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: List of Feature models.
+        :rtype: List[Feature]
+        '''
+
+        # Delegate to the feature service.
+        return self.feature_service.list(group_id=group_id)
+
+# ** event: remove_feature
+class RemoveFeature(DomainEvent):
+    '''
+    Event to remove an entire feature configuration by ID (idempotent).
+
+    This event delegates deletion semantics to the underlying
+    ``FeatureService.delete`` implementation, which is expected to behave
+    idempotently when the feature does not exist.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        '''
+        Initialize the RemoveFeature event.
+
+        :param feature_service: The feature service to use.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove a feature by ID.
+
+        :param id: The feature ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The removed feature ID.
+        :rtype: str
+        '''
+
+        # Delete the feature using the feature service.
+        # and treated as a successful no-op when the feature does not exist.
+        self.feature_service.delete(id)
+
+        # Return the feature identifier.
+        return id
+
+# ** event: update_feature
+class UpdateFeature(DomainEvent):
+    '''
+    Event to update basic metadata of an existing feature.
+
+    Supports updating the ``name`` or ``description`` attributes using the
+    Feature model helpers.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService) -> None:
+        '''
+        Initialize the UpdateFeature event.
+
+        :param feature_service: The feature service used to retrieve and
+            persist features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'attribute'])
+    def execute(
+            self,
+            id: str,
+            attribute: str,
+            value: Any,
+            **kwargs,
+        ) -> Feature:
+        '''
+        Update a feature's ``name`` or ``description`` attribute.
+
+        :param id: The identifier of the feature to update.
+        :type id: str
+        :param attribute: The attribute to update (``"name"`` or
+            ``"description"``).
+        :type attribute: str
+        :param value: The new value for the attribute.
+        :type value: Any
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The updated Feature instance.
+        :rtype: Feature
+        '''
+
+        # Validate that the attribute is supported.
+        self.verify(
+            expression=attribute in ('name', 'description'),
+            error_code=a.const.INVALID_FEATURE_ATTRIBUTE_ID,
+            message=f'Invalid feature attribute: {attribute}',
+            attribute=attribute,
+        )
+
+        # When updating the name, ensure a non-empty value is provided.
+        if attribute == 'name':
+            self.verify(
+                expression=isinstance(value, str) and bool(value.strip()),
+                error_code=a.const.FEATURE_NAME_REQUIRED_ID,
+                message='A feature name is required when updating the name attribute.',
+            )
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            feature_id=id,
+        )
+
+        # Apply the requested update using model helpers.
+        if attribute == 'name':
+            feature.rename(value)
+        elif attribute == 'description':
+            feature.set_description(value)
+
+        # Persist the updated feature.
+        self.feature_service.save(feature)
+
+        # Return the updated feature.
+        return feature
+
+# ** event: add_feature_step
+class AddFeatureStep(DomainEvent):
+    '''
+    Event to add a step to an existing feature.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService):
+        '''
+        Initialize the AddFeatureStep event.
+
+        :param feature_service: The feature service to use.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'service_id'])
+    def execute(
+            self,
+            id: str,
+            name: str,
+            service_id: str,
+            parameters: dict | None = None,
+            data_key: str | None = None,
+            pass_on_error: bool = False,
+            position: int | None = None,
+            **kwargs,
+        ) -> str:
+        '''
+        Add a step to an existing feature.
+
+        :param id: The feature ID.
+        :type id: str
+        :param name: The step name.
+        :type name: str
+        :param service_id: The service configuration ID for the step.
+        :type service_id: str
+        :param parameters: Optional step parameters.
+        :type parameters: dict | None
+        :param data_key: Optional result data key.
+        :type data_key: str | None
+        :param pass_on_error: Whether to pass on errors from this step.
+        :type pass_on_error: bool
+        :param position: Insertion position (None to append).
+        :type position: int | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The feature ID.
+        :rtype: str
+        '''
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            message=f'Feature not found: {id}',
+            feature_id=id,
+        )
+
+        # Add the step using the Feature model helper.
+        feature.add_step(
+            name=name,
+            service_id=service_id,
+            parameters=parameters or {},
+            data_key=data_key,
+            pass_on_error=pass_on_error,
+            position=position,
+        )
+
+        # Persist the updated feature.
+        self.feature_service.save(feature)
+
+        # Return the feature identifier.
+        return id
+
+# ** event: update_feature_step
+class UpdateFeatureStep(DomainEvent):
+    '''
+    Event to update an existing feature step within a feature workflow.
+
+    This event supports updating the following attributes on a
+    ``FeatureEvent`` instance: ``name``, ``service_id``, ``data_key``,
+    ``pass_on_error``, and ``parameters``.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService) -> None:
+        '''
+        Initialize the UpdateFeatureStep event.
+
+        :param feature_service: The feature service used to retrieve and
+            persist features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'position', 'attribute'])
+    def execute(
+            self,
+            id: str,
+            position: int,
+            attribute: str,
+            value: Any | None = None,
+            **kwargs,
+        ) -> str:
+        '''
+        Update an attribute on a feature step at the given position.
+
+        :param id: The identifier of the feature whose step will be
+            updated.
+        :type id: str
+        :param position: The zero-based index of the step within the
+            feature's step list.
+        :type position: int
+        :param attribute: The attribute to update. Supported values are
+            ``"name"``, ``"service_id"``, ``"data_key"``,
+            ``"pass_on_error"``, and ``"parameters"``.
+        :type attribute: str
+        :param value: The new value for the attribute. For ``name`` and
+            ``service_id`` this must be a non-empty value.
+        :type value: Any | None
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The feature identifier.
+        :rtype: str
+        '''
+
+        # Validate that the attribute name is supported.
+        valid_attributes = {
+            'name',
+            'service_id',
+            'data_key',
+            'pass_on_error',
+            'parameters',
+        }
+        self.verify(
+            expression=attribute in valid_attributes,
+            error_code=a.const.INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+            message=(
+                'Invalid feature step attribute: {attribute}. '
+                'Supported attributes are name, service_id, data_key, '
+                'pass_on_error, and parameters.'
+            ),
+            attribute=attribute,
+        )
+
+        # For name and service_id, enforce a non-empty value.
+        if attribute in {'name', 'service_id'}:
+            self.verify(
+                expression=(
+                    value is not None
+                    and (not isinstance(value, str) or bool(str(value).strip()))
+                ),
+                error_code=a.const.COMMAND_PARAMETER_REQUIRED_ID,
+                message=(
+                    f'The "value" parameter is required when updating the '
+                    f'"{attribute}" attribute for the '
+                    f'"{self.__class__.__name__}" command.'
+                ),
+                parameter='value',
+                command=self.__class__.__name__,
+            )
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            feature_id=id,
+        )
+
+        # Retrieve the target step from the feature.
+        step = feature.get_step(position)
+
+        # Verify that the step exists at the given position.
+        self.verify(
+            expression=step is not None,
+            error_code=a.const.FEATURE_COMMAND_NOT_FOUND_ID,
+            message=(
+                f'Feature step not found for feature {id} '
+                f'at position {position}.'
+            ),
+            feature_id=id,
+            position=position,
+        )
+
+        # Apply the attribute update using the FeatureEvent helper.
+        step.set_attribute(attribute, value)
+
+        # Persist the updated feature.
+        self.feature_service.save(feature)
+
+        # Return the feature identifier.
+        return id
+
+# ** event: remove_feature_step
+class RemoveFeatureStep(DomainEvent):
+    '''
+    Event to remove a step from an existing feature by position.
+
+    This event is idempotent: invalid positions result in silent success
+    with no mutation to the feature's step list.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService) -> None:
+        '''
+        Initialize the RemoveFeatureStep event.
+
+        :param feature_service: The feature service to use for retrieving and
+            persisting features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'position'])
+    def execute(
+            self,
+            id: str,
+            position: int,
+            **kwargs,
+        ) -> str:
+        '''
+        Remove a step from the feature at the given position.
+
+        :param id: The feature identifier.
+        :type id: str
+        :param position: The index of the step to remove.
+        :type position: int
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The feature identifier.
+        :rtype: str
+        '''
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            message=f'Feature not found: {id}',
+            feature_id=id,
+        )
+
+        # Attempt safe removal of the step at the given position. The
+        # underlying Feature.remove_step helper is idempotent and will
+        # return None without raising if the position is invalid.
+        feature.remove_step(position)
+
+        # Persist the feature, even if no step was removed.
+        self.feature_service.save(feature)
+
+        # Return the feature identifier.
+        return id
+
+# ** event: reorder_feature_step
+class ReorderFeatureStep(DomainEvent):
+    '''
+    Event to reorder an existing feature step within a feature workflow.
+
+    This event delegates to the ``Feature.reorder_step`` model helper,
+    which clamps the target position and behaves idempotently for invalid
+    start positions.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService) -> None:
+        '''
+        Initialize the ReorderFeatureStep event.
+
+        :param feature_service: The feature service used to retrieve and
+            persist features.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'start_position', 'end_position'])
+    def execute(
+            self,
+            id: str,
+            start_position: int,
+            end_position: int,
+            **kwargs,
+        ) -> str:
+        '''
+        Reorder a feature step by moving it from ``start_position`` to
+        ``end_position`` within the feature's step list.
+
+        :param id: The identifier of the feature whose step will be
+            reordered.
+        :type id: str
+        :param start_position: The current index of the step to move.
+        :type start_position: int
+        :param end_position: The desired new index for the step.
+        :type end_position: int
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The feature identifier.
+        :rtype: str
+        '''
+
+        # Retrieve the feature from the feature service.
+        feature = self.feature_service.get(id)
+
+        # Verify that the feature exists.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            message=f'Feature not found: {id}',
+            feature_id=id,
+        )
+
+        # Delegate the reordering logic to the Feature model helper. This
+        # method clamps ``end_position`` and is idempotent for invalid
+        # ``start_position`` values.
+        feature.reorder_step(start_position, end_position)
+
+        # Persist the updated feature configuration.
+        self.feature_service.save(feature)
+
+        # Return the feature identifier.
+        return id

--- a/tiferet/events/tests/test_feature.py
+++ b/tiferet/events/tests/test_feature.py
@@ -1,0 +1,997 @@
+"""Tiferet Tests for Feature Events"""
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..feature import (
+    AddFeature,
+    GetFeature,
+    ListFeatures,
+    RemoveFeature,
+    UpdateFeature,
+    AddFeatureStep,
+    UpdateFeatureStep,
+    RemoveFeatureStep,
+    ReorderFeatureStep,
+)
+from ..settings import DomainEvent, TiferetError, a
+from ...domain import Feature
+from ...interfaces import FeatureService
+from ...mappers import FeatureAggregate
+from .settings import DomainEventTestBase, ServiceEventTestBase
+
+# *** fixtures
+
+# ** fixture: sample_feature
+@pytest.fixture
+def sample_feature() -> Feature:
+    '''
+    A sample Feature instance for testing.
+
+    :return: A FeatureAggregate instance.
+    :rtype: FeatureAggregate
+    '''
+
+    # Create a sample feature aggregate.
+    return FeatureAggregate.new(
+        id='group.sample_feature',
+        name='Sample Feature',
+        group_id='group',
+        feature_key='sample_feature',
+        description='A sample feature for testing.',
+    )
+
+
+# *** tests
+
+# ** test: TestAddFeature
+class TestAddFeature(DomainEventTestBase):
+    '''
+    Tests for AddFeature using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddFeature
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        name='New Feature',
+        group_id='group',
+    )
+
+    # * attribute: required_params
+    required_params = ['name', 'group_id']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self) -> dict:
+        '''
+        Override to pre-configure exists to return False.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.exists.return_value = False
+        return {'feature_service': service}
+
+    # * method: test_minimal_success
+    def test_minimal_success(self, mock_dependencies):
+        '''
+        Test successful creation of a feature with minimal required parameters.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the feature was created with derived values.
+        assert isinstance(result, Feature)
+        assert result.name == 'New Feature'
+        assert result.group_id == 'group'
+        assert result.feature_key == 'new_feature'
+        assert result.id == 'group.new_feature'
+        assert result.description == 'New Feature'
+
+        # Assert the service was called correctly.
+        mock_dependencies['feature_service'].exists.assert_called_once_with(result.id)
+        mock_dependencies['feature_service'].save.assert_called_once_with(result)
+
+    # * method: test_full_parameters
+    def test_full_parameters(self, mock_dependencies):
+        '''
+        Test creation of a feature when all optional parameters are provided.
+        '''
+
+        # Execute with all parameters.
+        result = self.handle(
+            mock_dependencies,
+            name='Explicit Feature',
+            group_id='group',
+            feature_key='explicit_key',
+            id='group.explicit_key',
+            description='Explicit description.',
+            steps=[],
+            log_params={'foo': 'bar'},
+        )
+
+        # Assert explicit values are used.
+        assert result.name == 'Explicit Feature'
+        assert result.group_id == 'group'
+        assert result.feature_key == 'explicit_key'
+        assert result.id == 'group.explicit_key'
+        assert result.description == 'Explicit description.'
+        assert result.steps == []
+        assert result.log_params == {'foo': 'bar'}
+
+        # Assert the service was called correctly.
+        mock_dependencies['feature_service'].exists.assert_called_once_with(result.id)
+        mock_dependencies['feature_service'].save.assert_called_once_with(result)
+
+    # * method: test_duplicate_id
+    def test_duplicate_id(self, mock_dependencies):
+        '''
+        Test that adding a feature with an existing ID raises FEATURE_ALREADY_EXISTS.
+        '''
+
+        # Configure the service to report the ID already exists.
+        mock_dependencies['feature_service'].exists.return_value = True
+
+        # Execute and expect a FEATURE_ALREADY_EXISTS error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies)
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.FEATURE_ALREADY_EXISTS_ID
+
+        # Verify the feature was not saved.
+        mock_dependencies['feature_service'].exists.assert_called_once()
+        mock_dependencies['feature_service'].save.assert_not_called()
+
+
+# ** test: TestGetFeature
+class TestGetFeature(ServiceEventTestBase):
+    '''
+    Tests for GetFeature using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = GetFeature
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='group.sample_feature')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, sample_feature):
+        '''
+        Test successful retrieval of a feature.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the feature is returned.
+        assert result is sample_feature
+        mock_dependencies['feature_service'].get.assert_called_once_with('group.sample_feature')
+
+
+# ** test: TestListFeatures
+class TestListFeatures(DomainEventTestBase):
+    '''
+    Tests for ListFeatures using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListFeatures
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(group_id=None)
+
+    # * attribute: required_params
+    required_params = []
+
+    # * method: test_all
+    def test_all(self, mock_dependencies, sample_feature):
+        '''
+        Test listing all features.
+        '''
+
+        # Configure the service to return features.
+        mock_dependencies['feature_service'].list.return_value = [sample_feature]
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert.
+        assert result == [sample_feature]
+        mock_dependencies['feature_service'].list.assert_called_once_with(group_id=None)
+
+    # * method: test_by_group_id
+    def test_by_group_id(self, mock_dependencies, sample_feature):
+        '''
+        Test listing features filtered by group_id.
+        '''
+
+        # Configure the service to return features.
+        mock_dependencies['feature_service'].list.return_value = [sample_feature]
+
+        # Execute with group_id override.
+        result = self.handle(mock_dependencies, group_id='group')
+
+        # Assert.
+        assert result == [sample_feature]
+        mock_dependencies['feature_service'].list.assert_called_once_with(group_id='group')
+
+    # * method: test_empty_result
+    def test_empty_result(self, mock_dependencies):
+        '''
+        Test listing features when the service returns an empty list.
+        '''
+
+        # Configure the service to return an empty list.
+        mock_dependencies['feature_service'].list.return_value = []
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert.
+        assert result == []
+        mock_dependencies['feature_service'].list.assert_called_once_with(group_id=None)
+
+
+# ** test: TestRemoveFeature
+class TestRemoveFeature(DomainEventTestBase):
+    '''
+    Tests for RemoveFeature using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveFeature
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='group.sample_feature')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful deletion of a feature.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the feature ID is returned.
+        assert result == 'group.sample_feature'
+        mock_dependencies['feature_service'].delete.assert_called_once_with('group.sample_feature')
+
+    # * method: test_idempotent_multiple_calls
+    def test_idempotent_multiple_calls(self, mock_dependencies):
+        '''
+        Test idempotent deletion with multiple calls.
+        '''
+
+        # Call twice.
+        result_first = self.handle(mock_dependencies)
+        result_second = self.handle(mock_dependencies)
+
+        # Both should succeed.
+        assert result_first == 'group.sample_feature'
+        assert result_second == 'group.sample_feature'
+        assert mock_dependencies['feature_service'].delete.call_count == 2
+
+
+# ** test: TestUpdateFeature
+class TestUpdateFeature(ServiceEventTestBase):
+    '''
+    Tests for UpdateFeature using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = UpdateFeature
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='group.sample_feature',
+        attribute='name',
+        value='Updated Feature Name',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'attribute']
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.feature',
+        attribute='name',
+        value='Updated Feature Name',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: test_name_success
+    def test_name_success(self, mock_dependencies, sample_feature):
+        '''
+        Test successfully updating a feature name.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the name was updated.
+        assert result is sample_feature
+        assert result.name == 'Updated Feature Name'
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+    # * method: test_description_success
+    def test_description_success(self, mock_dependencies, sample_feature):
+        '''
+        Test successfully updating a feature description.
+        '''
+
+        # Execute with description override.
+        result = self.handle(
+            mock_dependencies,
+            attribute='description',
+            value='Updated description.',
+        )
+
+        # Assert the description was updated.
+        assert result is sample_feature
+        assert result.description == 'Updated description.'
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+    # * method: test_clear_description
+    def test_clear_description(self, mock_dependencies, sample_feature):
+        '''
+        Test clearing a feature description.
+        '''
+
+        # Execute with None value.
+        result = self.handle(
+            mock_dependencies,
+            attribute='description',
+            value=None,
+        )
+
+        # Assert the description was cleared.
+        assert result is sample_feature
+        assert result.description is None
+
+    # * method: test_invalid_attribute
+    def test_invalid_attribute(self, mock_dependencies):
+        '''
+        Test that an unsupported attribute raises INVALID_FEATURE_ATTRIBUTE.
+        '''
+
+        # Execute with invalid attribute.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, attribute='invalid', value='ignored')
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.INVALID_FEATURE_ATTRIBUTE_ID
+        mock_dependencies['feature_service'].get.assert_not_called()
+
+    # * method: test_missing_name_value
+    def test_missing_name_value(self, mock_dependencies):
+        '''
+        Test that updating name with empty value raises FEATURE_NAME_REQUIRED.
+        '''
+
+        # Execute with empty name value.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, attribute='name', value=' ')
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.FEATURE_NAME_REQUIRED_ID
+        mock_dependencies['feature_service'].get.assert_not_called()
+
+
+# ** test: TestAddFeatureStep
+class TestAddFeatureStep(ServiceEventTestBase):
+    '''
+    Tests for AddFeatureStep using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddFeatureStep
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='group.sample_feature',
+        name='do_something',
+        service_id='container.attribute',
+        parameters={'foo': 'bar'},
+        data_key='result_key',
+        pass_on_error=True,
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'service_id']
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.feature',
+        name='do_something',
+        service_id='container.attribute',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: test_append_success
+    def test_append_success(self, mock_dependencies, sample_feature):
+        '''
+        Test successfully appending a new step to a feature.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the feature ID is returned.
+        assert result == sample_feature.id
+
+        # Assert a step was appended.
+        assert len(sample_feature.steps) == 1
+        step = sample_feature.steps[0]
+        assert step.name == 'do_something'
+        assert step.service_id == 'container.attribute'
+        assert step.parameters == {'foo': 'bar'}
+        assert step.data_key == 'result_key'
+        assert step.pass_on_error is True
+
+        # Verify service calls.
+        mock_dependencies['feature_service'].get.assert_called_once_with(sample_feature.id)
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+    # * method: test_insert_success
+    def test_insert_success(self, mock_dependencies, sample_feature):
+        '''
+        Test inserting a step at a specific position.
+        '''
+
+        # Pre-populate the feature with two steps.
+        sample_feature.add_step(
+            name='first',
+            service_id='container.first',
+            parameters={'index': 0},
+            data_key='first_key',
+            pass_on_error=False,
+        )
+        sample_feature.add_step(
+            name='second',
+            service_id='container.second',
+            parameters={'index': 1},
+            data_key='second_key',
+        )
+
+        # Execute inserting at position 1.
+        result = self.handle(
+            mock_dependencies,
+            name='inserted',
+            service_id='container.inserted',
+            parameters={'index': 1},
+            data_key='inserted_key',
+            position=1,
+        )
+
+        # Assert correct ordering.
+        assert result == sample_feature.id
+        assert len(sample_feature.steps) == 3
+        assert sample_feature.steps[0].name == 'first'
+        assert sample_feature.steps[1].name == 'inserted'
+        assert sample_feature.steps[2].name == 'second'
+
+        # Assert the inserted step has the correct service_id.
+        inserted = sample_feature.steps[1]
+        assert inserted.service_id == 'container.inserted'
+
+
+# ** test: TestUpdateFeatureStep
+class TestUpdateFeatureStep(ServiceEventTestBase):
+    '''
+    Tests for UpdateFeatureStep using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = UpdateFeatureStep
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='group.sample_feature',
+        position=0,
+        attribute='name',
+        value='updated_name',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'position', 'attribute']
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.feature',
+        position=0,
+        attribute='name',
+        value='Updated Name',
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature with a step.
+        '''
+
+        # Pre-populate the feature with a single step.
+        sample_feature.add_step(
+            name='original',
+            service_id='container.original',
+            parameters={'foo': 'bar'},
+            data_key='original_key',
+            pass_on_error=False,
+        )
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: test_update_string_attributes_success
+    @pytest.mark.parametrize(
+        'attribute, new_value, getter',
+        [
+            ('name', 'updated_name', lambda cmd: cmd.name),
+            ('service_id', 'container.updated', lambda cmd: cmd.service_id),
+            ('data_key', 'updated_key', lambda cmd: cmd.data_key),
+        ],
+    )
+    def test_update_string_attributes_success(
+            self,
+            mock_dependencies,
+            sample_feature,
+            attribute,
+            new_value,
+            getter,
+        ):
+        '''
+        Test successfully updating simple string attributes on a feature step.
+        '''
+
+        # Execute via the harness.
+        step = sample_feature.steps[0]
+        result = self.handle(
+            mock_dependencies,
+            attribute=attribute,
+            value=new_value,
+        )
+
+        # Assert the update was applied.
+        assert result == sample_feature.id
+        assert getter(step) == new_value
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+    # * method: test_update_parameters_success
+    def test_update_parameters_success(self, mock_dependencies, sample_feature):
+        '''
+        Test updating the parameters attribute on a feature step.
+        '''
+
+        # Execute via the harness with parameters update.
+        step = sample_feature.steps[0]
+        result = self.handle(
+            mock_dependencies,
+            attribute='parameters',
+            value={'baz': 'qux', 'foo': None},
+        )
+
+        # Assert the parameters were merged.
+        assert result == sample_feature.id
+        assert step.parameters == {'baz': 'qux'}
+
+    # * method: test_update_pass_on_error_success
+    def test_update_pass_on_error_success(self, mock_dependencies, sample_feature):
+        '''
+        Test updating the pass_on_error flag.
+        '''
+
+        # Execute via the harness.
+        step = sample_feature.steps[0]
+        result = self.handle(
+            mock_dependencies,
+            attribute='pass_on_error',
+            value=True,
+        )
+
+        # Assert the flag was updated.
+        assert result == sample_feature.id
+        assert step.pass_on_error is True
+
+    # * method: test_invalid_attribute
+    def test_invalid_attribute(self, mock_dependencies):
+        '''
+        Test that an unsupported attribute raises INVALID_FEATURE_COMMAND_ATTRIBUTE.
+        '''
+
+        # Execute with invalid attribute.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, attribute='invalid')
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.INVALID_FEATURE_COMMAND_ATTRIBUTE_ID
+        mock_dependencies['feature_service'].get.assert_not_called()
+
+    # * method: test_missing_name_or_service_id_value
+    @pytest.mark.parametrize('attribute', ['name', 'service_id'])
+    def test_missing_name_or_service_id_value(self, mock_dependencies, attribute):
+        '''
+        Test that updating name or service_id with empty value raises COMMAND_PARAMETER_REQUIRED.
+        '''
+
+        # Execute with empty value.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, attribute=attribute, value=' ')
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        mock_dependencies['feature_service'].get.assert_not_called()
+
+    # * method: test_step_not_found
+    def test_step_not_found(self, mock_dependencies, sample_feature):
+        '''
+        Test that updating a step at an invalid position raises FEATURE_COMMAND_NOT_FOUND.
+        '''
+
+        # Execute with an out-of-range position.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, position=5)
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.FEATURE_COMMAND_NOT_FOUND_ID
+
+
+# ** test: TestRemoveFeatureStep
+class TestRemoveFeatureStep(ServiceEventTestBase):
+    '''
+    Tests for RemoveFeatureStep using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveFeatureStep
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='group.sample_feature',
+        position=0,
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'position']
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.feature',
+        position=0,
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, sample_feature):
+        '''
+        Test successfully removing a step at a valid position.
+        '''
+
+        # Pre-populate the feature with two steps.
+        first = sample_feature.add_step(
+            name='first',
+            service_id='container.first',
+            parameters={'index': 0},
+            data_key='first_key',
+        )
+        second = sample_feature.add_step(
+            name='second',
+            service_id='container.second',
+            parameters={'index': 1},
+            data_key='second_key',
+        )
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the first step was removed.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [second]
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+    # * method: test_invalid_position_idempotent
+    def test_invalid_position_idempotent(self, mock_dependencies, sample_feature):
+        '''
+        Test idempotent behavior when an invalid position is provided.
+        '''
+
+        # Pre-populate the feature with a single step.
+        original = sample_feature.add_step(
+            name='only',
+            service_id='container.only',
+            parameters={'index': 0},
+            data_key='only_key',
+        )
+
+        # Execute with out-of-range position.
+        result = self.handle(mock_dependencies, position=5)
+
+        # Assert the steps list is unchanged.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [original]
+        mock_dependencies['feature_service'].save.assert_called_once_with(sample_feature)
+
+
+# ** test: TestReorderFeatureStep
+class TestReorderFeatureStep(ServiceEventTestBase):
+    '''
+    Tests for ReorderFeatureStep using the service event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ReorderFeatureStep
+
+    # * attribute: dependencies
+    dependencies = {'feature_service': FeatureService}
+
+    # * attribute: service_attr
+    service_attr = 'feature_service'
+
+    # * attribute: not_found_error_code
+    not_found_error_code = a.const.FEATURE_NOT_FOUND_ID
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='group.sample_feature',
+        start_position=0,
+        end_position=2,
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'start_position', 'end_position']
+
+    # * attribute: not_found_kwargs
+    not_found_kwargs = dict(
+        id='missing.feature',
+        start_position=0,
+        end_position=1,
+    )
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, sample_feature) -> dict:
+        '''
+        Override to pre-configure get to return the sample feature.
+        '''
+
+        # Create the mock feature service.
+        service = mock.Mock(spec=FeatureService)
+        service.get.return_value = sample_feature
+        return {'feature_service': service}
+
+    # * method: _populate_three_steps
+    def _populate_three_steps(self, sample_feature):
+        '''
+        Helper to pre-populate the feature with three steps.
+        '''
+
+        first = sample_feature.add_step(
+            name='first',
+            service_id='container.first',
+            parameters={'index': 0},
+            data_key='first_key',
+        )
+        second = sample_feature.add_step(
+            name='second',
+            service_id='container.second',
+            parameters={'index': 1},
+            data_key='second_key',
+        )
+        third = sample_feature.add_step(
+            name='third',
+            service_id='container.third',
+            parameters={'index': 2},
+            data_key='third_key',
+        )
+        return first, second, third
+
+    # * method: test_forward
+    def test_forward(self, mock_dependencies, sample_feature):
+        '''
+        Test moving a feature step forward in the workflow.
+        '''
+
+        # Populate.
+        first, second, third = self._populate_three_steps(sample_feature)
+
+        # Execute: move first to end.
+        result = self.handle(mock_dependencies, start_position=0, end_position=2)
+
+        # Assert ordering.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [second, third, first]
+
+    # * method: test_backward
+    def test_backward(self, mock_dependencies, sample_feature):
+        '''
+        Test moving a feature step backward in the workflow.
+        '''
+
+        # Populate.
+        first, second, third = self._populate_three_steps(sample_feature)
+
+        # Execute: move last to front.
+        result = self.handle(mock_dependencies, start_position=2, end_position=0)
+
+        # Assert ordering.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [third, first, second]
+
+    # * method: test_clamp_low
+    def test_clamp_low(self, mock_dependencies, sample_feature):
+        '''
+        Test that end_position is clamped to the start of the list when below 0.
+        '''
+
+        # Populate.
+        first, second, third = self._populate_three_steps(sample_feature)
+
+        # Execute with negative end_position.
+        result = self.handle(mock_dependencies, start_position=2, end_position=-5)
+
+        # Assert clamped to front.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [third, first, second]
+
+    # * method: test_clamp_high
+    def test_clamp_high(self, mock_dependencies, sample_feature):
+        '''
+        Test that end_position is clamped to the end of the list when above max.
+        '''
+
+        # Populate.
+        first, second, third = self._populate_three_steps(sample_feature)
+
+        # Execute with large end_position.
+        result = self.handle(mock_dependencies, start_position=0, end_position=10)
+
+        # Assert clamped to end.
+        assert result == sample_feature.id
+        assert sample_feature.steps == [second, third, first]
+
+    # * method: test_invalid_start_position_idempotent
+    def test_invalid_start_position_idempotent(self, mock_dependencies, sample_feature):
+        '''
+        Test idempotent behavior when start_position is out of range.
+        '''
+
+        # Populate with two steps.
+        first = sample_feature.add_step(
+            name='first',
+            service_id='container.first',
+            parameters={'index': 0},
+            data_key='first_key',
+        )
+        second = sample_feature.add_step(
+            name='second',
+            service_id='container.second',
+            parameters={'index': 1},
+            data_key='second_key',
+        )
+        original_steps = list(sample_feature.steps)
+
+        # Execute with out-of-range start.
+        result = self.handle(mock_dependencies, start_position=5, end_position=0)
+
+        # Assert unchanged.
+        assert result == sample_feature.id
+        assert sample_feature.steps == original_steps


### PR DESCRIPTION
Add 9 feature domain events, test harness suite (55 tests), and usage guide.

## Changes
- **`tiferet/events/feature.py`** — New file. 9 event classes: `AddFeature`, `GetFeature`, `ListFeatures`, `RemoveFeature`, `UpdateFeature`, `AddFeatureStep`, `UpdateFeatureStep`, `RemoveFeatureStep`, `ReorderFeatureStep`.
- **`tiferet/events/tests/test_feature.py`** — New file. 9 test harness classes covering CRUD, step management, idempotency, validation, and error paths.
- **`docs/guides/events/feature.md`** — New file. Usage guide with parameters, examples, and v2.0.0a6 migration notes.

### Key v2.0 changes
- Class renames: `*Command` → `*Step` (e.g. `AddFeatureCommand` → `AddFeatureStep`)
- Parameter renames: `attribute_id` → `service_id`, `commands` → `steps`
- Artifact comments: `# *** commands` → `# *** events`

Closes #640

Co-Authored-By: Oz <oz-agent@warp.dev>