### PR TITLE
Events – Add Logging Events (#637)

### DIFF
--- a/docs/guides/events/logging.md
+++ b/docs/guides/events/logging.md
@@ -1,0 +1,198 @@
+# Events – Logging Configuration Management
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/logging.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The logging event module provides create, list, and remove operations for the three logging domain objects — `Formatter`, `Handler`, and `Logger`. Every event in this module depends on an injected `LoggingService` and operates through the corresponding aggregate mappers (`FormatterAggregate`, `HandlerAggregate`, `LoggerAggregate`).
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `ListAllLoggingConfigs` | Read (all) | *(none)* | `Tuple[List[Formatter], List[Handler], List[Logger]]` |
+| `AddFormatter` | Create | `id`, `name`, `format` | `Formatter` |
+| `RemoveFormatter` | Delete | `id` | `str` (ID) |
+| `AddHandler` | Create | `id`, `name`, `module_path`, `class_name`, `level`, `formatter` | `Handler` |
+| `RemoveHandler` | Delete | `id` | `str` (ID) |
+| `AddLogger` | Create | `id`, `name`, `level`, `handlers` | `Logger` |
+| `RemoveLogger` | Delete | `id` | `str` (ID) |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`logging_service: LoggingService`** — the service interface for persisting and retrieving logging configuration objects.
+
+## Event Details
+
+### ListAllLoggingConfigs
+
+Retrieves all logging configurations (formatters, handlers, loggers) via a single service call.
+
+**Required:** *(none)*
+
+**Returns:** A tuple of `(List[Formatter], List[Handler], List[Logger])`.
+
+```python
+formatters, handlers, loggers = DomainEvent.handle(
+    ListAllLoggingConfigs,
+    dependencies={'logging_service': logging_service},
+)
+```
+
+### AddFormatter
+
+Creates a new `Formatter` aggregate and persists it via `LoggingService.save_formatter()`.
+
+**Required:** `id`, `name`, `format`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `description` | `str` | `None` | Optional description of the formatter |
+| `datefmt` | `str` | `None` | Optional date format string |
+
+**Returns:** The created `Formatter` instance.
+
+```python
+result = DomainEvent.handle(
+    AddFormatter,
+    dependencies={'logging_service': logging_service},
+    id='detailed',
+    name='Detailed Formatter',
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+```
+
+### RemoveFormatter
+
+Removes a formatter configuration by ID. The operation is idempotent — no error is raised if the formatter does not exist.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed formatter ID.
+
+```python
+DomainEvent.handle(
+    RemoveFormatter,
+    dependencies={'logging_service': logging_service},
+    id='old_formatter',
+)
+```
+
+### AddHandler
+
+Creates a new `Handler` aggregate and persists it via `LoggingService.save_handler()`.
+
+**Required:** `id`, `name`, `module_path`, `class_name`, `level`, `formatter`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `description` | `str` | `None` | Optional description of the handler |
+| `stream` | `str` | `None` | Stream specification (e.g., `ext://sys.stdout`) |
+| `filename` | `str` | `None` | Filename for file-based handlers |
+
+**Returns:** The created `Handler` instance.
+
+```python
+# File handler
+result = DomainEvent.handle(
+    AddHandler,
+    dependencies={'logging_service': logging_service},
+    id='file_handler',
+    name='File Handler',
+    module_path='logging.handlers',
+    class_name='RotatingFileHandler',
+    level='DEBUG',
+    formatter='detailed',
+    filename='/var/log/app.log',
+)
+
+# Stream handler
+result = DomainEvent.handle(
+    AddHandler,
+    dependencies={'logging_service': logging_service},
+    id='console',
+    name='Console Handler',
+    module_path='logging',
+    class_name='StreamHandler',
+    level='INFO',
+    formatter='simple',
+    stream='ext://sys.stdout',
+)
+```
+
+### RemoveHandler
+
+Removes a handler configuration by ID. The operation is idempotent.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed handler ID.
+
+```python
+DomainEvent.handle(
+    RemoveHandler,
+    dependencies={'logging_service': logging_service},
+    id='old_handler',
+)
+```
+
+### AddLogger
+
+Creates a new `Logger` aggregate and persists it via `LoggingService.save_logger()`.
+
+**Required:** `id`, `name`, `level`, `handlers`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `description` | `str` | `None` | Optional description of the logger |
+| `propagate` | `bool` | `True` | Whether to propagate messages to parent loggers |
+
+**Returns:** The created `Logger` instance.
+
+```python
+result = DomainEvent.handle(
+    AddLogger,
+    dependencies={'logging_service': logging_service},
+    id='app.database',
+    name='Database Logger',
+    level='WARNING',
+    handlers=['console', 'file_handler'],
+    propagate=False,
+)
+```
+
+### RemoveLogger
+
+Removes a logger configuration by ID. The operation is idempotent.
+
+**Required:** `id`
+
+**Returns:** `str` — the removed logger ID.
+
+```python
+DomainEvent.handle(
+    RemoveLogger,
+    dependencies={'logging_service': logging_service},
+    id='old_logger',
+)
+```
+
+## Migration Notes (v2.0)
+
+- **Artifact comments:** `# *** commands` → `# *** events`; `# ** command:` → `# ** event:`.
+- **Docstrings:** "Command to" → "Event to" throughout.
+- **Aggregate factory:** `Aggregate.new(FormatterAggregate, ...)` → `FormatterAggregate.new(...)` (same for Handler and Logger aggregates). The `Aggregate` base import is no longer needed.
+- **No parameter renames** — logging events do not use `attribute_id`.
+- **Tests:** Converted from 13 function-based tests to 7 harness classes using `DomainEventTestBase` (27 pass, 1 skip).

--- a/tiferet/events/logging.py
+++ b/tiferet/events/logging.py
@@ -1,0 +1,400 @@
+"""Tiferet Logging Events"""
+
+# *** imports
+
+# ** core
+from typing import List, Tuple
+
+# ** app
+from ..domain import Formatter, Handler, Logger
+from ..interfaces import LoggingService
+from ..mappers import FormatterAggregate, HandlerAggregate, LoggerAggregate
+from .settings import DomainEvent, a
+
+
+# *** events
+
+# ** event: list_all_logging_configs
+class ListAllLoggingConfigs(DomainEvent):
+    '''
+    Event to list all logging configurations (formatters, handlers, loggers).
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the ListAllLoggingConfigs event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    def execute(self, **kwargs) -> Tuple[List[Formatter], List[Handler], List[Logger]]:
+        '''
+        List all logging configurations.
+
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: A tuple of (formatters, handlers, loggers).
+        :rtype: Tuple[List[Formatter], List[Handler], List[Logger]]
+        '''
+
+        # Delegate to the logging service.
+        return self.logging_service.list_all()
+
+
+# ** event: add_formatter
+class AddFormatter(DomainEvent):
+    '''
+    Event to add a new logging formatter configuration.
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the AddFormatter event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'format'])
+    def execute(
+            self,
+            id: str,
+            name: str,
+            format: str,
+            description: str | None = None,
+            datefmt: str | None = None,
+            **kwargs,
+        ) -> Formatter:
+        '''
+        Add a new formatter.
+
+        :param id: The unique identifier for the formatter.
+        :type id: str
+        :param name: The name of the formatter.
+        :type name: str
+        :param format: The format string for log messages.
+        :type format: str
+        :param description: Optional description of the formatter.
+        :type description: str | None
+        :param datefmt: Optional date format string.
+        :type datefmt: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The created Formatter aggregate.
+        :rtype: Formatter
+        '''
+
+        # Create the formatter aggregate.
+        formatter = FormatterAggregate.new(
+            id=id,
+            name=name,
+            format=format,
+            description=description,
+            datefmt=datefmt,
+            **kwargs,
+        )
+
+        # Persist the formatter.
+        self.logging_service.save_formatter(formatter)
+
+        # Return the created formatter.
+        return formatter
+
+
+# ** event: remove_formatter
+class RemoveFormatter(DomainEvent):
+    '''
+    Event to remove a formatter configuration by ID (idempotent).
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the RemoveFormatter event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove a formatter by ID.
+
+        :param id: The formatter ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The removed formatter ID.
+        :rtype: str
+        '''
+
+        # Delete the formatter (idempotent operation).
+        self.logging_service.delete_formatter(id)
+
+        # Return the formatter ID.
+        return id
+
+
+# ** event: add_handler
+class AddHandler(DomainEvent):
+    '''
+    Event to add a new logging handler configuration.
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the AddHandler event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'module_path', 'class_name', 'level', 'formatter'])
+    def execute(
+            self,
+            id: str,
+            name: str,
+            module_path: str,
+            class_name: str,
+            level: str,
+            formatter: str,
+            description: str | None = None,
+            stream: str | None = None,
+            filename: str | None = None,
+            **kwargs,
+        ) -> Handler:
+        '''
+        Add a new handler.
+
+        :param id: The unique identifier for the handler.
+        :type id: str
+        :param name: The name of the handler.
+        :type name: str
+        :param module_path: The module path for the handler class.
+        :type module_path: str
+        :param class_name: The class name of the handler.
+        :type class_name: str
+        :param level: The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        :type level: str
+        :param formatter: The formatter ID to use.
+        :type formatter: str
+        :param description: Optional description of the handler.
+        :type description: str | None
+        :param stream: Optional stream specification (e.g., ext://sys.stdout).
+        :type stream: str | None
+        :param filename: Optional filename for FileHandler.
+        :type filename: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The created Handler aggregate.
+        :rtype: Handler
+        '''
+
+        # Create the handler aggregate.
+        handler = HandlerAggregate.new(
+            id=id,
+            name=name,
+            module_path=module_path,
+            class_name=class_name,
+            level=level,
+            formatter=formatter,
+            description=description,
+            stream=stream,
+            filename=filename,
+            **kwargs,
+        )
+
+        # Persist the handler.
+        self.logging_service.save_handler(handler)
+
+        # Return the created handler.
+        return handler
+
+
+# ** event: remove_handler
+class RemoveHandler(DomainEvent):
+    '''
+    Event to remove a handler configuration by ID (idempotent).
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the RemoveHandler event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove a handler by ID.
+
+        :param id: The handler ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The removed handler ID.
+        :rtype: str
+        '''
+
+        # Delete the handler (idempotent operation).
+        self.logging_service.delete_handler(id)
+
+        # Return the handler ID.
+        return id
+
+
+# ** event: add_logger
+class AddLogger(DomainEvent):
+    '''
+    Event to add a new logger configuration.
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the AddLogger event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'level', 'handlers'])
+    def execute(
+            self,
+            id: str,
+            name: str,
+            level: str,
+            handlers: List[str],
+            description: str | None = None,
+            propagate: bool = True,
+            **kwargs,
+        ) -> Logger:
+        '''
+        Add a new logger.
+
+        :param id: The unique identifier for the logger.
+        :type id: str
+        :param name: The name of the logger.
+        :type name: str
+        :param level: The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        :type level: str
+        :param handlers: List of handler IDs to attach to this logger.
+        :type handlers: List[str]
+        :param description: Optional description of the logger.
+        :type description: str | None
+        :param propagate: Whether to propagate messages to parent loggers.
+        :type propagate: bool
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The created Logger aggregate.
+        :rtype: Logger
+        '''
+
+        # Create the logger aggregate.
+        logger = LoggerAggregate.new(
+            id=id,
+            name=name,
+            level=level,
+            handlers=handlers,
+            description=description,
+            propagate=propagate,
+            **kwargs,
+        )
+
+        # Persist the logger.
+        self.logging_service.save_logger(logger)
+
+        # Return the created logger.
+        return logger
+
+
+# ** event: remove_logger
+class RemoveLogger(DomainEvent):
+    '''
+    Event to remove a logger configuration by ID (idempotent).
+    '''
+
+    # * attribute: logging_service
+    logging_service: LoggingService
+
+    # * init
+    def __init__(self, logging_service: LoggingService):
+        '''
+        Initialize the RemoveLogger event.
+
+        :param logging_service: The logging service to use.
+        :type logging_service: LoggingService
+        '''
+
+        # Set the logging service dependency.
+        self.logging_service = logging_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> str:
+        '''
+        Remove a logger by ID.
+
+        :param id: The logger ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments (unused).
+        :type kwargs: dict
+        :return: The removed logger ID.
+        :rtype: str
+        '''
+
+        # Delete the logger (idempotent operation).
+        self.logging_service.delete_logger(id)
+
+        # Return the logger ID.
+        return id

--- a/tiferet/events/tests/test_logging.py
+++ b/tiferet/events/tests/test_logging.py
@@ -1,0 +1,489 @@
+"""Tiferet Tests for Logging Events"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..logging import (
+    ListAllLoggingConfigs,
+    AddFormatter,
+    RemoveFormatter,
+    AddHandler,
+    RemoveHandler,
+    AddLogger,
+    RemoveLogger,
+)
+from ..settings import DomainEvent, a
+from ...domain import Formatter, Handler, Logger
+from ...interfaces import LoggingService
+from ...mappers import FormatterAggregate, HandlerAggregate, LoggerAggregate
+from .settings import DomainEventTestBase
+
+
+# *** fixtures
+
+# ** fixture: sample_formatter
+@pytest.fixture
+def sample_formatter() -> Formatter:
+    '''
+    A sample Formatter instance for testing.
+
+    :return: A FormatterAggregate instance.
+    :rtype: Formatter
+    '''
+
+    # Create a sample formatter aggregate.
+    return FormatterAggregate.new(
+        id='simple',
+        name='Simple Formatter',
+        format='%(levelname)s - %(message)s',
+        description='A simple formatter.',
+    )
+
+
+# ** fixture: sample_handler
+@pytest.fixture
+def sample_handler() -> Handler:
+    '''
+    A sample Handler instance for testing.
+
+    :return: A HandlerAggregate instance.
+    :rtype: Handler
+    '''
+
+    # Create a sample handler aggregate.
+    return HandlerAggregate.new(
+        id='console',
+        name='Console Handler',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='INFO',
+        formatter='simple',
+        stream='ext://sys.stdout',
+        description='A console handler.',
+    )
+
+
+# ** fixture: sample_logger
+@pytest.fixture
+def sample_logger() -> Logger:
+    '''
+    A sample Logger instance for testing.
+
+    :return: A LoggerAggregate instance.
+    :rtype: Logger
+    '''
+
+    # Create a sample logger aggregate.
+    return LoggerAggregate.new(
+        id='app',
+        name='Application Logger',
+        level='INFO',
+        handlers=['console'],
+        description='The main application logger.',
+        propagate=True,
+    )
+
+
+# *** tests
+
+# ** test: TestListAllLoggingConfigs
+class TestListAllLoggingConfigs(DomainEventTestBase):
+    '''
+    Tests for ListAllLoggingConfigs using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ListAllLoggingConfigs
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = {}
+
+    # * attribute: required_params
+    required_params = []
+
+    # * method: test_success
+    def test_success(self, mock_dependencies, sample_formatter, sample_handler, sample_logger):
+        '''
+        Test successful listing of all logging configurations.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        :param sample_formatter: The sample formatter instance.
+        :type sample_formatter: Formatter
+        :param sample_handler: The sample handler instance.
+        :type sample_handler: Handler
+        :param sample_logger: The sample logger instance.
+        :type sample_logger: Logger
+        '''
+
+        # Arrange the logging service to return sample configs.
+        mock_dependencies['logging_service'].list_all.return_value = (
+            [sample_formatter],
+            [sample_handler],
+            [sample_logger],
+        )
+
+        # Execute via the harness.
+        formatters, handlers, loggers = self.handle(mock_dependencies)
+
+        # Assert that the configs are returned and the service was called.
+        assert formatters == [sample_formatter]
+        assert handlers == [sample_handler]
+        assert loggers == [sample_logger]
+        mock_dependencies['logging_service'].list_all.assert_called_once_with()
+
+    # * method: test_empty
+    def test_empty(self, mock_dependencies):
+        '''
+        Test listing when no configurations exist.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Arrange the logging service to return empty lists.
+        mock_dependencies['logging_service'].list_all.return_value = ([], [], [])
+
+        # Execute via the harness.
+        formatters, handlers, loggers = self.handle(mock_dependencies)
+
+        # Assert that empty lists are returned.
+        assert formatters == []
+        assert handlers == []
+        assert loggers == []
+        mock_dependencies['logging_service'].list_all.assert_called_once_with()
+
+
+# ** test: TestAddFormatter
+class TestAddFormatter(DomainEventTestBase):
+    '''
+    Tests for AddFormatter using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddFormatter
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='detailed',
+        name='Detailed Formatter',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        description='A detailed formatter with timestamps.',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'format']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful addition of a formatter.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the formatter was created and saved.
+        assert isinstance(result, Formatter)
+        assert result.id == 'detailed'
+        assert result.name == 'Detailed Formatter'
+        assert result.format == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        assert result.datefmt == '%Y-%m-%d %H:%M:%S'
+        mock_dependencies['logging_service'].save_formatter.assert_called_once()
+        saved_formatter = mock_dependencies['logging_service'].save_formatter.call_args[0][0]
+        assert saved_formatter.id == 'detailed'
+
+    # * method: test_minimal
+    def test_minimal(self, mock_dependencies):
+        '''
+        Test adding a formatter with only required fields.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute with only required fields.
+        result = self.handle(
+            mock_dependencies,
+            id='minimal',
+            name='Minimal Formatter',
+            format='%(message)s',
+            description=None,
+            datefmt=None,
+        )
+
+        # Assert the formatter was created with defaults.
+        assert result.id == 'minimal'
+        assert result.name == 'Minimal Formatter'
+        assert result.format == '%(message)s'
+        assert result.description is None
+        assert result.datefmt is None
+        mock_dependencies['logging_service'].save_formatter.assert_called_once()
+
+
+# ** test: TestRemoveFormatter
+class TestRemoveFormatter(DomainEventTestBase):
+    '''
+    Tests for RemoveFormatter using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveFormatter
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='old_formatter')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful removal of a formatter.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the formatter ID is returned and deletion was called.
+        assert result == 'old_formatter'
+        mock_dependencies['logging_service'].delete_formatter.assert_called_once_with('old_formatter')
+
+
+# ** test: TestAddHandler
+class TestAddHandler(DomainEventTestBase):
+    '''
+    Tests for AddHandler using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddHandler
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='file_handler',
+        name='File Handler',
+        module_path='logging.handlers',
+        class_name='RotatingFileHandler',
+        level='DEBUG',
+        formatter='detailed',
+        description='A rotating file handler.',
+        filename='/var/log/app.log',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'module_path', 'class_name', 'level', 'formatter']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful addition of a handler.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the handler was created and saved.
+        assert isinstance(result, Handler)
+        assert result.id == 'file_handler'
+        assert result.name == 'File Handler'
+        assert result.level == 'DEBUG'
+        assert result.filename == '/var/log/app.log'
+        mock_dependencies['logging_service'].save_handler.assert_called_once()
+
+    # * method: test_with_stream
+    def test_with_stream(self, mock_dependencies):
+        '''
+        Test adding a stream handler.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute with stream parameter.
+        result = self.handle(
+            mock_dependencies,
+            id='stderr_handler',
+            name='Stderr Handler',
+            module_path='logging',
+            class_name='StreamHandler',
+            level='ERROR',
+            formatter='simple',
+            stream='ext://sys.stderr',
+            filename=None,
+        )
+
+        # Assert the handler was created with stream.
+        assert result.id == 'stderr_handler'
+        assert result.stream == 'ext://sys.stderr'
+        assert result.filename is None
+        mock_dependencies['logging_service'].save_handler.assert_called_once()
+
+
+# ** test: TestRemoveHandler
+class TestRemoveHandler(DomainEventTestBase):
+    '''
+    Tests for RemoveHandler using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveHandler
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='old_handler')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful removal of a handler.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the handler ID is returned and deletion was called.
+        assert result == 'old_handler'
+        mock_dependencies['logging_service'].delete_handler.assert_called_once_with('old_handler')
+
+
+# ** test: TestAddLogger
+class TestAddLogger(DomainEventTestBase):
+    '''
+    Tests for AddLogger using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddLogger
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='app.database',
+        name='Database Logger',
+        level='WARNING',
+        handlers=['console', 'file_handler'],
+        description='Logger for database operations.',
+        propagate=False,
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'level', 'handlers']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful addition of a logger.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the logger was created and saved.
+        assert isinstance(result, Logger)
+        assert result.id == 'app.database'
+        assert result.name == 'Database Logger'
+        assert result.level == 'WARNING'
+        assert result.handlers == ['console', 'file_handler']
+        assert result.propagate is False
+        mock_dependencies['logging_service'].save_logger.assert_called_once()
+
+    # * method: test_minimal
+    def test_minimal(self, mock_dependencies):
+        '''
+        Test adding a logger with only required fields.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute with only required fields.
+        result = self.handle(
+            mock_dependencies,
+            id='simple_logger',
+            name='Simple Logger',
+            level='INFO',
+            handlers=['console'],
+            description=None,
+            propagate=True,
+        )
+
+        # Assert the logger was created with defaults.
+        assert result.id == 'simple_logger'
+        assert result.propagate is True
+        assert result.description is None
+        mock_dependencies['logging_service'].save_logger.assert_called_once()
+
+
+# ** test: TestRemoveLogger
+class TestRemoveLogger(DomainEventTestBase):
+    '''
+    Tests for RemoveLogger using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = RemoveLogger
+
+    # * attribute: dependencies
+    dependencies = {'logging_service': LoggingService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(id='old_logger')
+
+    # * attribute: required_params
+    required_params = ['id']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful removal of a logger.
+
+        :param mock_dependencies: The mocked dependencies dict.
+        :type mock_dependencies: dict
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the logger ID is returned and deletion was called.
+        assert result == 'old_logger'
+        mock_dependencies['logging_service'].delete_logger.assert_called_once_with('old_logger')


### PR DESCRIPTION
Add 7 logging domain events, test harness classes, and guide document.

## Changes
- **`tiferet/events/logging.py`** — 7 event classes: `ListAllLoggingConfigs`, `AddFormatter`, `RemoveFormatter`, `AddHandler`, `RemoveHandler`, `AddLogger`, `RemoveLogger`.
- **`tiferet/events/tests/test_logging.py`** — 7 test harness classes using `DomainEventTestBase` (27 passed, 1 expected skip).
- **`docs/guides/events/logging.md`** — Usage guide with event details, parameters, and migration notes.

Closes #637

Co-Authored-By: Oz <oz-agent@warp.dev>