### PR TITLE
Events – Add SQLite Events (#641)

### DIFF
--- a/docs/guides/events/sqlite.md
+++ b/docs/guides/events/sqlite.md
@@ -1,0 +1,213 @@
+# Events – SQLite Operations
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/events/sqlite.py`  
+**Version:** 2.0.0a6
+
+## Overview
+
+The SQLite event module provides domain events for executing SQL operations against a SQLite database through an injected `SqliteService`. All events use the context manager protocol (`with self.sqlite_service as sql:`) to ensure proper connection lifecycle management, auto-commit on success, and auto-rollback on failure.
+
+## Events at a Glance
+
+| Event | Operation | Required Parameters | Returns |
+|---|---|---|---|
+| `QuerySql` | SELECT | `query` | `List[Dict]` or `Dict` or `None` |
+| `MutateSql` | INSERT/UPDATE/DELETE | `statement` | `Dict` (rowcount, lastrowid) |
+| `BulkMutateSql` | Batch INSERT/UPDATE/DELETE | `statement`, `parameters_list` | `Dict` (total_rowcount, lastrowids) |
+| `ExecuteScriptSql` | Multi-statement script | `script` | `Dict` (success) |
+| `BackupSql` | Online backup | `target_path` | `Dict` (success, message) |
+| `CreateTableSql` | CREATE TABLE | `table_name`, `columns` | `Dict` (success) |
+| `DropTableSql` | DROP TABLE | `table_name` | `Dict` (success) |
+
+## Dependency
+
+All events inject a single dependency:
+
+- **`sqlite_service: SqliteService`** — the service interface for SQLite database operations, implementing the context manager protocol.
+
+## Event Details
+
+### QuerySql
+
+Executes a read-only SQL query (SELECT or WITH) and returns results as dictionaries.
+
+**Required:** `query`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `parameters` | `Sequence[Any]` | `()` | Bind parameters (tuple or dict) |
+| `fetch_one` | `bool` | `False` | If True, return single row or None |
+
+**Returns:** `List[Dict]` (default) or `Dict`/`None` (when `fetch_one=True`).
+
+**Validation:** Query must start with `SELECT` or `WITH`.
+
+```python
+# Multi-row query
+rows = DomainEvent.handle(
+    QuerySql,
+    dependencies={'sqlite_service': sqlite_service},
+    query="SELECT * FROM users WHERE active = ?",
+    parameters=(1,),
+)
+
+# Single-row query
+row = DomainEvent.handle(
+    QuerySql,
+    dependencies={'sqlite_service': sqlite_service},
+    query="SELECT * FROM users WHERE id = ?",
+    parameters=(42,),
+    fetch_one=True,
+)
+```
+
+### MutateSql
+
+Executes a single INSERT, UPDATE, or DELETE statement and returns operation metadata.
+
+**Required:** `statement`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `parameters` | `Sequence[Any]` | `()` | Bind parameters (tuple or dict) |
+
+**Returns:** `{"rowcount": int, "lastrowid": int | None}` — `lastrowid` is populated only for INSERT.
+
+**Validation:** Statement must start with `INSERT`, `UPDATE`, or `DELETE`.
+
+```python
+result = DomainEvent.handle(
+    MutateSql,
+    dependencies={'sqlite_service': sqlite_service},
+    statement="INSERT INTO users (name, email) VALUES (?, ?)",
+    parameters=('Alice', 'alice@example.com'),
+)
+# result == {"rowcount": 1, "lastrowid": 42}
+```
+
+### BulkMutateSql
+
+Executes a single statement across multiple parameter sets via `executemany`.
+
+**Required:** `statement`, `parameters_list`
+
+**Returns:** `{"total_rowcount": int, "lastrowids": List[int] | None}` — `lastrowids` populated only for INSERT.
+
+**Validation:** Statement must start with `INSERT`/`UPDATE`/`DELETE`; `parameters_list` must be non-empty.
+
+```python
+result = DomainEvent.handle(
+    BulkMutateSql,
+    dependencies={'sqlite_service': sqlite_service},
+    statement="INSERT INTO users (name) VALUES (?)",
+    parameters_list=[('Alice',), ('Bob',), ('Carol',)],
+)
+```
+
+### ExecuteScriptSql
+
+Executes a multi-statement SQL script (DDL + DML) in a single operation via `executescript`.
+
+**Required:** `script`
+
+**Returns:** `{"success": bool}`
+
+```python
+result = DomainEvent.handle(
+    ExecuteScriptSql,
+    dependencies={'sqlite_service': sqlite_service},
+    script="CREATE TABLE test (id INTEGER); INSERT INTO test VALUES (1);",
+)
+```
+
+### BackupSql
+
+Performs an online backup of the current SQLite database to a target file.
+
+**Required:** `target_path`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pages` | `int` | `-1` | Pages per step (-1 = all at once) |
+| `progress` | `Callable` | `None` | Optional callback(status, remaining, total) |
+
+**Returns:** `{"success": bool, "message": str | None}`
+
+**Errors:** `SQLITE_BACKUP_FAILED` on failure.
+
+```python
+result = DomainEvent.handle(
+    BackupSql,
+    dependencies={'sqlite_service': sqlite_service},
+    target_path='/backups/db_backup.sqlite',
+    pages=100,
+)
+```
+
+### CreateTableSql
+
+Generates and executes a CREATE TABLE statement from a columns dictionary and optional constraints.
+
+**Required:** `table_name`, `columns`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `constraints` | `List[str]` | `()` | Table-level constraints (e.g., `UNIQUE(name)`) |
+| `if_not_exists` | `bool` | `True` | Add IF NOT EXISTS clause |
+
+**Returns:** `{"success": bool}`
+
+**Validation:** Table name must be a valid identifier (alphanumeric + underscore, no leading digit). Columns must be a non-empty dict with non-empty string keys and values.
+
+```python
+result = DomainEvent.handle(
+    CreateTableSql,
+    dependencies={'sqlite_service': sqlite_service},
+    table_name='products',
+    columns={'id': 'INTEGER PRIMARY KEY', 'name': 'TEXT NOT NULL', 'price': 'REAL'},
+    constraints=['UNIQUE(name)', 'CHECK(price >= 0)'],
+)
+```
+
+### DropTableSql
+
+Generates and executes a DROP TABLE statement with optional IF EXISTS clause.
+
+**Required:** `table_name`
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `if_exists` | `bool` | `True` | Add IF EXISTS clause |
+
+**Returns:** `{"success": bool}`
+
+**Validation:** Table name must be a valid identifier.
+
+```python
+result = DomainEvent.handle(
+    DropTableSql,
+    dependencies={'sqlite_service': sqlite_service},
+    table_name='old_table',
+    if_exists=True,
+)
+```
+
+## Migration Notes (v2.0)
+
+- **Module docstring:** Added `"""Tiferet SQLite Events"""`.
+- **Artifact comments:** `# *** commands` → `# *** events`; `# ** command:` → `# ** event:`.
+- **Docstrings:** "Helper command to" → "Event to" for `CreateTableSql` and `DropTableSql`.
+- **No parameter renames** — SQLite events do not use `attribute_id`.
+- **Tests:** Converted from 42 function-based tests to 7 harness classes using `SqliteEventTestBase` (a `DomainEventTestBase` subclass with MagicMock context manager support). Result: 49 pass, 0 skip.

--- a/tiferet/events/sqlite.py
+++ b/tiferet/events/sqlite.py
@@ -1,0 +1,517 @@
+"""Tiferet SQLite Events"""
+
+# *** imports
+
+# ** core
+from typing import List, Dict, Any, Sequence, Optional, Callable
+import sqlite3
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces.sqlite import SqliteService
+
+# *** events
+
+# ** event: mutate_sql
+class MutateSql(DomainEvent):
+    '''
+    Execute a single INSERT, UPDATE or DELETE statement and return operation metadata.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            cursor = sql.execute(statement, parameters)
+            return {"rowcount": cursor.rowcount, "lastrowid": cursor.lastrowid if ...}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['statement'])
+    def execute(
+        self,
+        statement: str,
+        parameters: Sequence[Any] = (),
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Execute a mutation statement and return result metadata.
+
+        :param statement: SQL INSERT / UPDATE / DELETE statement
+        :param parameters: Bind parameters (tuple or dict)
+        :return: {"rowcount": int, "lastrowid": int | None}
+        '''
+        # Validate statement type
+        clean_statement = statement.strip().upper()
+        self.verify(
+            any(clean_statement.startswith(prefix) for prefix in ('INSERT', 'UPDATE', 'DELETE')),
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message=f'Statement must start with INSERT, UPDATE, or DELETE. Got: {statement[:20]}...',
+            parameter='statement',
+            command='MutateSql'
+        )
+
+        try:
+            with self.sqlite_service as sql:
+                cursor = sql.execute(statement, parameters)
+                
+                return {
+                    "rowcount": cursor.rowcount,
+                    "lastrowid": cursor.lastrowid if clean_statement.startswith("INSERT") else None
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+# ** event: query_sql
+class QuerySql(DomainEvent):
+    '''
+    Execute a read-only SQL query and return results as list of dictionaries.
+
+    Uses SqliteService convenience methods (fetch_all / fetch_one) which internally
+    wrap execute + fetch. All calls MUST occur inside a 'with' block.
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['query'])
+    def execute(
+        self,
+        query: str,
+        parameters: Sequence[Any] = (),
+        fetch_one: bool = False,
+        **kwargs
+    ) -> List[Dict[str, Any]] | Dict[str, Any] | None:
+        '''
+        Execute SELECT query and return results.
+
+        :param query: SQL SELECT (or WITH … SELECT) statement
+        :param parameters: Bind parameters (tuple or dict)
+        :param fetch_one: If True, return single row or None instead of list
+        :return: List of row dicts, or single dict/None if fetch_one=True
+        '''
+        # Validate query starts with SELECT or WITH
+        clean_query = query.strip().upper()
+        self.verify(
+            clean_query.startswith('SELECT') or clean_query.startswith('WITH'),
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message=f'Query must start with SELECT or WITH. Got: {query[:20]}...',
+            parameter='query',
+            command='QuerySql'
+        )
+
+        # Execute the SQL query.
+        # An APP_ERROR shall be raised in case of error.
+        try:
+            with self.sqlite_service as sql:
+                if fetch_one:
+                    return sql.fetch_one(query, parameters)
+                else:
+                    return sql.fetch_all(query, parameters)
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+# ** event: bulk_mutate_sql
+class BulkMutateSql(DomainEvent):
+    '''
+    Execute a single INSERT, UPDATE or DELETE statement across multiple parameter sets.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            cursor = sql.executemany(statement, parameters_list)
+            return {"total_rowcount": cursor.rowcount, "lastrowids": ...}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['statement', 'parameters_list'])
+    def execute(
+        self,
+        statement: str,
+        parameters_list: Sequence[Sequence[Any] | Dict[str, Any]],
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Execute batch mutation and return aggregated metadata.
+
+        :param statement: SQL INSERT / UPDATE / DELETE statement
+        :param parameters_list: Sequence of parameter tuples or dicts
+        :return: {"total_rowcount": int, "lastrowids": List[int] | None}
+        '''
+        # Validate statement type
+        clean_statement = statement.strip().upper()
+        self.verify(
+            any(clean_statement.startswith(prefix) for prefix in ('INSERT', 'UPDATE', 'DELETE')),
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message=f'Statement must start with INSERT, UPDATE, or DELETE. Got: {statement[:20]}...',
+            parameter='statement',
+            command='BulkMutateSql'
+        )
+
+        # Validate parameters_list is not empty
+        self.verify(
+            len(parameters_list) > 0,
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message='Parameters list must not be empty.',
+            parameter='parameters_list',
+            command='BulkMutateSql'
+        )
+
+        try:
+            with self.sqlite_service as sql:
+                cursor = sql.executemany(statement, parameters_list)
+                
+                return {
+                    "total_rowcount": cursor.rowcount,
+                    "lastrowids": [cursor.lastrowid] if clean_statement.startswith("INSERT") else None
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+# ** event: execute_script_sql
+class ExecuteScriptSql(DomainEvent):
+    '''
+    Execute a multi-statement SQL script (DDL + DML) in a single operation.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            sql.executescript(script)
+            return {"success": True}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['script'])
+    def execute(
+        self,
+        script: str,
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Run a semicolon-separated SQL script and return success status.
+
+        :param script: Multi-statement SQL script
+        :return: {"success": bool}
+        '''
+        try:
+            with self.sqlite_service as sql:
+                sql.executescript(script)
+                
+                return {
+                    "success": True
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+# ** event: backup_sql
+class BackupSql(DomainEvent):
+    '''
+    Perform an online backup of the current SQLite database to a target file.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            sql.backup(target_path, pages=pages, progress=progress)
+            return {"success": True, "message": None}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['target_path'])
+    def execute(
+        self,
+        target_path: str,
+        pages: int = -1,
+        progress: Optional[Callable[[int, int, int], None]] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Backup the database to the specified target path.
+
+        :param target_path: Destination file path for the backup database
+        :param pages: Number of pages to copy per step (-1 = all at once)
+        :param progress: Optional callback(status, remaining, total)
+        :return: {"success": bool, "message": str | None}
+        '''
+        try:
+            with self.sqlite_service as sql:
+                sql.backup(target_path, pages=pages, progress=progress)
+                
+                return {
+                    "success": True,
+                    "message": None
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                a.const.SQLITE_BACKUP_FAILED_ID,
+                f'Backup to {target_path} failed: {str(e)}',
+                target_path=target_path,
+                original_error=str(e)
+            )
+
+# ** event: create_table_sql
+class CreateTableSql(DomainEvent):
+    '''
+    Event to create a table with specified columns and constraints.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            sql.execute(generated_sql)
+            return {"success": True}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['table_name', 'columns'])
+    def execute(
+        self,
+        table_name: str,
+        columns: Dict[str, str],
+        constraints: List[str] = (),
+        if_not_exists: bool = True,
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Create a table with the given structure.
+
+        :param table_name: Name of the table to create
+        :type table_name: str
+        :param columns: Dict[column_name → type_definition] e.g. {"id": "INTEGER PRIMARY KEY", "name": "TEXT NOT NULL"}
+        :type columns: Dict[str, str]
+        :param constraints: List of additional table-level constraints e.g. ["UNIQUE(name)", "CHECK(age > 0)"]
+        :type constraints: List[str]
+        :param if_not_exists: Add IF NOT EXISTS clause (default: True)
+        :type if_not_exists: bool
+        :return: {"success": bool}
+        :rtype: Dict[str, Any]
+        '''
+        # Validate table_name is a valid SQLite identifier (basic check)
+        self.verify(
+            table_name and isinstance(table_name, str) and self._is_valid_identifier(table_name),
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message=f'Invalid table name: {table_name}. Must be non-empty and contain only alphanumeric characters and underscores.',
+            parameter='table_name',
+            command='CreateTableSql'
+        )
+
+        # Validate columns is present and non-empty
+        self.verify(
+            isinstance(columns, dict) and len(columns) > 0,
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message='Columns must be a non-empty dictionary.',
+            parameter='columns',
+            command='CreateTableSql'
+        )
+
+        # Validate all column names and types are non-empty strings
+        for col_name, col_type in columns.items():
+            self.verify(
+                col_name and isinstance(col_name, str),
+                a.const.COMMAND_PARAMETER_REQUIRED_ID,
+                message=f'Column name must be a non-empty string. Got: {col_name}',
+                parameter='columns',
+                command='CreateTableSql'
+            )
+            self.verify(
+                col_type and isinstance(col_type, str),
+                a.const.COMMAND_PARAMETER_REQUIRED_ID,
+                message=f'Column type for "{col_name}" must be a non-empty string. Got: {col_type}',
+                parameter='columns',
+                command='CreateTableSql'
+            )
+
+        # Generate the CREATE TABLE SQL statement
+        sql_parts = []
+        
+        # Add IF NOT EXISTS clause if requested
+        if if_not_exists:
+            sql_parts.append(f'CREATE TABLE IF NOT EXISTS "{table_name}" (')
+        else:
+            sql_parts.append(f'CREATE TABLE "{table_name}" (')
+
+        # Add column definitions
+        column_defs = [f'  "{col_name}" {col_type}' for col_name, col_type in columns.items()]
+        
+        # Add constraints if provided
+        constraint_list = list(constraints) if constraints else []
+        if constraint_list:
+            constraint_defs = [f'  {constraint}' for constraint in constraint_list]
+            all_defs = column_defs + constraint_defs
+        else:
+            all_defs = column_defs
+        
+        sql_parts.append(',\n'.join(all_defs))
+        sql_parts.append(')')
+        
+        generated_sql = '\n'.join(sql_parts)
+
+        # Execute the SQL statement
+        try:
+            with self.sqlite_service as sql:
+                sql.execute(generated_sql)
+                
+                return {
+                    "success": True
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+    # * method: _is_valid_identifier (static)
+    @staticmethod
+    def _is_valid_identifier(name: str) -> bool:
+        '''
+        Validate that a name is a valid SQLite identifier.
+
+        :param name: The identifier to validate
+        :type name: str
+        :return: True if valid, False otherwise
+        :rtype: bool
+        '''
+        # Basic check: alphanumeric and underscore only, doesn't start with digit
+        if not name:
+            return False
+        if name[0].isdigit():
+            return False
+        return all(c.isalnum() or c == '_' for c in name)
+
+# ** event: drop_table_sql
+class DropTableSql(DomainEvent):
+    '''
+    Event to drop a table safely with optional IF EXISTS clause.
+
+    IMPORTANT: All interactions with sqlite_service MUST occur inside a 'with' block.
+    Example:
+        with self.sqlite_service as sql:
+            sql.execute(generated_sql)
+            return {"success": True}
+    '''
+
+    # * attribute: sqlite_service
+    sqlite_service: SqliteService
+
+    # * init
+    def __init__(self, sqlite_service: SqliteService):
+        self.sqlite_service = sqlite_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['table_name'])
+    def execute(
+        self,
+        table_name: str,
+        if_exists: bool = True,
+        **kwargs
+    ) -> Dict[str, Any]:
+        '''
+        Drop the specified table.
+
+        :param table_name: Name of the table to drop
+        :type table_name: str
+        :param if_exists: Add IF EXISTS clause (default: True)
+        :type if_exists: bool
+        :return: {"success": bool}
+        :rtype: Dict[str, Any]
+        '''
+        # Validate table_name is a valid SQLite identifier (basic check)
+        self.verify(
+            table_name and isinstance(table_name, str) and self._is_valid_identifier(table_name),
+            a.const.COMMAND_PARAMETER_REQUIRED_ID,
+            message=f'Invalid table name: {table_name}. Must be non-empty and contain only alphanumeric characters and underscores.',
+            parameter='table_name',
+            command='DropTableSql'
+        )
+
+        # Generate the DROP TABLE SQL statement
+        if if_exists:
+            generated_sql = f'DROP TABLE IF EXISTS "{table_name}"'
+        else:
+            generated_sql = f'DROP TABLE "{table_name}"'
+
+        # Execute the SQL statement
+        try:
+            with self.sqlite_service as sql:
+                sql.execute(generated_sql)
+
+                return {
+                    "success": True
+                }
+        except sqlite3.Error as e:
+            self.raise_error(
+                'APP_ERROR',
+                f'SQLite execution failed: {str(e)}',
+                original_error=str(e)
+            )
+
+    # * method: _is_valid_identifier (static)
+    @staticmethod
+    def _is_valid_identifier(name: str) -> bool:
+        '''
+        Validate that a name is a valid SQLite identifier.
+
+        :param name: The identifier to validate
+        :type name: str
+        :return: True if valid, False otherwise
+        :rtype: bool
+        '''
+        # Basic check: alphanumeric and underscore only, doesn't start with digit
+        if not name:
+            return False
+        if name[0].isdigit():
+            return False
+        return all(c.isalnum() or c == '_' for c in name)

--- a/tiferet/events/tests/test_sqlite.py
+++ b/tiferet/events/tests/test_sqlite.py
@@ -1,0 +1,844 @@
+"""Tiferet Tests for SQLite Events"""
+
+# *** imports
+
+# ** core
+import sqlite3
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from ..sqlite import (
+    QuerySql,
+    MutateSql,
+    BulkMutateSql,
+    ExecuteScriptSql,
+    BackupSql,
+    CreateTableSql,
+    DropTableSql,
+)
+from ..settings import DomainEvent, a, TiferetError
+from ...interfaces import SqliteService
+from .settings import DomainEventTestBase
+
+
+# *** classes
+
+# ** class: SqliteEventTestBase
+class SqliteEventTestBase(DomainEventTestBase):
+    '''
+    Base class for SQLite event tests.
+
+    Overrides mock_dependencies to provide a MagicMock with
+    context manager support required by all SQLite events.
+    '''
+
+    # * attribute: dependencies
+    dependencies = {'sqlite_service': SqliteService}
+
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self) -> dict:
+        '''
+        Fixture providing a MagicMock SqliteService with context manager support.
+
+        :return: A dict containing the mocked sqlite_service.
+        :rtype: dict
+        '''
+
+        # Create a MagicMock with context manager support.
+        service = mock.MagicMock(spec=SqliteService)
+        service.__enter__.return_value = service
+        service.__exit__.return_value = None
+        return {'sqlite_service': service}
+
+
+# *** tests
+
+# ** test: TestQuerySql
+class TestQuerySql(SqliteEventTestBase):
+    '''
+    Tests for QuerySql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = QuerySql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(query="SELECT * FROM users")
+
+    # * attribute: required_params
+    required_params = ['query']
+
+    # * method: test_fetch_all
+    def test_fetch_all(self, mock_dependencies):
+        '''
+        Test successful execution of a multi-row query.
+        '''
+
+        # Arrange the service to return multiple rows.
+        expected = [{'id': 1, 'name': 'Alice'}, {'id': 2, 'name': 'Bob'}]
+        mock_dependencies['sqlite_service'].fetch_all.return_value = expected
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the results and service calls.
+        assert result == expected
+        mock_dependencies['sqlite_service'].fetch_all.assert_called_once_with("SELECT * FROM users", ())
+        mock_dependencies['sqlite_service'].fetch_one.assert_not_called()
+
+    # * method: test_fetch_one
+    def test_fetch_one(self, mock_dependencies):
+        '''
+        Test successful execution of a single-row query.
+        '''
+
+        # Arrange the service to return a single row.
+        query = "SELECT * FROM users WHERE id = ?"
+        expected = {'id': 1, 'name': 'Alice'}
+        mock_dependencies['sqlite_service'].fetch_one.return_value = expected
+
+        # Execute with fetch_one=True.
+        result = self.handle(mock_dependencies, query=query, parameters=(1,), fetch_one=True)
+
+        # Assert the result and service calls.
+        assert result == expected
+        mock_dependencies['sqlite_service'].fetch_one.assert_called_once_with(query, (1,))
+        mock_dependencies['sqlite_service'].fetch_all.assert_not_called()
+
+    # * method: test_empty_result
+    def test_empty_result(self, mock_dependencies):
+        '''
+        Test execution returning empty result (no rows).
+        '''
+
+        # Arrange the service to return empty list.
+        mock_dependencies['sqlite_service'].fetch_all.return_value = []
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies, query="SELECT * FROM users WHERE id = 999")
+
+        # Assert empty list returned.
+        assert result == []
+
+    # * method: test_parameterized
+    def test_parameterized(self, mock_dependencies):
+        '''
+        Test execution with named parameters.
+        '''
+
+        # Arrange the service to return filtered results.
+        query = "SELECT * FROM users WHERE name = :name"
+        params = {'name': 'Alice'}
+        expected = [{'id': 1, 'name': 'Alice'}]
+        mock_dependencies['sqlite_service'].fetch_all.return_value = expected
+
+        # Execute with named parameters.
+        result = self.handle(mock_dependencies, query=query, parameters=params)
+
+        # Assert the result and parameter passing.
+        assert result == expected
+        mock_dependencies['sqlite_service'].fetch_all.assert_called_once_with(query, params)
+
+    # * method: test_invalid_query
+    def test_invalid_query(self, mock_dependencies):
+        '''
+        Test validation failure for non-SELECT query.
+        '''
+
+        # Execute with an INSERT statement, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, query="INSERT INTO users VALUES (1, 'Alice')")
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Query must start with SELECT or WITH" in str(exc_info.value)
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].fetch_all.side_effect = sqlite3.Error("no such table: invalid_table")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, query="SELECT * FROM invalid_table")
+
+        # Assert the error code and original error.
+        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.kwargs.get('original_error') == "no such table: invalid_table"
+
+
+# ** test: TestMutateSql
+class TestMutateSql(SqliteEventTestBase):
+    '''
+    Tests for MutateSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = MutateSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(statement="INSERT INTO users (name) VALUES ('Alice')")
+
+    # * attribute: required_params
+    required_params = ['statement']
+
+    # * method: test_insert_success
+    def test_insert_success(self, mock_dependencies):
+        '''
+        Test successful INSERT execution.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        cursor = mock.Mock(rowcount=1, lastrowid=100)
+        mock_dependencies['sqlite_service'].execute.return_value = cursor
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result metadata.
+        assert result['rowcount'] == 1
+        assert result['lastrowid'] == 100
+        mock_dependencies['sqlite_service'].execute.assert_called_once_with(
+            "INSERT INTO users (name) VALUES ('Alice')", ()
+        )
+
+    # * method: test_update_success
+    def test_update_success(self, mock_dependencies):
+        '''
+        Test successful UPDATE execution.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        cursor = mock.Mock(rowcount=5, lastrowid=None)
+        mock_dependencies['sqlite_service'].execute.return_value = cursor
+
+        # Execute with an UPDATE statement.
+        result = self.handle(mock_dependencies, statement="UPDATE users SET name = 'Bob' WHERE id = 1")
+
+        # Assert lastrowid is None for UPDATE.
+        assert result['rowcount'] == 5
+        assert result['lastrowid'] is None
+
+    # * method: test_delete_success
+    def test_delete_success(self, mock_dependencies):
+        '''
+        Test successful DELETE execution.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        cursor = mock.Mock(rowcount=1)
+        mock_dependencies['sqlite_service'].execute.return_value = cursor
+
+        # Execute with a DELETE statement.
+        result = self.handle(mock_dependencies, statement="DELETE FROM users WHERE id = 1")
+
+        # Assert lastrowid is None for DELETE.
+        assert result['rowcount'] == 1
+        assert result['lastrowid'] is None
+
+    # * method: test_parameterized
+    def test_parameterized(self, mock_dependencies):
+        '''
+        Test execution with parameters.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        statement = "INSERT INTO users (name) VALUES (?)"
+        params = ('Alice',)
+        cursor = mock.Mock(rowcount=1, lastrowid=101)
+        mock_dependencies['sqlite_service'].execute.return_value = cursor
+
+        # Execute with parameters.
+        result = self.handle(mock_dependencies, statement=statement, parameters=params)
+
+        # Assert the result and parameter passing.
+        assert result == {'rowcount': 1, 'lastrowid': 101}
+        mock_dependencies['sqlite_service'].execute.assert_called_once_with(statement, params)
+
+    # * method: test_invalid_statement
+    def test_invalid_statement(self, mock_dependencies):
+        '''
+        Test validation failure for non-mutation statement.
+        '''
+
+        # Execute with a SELECT statement, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, statement="SELECT * FROM users")
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Statement must start with INSERT, UPDATE, or DELETE" in str(exc_info.value)
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].execute.side_effect = sqlite3.Error("constraint failed")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, statement="INSERT INTO users VALUES (1)")
+
+        # Assert the error code.
+        assert exc_info.value.error_code == 'APP_ERROR'
+
+
+# ** test: TestBulkMutateSql
+class TestBulkMutateSql(SqliteEventTestBase):
+    '''
+    Tests for BulkMutateSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = BulkMutateSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        statement="INSERT INTO users (name) VALUES (?)",
+        parameters_list=[('Alice',), ('Bob',)],
+    )
+
+    # * attribute: required_params
+    required_params = ['statement', 'parameters_list']
+
+    # * method: test_insert_success
+    def test_insert_success(self, mock_dependencies):
+        '''
+        Test successful bulk INSERT execution.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        cursor = mock.Mock(rowcount=2, lastrowid=102)
+        mock_dependencies['sqlite_service'].executemany.return_value = cursor
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the result metadata.
+        assert result['total_rowcount'] == 2
+        assert result['lastrowids'] == [102]
+        mock_dependencies['sqlite_service'].executemany.assert_called_once()
+
+    # * method: test_update_success
+    def test_update_success(self, mock_dependencies):
+        '''
+        Test successful bulk UPDATE execution.
+        '''
+
+        # Arrange the service to return a cursor mock.
+        cursor = mock.Mock(rowcount=2, lastrowid=None)
+        mock_dependencies['sqlite_service'].executemany.return_value = cursor
+
+        # Execute with an UPDATE statement.
+        result = self.handle(
+            mock_dependencies,
+            statement="UPDATE users SET active = 1 WHERE id = ?",
+            parameters_list=[(1,), (2,)],
+        )
+
+        # Assert lastrowids is None for UPDATE.
+        assert result['total_rowcount'] == 2
+        assert result['lastrowids'] is None
+
+    # * method: test_invalid_statement
+    def test_invalid_statement(self, mock_dependencies):
+        '''
+        Test validation failure for non-mutation statement.
+        '''
+
+        # Execute with a SELECT statement, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, statement="SELECT * FROM users", parameters_list=[(1,)])
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Statement must start with INSERT, UPDATE, or DELETE" in str(exc_info.value)
+
+    # * method: test_empty_parameters_list
+    def test_empty_parameters_list(self, mock_dependencies):
+        '''
+        Test validation failure for empty parameters list.
+        '''
+
+        # Execute with empty parameters list, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, parameters_list=[])
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Parameters list must not be empty" in str(exc_info.value)
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors during bulk mutation.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].executemany.side_effect = sqlite3.Error("constraint failed")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies)
+
+        # Assert the error code.
+        assert exc_info.value.error_code == 'APP_ERROR'
+
+
+# ** test: TestExecuteScriptSql
+class TestExecuteScriptSql(SqliteEventTestBase):
+    '''
+    Tests for ExecuteScriptSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = ExecuteScriptSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(script="CREATE TABLE test (id INTEGER); INSERT INTO test VALUES (1);")
+
+    # * attribute: required_params
+    required_params = ['script']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful execution of a multi-statement script.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the success result.
+        assert result['success'] is True
+        mock_dependencies['sqlite_service'].executescript.assert_called_once_with(
+            "CREATE TABLE test (id INTEGER); INSERT INTO test VALUES (1);"
+        )
+
+    # * method: test_whitespace_only_script
+    def test_whitespace_only_script(self, mock_dependencies):
+        '''
+        Test validation failure for whitespace-only script.
+        '''
+
+        # Execute with whitespace-only script, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, script="   \n   ")
+
+        # Assert the error code.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert 'script' in exc_info.value.kwargs.get('parameters')
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors during script execution.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].executescript.side_effect = sqlite3.Error("syntax error")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, script="INVALID SQL;")
+
+        # Assert the error code.
+        assert exc_info.value.error_code == 'APP_ERROR'
+
+
+# ** test: TestBackupSql
+class TestBackupSql(SqliteEventTestBase):
+    '''
+    Tests for BackupSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = BackupSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(target_path='/tmp/backup.db')
+
+    # * attribute: required_params
+    required_params = ['target_path']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful database backup.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the success result.
+        assert result['success'] is True
+        assert result['message'] is None
+        mock_dependencies['sqlite_service'].backup.assert_called_once_with(
+            '/tmp/backup.db', pages=-1, progress=None
+        )
+
+    # * method: test_with_options
+    def test_with_options(self, mock_dependencies):
+        '''
+        Test backup with custom pages and progress callback.
+        '''
+
+        # Arrange a progress callback.
+        progress_callback = mock.Mock()
+
+        # Execute with custom options.
+        result = self.handle(mock_dependencies, pages=5, progress=progress_callback)
+
+        # Assert the success result and option passing.
+        assert result['success'] is True
+        mock_dependencies['sqlite_service'].backup.assert_called_once_with(
+            '/tmp/backup.db', pages=5, progress=progress_callback
+        )
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors during backup.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].backup.side_effect = sqlite3.Error("permission denied")
+
+        # Execute and expect a SQLITE_BACKUP_FAILED error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, target_path='/invalid/path/backup.db')
+
+        # Assert the error code.
+        assert exc_info.value.error_code == a.const.SQLITE_BACKUP_FAILED_ID
+
+
+# ** test: TestCreateTableSql
+class TestCreateTableSql(SqliteEventTestBase):
+    '''
+    Tests for CreateTableSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = CreateTableSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        table_name='users',
+        columns={
+            'id': 'INTEGER PRIMARY KEY',
+            'name': 'TEXT NOT NULL',
+            'email': 'TEXT',
+        },
+    )
+
+    # * attribute: required_params
+    required_params = ['table_name', 'columns']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful table creation with columns.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the success result.
+        assert result['success'] is True
+        mock_dependencies['sqlite_service'].execute.assert_called_once()
+
+        # Verify the generated SQL contains expected elements.
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'CREATE TABLE IF NOT EXISTS "users"' in generated_sql
+        assert '"id" INTEGER PRIMARY KEY' in generated_sql
+        assert '"name" TEXT NOT NULL' in generated_sql
+        assert '"email" TEXT' in generated_sql
+
+    # * method: test_with_constraints
+    def test_with_constraints(self, mock_dependencies):
+        '''
+        Test table creation with constraints.
+        '''
+
+        # Execute with constraints.
+        result = self.handle(
+            mock_dependencies,
+            table_name='products',
+            columns={'id': 'INTEGER PRIMARY KEY', 'name': 'TEXT NOT NULL', 'price': 'REAL'},
+            constraints=['UNIQUE(name)', 'CHECK(price >= 0)'],
+        )
+
+        # Assert the success and constraint inclusion.
+        assert result['success'] is True
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'UNIQUE(name)' in generated_sql
+        assert 'CHECK(price >= 0)' in generated_sql
+
+    # * method: test_if_not_exists_false
+    def test_if_not_exists_false(self, mock_dependencies):
+        '''
+        Test table creation without IF NOT EXISTS clause.
+        '''
+
+        # Execute with if_not_exists=False.
+        result = self.handle(
+            mock_dependencies,
+            table_name='temp_table',
+            columns={'id': 'INTEGER'},
+            if_not_exists=False,
+        )
+
+        # Assert the SQL omits IF NOT EXISTS.
+        assert result['success'] is True
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'CREATE TABLE "temp_table"' in generated_sql
+        assert 'IF NOT EXISTS' not in generated_sql
+
+    # * method: test_idempotent
+    def test_idempotent(self, mock_dependencies):
+        '''
+        Test that creating an existing table with if_not_exists=True succeeds.
+        '''
+
+        # Execute twice, both should succeed.
+        result1 = self.handle(mock_dependencies, table_name='existing_table', columns={'id': 'INTEGER'})
+        result2 = self.handle(mock_dependencies, table_name='existing_table', columns={'id': 'INTEGER'})
+
+        # Assert both succeed.
+        assert result1['success'] is True
+        assert result2['success'] is True
+        assert mock_dependencies['sqlite_service'].execute.call_count == 2
+
+    # * method: test_duplicate_without_if_not_exists
+    def test_duplicate_without_if_not_exists(self, mock_dependencies):
+        '''
+        Test that creating an existing table with if_not_exists=False raises error.
+        '''
+
+        # Arrange the service to raise on duplicate table.
+        mock_dependencies['sqlite_service'].execute.side_effect = sqlite3.Error("table existing_table already exists")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(
+                mock_dependencies,
+                table_name='existing_table',
+                columns={'id': 'INTEGER'},
+                if_not_exists=False,
+            )
+
+        # Assert the error code.
+        assert exc_info.value.error_code == 'APP_ERROR'
+
+    # * method: test_invalid_table_name
+    def test_invalid_table_name(self, mock_dependencies):
+        '''
+        Test validation failure for invalid table name (special characters).
+        '''
+
+        # Test with spaces.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='invalid table', columns={'id': 'INTEGER'})
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Invalid table name" in str(exc_info.value)
+
+        # Test with hyphens.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='table-name', columns={'id': 'INTEGER'})
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+
+    # * method: test_empty_columns
+    def test_empty_columns(self, mock_dependencies):
+        '''
+        Test validation failure for empty columns dictionary.
+        '''
+
+        # Execute with empty columns, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, columns={})
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Columns must be a non-empty dictionary" in str(exc_info.value)
+
+    # * method: test_invalid_column_name
+    def test_invalid_column_name(self, mock_dependencies):
+        '''
+        Test validation failure for invalid column name.
+        '''
+
+        # Execute with empty column name, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, columns={'': 'INTEGER'})
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Column name must be a non-empty string" in str(exc_info.value)
+
+    # * method: test_invalid_column_type
+    def test_invalid_column_type(self, mock_dependencies):
+        '''
+        Test validation failure for invalid column type.
+        '''
+
+        # Execute with empty column type, expect validation error.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, columns={'id': ''})
+
+        # Assert the error code and message.
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Column type" in str(exc_info.value)
+        assert "must be a non-empty string" in str(exc_info.value)
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors during table creation.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].execute.side_effect = sqlite3.Error("syntax error")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, columns={'id': 'INVALID_TYPE'})
+
+        # Assert the error code.
+        assert exc_info.value.error_code == 'APP_ERROR'
+
+
+# ** test: TestDropTableSql
+class TestDropTableSql(SqliteEventTestBase):
+    '''
+    Tests for DropTableSql using the SQLite event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = DropTableSql
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(table_name='users')
+
+    # * attribute: required_params
+    required_params = ['table_name']
+
+    # * method: test_success
+    def test_success(self, mock_dependencies):
+        '''
+        Test successful table drop.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies)
+
+        # Assert the success result.
+        assert result['success'] is True
+        mock_dependencies['sqlite_service'].execute.assert_called_once()
+
+        # Verify the generated SQL contains expected elements.
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'DROP TABLE IF EXISTS "users"' in generated_sql
+
+    # * method: test_without_if_exists
+    def test_without_if_exists(self, mock_dependencies):
+        '''
+        Test table drop without IF EXISTS clause.
+        '''
+
+        # Execute with if_exists=False.
+        result = self.handle(mock_dependencies, table_name='temp_table', if_exists=False)
+
+        # Assert the SQL omits IF EXISTS.
+        assert result['success'] is True
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'DROP TABLE "temp_table"' in generated_sql
+        assert 'IF EXISTS' not in generated_sql
+
+    # * method: test_idempotent
+    def test_idempotent(self, mock_dependencies):
+        '''
+        Test that dropping a non-existent table with if_exists=True succeeds.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies, table_name='non_existent_table')
+
+        # Assert success.
+        assert result['success'] is True
+        generated_sql = mock_dependencies['sqlite_service'].execute.call_args[0][0]
+        assert 'DROP TABLE IF EXISTS "non_existent_table"' in generated_sql
+
+    # * method: test_non_existent_without_if_exists
+    def test_non_existent_without_if_exists(self, mock_dependencies):
+        '''
+        Test that dropping a non-existent table with if_exists=False raises error.
+        '''
+
+        # Arrange the service to raise on missing table.
+        mock_dependencies['sqlite_service'].execute.side_effect = sqlite3.Error("no such table: non_existent_table")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='non_existent_table', if_exists=False)
+
+        # Assert the error code and original error.
+        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.kwargs.get('original_error') == "no such table: non_existent_table"
+
+    # * method: test_invalid_table_name
+    def test_invalid_table_name(self, mock_dependencies):
+        '''
+        Test validation failure for invalid table name (special characters).
+        '''
+
+        # Test with spaces.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='invalid table')
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+        assert "Invalid table name" in str(exc_info.value)
+
+        # Test with hyphens.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='table-name')
+        assert exc_info.value.error_code == a.const.COMMAND_PARAMETER_REQUIRED_ID
+
+    # * method: test_with_data
+    def test_with_data(self, mock_dependencies):
+        '''
+        Test dropping a table with existing data succeeds.
+        '''
+
+        # Execute via the harness.
+        result = self.handle(mock_dependencies, table_name='populated_table')
+
+        # Assert success.
+        assert result['success'] is True
+        mock_dependencies['sqlite_service'].execute.assert_called_once()
+
+    # * method: test_execution_error
+    def test_execution_error(self, mock_dependencies):
+        '''
+        Test handling of underlying SQLite errors during table drop.
+        '''
+
+        # Arrange the service to raise a sqlite3.Error.
+        mock_dependencies['sqlite_service'].execute.side_effect = sqlite3.Error("database is locked")
+
+        # Execute and expect an APP_ERROR.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(mock_dependencies, table_name='test_table')
+
+        # Assert the error code and original error.
+        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.kwargs.get('original_error') == "database is locked"

--- a/tiferet/interfaces/file.py
+++ b/tiferet/interfaces/file.py
@@ -46,3 +46,26 @@ class FileService(Service):
         :type file: IO[Any]
         '''
         raise NotImplementedError()
+
+    # * method: __enter__
+    @abstractmethod
+    def __enter__(self) -> 'FileService':
+        '''
+        Enter the context manager.
+
+        :return: The file service instance.
+        :rtype: FileService
+        '''
+        raise NotImplementedError()
+
+    # * method: __exit__
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        '''
+        Exit the context manager.
+
+        :param exc_type: The exception type, if any.
+        :param exc_val: The exception value, if any.
+        :param exc_tb: The exception traceback, if any.
+        '''
+        raise NotImplementedError()

--- a/tiferet/interfaces/sqlite.py
+++ b/tiferet/interfaces/sqlite.py
@@ -4,15 +4,15 @@
 
 # ** core
 from abc import abstractmethod
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Optional
 
 # ** app
-from .settings import Service
+from .file import FileService
 
 # *** interfaces
 
 # ** interface: sqlite_service
-class SqliteService(Service):
+class SqliteService(FileService):
     '''
     Service contract for SQLite database operations.
     '''
@@ -62,22 +62,30 @@ class SqliteService(Service):
 
     # * method: fetch_one
     @abstractmethod
-    def fetch_one(self) -> tuple | None:
+    def fetch_one(self, query: str, parameters: Iterable[Any] = ()) -> tuple | None:
         '''
-        Fetch the next row.
+        Execute a query and fetch a single row.
 
-        :return: The next row as a tuple, or None if no more rows.
+        :param query: The SQL query to execute.
+        :type query: str
+        :param parameters: Parameters for the SQL query.
+        :type parameters: Iterable[Any]
+        :return: The first row as a tuple, or None if no rows.
         :rtype: tuple | None
         '''
         raise NotImplementedError()
 
     # * method: fetch_all
     @abstractmethod
-    def fetch_all(self) -> list[tuple]:
+    def fetch_all(self, query: str, parameters: Iterable[Any] = ()) -> list[tuple]:
         '''
-        Fetch all remaining rows.
+        Execute a query and fetch all rows.
 
-        :return: All remaining rows as a list of tuples.
+        :param query: The SQL query to execute.
+        :type query: str
+        :param parameters: Parameters for the SQL query.
+        :type parameters: Iterable[Any]
+        :return: All rows as a list of tuples.
         :rtype: list[tuple]
         '''
         raise NotImplementedError()
@@ -100,13 +108,19 @@ class SqliteService(Service):
 
     # * method: backup
     @abstractmethod
-    def backup(self, target: 'SqliteService', pages: int = -1) -> None:
+    def backup(self,
+            target_path: str,
+            pages: int = -1,
+            progress: Optional[Callable[[int, int, int], None]] = None,
+        ) -> None:
         '''
-        Backup database to another connection.
+        Backup database to a target file path.
 
-        :param target: The target SQLite service to backup to.
-        :type target: SqliteService
+        :param target_path: The file path for the backup database.
+        :type target_path: str
         :param pages: Number of pages to copy at a time (-1 for all).
         :type pages: int
+        :param progress: Optional progress callback(status, remaining, total).
+        :type progress: Optional[Callable[[int, int, int], None]]
         '''
         raise NotImplementedError()


### PR DESCRIPTION
Add 7 SQLite domain event classes and test suite with guide documentation.

## Changes
- **`tiferet/events/sqlite.py`** — New file. 7 event classes: `QuerySql`, `MutateSql`, `BulkMutateSql`, `ExecuteScriptSql`, `BackupSql`, `CreateTableSql`, `DropTableSql`. All use `with self.sqlite_service as sql:` for connection lifecycle.
- **`tiferet/events/tests/test_sqlite.py`** — New file. `SqliteEventTestBase` (MagicMock with context manager support) + 7 test harness classes (49 tests).
- **`docs/guides/events/sqlite.md`** — New file. Usage guide with event details, parameters, examples, and migration notes.

## Deviations from TRD
- **`tiferet/interfaces/file.py`** — Added `__enter__`/`__exit__` abstract methods (context manager protocol) to `FileService`.
- **`tiferet/interfaces/sqlite.py`** — Updated `SqliteService` to extend `FileService` (was `Service`), aligned `fetch_one`/`fetch_all`/`backup` signatures with `v2.0-proto`. Required for `MagicMock(spec=SqliteService)` to support the context manager protocol.

Closes #641

Co-Authored-By: Oz <oz-agent@warp.dev>