### PR TITLE
Docs/Version – v2.0.0a6 Release Updates (#666)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a5`
+- **Version:** `2.0.0a6`
 
 ## Architecture
 
@@ -70,7 +70,7 @@ All code follows a strict artifact comment hierarchy. **This is mandatory.**
 
 ### Comment Levels
 
-- `# *** <section>` — Top-level: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `constants`, `classes`
+- `# *** <section>` — Top-level: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `repos`, `constants`, `classes`
 - `# ** <category>: <name>` — Mid-level: `core`, `infra`, `app` (for imports); `model: <name>`, `event: <name>`, `context: <name>`, etc.
 - `# * <component>` — Low-level: `attribute: <name>`, `init`, `method: <name>`, `method: <name> (static)`
 
@@ -157,7 +157,7 @@ result = DomainEvent.handle(
 ### Domain Modules
 
 - `domain/app.py` — `AppInterface`, `AppServiceDependency`
-- `domain/cli.py` — `CliArgument`, `CliCommand`
+- `domain/cli.py` — `CliCommand`, `CliArgument`
 - `domain/di.py` — `ServiceConfiguration`, `FlaggedDependency`
 - `domain/error.py` — `Error`, `ErrorMessage`
 - `domain/feature.py` — `Feature`, `FeatureStep`, `FeatureEvent`
@@ -168,7 +168,7 @@ result = DomainEvent.handle(
 - Extend `Service` (ABC) from `tiferet/interfaces/settings.py`.
 - All methods marked `@abstractmethod`.
 - Artifact comments use `# *** interfaces` / `# ** interface: <name>`.
-- Services: `AppService`, `CliService`, `ConfigurationService`, `DIService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
+- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
 
 ## Mappers
 
@@ -184,10 +184,20 @@ Split into two classes:
 
 ## Repositories
 
-Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backed:
+Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backed. Repositories are **never exported** from `__init__.py` — they are resolved at runtime through DI configuration.
 
-- `AppYamlRepository`, `CliYamlRepository`, `DIYamlRepository`
-- `ErrorYamlRepository`, `FeatureYamlRepository`, `LoggingYamlRepository`
+- `AppYamlRepository`, `CliYamlRepository`, `ContainerYamlRepository`
+- `DIYamlRepository`, `ErrorYamlRepository`, `FeatureYamlRepository`, `LoggingYamlRepository`
+
+Key patterns:
+- Artifact comments use `# *** repos` / `# ** repo: <name>`.
+- Three-attribute foundation: `yaml_file`, `encoding`, `default_role`.
+- Constructor param convention: `<domain>_yaml_file` (e.g., `error_yaml_file`).
+- Reads use `Yaml` utility with `start_node` lambdas; writes use `TransferObject.from_model` → `to_primitive(default_role)` → `Yaml.save`.
+- Delete operations are always idempotent.
+- Tests are integration tests using `tmp_path` fixtures with real temporary YAML files.
+
+See [docs/core/repos.md](docs/core/repos.md) for structured code design and [docs/guides/repos.md](docs/guides/repos.md) for cross-cutting strategies.
 
 ## Error Handling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ All contributions should be tied to a GitHub issue. If one doesn't exist for the
 For non-trivial changes (new features, refactors, architectural updates), a **Technical Requirements Document** is required before implementation begins. TRDs ensure clarity, alignment, and traceability across the project.
 
 See the full TRD authoring guide:
-**[docs/guides/tech_requirements.md](docs/guides/tech_requirements.md)**
+**[docs/guides/tech_requirements.md](docs/contrib/tech_requirements.md)**
 
 Key points:
 - Follow the standard structure (Overview, Scope, Components Affected, Detailed Requirements, Acceptance Criteria).
@@ -40,7 +40,9 @@ Key points:
   - [mappers.md](docs/core/mappers.md) — Aggregates and transfer objects
   - [interfaces.md](docs/core/interfaces.md) — Service interfaces
   - [contexts.md](docs/core/contexts.md) — Application contexts
-- Write tests using `pytest`. Follow existing test structure (`# *** fixtures`, `# *** tests`).
+  - [repos.md](docs/core/repos.md) — Repositories
+  - [utils.md](docs/core/utils.md) — Utilities
+- Write tests using `pytest`.
 
 ### 4. Commit Hygiene
 
@@ -60,7 +62,7 @@ Key points:
 Upon completion of a story or issue, a **Collaboration Report** is published as a comment on the originating GitHub issue. This report documents the implementation, deviations from the TRD, git state, and a log of key decisions made during development.
 
 See the full report format guide:
-**[docs/guides/collab_report.md](docs/guides/collab_report.md)**
+**[docs/guides/collab_report.md](docs/contrib/collab_report.md)**
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -1,677 +1,159 @@
-# Tiferet - A Python Framework for Domain-Driven Design
+# Tiferet – Domain-Driven Design, beautifully balanced
 
-## Introduction
+[![PyPI](https://img.shields.io/pypi/v/tiferet?style=flat-square&logo=python&logoColor=white&color=3775A9)](https://pypi.org/project/tiferet/)
+[![Python](https://img.shields.io/pypi/pyversions/tiferet?style=flat-square&logo=python&logoColor=white&color=3775A9)](https://pypi.org/project/tiferet/)
+[![License](https://img.shields.io/github/license/greatstrength/tiferet?style=flat-square)](LICENSE)
 
-Tiferet is a Python framework that elegantly distills Domain-Driven Design (DDD) into a practical, powerful tool. Drawing inspiration from the concept of beauty in balance as expressed in Kabbalah, Tiferet weaves purpose and functionality into software that not only performs but resonates deeply with its intended vision. As a cornerstone for crafting diverse applications, Tiferet empowers developers to build solutions with clarity, grace, and thoughtful design.
+**Tiferet** is a Python framework that brings **Domain-Driven Design** into focus with elegance and clarity.
 
-Tiferet embraces the complexity of real-world processes through DDD, transforming intricate business logic and evolving requirements into clear, manageable models. Far from merely navigating this labyrinth, Tiferet provides a graceful path to craft software that reflects its intended purpose with wisdom and precision, embodying beauty and balance in form and function. This tutorial guides you through building a simple calculator application, demonstrating how Tiferet harmonizes code and concept. By defining domain events and their configurations, you'll create a robust and extensible calculator that resonates with Tiferet's philosophy.
+Inspired by the Kabbalistic principle of harmony and beauty in balance, Tiferet helps you turn complex business logic into maintainable, configuration-driven applications — where purpose, structure, and execution feel naturally aligned.
 
-## Getting Started with Tiferet
-Embark on your Tiferet journey with a few simple steps to set up your Python environment. Whether you're new to Python or a seasoned developer, these instructions will prepare you to craft a calculator application with grace and precision.
+### At a glance
 
-### Installing Python
-Tiferet requires Python 3.10 or later. Follow these steps to install it:
+- Domain events as the core unit of behavior  
+- YAML for features, workflows, dependency injection, errors, CLI commands  
+- Clean layering: domain objects • aggregates • transfer objects • services  
+- Structured, multilingual errors built-in  
+- Easy to extend to CLI, web, scripts, TUI, …
 
-#### Windows
+Current status: **2.0.0a6** (pre-release – actively evolving toward stable v2)
 
-Visit python.org, navigate to the Downloads section, and select the Python 3.10 installer for Windows.
-Run the installer, ensuring you check "Add Python 3.10 to PATH," then click "Install Now."
-
-#### macOS
-
-Download the Python 3.10 installer from python.org.
-Open the .pkg file and follow the installation prompts.
-
-#### Linux (Ubuntu/Debian)
-```bash
-sudo apt update
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt update
-sudo apt install python3.10
-```
-
-#### Verify the installation by running:
-```bash
-python3.10 --version
-```
-
-You should see Python 3.10.x if successful.
-
-### Setting Up a Virtual Environment
-To keep your project dependencies organized, create a virtual environment named `tiferet_app` for your calculator application:
-
-#### Create the Environment
+## Quick Start – Add two numbers in ~3 minutes
 
 ```bash
-# Windows
-python -m venv tiferet_app
-
-# macOS/Linux
-python3.10 -m venv tiferet_app
-```
-
-#### Activate the Environment
-Activate the environment to isolate your project's dependencies:
-
-```bash
-# Windows (Command Prompt)
-tiferet_app\Scripts\activate
-
-# Windows (PowerShell)
-.\tiferet_app\Scripts\Activate.ps1
-
-# macOS/Linux
-source tiferet_app/bin/activate
-```
-
-Your terminal should display `(tiferet_app)`, confirming the environment is active. You can now install Tiferet and other dependencies without affecting your system’s Python setup.
-Deactivate the Environment
-When finished, deactivate the environment with:
-deactivate
-
-## Your First Calculator App
-With your `tiferet_app` virtual environment activated, you're ready to install Tiferet and start building your calculator application. Follow these steps to set up your project and begin crafting with Tiferet’s elegant approach.
-
-### Installing Tiferet
-Install the Tiferet package using pip in your activated virtual environment:
-
-```bash
-# Windows
+# 1. Set up environment
+python3 -m venv tiferet-demo && source tiferet-demo/bin/activate
 pip install tiferet
-
-# macOS/Linux
-pip3 install tiferet
 ```
 
-### Project Structure
-Create a project directory structure to organize your calculator application:
+Create these files in your project folder:
 
-```plaintext
-project_root/
-├── basic_calc.py
-├── calc_cli.py
-└── app/
-    ├── events/
-    │   ├── __init__.py
-    │   ├── calc.py
-    │   └── settings.py
-    └── configs/
-        ├── __init__.py
-        ├── app.yml
-        ├── cli.yml
-        ├── di.yml
-        ├── error.yml
-        ├── feature.yml
-        └── logging.yml
-```
-
-The `app/events/` directory holds domain event classes for arithmetic operations (`calc.py`) and input validation (`settings.py`). The `app/configs/` directory contains configuration files for application settings (`app.yml`), CLI commands (`cli.yml`), dependency injection (`di.yml`), error handling (`error.yml`), feature workflows (`feature.yml`), and logging (`logging.yml`). The `basic_calc.py` script at the root initializes and runs the application. We recommend keeping the `app` directory name for internal projects to ensure consistency, though it can be customized for package releases. The `calc_cli.py` script provides a flexible command-line interface, easily integrated with shell scripts or external systems.
-
-## Crafting the Calculator Application
-With Tiferet installed and your project structured, it's time to build your calculator application. This section guides you through creating a base domain event for numeric validation, defining arithmetic domain events, and setting up the application's behavior with configurations. By weaving together domain events and configurations, you'll experience Tiferet's elegant design, harmonizing functionality with clarity and precision.
-
-### Defining Base and Arithmetic Domain Event Classes
-Start by creating domain event classes for numeric validation and arithmetic operations. The `BasicCalcEvent` in `app/events/settings.py` provides validation logic, while arithmetic domain events (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber`) in `app/events/calc.py` perform calculations. All arithmetic domain events inherit from `BasicCalcEvent`, which extends Tiferet's `DomainEvent` class, ensuring robust numeric validation and core event functionality.
-
-#### Base Domain Event in events/settings.py
-Numeric validation is critical to ensure the calculator handles inputs correctly, preventing errors from invalid data. The `BasicCalcEvent` class centralizes validation logic, making it reusable across all arithmetic domain events by converting string inputs to integers or floats.
-
-Create `app/events/settings.py` with the following contents:
-
+**demo.py**
 ```python
-# *** imports
+from tiferet import App
 
-# ** infra
-from tiferet.events import *
+app = App()                     # loads configs from app/configs/ by default
 
-# *** events
+result = app.run(
+    interface_id="basic_calc",
+    feature_id="calc.add",
+    data={"a": 19, "b": 23}
+)
 
-# ** event: basic_calc_event
-class BasicCalcEvent(DomainEvent):
-    '''
-    A domain event to validate that a value can be a Number object.
-    '''
-    
-    # * method: verify_number
-    def verify_number(self, value: str) -> int | float:
-        '''
-        Verify that the value can be converted to an integer or float.
-        
-        :param value: The value to verify.
-        :type value: str
-        :return: The numeric value as an integer or float.
-        :rtype: int | float
-        '''
-        
-        # Check if the value is a valid number.
-        is_valid = isinstance(value, str) and (value.isdigit() or (value.replace('.', '', 1).isdigit() and value.count('.') < 2))
-
-        # Verify the value.
-        self.verify(
-            is_valid,
-            'INVALID_INPUT',
-            f"Invalid number: {value}",
-            value
-        )
-
-        # If valid, return the value as a float or int.
-        if '.' in value:
-            return float(value)
-        return int(value)
+print(f"19 + 23 = {result}")    # → 42
 ```
 
-The `BasicCalcEvent` extends Tiferet's `DomainEvent` class, providing a `verify_number` method that validates string inputs and returns them as `int` or `float`. It raises an `INVALID_INPUT` error for invalid inputs, ensuring all arithmetic domain events inherit robust validation.
-
-#### Arithmetic Domain Events in events/calc.py
-The arithmetic domain events are the heart of the calculator, delivering core mathematical operations: addition, subtraction, multiplication, division, and exponentiation. These domain events leverage Python's numeric capabilities, processing validated inputs to produce precise results.
-
-Create `app/events/calc.py` with the following content:
-
-```python
-# *** imports
-
-# ** core
-from typing import Any
-
-# ** infra
-from tiferet.events import *
-
-# ** app
-from .settings import BasicCalcEvent
-
-# *** events
-
-# ** event: add_number
-class AddNumber(BasicCalcEvent):
-    '''
-    A domain event to perform addition of two numbers.
-    '''
-    def execute(self, a: Any, b: Any, **kwargs) -> int | float:
-        '''
-        Execute the addition event.
-
-        :param a: A number representing the first operand.
-        :type a: Any
-        :param b: A number representing the second operand.
-        :type b: Any
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The sum of a and b.
-        :rtype: int | float
-        '''
-        # Verify numeric inputs
-        a_verified = self.verify_number(str(a))
-        b_verified = self.verify_number(str(b))
-
-        # Add verified values of a and b.
-        result = a_verified + b_verified
-
-        # Return the result.
-        return result
-
-# ** event: subtract_number
-class SubtractNumber(BasicCalcEvent):
-    '''
-    A domain event to perform subtraction of two numbers.
-    '''
-    def execute(self, a: Any, b: Any, **kwargs) -> int | float:
-        '''
-        Execute the subtraction event.
-
-        :param a: A number representing the first operand.
-        :type a: Any
-        :param b: A number representing the second operand.
-        :type b: Any
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The difference of a and b.
-        :rtype: int | float
-        '''
-        # Verify numeric inputs
-        a_verified = self.verify_number(str(a))
-        b_verified = self.verify_number(str(b))
-
-        # Subtract verified values of b from a.
-        result = a_verified - b_verified
-
-        # Return the result.
-        return result
-
-# ** event: multiply_number
-class MultiplyNumber(BasicCalcEvent):
-    '''
-    A domain event to perform multiplication of two numbers.
-    '''
-    def execute(self, a: Any, b: Any, **kwargs) -> int | float:
-        '''
-        Execute the multiplication event.
-
-        :param a: A number representing the first operand.
-        :type a: Any
-        :param b: A number representing the second operand.
-        :type b: Any
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The product of a and b.
-        :rtype: int | float
-        '''
-        # Verify numeric inputs
-        a_verified = self.verify_number(str(a))
-        b_verified = self.verify_number(str(b))
-
-        # Multiply the verified values of a and b.
-        result = a_verified * b_verified
-
-        # Return the result.
-        return result
-
-# ** event: divide_number
-class DivideNumber(BasicCalcEvent):
-    '''
-    A domain event to perform division of two numbers.
-    '''
-    def execute(self, a: Any, b: Any, **kwargs) -> int | float:
-        '''
-        Execute the division event.
-
-        :param a: A number representing the numerator.
-        :type a: Any
-        :param b: A number representing the denominator, must be non-zero.
-        :type b: Any
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The quotient of a and b.
-        :rtype: int | float
-        '''
-        # Verify numeric inputs
-        a_verified = self.verify_number(str(a))
-        b_verified = self.verify_number(str(b))
-
-        # Check if b is zero to avoid division by zero.
-        self.verify(b_verified != 0, 'DIVISION_BY_ZERO')
-
-        # Divide the verified values of a by b.
-        result = a_verified / b_verified
-
-        # Return the result.
-        return result
-
-# ** event: exponentiate_number
-class ExponentiateNumber(BasicCalcEvent):
-    '''
-    A domain event to perform exponentiation of two numbers.
-    '''
-    def execute(self, a: Any, b: Any, **kwargs) -> int | float:
-        '''
-        Execute the exponentiation event.
-
-        :param a: A number representing the base.
-        :type a: Any
-        :param b: A number representing the exponent.
-        :type b: Any
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The result of a raised to the power of b.
-        :rtype: int | float
-        '''
-        # Verify numeric inputs
-        a_verified = self.verify_number(str(a))
-        b_verified = self.verify_number(str(b))
-
-        # Exponentiate the verified value of a by b.
-        result = a_verified ** b_verified
-
-        # Return the result.
-        return result
-```
-
-These domain events perform arithmetic operations on flexible input values, validated by `BasicCalcEvent.verify_number` to ensure they are valid integers or floats. The method converts string inputs to `int` or `float` before computation, returning the result as a numeric value. The `DivideNumber` event includes a check to prevent division by zero, raising a configured `DIVISION_BY_ZERO` error if needed.
-
-### Configuring the Calculator Application
-With domain event classes defined, it's time to configure the Tiferet application to recognize and orchestrate them, enabling seamless user interaction through features and interfaces. This section guides you through setting up the application interface (`app/configs/app.yml`), defining domain event classes as container attributes (`app/configs/container.yml`), specifying error messages (`app/configs/error.yml`), and organizing features (`app/configs/feature.yml`). These configurations weave together Tiferet's dependency injection and feature-driven design, ensuring a robust and extensible calculator.
-
-#### Configuring the App Interface in `configs/app.yml`
-Define the calculator's user interface in `app/configs/app.yml` to specify the interface type and its core attributes. This configuration enables Tiferet to initialize the application with default settings, supporting multiple interfaces for flexible feature execution.
-
-Create `app/configs/app.yml` with the following content:
-
+**app/configs/app.yml**
 ```yaml
 interfaces:
   basic_calc:
     name: Basic Calculator
-    description: Perform basic calculator operations
 ```
 
-The `interfaces` section configures the `basic_calc` interface with a name and description, using Tiferet's default settings to streamline application setup. This setup aligns with the project structure, preparing the calculator for domain event and feature integration.
+**app/configs/feature.yml**
+```yaml
+features:
+  calc:
+    add:
+      name: Add Numbers
+      commands:
+        - attribute_id: add_number_event
+```
 
-#### Configuring the Container in `configs/container.yml`
-Expose domain event classes to Tiferet by defining them as container attributes in `app/configs/container.yml`. This configuration maps each domain event to its module and class, enabling dependency injection for seamless feature execution.
-
-Create the `app/configs/container.yml` with the following content:
-
+**app/configs/container.yml**
 ```yaml
 attrs:
   add_number_event:
     module_path: app.events.calc
     class_name: AddNumber
-  subtract_number_event:
-    module_path: app.events.calc
-    class_name: SubtractNumber
-  multiply_number_event:
-    module_path: app.events.calc
-    class_name: MultiplyNumber
-  divide_number_event:
-    module_path: app.events.calc
-    class_name: DivideNumber
-  exponentiate_number_event:
-    module_path: app.events.calc
-    class_name: ExponentiateNumber
 ```
 
-The `attrs` section lists each domain event with a unique identifier (ending in `_event`), specifying its module path and class name. This setup ensures Tiferet can instantiate and execute the calculator's arithmetic domain events efficiently.
-
-#### Configuring the Errors in `configs/error.yml`
-Handle errors gracefully by defining error messages in `app/configs/error.yml`. This configuration specifies error codes and multilingual messages, ensuring clear feedback for invalid inputs or operations.
-
-Create `app/configs/error.yml` with the following content:
-
-```yaml
-errors:
-  invalid_input:
-    name: Invalid Numeric Input
-    message:
-      - lang: en_US
-        text: 'Value {} must be a number'
-      - lang: es_ES
-        text: 'El valor {} debe ser un número'
-  division_by_zero:
-    name: Division By Zero
-    message:
-      - lang: en_US
-        text: 'Cannot divide by zero'
-      - lang: es_ES
-        text: 'No se puede dividir por cero'
-```
-
-The `errors` section defines `invalid_input` for failed numeric validations and `division_by_zero` for division errors, supporting English (`en_US`) and Spanish (`es_ES`) messages. This configuration enhances user experience with localized, precise error handling.
-
-#### Configuring the Features in `configs/feature.yml`
-Orchestrate domain event execution by defining features in `app/configs/feature.yml`. This configuration organizes arithmetic operations into reusable workflows, mapping each feature to its corresponding domain event for streamlined execution.
-
-Create `app/configs/feature.yml` with the following content:
-
-```yaml
-features:
-  calc:
-    add:
-      name: 'Add Number'
-      description: 'Adds one number to another'
-      commands:
-        - attribute_id: add_number_event
-          name: Add `a` and `b`
-    subtract:
-      name: 'Subtract Number'
-      description: 'Subtracts one number from another'
-      commands:
-        - attribute_id: subtract_number_event
-          name: Subtract `b` from `a`
-    multiply:
-      name: 'Multiply Number'
-      description: 'Multiplies one number by another'
-      commands:
-        - attribute_id: multiply_number_event
-          name: Multiply `a` and `b`
-    divide:
-      name: 'Divide Number'
-      description: 'Divides one number by another'
-      commands:
-        - attribute_id: divide_number_event
-          name: Divide `a` by `b`
-    exp:
-      name: 'Exponentiate Number'
-      description: 'Raises one number to the power of another'
-      commands:
-        - attribute_id: exponentiate_number_event
-          name: Raise `a` to the power of `b`
-    sqrt:
-      name: 'Square Root'
-      description: 'Calculates the square root of a number'
-      commands:
-        - attribute_id: exponentiate_number_event
-          name: Calculate square root of `a`
-          params:
-            b: '0.5'  # Square root is equivalent to raising to the power of 0.5
-```
-
-The `features` section maps each operation (e.g., `calc.add`, `calc.sqrt`) to its domain event via `attribute_id`, with descriptive names and parameters. The `calc.sqrt` feature reuses `exponentiate_number_event` with a fixed `b` value of `0.5`, showcasing Tiferet's flexible workflow design.
-
-### Initializing and Demonstrating the Calculator in basic_calc.py
-Bring the Tiferet calculator to life with `basic_calc.py`, a script that initializes the application and demonstrates its arithmetic prowess. This script leverages Tiferet’s `App` class to load the `basic_calc` interface and execute features, showcasing robust calculations and error handling.
-
-Create `basic_calc.py` with the following content:
+**app/events/calc.py**  
+(the domain event itself – very minimal)
 
 ```python
-from tiferet import App, TiferetError
+from tiferet.events import DomainEvent
 
-# Initialize the Tiferet application with configuration settings.
-app = App()
-
-# Define test cases for calculator features.
-test_cases = [
-    ('calc.add', dict(a=1, b=2), '{} + {} = {}'),
-    ('calc.subtract', dict(a=5, b=3), '{} - {} = {}'),
-    ('calc.multiply', dict(a=4, b=3), '{} * {} = {}'),
-    ('calc.divide', dict(a=8, b=2), '{} / {} = {}'),
-    ('calc.divide', dict(a=8, b=0), '{} / {} = {}'),  # Expect error
-    ('calc.exp', dict(a=2, b=3), '{} ** {} = {}'),
-    ('calc.sqrt', dict(a=16), '√{} = {}')
-]
-
-# Execute each test case, demonstrating calculator features.
-for feature_id, data, format_str in test_cases:
-    a, b = data.get('a'), data.get('b', None)
-    try:
-        result = app.run('basic_calc', feature_id, data=data)
-        print(format_str.format(a, b if b is not None else a, result))
-    except TiferetError as e:
-        print(f'Error: {e.message}')
+class AddNumber(DomainEvent):
+    def execute(self, a: int, b: int, **kwargs) -> int:
+        return a + b
 ```
 
-The `basic_calc.py` script initializes the Tiferet application with settings from `app/configs/app.yml`, executes a series of test cases for arithmetic features, and handles errors gracefully. It demonstrates the calculator’s core functionality, from addition to square root, with clear output formatting.
-
-### Demonstrating the Calculator
-
-Run the calculator to see its features in action, ensuring Tiferet’s power is fully unleashed. Activate your `tiferet_app` virtual environment and confirm Tiferet is installed, then execute the script to observe the results.
-
-Execute the following command:
+Run:
 
 ```bash
-python basic_calc.py
+python demo.py
 ```
 
-This command runs `basic_calc.py`, producing output for each arithmetic operation and error case, leveraging configurations from `app/configs/` to deliver precise, user-friendly results.
+You should see:
 
-## The Calculator as a CLI App
-Unleash the calculator’s full potential with a dynamic command-line interface (CLI) powered by Tiferet’s `CliContext`. Implemented in `calc_cli.py` at the project root, this script offers a scriptable, user-friendly interface that complements the `basic_calc.py` test script for debugging. Leveraging Tiferet’s `App` class and `CliContext`, it executes features defined in `app/configs/feature.yml`, accepting command-line arguments for operations like addition (`calc.add`), subtraction (`calc.subtract`), multiplication (`calc.multiply`), division (`calc.divide`), exponentiation (`calc.exp`), and square root (`calc.sqrt`). This CLI interface seamlessly integrates with shell scripts and external systems, showcasing Tiferet’s flexibility in runtime environments.
-
-### Configure CLI Commands in configs/cli.yml
-Define the CLI’s command structure in `app/configs/cli.yml` to enable `CliContext` to parse user inputs. This configuration specifies commands, their arguments, and descriptions, ensuring intuitive interaction with the calculator’s features.
-
-Create `app/configs/cli.yml` with the following content:
-
-```yaml
-cli:
-  cmds:
-    calc:
-      add:
-        group_key: calc
-        key: add
-        description: Adds two numbers.
-        args:
-          - name_or_flags:
-              - a
-            description: The first number to add.
-          - name_or_flags:
-              - b
-            description: The second number to add.
-        name: Add Number Command
-      subtract:
-        group_key: calc
-        key: subtract
-        description: Subtracts one number from another.
-        args:
-          - name_or_flags:
-              - a
-            description: The number to subtract from.
-          - name_or_flags:
-              - b
-            description: The number to subtract.
-        name: Subtract Number Command
-      multiply:
-        group_key: calc
-        key: multiply
-        description: Multiplies two numbers.
-        args:
-          - name_or_flags:
-              - a
-            description: The first number to multiply.
-          - name_or_flags:
-              - b
-            description: The second number to multiply.
-        name: Multiply Number Command
-      divide:
-        group_key: calc
-        key: divide
-        description: Divides one number by another.
-        args:
-          - name_or_flags:
-              - a
-            description: The numerator.
-          - name_or_flags:
-              - b
-            description: The denominator.
-        name: Divide Number Command
-      sqrt:
-        group_key: calc
-        key: sqrt
-        description: Calculates the square root of a number.
-        args:
-          - name_or_flags:
-              - a
-            description: The number to square root.
-        name: Square Root Command
+```
+19 + 23 = 42
 ```
 
-The `cli.cmds` section maps each feature (e.g., `calc.add`) to its command group (`calc`), key (e.g., `add`), and arguments (`a`, `b`), enabling `CliContext` to parse inputs and execute features with precision.
+→ Want a full calculator (add, subtract, multiply, divide, sqrt, …) with CLI, validation and proper error handling?  
+→ Continue with the **[step-by-step Calculator Tutorial →](docs/tutorial/basic_calculator/index.md)**
 
-### Configuring the CLI Interface in configs/app.yml
-Enable the CLI interface by adding the `calc_cli` interface to `app/configs/app.yml`. This configuration integrates `CliContext` with its dependencies, `CliYamlProxy` and `CliHandler`, to manage command-line interactions.
+## Why Tiferet?
 
-Add the `calc_cli` interface to the `interfaces` section:
+- **Configuration as code** — features, DI, errors, CLI all live in YAML  
+- **Domain logic stays pure** — focused events & aggregates  
+- **Infrastructure is injectable** — file/db/utils behind clean service contracts  
+- **Built for evolution** — today CLI, tomorrow FastAPI or TUI  
+- **Strong testability** — events are easy to invoke in isolation
 
-```yaml
-interfaces:
-  basic_calc:
-    name: Basic Calculator
-    description: Perform basic calculator operations
-  calc_cli:
-    name: Calculator CLI
-    description: Perform basic calculator operations via CLI
-    module_path: tiferet.contexts.cli
-    class_name: CliContext
-    attrs:
-      cli_repo:
-        module_path: tiferet.proxies.yaml.cli
-        class_name: CliYamlProxy
-        params:
-          cli_config_file: app/configs/cli.yml
-      cli_service:
-        module_path: tiferet.handlers.cli
-        class_name: CliHandler
-```
+## Documentation & Guides
 
-The `calc_cli` interface specifies `CliContext` as its implementation, with `cli_repo` and `cli_service` attributes linking to `CliYamlProxy` (loading `cli.yml`) and `CliHandler` for command processing. This setup ensures robust CLI functionality within Tiferet’s ecosystem.
+**Core architecture**  
+- [Code Style & Artifact Comments](docs/core/code_style.md)  
+- [Domain Objects](docs/core/domain.md)  
+- [Domain Events](docs/core/events.md)  
+- [Aggregates & Transfer Objects (Mappers)](docs/core/mappers.md)  
+- [Service Interfaces](docs/core/interfaces.md)  
+- [Contexts](docs/core/contexts.md)  
+- [Repositories](docs/core/repos.md)  
+- [Utilities (File/Yaml/Json/Csv/Sqlite)](docs/core/utils.md)
 
-### Creating the CLI Script
-Craft a streamlined CLI script in `calc_cli.py` to initialize and run the calculator’s command-line interface. This script uses Tiferet’s `App` class to load the `calc_cli` interface, powered by `CliContext`, for seamless command execution.
+### Practical Guides 
+**Domain Guides**  
+- [Application Management](docs/guides/domain/app.md)  
+- [Dependency Injection](docs/guides/domain/di.md)  
+- [Feature Workflows](docs/guides/domain/feature.md)  
+- [Error Handling](docs/guides/domain/error.md)  
+- [CLI Integration](docs/guides/domain/cli.md)  
+- [Logging](docs/guides/domain/logging.md)
 
-Create `calc_cli.py` with the following content:
+**Event Guides**  
+- [Application Events](docs/guides/events/app.md)  
+- [Dependency Injection Events](docs/guides/events/di.md)  
+- [Feature Events](docs/guides/events/feature.md)  
+- [Error Events](docs/guides/events/error.md)  
+- [CLI Integration Events](docs/guides/events/cli.md)  
+- [Logging Events](docs/guides/events/logging.md)  
+- [SQLite Events](docs/guides/events/sqlite.md)
 
-```python
-from tiferet import App
+**Utility Guides**  
+- [File Loader](docs/guides/utils/file.md)  
+- [YAML Loader](docs/guides/utils/yaml.md)  
+- [JSON Loader](docs/guides/utils/json.md)  
+- [CSV Loader](docs/guides/utils/csv.md)  
+- [Sqlite Connector](docs/guides/utils/sqlite.md)
 
-# Create new app (manager) instance.
-app = App()
+**Other Component Guides**  
+- [Interfaces](docs/guides/interfaces.md)  
+- [Mappers (Aggregates & Transfer Objects)](docs/guides/mappers.md)  
+- [Repositories](docs/guides/repos.md)
 
-# Load the CLI app instance.
-cli = app.load_interface('calc_cli')
+**Tutorial**  
+→ [Build a complete Calculator (events + CLI + configs)](docs/tutorial/basic_calculator/index.md)
 
-# Run the CLI app.
-if __name__ == '__main__':
-    cli.run()
-```
+## Contributing
 
-The `calc_cli.py` script initializes the `App`, loads the `calc_cli` interface, and executes commands via `CliContext`, with error handling to ensure user-friendly feedback for invalid inputs or operations.
+We welcome bug reports, documentation improvements, feature ideas, and early adopters.
 
-### Demonstrating the CLI Calculator
-Experience the calculator’s CLI in action by running commands that showcase its arithmetic and error-handling capabilities. Ensure the `tiferet_app` virtual environment is activated and Tiferet is installed, then execute the script with feature-specific arguments.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow (issues → TRD → feature branch → PR).
 
-Run the CLI with commands like:
+Questions, feedback, or just want to say hi?  
+Open an issue or reach out via email: andrew@greatstrength.me
 
-```bash
-# Add two numbers
-python calc_cli.py calc add 1 2
-# Output: 3
-
-# Calculate square root
-python calc_cli.py calc sqrt 4
-# Output: 2.0
-
-# Division by zero
-python calc_cli.py calc divide 5 0
-# Output: Error: Cannot divide by zero
-```
-
-The `calc_cli.py` script offers a versatile, scriptable interface that integrates effortlessly with shell scripts or external systems, powered by `CliContext` for robust command execution. For quick testing or debugging, use `basic_calc.py` to run individual features with predefined values, while the CLI provides precise, argument-driven control.
-
-## Documentation
-
-Tiferet provides detailed documentation for framework internals and utility usage.
-
-### Core Design Documents
-
-Architectural references for framework contributors and advanced users:
-
-- [Code Style](docs/core/code_style.md) — Artifact comments, spacing, docstrings, and formatting conventions
-- [Domain Objects](docs/core/domain.md) — Domain model structure and factory patterns
-- [Domain Events](docs/core/events.md) — Event patterns, validation, and testing
-- [Interfaces](docs/core/interfaces.md) — Service contract conventions
-- [Mappers](docs/core/mappers.md) — Aggregate and TransferObject patterns
-- [Utilities](docs/core/utils.md) — Infrastructure utilities design and best practices
-
-### Domain Guides
-
-Practical guides for working with Tiferet's domain layers:
-
-- [App (Bootstrap & Assembly)](docs/guides/domain/app.md) — Application interfaces, service dependency bindings, runtime wiring
-- [CLI (Command-Line Interface)](docs/guides/domain/cli.md) — CLI commands, arguments, CLI-to-feature bridge
-- [DI (Dependency Injection)](docs/guides/domain/di.md) — Service configurations, flagged dependencies, flag-based resolution
-- [Error (Structured Error Handling)](docs/guides/domain/error.md) — Error definitions, multilingual messages, formatting flow
-- [Feature (Workflow Orchestration)](docs/guides/domain/feature.md) — Features, steps, parameter resolution, execution flow
-- [Logging (Observability)](docs/guides/domain/logging.md) — Formatters, handlers, loggers, dictConfig assembly
-
-### Utility Guides
-
-Practical guides for using Tiferet's built-in utilities:
-
-- [FileLoader (File)](docs/guides/utils/file.md) — Base file I/O with context-manager lifecycle
-- [YamlLoader (Yaml)](docs/guides/utils/yaml.md) — YAML read/write with node navigation
-- [JsonLoader (Json)](docs/guides/utils/json.md) — JSON read/write with path support
-- [CsvLoader (Csv)](docs/guides/utils/csv.md) — List and dict-based CSV operations
-- [SqliteClient (Sqlite)](docs/guides/utils/sqlite.md) — SQLite database client with transaction management
-
-## Conclusion
-Embark on a journey of elegance and precision with Tiferet's Domain-Driven Design framework, as this tutorial has crafted a robust calculator application. You've defined arithmetic and validation domain events in `app/events/calc.py` and `app/events/settings.py`, orchestrated them with configurations in `app/configs/app.yml`, `app/configs/feature.yml`, and `app/configs/cli.yml`, and brought them to life through `basic_calc.py` and the `CliContext`-powered `calc_cli.py`. This configuration-driven approach, enriched with dependency injection and multilingual error handling, reflects Tiferet's harmonious balance of clarity and power, making development both functional and delightful.
-
-Extend your calculator's potential with Tiferet's modular design. Create a terminal user interface (TUI) in `calc_tui.py`, leveraging `CliContext` for interactive operation, or define a scientific calculator interface (`sci_calc`) in `app/configs/app.yml` with advanced features like trigonometric functions. Integrate the calculator into larger systems, such as financial modeling, by adding new domain events and features in `app/configs/feature.yml`. Experiment with `calc_cli.py` to test additional operations, tweak configurations in `app/configs/`, or explore Tiferet's documentation for advanced DDD techniques. Let Tiferet's graceful framework guide you to solutions that resonate with purpose and precision, transforming complexity into clarity.
+Let's build software that feels as good as it works.

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -220,6 +220,99 @@ def test_get_feature_success(mock_feature_service: FeatureService, sample_featur
     mock_feature_service.get.assert_called_once_with('test.feature')
 ```
 
+## Domain Event Test Harness Style
+
+Domain event tests use a class-based harness that provides auto-mocking, auto-parametrized validation tests, and a consistent invocation helper. All harness-based test classes follow these conventions.
+
+### Artifact Comments
+
+Harness test classes use `# ** test: TestClassName` (PascalCase) as the mid-level comment. Within each class:
+
+- `# * attribute: <name>` — class-level configuration attributes.
+- `# * fixture: <name>` — fixture overrides.
+- `# * method: <name>` — custom test methods.
+
+```python
+# *** tests
+
+# ** test: TestAddAppInterface
+class TestAddAppInterface(DomainEventTestBase):
+    '''
+    Tests for AddAppInterface using the domain event test harness.
+    '''
+
+    # * attribute: event_cls
+    event_cls = AddAppInterface
+
+    # * attribute: dependencies
+    dependencies = {'app_service': AppService}
+
+    # * attribute: sample_kwargs
+    sample_kwargs = dict(
+        id='test.interface',
+        name='Test Interface',
+        module_path='tiferet.contexts.app',
+        class_name='AppContext',
+    )
+
+    # * attribute: required_params
+    required_params = ['id', 'name', 'module_path', 'class_name']
+
+    # * method: test_minimal_success
+    def test_minimal_success(self, mock_dependencies):
+        '''
+        Test creating a minimal app interface with only required parameters.
+        '''
+
+        # Execute via the harness handle helper.
+        interface = self.handle(mock_dependencies)
+
+        # Assert the result is an AppInterface instance.
+        assert isinstance(interface, AppInterface)
+
+        # Assert the interface is saved via the app service.
+        mock_dependencies['app_service'].save.assert_called_once_with(interface)
+```
+
+### Required Class Attributes
+
+Every harness test class must declare these attributes with `# * attribute:` comments:
+
+| Attribute | Base | Description |
+|---|---|---|
+| `event_cls` | `DomainEventTestBase` | The `DomainEvent` subclass under test |
+| `dependencies` | `DomainEventTestBase` | Dict of dependency name → type (auto-mocked) |
+| `sample_kwargs` | `DomainEventTestBase` | Default kwargs for a successful `execute()` |
+| `required_params` | `DomainEventTestBase` | List of param names for auto validation tests |
+| `service_attr` | `ServiceEventTestBase` | Dependency name for the primary service |
+| `not_found_error_code` | `ServiceEventTestBase` | Error code for the not-found auto-test |
+| `not_found_kwargs` | `ServiceEventTestBase` | Kwargs that trigger the not-found path |
+
+### Fixture Overrides
+
+When a test class needs a pre-configured service mock (e.g., `get()` returns a real aggregate), override `mock_dependencies` as a fixture within the class:
+
+```python
+    # * fixture: mock_dependencies
+    @pytest.fixture
+    def mock_dependencies(self, app_interface):
+        '''
+        Override to provide a service mock pre-configured with an app_interface.
+        '''
+
+        # Create a mock AppService that returns the app_interface on get.
+        service = mock.Mock(spec=AppService)
+        service.get.return_value = app_interface
+        return {'app_service': service}
+```
+
+### Spacing Rules
+
+Harness test classes follow the same spacing conventions as production code:
+- One empty line between each `# *` section.
+- One empty line after docstrings and between code snippets within methods.
+- One empty line between test classes.
+
 ## Best Practices Summary
 
 - Use artifact comments consistently.
@@ -228,14 +321,19 @@ def test_get_feature_success(mock_feature_service: FeatureService, sample_featur
 - Write clear RST docstrings.
 - Break methods into commented snippets.
 - Maintain consistent spacing.
+- Prefer the domain event test harness (`DomainEventTestBase` / `ServiceEventTestBase`) for all new event tests.
 
 These practices ensure Tiferet code remains consistent, maintainable, and AI-friendly. Explore source modules in `tiferet/` for implementation examples.
 
 ## Additional Linked Code Style Documents
 
-The Tiferet framework maintains a suite of focused documentation in `tiferet/assets/docs/core/` to guide consistent implementation across different component types. These documents complement the main **Structured Code Style** guidelines and provide domain-specific conventions.
+The Tiferet framework maintains a suite of focused documentation in `docs/core/` to guide consistent implementation across different component types. These documents complement the main **Structured Code Style** guidelines and provide domain-specific conventions.
 
-- **[models.md](https://github.com/greatstrength/tiferet/blob/v1.x-proto/tiferet/assets/docs/core/models.md)** – Model-specific conventions (dual role, mutation helpers, factory methods).
-- **[commands.md](https://github.com/greatstrength/tiferet/blob/v1.x-proto/tiferet/assets/docs/core/commands.md)** – Command-specific conventions (dependency injection, validation, return patterns, static commands).
+- **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain object conventions (dual role, factory methods, read-only design).
+- **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event conventions (dependency injection, validation, test harness).
+- **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.
+- **[interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md)** – Service interface conventions.
+- **[repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md)** – Repository implementation conventions.
+- **[utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md)** – Utility and infrastructure conventions.
 
-Additional component-style documents (e.g., contexts, repositories, data objects) will be added as the framework evolves. Refer to this list for the current set of authoritative style guides.
+Additional component-style documents (e.g., contexts) will be added as the framework evolves. Refer to this list for the current set of authoritative style guides.

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -54,10 +54,10 @@ class DomainEvent(object):
 
     # * method: handle (static)
     @staticmethod
-    def handle(command: type, dependencies: Dict[str, Any] = {}, **kwargs) -> Any:
+    def handle(event_cls: type, dependencies: Dict[str, Any] = {}, **kwargs) -> Any:
         '''Instantiate → execute pattern.'''
-        command_handler = command(**dependencies)
-        result = command_handler.execute(**kwargs)
+        event_handler = event_cls(**dependencies)
+        result = event_handler.execute(**kwargs)
         return result
 ```
 
@@ -184,16 +184,109 @@ def execute(self, **kwargs) -> Any:
 
 Tests validate input validation, service interactions, and error handling using `pytest`.
 
-**Structure:**
-- `# *** fixtures`
-- `# ** fixture: <name>`
-- `# *** tests`
-- `# ** test: <name>`
+### Test Harness
 
-**Invocation**: Always use `DomainEvent.handle` in tests.
+The domain event test harness (`tiferet/events/tests/settings.py`) provides two base classes that eliminate boilerplate and enforce consistency across all event test modules.
 
-**Example** – `AddError` test:
+#### DomainEventTestBase
+
+Base class for testing any `DomainEvent` subclass. Subclasses declare four class attributes:
+
+- **`event_cls`** — the `DomainEvent` class under test.
+- **`dependencies`** — dict mapping dependency name → type (auto-mocked via the `mock_dependencies` fixture).
+- **`sample_kwargs`** — default kwargs for a successful `execute()` call.
+- **`required_params`** — list of required parameter names (auto-parametrized validation tests).
+
+Provides:
+- **`mock_dependencies`** fixture — creates `mock.Mock(spec=Type)` for each declared dependency.
+- **`handle(mock_dependencies, **overrides)`** — merges `sample_kwargs` with overrides and invokes `DomainEvent.handle`.
+- **`test_missing_required_params`** — auto-parametrized test that sets each required param to `None` and asserts `COMMAND_PARAMETER_REQUIRED` is raised.
+
 ```python
+class TestAddError(DomainEventTestBase):
+    event_cls = AddError
+    dependencies = {'error_service': ErrorService}
+    sample_kwargs = dict(id='ERR_001', name='Test Error', message='A test error.')
+    required_params = ['id', 'name', 'message']
+
+    def test_success(self, mock_dependencies):
+        mock_dependencies['error_service'].exists.return_value = False
+        result = self.handle(mock_dependencies)
+        assert result is not None
+        mock_dependencies['error_service'].save.assert_called_once()
+```
+
+#### ServiceEventTestBase
+
+Extends `DomainEventTestBase` for events that follow the retrieve → verify → mutate → save pattern with a single service. Adds three class attributes:
+
+- **`service_attr`** — the dependency name (e.g., `'error_service'`).
+- **`not_found_error_code`** — error code raised when the service returns `None`.
+- **`not_found_kwargs`** — kwargs that trigger the not-found path (defaults to `sample_kwargs`).
+
+Provides:
+- **`get_service_mock(mock_dependencies)`** — retrieves the primary service mock by `service_attr`.
+- **`test_not_found`** — auto test that configures `service.get()` to return `None` and asserts the configured error code is raised.
+
+```python
+class TestGetError(ServiceEventTestBase):
+    event_cls = GetError
+    dependencies = {'error_service': ErrorService}
+    service_attr = 'error_service'
+    sample_kwargs = dict(id='ERR_001')
+    required_params = ['id']
+    not_found_error_code = a.const.ERROR_NOT_FOUND_ID
+    not_found_kwargs = dict(id='missing_error')
+
+    def test_success(self, mock_dependencies):
+        mock_dependencies['error_service'].get.return_value = sample_error
+        result = self.handle(mock_dependencies)
+        assert result is sample_error
+```
+
+#### Conftest Hook
+
+The `pytest_generate_tests` hook in `tiferet/events/tests/conftest.py` dynamically parametrizes `test_missing_required_params` over the `required_params` list for any `DomainEventTestBase` subclass:
+
+```python
+def pytest_generate_tests(metafunc):
+    cls = metafunc.cls
+    if cls and issubclass(cls, DomainEventTestBase) and metafunc.function.__name__ == 'test_missing_required_params':
+        params = getattr(cls, 'required_params', [])
+        metafunc.parametrize('required_param', params)
+```
+
+#### Overriding `mock_dependencies`
+
+For events that need a pre-configured service mock (e.g., `service.get()` returns a real aggregate), override the `mock_dependencies` fixture:
+
+```python
+class TestUpdateError(ServiceEventTestBase):
+    event_cls = UpdateError
+    dependencies = {'error_service': ErrorService}
+    service_attr = 'error_service'
+    # ...
+
+    @pytest.fixture
+    def mock_dependencies(self, sample_error):
+        service = mock.Mock(spec=ErrorService)
+        service.get.return_value = sample_error
+        return {'error_service': service}
+```
+
+The `test_not_found` auto-test reconfigures `service.get.return_value = None` before executing, so the override is safe for both paths.
+
+### Standalone Tests
+
+For simple events or edge cases that don't fit the harness, standalone test functions with module-level fixtures remain valid:
+
+```python
+# ** fixture: mock_error_service
+@pytest.fixture
+def mock_error_service():
+    return mock.Mock(spec=ErrorService)
+
+# ** test: add_error_success
 def test_add_error_success(mock_error_service):
     mock_error_service.exists.return_value = False
     result = DomainEvent.handle(
@@ -208,20 +301,35 @@ def test_add_error_success(mock_error_service):
 ```
 
 ### Best Practices
-- Mock injected services.
+- Prefer the harness for all new event tests.
+- Mock injected services; avoid real I/O in unit tests.
 - Test success, validation failures, and not-found cases.
 - Verify service calls and return values.
 - Use `DomainEvent.handle` for consistent instantiation and execution.
+- Override `mock_dependencies` when tests need a pre-configured aggregate.
 
 ## Package Layout
 
 Domain events are defined in `tiferet/events/`:
 
 - `settings.py` – `DomainEvent` base class, `@parameters_required` decorator.
+- `static.py` – Static utility events (`ParseParameter`, `ImportDependency`, `RaiseError`).
+- `app.py` – App interface management events.
+- `cli.py` – CLI command management events.
+- `container.py` – Container attribute management events.
+- `dependencies.py` – DI service configuration events.
+- `error.py` – Error management events.
+- `feature.py` – Feature workflow management events.
+- `logging.py` – Logging configuration events.
+- `sqlite.py` – SQLite management events.
 - `__init__.py` – Public exports (`DomainEvent`, `TiferetError`, `a`).
 
-Tests live in `tiferet/events/tests/`.
+Tests live in `tiferet/events/tests/`:
+
+- `settings.py` – Test harness (`DomainEventTestBase`, `ServiceEventTestBase`).
+- `conftest.py` – `pytest_generate_tests` hook for auto-parametrization.
+- `test_app.py`, `test_cli.py`, `test_container.py`, etc. – Per-module test suites.
 
 ## Conclusion
 
-Domain events are the operational core of Tiferet applications, providing validated, injectable domain operations. Their structured design ensures consistency, testability, and extensibility. Developers can create new events by following the artifact pattern and using `DomainEvent.handle` for invocation. Explore `tiferet/events/` for source and `tiferet/events/tests/` for test examples.
+Domain events are the operational core of Tiferet applications, providing validated, injectable domain operations. Their structured design ensures consistency, testability, and extensibility. The test harness (`DomainEventTestBase` / `ServiceEventTestBase`) eliminates boilerplate while enforcing consistent coverage of required-parameter validation and not-found error paths. Developers can create new events by following the artifact pattern and new tests by extending the harness. Explore `tiferet/events/` for source and `tiferet/events/tests/` for test examples.

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -8,8 +8,8 @@
 try:
     from .assets import TiferetError, TiferetAPIError
     from .contexts import AppManagerContext as App
-    from .models import (
-        ModelObject,
+    from .domain import (
+        DomainObject,
         StringType,
         IntegerType,
         BooleanType,
@@ -18,33 +18,14 @@ try:
         DictType,
         ModelType,
     )
-    from .commands import *
-    from .commands import (
-        Command,
-        ParseParameter
+    from .events import (
+        DomainEvent,
+        ParseParameter,
     )
-    from .contracts import (
-        ModelContract,
-        Repository,
-        Service,
-    )
-    from .data import DataObject
-    from .proxies import (
-        YamlFileProxy,
-        JsonFileProxy,
-        CsvFileProxy
-    )
-    from .middleware import (
-        File,
-        FileLoaderMiddleware,
-        Yaml,
-        YamlLoaderMiddleware,
-        Json,
-        JsonLoaderMiddleware,
-        Csv,
-        CsvLoaderMiddleware,
-        CsvDict,
-        CsvDictLoaderMiddleware
+    from .interfaces import Service
+    from .mappers import (
+        Aggregate,
+        TransferObject,
     )
     from .utils import (
         FileLoader,
@@ -69,4 +50,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a5'
+__version__ = '2.0.0a6'


### PR DESCRIPTION
Version bump, export refactor, and documentation updates for the v2.0.0a6 release.

## Changes
- **`tiferet/__init__.py`**: Version `2.0.0a5` → `2.0.0a6`, replace legacy exports with forward-compatible packages (`DomainObject`, `DomainEvent`, `Service`, `Aggregate`, `TransferObject`).
- **`README.md`**: Full replacement — old tutorial-style README replaced with concise project landing page (badges, quick start, documentation index, tutorial link).
- **`AGENTS.md`**: Version bump, `repos` in comment levels, `DIService` → `ContainerService`, expanded Repositories section with patterns and doc links.
- **`CONTRIBUTING.md`**: Fix two broken link paths (`docs/guides/` → `docs/contrib/`), add `repos.md` and `utils.md` to core guides.
- **`docs/core/events.md`**: `handle()` signature rename (`command` → `event_cls`), comprehensive test harness documentation, expanded package layout.
- **`docs/core/code_style.md`**: "Domain Event Test Harness Style" section, updated linked docs from legacy to current paths.

Closes #666

Co-Authored-By: Oz <oz-agent@warp.dev>