### PR TITLE
DI – Introduce ServiceProvider Package (#686)

### DIFF
--- a/docs/core/di.md
+++ b/docs/core/di.md
@@ -1,0 +1,373 @@
+# Dependency Injection in Tiferet
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+
+## Overview
+
+The `tiferet/di/` package provides the **app-level dependency injection** layer for the Tiferet framework. It defines the `ServiceProvider` abstract base class and its concrete implementation, `DependenciesServiceProvider`, which backs the `AppManagerContext` during interface loading.
+
+The `di/` package is distinct from the feature-level DI managed by `DIContext` (`contexts/di.py`):
+
+- **`tiferet/di/`** — App-level DI. Manages the lifecycle of injected contexts and repositories for an interface (e.g., `FeatureContext`, `ErrorContext`, `LoggingContext`). Consumed by `AppManagerContext`.
+- **`tiferet/contexts/di.py` (`DIContext`)** — Feature-level DI. Loads `ServiceConfiguration` objects, resolves flagged dependencies, and builds per-flag injectors for feature execution. Consumed by `FeatureContext`.
+
+This document describes the structure, design principles, and best practices for writing and extending the DI layer, adhering to Tiferet's structured code style ([docs/core/code_style.md](code_style.md)).
+
+## What is a ServiceProvider?
+
+A `ServiceProvider` is an abstract class that manages a registry of service IDs and their corresponding types or values. It wraps the runtime dependency injector and exposes a simple, consistent API for registering and resolving services.
+
+Key characteristics:
+- Extends `ServiceProvider` (ABC) from `tiferet/di/settings.py`.
+- Maintains a `services` dictionary mapping service IDs to types or scalar values.
+- Rebuilds its internal injector every time the registry is mutated.
+- Uses `RaiseError.execute()` for structured error handling.
+- Returns fully resolved instances via `get_service()` — callers never interact with the injector directly.
+
+### Role in Runtime
+
+`AppManagerContext` holds a single `ServiceProvider` instance for the lifetime of an interface load:
+
+1. `AppManagerContext.__init__` creates a `DependenciesServiceProvider` (or accepts an injected one).
+2. `load_interface` calls `app_interface.get_service_type_mapping()` to obtain a `Dict[str, type]`.
+3. `load_app_instance` calls `service_provider.add_services(dependencies)` to register all interface dependencies.
+4. `service_provider.get_service('app_context')` resolves and returns the fully constructed `AppInterfaceContext`.
+
+## The ServiceProvider Abstract Base
+
+`ServiceProvider` is defined in `tiferet/di/settings.py` and declares the contract all implementations must satisfy:
+
+```python
+# tiferet/di/settings.py
+
+# *** classes
+
+# ** class: service_provider
+class ServiceProvider(ABC):
+    '''
+    Service provider for app context dependencies.
+    '''
+
+    # * method: add_service
+    @abstractmethod
+    def add_service(self, service_id: str, service_type: type): ...
+
+    # * method: add_services
+    @abstractmethod
+    def add_services(self, services: Dict[str, type]): ...
+
+    # * method: add_constants
+    @abstractmethod
+    def add_constants(self, constants: Dict[str, Any]): ...
+
+    # * method: get_service
+    @abstractmethod
+    def get_service(self, service_id: str) -> Any: ...
+
+    # * method: remove_service
+    @abstractmethod
+    def remove_service(self, service_id: str): ...
+```
+
+### Method Semantics
+
+- **`add_service(service_id, service_type)`** — Registers a single service type under an ID.
+- **`add_services(services)`** — Bulk-registers a `Dict[str, type]` mapping. Equivalent to calling `add_service` for each entry. Prefer this for registering multiple services at once (e.g., all interface dependencies from `get_service_type_mapping()`).
+- **`add_constants(constants)`** — Registers scalar values (strings, integers, etc.) as constructor injection parameters. **Important:** scalars registered this way are injected into other services at construction time; they cannot be resolved directly via `get_service`. See [Scalar Constants vs. Service Types](#scalar-constants-vs-service-types) below.
+- **`get_service(service_id)`** — Returns the fully resolved service instance. Raises `INVALID_DEPENDENCY_ERROR` if the service cannot be resolved.
+- **`remove_service(service_id)`** — Deregisters a service. No-op if the ID is not present.
+
+## The DependenciesServiceProvider
+
+`DependenciesServiceProvider` is the concrete implementation in `tiferet/di/dependencies.py`. It satisfies the `ServiceProvider` contract using the [`dependencies`](https://pypi.org/project/dependencies/) library's `Injector` as its backing resolver.
+
+### Key Design Decisions
+
+**Injector rebuild on every mutation.** Each call to `add_service`, `add_services`, `add_constants`, or `remove_service` triggers `build_injector()`, which creates a new `Injector` subclass type from the current `services` dict. This is intentional — injectors in the `dependencies` library are immutable class definitions, so they must be recreated to reflect changes.
+
+**Empty scope guard.** The `dependencies` library raises `DependencyError: Extension scope can not be empty` when an `Injector` is created with no attributes. `build_injector` guards against this by setting `self.injector = None` when `services` is empty. `get_service` checks for `None` and raises `INVALID_DEPENDENCY_ERROR` immediately rather than letting the library raise.
+
+**Named injector.** The `_name` attribute is stored at construction time and used as the class name for every rebuilt `Injector` type. The default is `'TiferetInjector'`. Pass a custom `name` via `__init__` or `new()` when you need distinguishable repr output (e.g., in tests or logging).
+
+```python
+# tiferet/di/dependencies.py
+
+# ** class: dependencies_service_provider
+class DependenciesServiceProvider(ServiceProvider):
+
+    # * attribute: services
+    services: Dict[str, type]
+
+    # * attribute: injector
+    injector: type          # Injector subclass type, or None if empty
+
+    # * attribute: _name
+    _name: str
+
+    # * init
+    def __init__(self, services: Dict[str, type] = None, name: str = 'TiferetInjector'):
+        self._name = name
+        self.services = services or {}
+        self.build_injector()
+
+    # * method: new (static)
+    @staticmethod
+    def new(name: str, dependencies: Dict[str, type]) -> 'DependenciesServiceProvider':
+        return DependenciesServiceProvider(services=dependencies, name=name)
+
+    # * method: build_injector
+    def build_injector(self):
+        if self.services:
+            self.injector = type(self._name, (Injector,), self.services)
+        else:
+            self.injector = None
+```
+
+## Structured Code Design
+
+The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consistent with other `settings.py` modules in the framework (e.g., `domain/settings.py`).
+
+### Artifact Comments
+
+- `# *** classes` — top-level section for the module.
+- `# ** class: <snake_case_name>` — individual class definition.
+- `# * attribute: <name>` — instance attributes (type hints only, no assignment).
+- `# * init` — constructor.
+- `# * method: <name>` — instance methods.
+- `# * method: <name> (static)` — static methods.
+
+**Spacing rules** follow `code_style.md`: one empty line between `# ***` and the first `# **`, one empty line between each `# *` section, one empty line after docstrings, and one empty line between code snippets.
+
+**Example** — `settings.py` layout:
+```python
+# *** imports
+
+# ** core
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+# *** classes
+
+# ** class: service_provider
+class ServiceProvider(ABC):
+    '''...'''
+
+    # * method: add_service
+    @abstractmethod
+    def add_service(self, service_id: str, service_type: type):
+        ...
+```
+
+**Example** — `dependencies.py` layout:
+```python
+# *** imports
+
+# ** core
+from typing import Any, Dict
+
+# ** infra
+from dependencies import Injector
+from dependencies.exceptions import DependencyError
+
+# ** app
+from ..events import RaiseError
+from .settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: dependencies_service_provider
+class DependenciesServiceProvider(ServiceProvider):
+    '''...'''
+
+    # * attribute: services
+    services: Dict[str, type]
+
+    # * init
+    def __init__(self, services: Dict[str, type] = None, name: str = 'TiferetInjector'):
+        ...
+
+    # * method: new (static)
+    @staticmethod
+    def new(name: str, dependencies: Dict[str, type]) -> 'DependenciesServiceProvider':
+        ...
+```
+
+## Scalar Constants vs. Service Types
+
+The `add_constants` method accepts plain scalar values (strings, numbers, booleans) alongside class types. These behave differently inside the injector:
+
+- **Service types** (classes): Resolved by the `dependencies` library through instantiation. Accessed via `get_service(service_id)`.
+- **Scalar constants**: Injected as constructor parameters into other services that declare them as `__init__` arguments. They **cannot** be accessed directly via `get_service` — the library raises `DependencyError: Scalar dependencies could only be used to instantiate classes`.
+
+```python
+# Correct use of add_constants — injectable into a service constructor.
+provider.add_services({'configurable_repo': MyYamlRepository})
+provider.add_constants({'my_yaml_file': 'app/configs/my.yml'})
+
+# MyYamlRepository(my_yaml_file) is resolved correctly:
+repo = provider.get_service('configurable_repo')  # ✓
+
+# Accessing the scalar directly raises INVALID_DEPENDENCY_ERROR:
+path = provider.get_service('my_yaml_file')  # ✗
+```
+
+## Creating a New ServiceProvider Implementation
+
+To provide an alternative DI backend (e.g., backed by a different IoC library or a simple dict for testing), extend `ServiceProvider` from `tiferet/di/settings.py` and implement all abstract methods.
+
+**Example** — `SimpleServiceProvider` (dict-backed, for testing):
+```python
+# *** imports
+
+# ** core
+from typing import Any, Dict
+
+# ** app
+from ..events import RaiseError
+from .settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: simple_service_provider
+class SimpleServiceProvider(ServiceProvider):
+    '''
+    A minimal dict-backed service provider for testing.
+    '''
+
+    # * attribute: registry
+    registry: Dict[str, Any]
+
+    # * init
+    def __init__(self):
+        '''Initialize with an empty registry.'''
+
+        # Initialize the registry.
+        self.registry = {}
+
+    # * method: add_service
+    def add_service(self, service_id: str, service_type: type):
+        '''Register a service type by ID.'''
+
+        # Store the type in the registry.
+        self.registry[service_id] = service_type
+
+    # * method: add_services
+    def add_services(self, services: Dict[str, type]):
+        '''Bulk-register service types.'''
+
+        # Merge the services into the registry.
+        self.registry.update(services)
+
+    # * method: add_constants
+    def add_constants(self, constants: Dict[str, Any]):
+        '''Register scalar constants.'''
+
+        # Merge the constants into the registry.
+        self.registry.update(constants)
+
+    # * method: get_service
+    def get_service(self, service_id: str) -> Any:
+        '''Return the registered value for service_id.'''
+
+        # Raise an error if the service is not registered.
+        if service_id not in self.registry:
+            RaiseError.execute(
+                'INVALID_DEPENDENCY_ERROR',
+                f'Dependency {service_id} could not be resolved.',
+                dependency_name=service_id,
+                exception='Service not registered.',
+            )
+
+        # Return the registered value.
+        return self.registry[service_id]
+
+    # * method: remove_service
+    def remove_service(self, service_id: str):
+        '''Deregister a service by ID.'''
+
+        # Remove the service from the registry if present.
+        self.registry.pop(service_id, None)
+```
+
+Inject a custom provider into `AppManagerContext` via the `service_provider` parameter:
+
+```python
+app = AppManagerContext(service_provider=SimpleServiceProvider())
+```
+
+## Testing ServiceProvider Implementations
+
+Tests live in `tiferet/di/tests/` and follow the standard artifact comment structure.
+
+### Key Patterns
+
+- Test `init` with no services — assert `injector is None` (empty scope guard).
+- Test `init` with services — assert types are registered and resolvable.
+- Test `add_service` / `add_services` — assert services resolve to the correct types.
+- Test `add_constants` — register a service that depends on the constant, resolve the service, and assert the value was injected.
+- Test `get_service` on an unregistered ID — assert `TiferetError` with `error_code == 'INVALID_DEPENDENCY_ERROR'`.
+- Test `remove_service` — assert the service is gone and no longer resolvable.
+- Test `remove_service` on an unknown ID — assert no exception is raised.
+- Test injector rebuild — assert `injector` reference changes after mutation.
+
+```python
+# *** fixtures
+
+# ** fixture: populated_provider
+@pytest.fixture
+def populated_provider() -> DependenciesServiceProvider:
+    '''Pre-populated provider for success-path tests.'''
+    return DependenciesServiceProvider(services={'my_service': MyService})
+
+
+# *** tests
+
+# ** test: get_service_success
+def test_get_service_success(populated_provider: DependenciesServiceProvider):
+    '''Test that a registered service resolves to the correct type.'''
+
+    # Resolve the service.
+    service = populated_provider.get_service('my_service')
+
+    # Assert it is the expected type.
+    assert isinstance(service, MyService)
+
+
+# ** test: get_service_not_found
+def test_get_service_not_found():
+    '''Test that an unregistered service raises INVALID_DEPENDENCY_ERROR.'''
+
+    # Create an empty provider.
+    provider = DependenciesServiceProvider()
+
+    # Attempt to resolve an unknown service.
+    with pytest.raises(TiferetError) as exc_info:
+        provider.get_service('missing')
+
+    # Assert the correct error code.
+    assert exc_info.value.error_code == 'INVALID_DEPENDENCY_ERROR'
+```
+
+## Package Layout
+
+```
+tiferet/di/
+├── __init__.py          — Exports: ServiceProvider, DependenciesServiceProvider
+├── settings.py          — ServiceProvider (ABC)
+├── dependencies.py      — DependenciesServiceProvider (dependencies-library-backed)
+└── tests/
+    ├── __init__.py
+    └── test_dependencies.py
+```
+
+## Conclusion
+
+The `tiferet/di/` package provides the app-level DI foundation for the Tiferet framework, abstracting the lifecycle of contexts and repositories behind the `ServiceProvider` contract. The `DependenciesServiceProvider` satisfies this contract using the `dependencies` library while handling the library's constraints (empty scope guard, scalar injection limitations) transparently.
+
+New implementations extend `ServiceProvider` and override all abstract methods. Inject them into `AppManagerContext` via the `service_provider` constructor parameter to swap backends without changing application code.
+
+Explore source in `tiferet/di/`, runtime consumers in `tiferet/contexts/app.py`, and tests in `tiferet/di/tests/`.

--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -1,0 +1,5 @@
+# *** exports
+
+# ** app
+from .settings import ServiceProvider
+from .dependencies import DependenciesServiceProvider

--- a/tiferet/di/dependencies.py
+++ b/tiferet/di/dependencies.py
@@ -1,0 +1,168 @@
+"""Dependencies DI Service Provider"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict
+
+# ** infra
+from dependencies import Injector
+from dependencies.exceptions import DependencyError
+
+# ** app
+from ..events import RaiseError
+from .settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: dependencies_service_provider
+class DependenciesServiceProvider(ServiceProvider):
+    '''
+    A service provider for managing app context dependencies via the
+    dependencies library injector.
+    '''
+
+    # * attribute: services
+    services: Dict[str, type]
+
+    # * attribute: injector
+    injector: type
+
+    # * attribute: _name
+    _name: str
+
+    # * init
+    def __init__(self, services: Dict[str, type] = None, name: str = 'TiferetInjector'):
+        '''
+        Initialize the dependencies service provider.
+
+        :param services: Initial service ID-to-type mapping.
+        :type services: Dict[str, type]
+        :param name: Name used for the internal injector class.
+        :type name: str
+        '''
+
+        # Store the name and services, then build the injector.
+        self._name = name
+        self.services = services or {}
+        self.build_injector()
+
+    # * method: new (static)
+    @staticmethod
+    def new(name: str, dependencies: Dict[str, type]) -> 'DependenciesServiceProvider':
+        '''
+        Create a new service provider instance with the given dependencies.
+
+        :param name: The name of the service provider.
+        :type name: str
+        :param dependencies: The dependencies to include in the service provider.
+        :type dependencies: Dict[str, type]
+        :return: A new service provider instance.
+        :rtype: DependenciesServiceProvider
+        '''
+
+        # Return a new provider instance pre-populated with the given dependencies.
+        return DependenciesServiceProvider(services=dependencies, name=name)
+
+    # * method: add_service
+    def add_service(self, service_id: str, service_type: type):
+        '''
+        Add a service dependency to the service provider.
+
+        :param service_id: The ID of the service to add.
+        :type service_id: str
+        :param service_type: The type of the service to add.
+        :type service_type: type
+        '''
+
+        # Add the service to the services dictionary and rebuild the injector.
+        self.services[service_id] = service_type
+        self.build_injector()
+
+    # * method: add_services
+    def add_services(self, services: Dict[str, type]):
+        '''
+        Add multiple service dependencies to the service provider.
+
+        :param services: A dictionary of service IDs and their corresponding types.
+        :type services: Dict[str, type]
+        '''
+
+        # Merge the given services and rebuild the injector.
+        self.services.update(services)
+        self.build_injector()
+
+    # * method: add_constants
+    def add_constants(self, constants: Dict[str, Any]):
+        '''
+        Add constant dependencies to the service provider.
+
+        :param constants: A dictionary of constant names and their corresponding values.
+        :type constants: Dict[str, Any]
+        '''
+
+        # Merge the constants into the services dictionary and rebuild the injector.
+        self.services.update(constants)
+        self.build_injector()
+
+    # * method: get_service
+    def get_service(self, service_id: str) -> Any:
+        '''
+        Get a service dependency by its ID.
+
+        :param service_id: The service ID.
+        :type service_id: str
+        :return: The resolved service dependency instance.
+        :rtype: Any
+        '''
+
+        # If no services have been registered the injector is None — raise immediately.
+        if self.injector is None:
+            RaiseError.execute(
+                'INVALID_DEPENDENCY_ERROR',
+                f'Dependency {service_id} could not be resolved: no services are registered.',
+                dependency_name=service_id,
+                exception='No services registered in the service provider.',
+            )
+
+        # Attempt to retrieve the resolved service from the injector.
+        try:
+            return getattr(self.injector, service_id)
+
+        # If the dependency does not exist or cannot be resolved, raise an error.
+        except (DependencyError, AttributeError) as e:
+            RaiseError.execute(
+                'INVALID_DEPENDENCY_ERROR',
+                f'Dependency {service_id} could not be resolved: {str(e)}',
+                dependency_name=service_id,
+                exception=str(e)
+            )
+
+    # * method: remove_service
+    def remove_service(self, service_id: str):
+        '''
+        Remove a service dependency from the service provider.
+
+        :param service_id: The service ID to remove.
+        :type service_id: str
+        '''
+
+        # Remove the service from the services dictionary and rebuild the injector.
+        if service_id in self.services:
+            del self.services[service_id]
+            self.build_injector()
+
+    # * method: build_injector
+    def build_injector(self):
+        '''
+        Rebuild the internal injector from the current services dictionary.
+        The injector is set to None when no services are registered, as the
+        dependencies library requires a non-empty scope.
+        '''
+
+        # Only build the injector when there are services to register.
+        if self.services:
+            self.injector = type(self._name, (Injector,), self.services)
+        else:
+            self.injector = None

--- a/tiferet/di/settings.py
+++ b/tiferet/di/settings.py
@@ -1,0 +1,78 @@
+# *** imports
+
+# ** core
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+# *** classes
+
+# ** class: service_provider
+class ServiceProvider(ABC):
+    '''
+    Service provider for app context dependencies.
+    '''
+
+    # * method: add_service
+    @abstractmethod
+    def add_service(self, service_id: str, service_type: type):
+        '''
+        Add a service dependency to the service provider.
+
+        :param service_id: The service ID.
+        :type service_id: str
+        :param service_type: The type of the service dependency.
+        :type service_type: type
+        '''
+
+        pass
+
+    # * method: add_services
+    @abstractmethod
+    def add_services(self, services: Dict[str, type]):
+        '''
+        Add multiple service dependencies to the service provider.
+
+        :param services: A dictionary of service IDs and their corresponding types.
+        :type services: Dict[str, type]
+        '''
+
+        pass
+
+    # * method: add_constants
+    @abstractmethod
+    def add_constants(self, constants: Dict[str, Any]):
+        '''
+        Add constant dependencies to the service provider.
+
+        :param constants: A dictionary of constant names and their corresponding values.
+        :type constants: Dict[str, Any]
+        '''
+
+        pass
+
+    # * method: get_service
+    @abstractmethod
+    def get_service(self, service_id: str) -> Any:
+        '''
+        Get a service dependency by its ID.
+
+        :param service_id: The service ID.
+        :type service_id: str
+        :return: The service dependency instance.
+        :rtype: Any
+        '''
+
+        pass
+
+    # * method: remove_service
+    @abstractmethod
+    def remove_service(self, service_id: str):
+        '''
+        Remove a service dependency from the service provider.
+
+        :param service_id: The service ID.
+        :type service_id: str
+        '''
+
+        pass

--- a/tiferet/di/tests/test_dependencies.py
+++ b/tiferet/di/tests/test_dependencies.py
@@ -1,0 +1,318 @@
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...assets.exceptions import TiferetError
+from ..dependencies import DependenciesServiceProvider
+from ..settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: simple_service
+class SimpleService:
+    '''A dependency-free service used for testing.'''
+
+    pass
+
+
+# ** class: dependent_service
+class DependentService:
+    '''A service with a constructor dependency on SimpleService.'''
+
+    # * attribute: simple_service
+    simple_service: SimpleService
+
+    # * init
+    def __init__(self, simple_service: SimpleService):
+        '''
+        Initialize the dependent service.
+
+        :param simple_service: The injected simple service.
+        :type simple_service: SimpleService
+        '''
+
+        # Assign the injected dependency.
+        self.simple_service = simple_service
+
+
+# ** class: configurable_service
+class ConfigurableService:
+    '''A service with a scalar constructor parameter, used to test constant injection.'''
+
+    # * attribute: config_value
+    config_value: str
+
+    # * init
+    def __init__(self, config_value: str):
+        '''
+        Initialize the configurable service.
+
+        :param config_value: A scalar configuration value injected at construction.
+        :type config_value: str
+        '''
+
+        # Assign the injected constant.
+        self.config_value = config_value
+
+
+# *** fixtures
+
+# ** fixture: empty_provider
+@pytest.fixture
+def empty_provider() -> DependenciesServiceProvider:
+    '''
+    Fixture to create an empty DependenciesServiceProvider.
+
+    :return: An empty provider instance.
+    :rtype: DependenciesServiceProvider
+    '''
+
+    # Return a provider with no initial services.
+    return DependenciesServiceProvider()
+
+
+# ** fixture: populated_provider
+@pytest.fixture
+def populated_provider() -> DependenciesServiceProvider:
+    '''
+    Fixture to create a DependenciesServiceProvider pre-populated with a SimpleService.
+
+    :return: A provider with SimpleService registered.
+    :rtype: DependenciesServiceProvider
+    '''
+
+    # Return a provider with SimpleService registered under 'simple_service'.
+    return DependenciesServiceProvider(services={'simple_service': SimpleService})
+
+
+# *** tests
+
+# ** test: init_empty
+def test_init_empty(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that an empty provider initializes with no services and a None injector.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Assert that the services dictionary is empty.
+    assert empty_provider.services == {}
+
+    # Injector is None until services are registered (empty scope is not allowed
+    # by the dependencies library).
+    assert empty_provider.injector is None
+
+
+# ** test: init_with_services
+def test_init_with_services(populated_provider: DependenciesServiceProvider):
+    '''
+    Test that a provider initialized with services registers them correctly.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DependenciesServiceProvider
+    '''
+
+    # Assert that the service is present in the services dictionary.
+    assert 'simple_service' in populated_provider.services
+    assert populated_provider.services['simple_service'] is SimpleService
+
+
+# ** test: is_service_provider
+def test_is_service_provider(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that DependenciesServiceProvider is an instance of ServiceProvider.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Assert that the provider satisfies the ServiceProvider contract.
+    assert isinstance(empty_provider, ServiceProvider)
+
+
+# ** test: new_static_factory
+def test_new_static_factory():
+    '''
+    Test the new() static factory creates a correctly named and populated provider.
+    '''
+
+    # Create a provider via the static factory.
+    provider = DependenciesServiceProvider.new('MyProvider', {'simple_service': SimpleService})
+
+    # Assert the provider is the correct type.
+    assert isinstance(provider, DependenciesServiceProvider)
+
+    # Assert the services were registered.
+    assert 'simple_service' in provider.services
+
+    # Assert the injector name is set correctly.
+    assert provider._name == 'MyProvider'
+
+
+# ** test: add_service
+def test_add_service(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that add_service registers a service and makes it resolvable.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Add a single service.
+    empty_provider.add_service('simple_service', SimpleService)
+
+    # Assert it was added to the services dictionary.
+    assert 'simple_service' in empty_provider.services
+
+    # Assert the resolved instance is of the expected type.
+    service = empty_provider.get_service('simple_service')
+    assert isinstance(service, SimpleService)
+
+
+# ** test: add_services
+def test_add_services(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that add_services registers multiple services at once.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Add multiple services.
+    empty_provider.add_services({
+        'simple_service': SimpleService,
+        'dependent_service': DependentService,
+    })
+
+    # Assert both were added.
+    assert 'simple_service' in empty_provider.services
+    assert 'dependent_service' in empty_provider.services
+
+    # Assert both resolve correctly.
+    assert isinstance(empty_provider.get_service('simple_service'), SimpleService)
+    assert isinstance(empty_provider.get_service('dependent_service'), DependentService)
+
+
+# ** test: add_constants
+def test_add_constants(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that add_constants registers scalar values that are injected into
+    dependent services as constructor parameters.
+
+    Note: The dependencies library treats scalars as injection parameters only;
+    they cannot be resolved directly via get_service.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Register a scalar constant and a service that depends on it.
+    empty_provider.add_services({'configurable_service': ConfigurableService})
+    empty_provider.add_constants({'config_value': 'test_config'})
+
+    # Assert both were stored in the services dictionary.
+    assert 'config_value' in empty_provider.services
+    assert 'configurable_service' in empty_provider.services
+
+    # Resolve the service and assert the constant was injected correctly.
+    service = empty_provider.get_service('configurable_service')
+    assert isinstance(service, ConfigurableService)
+    assert service.config_value == 'test_config'
+
+
+# ** test: get_service_success
+def test_get_service_success(populated_provider: DependenciesServiceProvider):
+    '''
+    Test that get_service resolves a registered service to the correct type.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DependenciesServiceProvider
+    '''
+
+    # Resolve the service.
+    service = populated_provider.get_service('simple_service')
+
+    # Assert it is an instance of SimpleService.
+    assert isinstance(service, SimpleService)
+
+
+# ** test: get_service_not_found
+def test_get_service_not_found(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that get_service raises TiferetError for an unregistered service ID.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Attempt to resolve a service that was never registered.
+    with pytest.raises(TiferetError) as exc_info:
+        empty_provider.get_service('nonexistent_service')
+
+    # Assert the correct error code was raised.
+    assert exc_info.value.error_code == 'INVALID_DEPENDENCY_ERROR'
+
+    # Assert the dependency name is in the error kwargs.
+    assert exc_info.value.kwargs.get('dependency_name') == 'nonexistent_service'
+
+
+# ** test: remove_service
+def test_remove_service(populated_provider: DependenciesServiceProvider):
+    '''
+    Test that remove_service deregisters a service from the provider.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DependenciesServiceProvider
+    '''
+
+    # Remove the registered service.
+    populated_provider.remove_service('simple_service')
+
+    # Assert it was removed from the services dictionary.
+    assert 'simple_service' not in populated_provider.services
+
+    # Assert it is no longer resolvable.
+    with pytest.raises(TiferetError):
+        populated_provider.get_service('simple_service')
+
+
+# ** test: remove_service_nonexistent
+def test_remove_service_nonexistent(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that remove_service is a no-op for an unregistered service ID.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # Removing an ID that was never registered should not raise.
+    empty_provider.remove_service('nonexistent_service')
+
+    # Assert the services dictionary is still empty.
+    assert empty_provider.services == {}
+
+
+# ** test: build_injector_rebuilds_on_mutation
+def test_build_injector_rebuilds_on_mutation(empty_provider: DependenciesServiceProvider):
+    '''
+    Test that each mutation rebuilds the injector to reflect the current services.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DependenciesServiceProvider
+    '''
+
+    # With no services the injector starts as None.
+    assert empty_provider.injector is None
+
+    # Add a service, which should trigger a rebuild.
+    empty_provider.add_service('simple_service', SimpleService)
+
+    # Assert the injector was created (no longer None).
+    assert empty_provider.injector is not None
+
+    # Assert the new injector resolves the added service.
+    assert isinstance(empty_provider.get_service('simple_service'), SimpleService)


### PR DESCRIPTION
## Summary

Introduces the `tiferet/di/` package as a new first-class component of the Tiferet framework, establishing the app-level dependency injection layer for v2.0.0a7.

## Changes

- **`tiferet/di/settings.py`** — `ServiceProvider` ABC with five abstract methods (`add_service`, `add_services`, `add_constants`, `get_service`, `remove_service`).
- **`tiferet/di/dependencies.py`** — `DependenciesServiceProvider` concrete implementation backed by the `dependencies` library, with empty scope guard and injector rebuild on mutation.
- **`tiferet/di/__init__.py`** — Package exports for `ServiceProvider` and `DependenciesServiceProvider`.
- **`tiferet/di/tests/test_dependencies.py`** — 12 unit tests covering all methods and error paths.
- **`docs/core/di.md`** — Core style guide covering two-layer DI distinction, method semantics, design decisions, scalar constants caveat, custom implementation example, and testing patterns.

## Acceptance Criteria

- [x] `tiferet/di/__init__.py` exports `ServiceProvider` and `DependenciesServiceProvider`
- [x] All 12 tests pass (`pytest tiferet/di/` exits 0)
- [x] `DependenciesServiceProvider()` initializes without error; `injector is None`
- [x] `get_service(id)` raises `TiferetError(error_code="INVALID_DEPENDENCY_ERROR")` for unresolvable IDs
- [x] `docs/core/di.md` exists and covers all required sections

Closes #686

Co-Authored-By: Oz <oz-agent@warp.dev>