### PR TITLE
Contexts – DIContext: Forward-Compatible DI Container Context (#681)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -72,6 +72,16 @@ DEFAULT_SERVICES = [
         'class_name': 'ContainerContext',
     },
     {
+        'service_id': 'di_list_all_configs_evt',
+        'module_path': 'tiferet.events.di',
+        'class_name': 'ListAllSettings',
+    },
+    {
+        'service_id': 'services',
+        'module_path': 'tiferet.contexts.di',
+        'class_name': 'DIContext',
+    },
+    {
         'service_id': 'features',
         'module_path': 'tiferet.contexts.feature',
         'class_name': 'FeatureContext',

--- a/tiferet/contexts/__init__.py
+++ b/tiferet/contexts/__init__.py
@@ -8,6 +8,7 @@ from .request import RequestContext
 from .cache import CacheContext
 from .error import ErrorContext
 from .container import ContainerContext
+from .di import DIContext
 from .feature import FeatureContext
 from .app import (
     AppManagerContext,

--- a/tiferet/contexts/di.py
+++ b/tiferet/contexts/di.py
@@ -1,0 +1,184 @@
+# *** imports
+
+# ** core
+from typing import Callable, Any, List, Dict
+
+# ** app
+from .cache import CacheContext
+from ..assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
+from ..di import ServiceProvider, DependenciesServiceProvider
+from ..domain.di import ServiceConfiguration
+from ..events import DomainEvent, RaiseError, ParseParameter
+
+
+# *** contexts
+
+# ** context: di_context
+class DIContext(object):
+    '''
+    A context for managing dependency injection configuration and service provider lifecycle.
+    '''
+
+    # * attribute: cache
+    cache: CacheContext
+
+    # * attribute: list_all_configs_handler
+    list_all_configs_handler: Callable
+
+    # * init
+    def __init__(self, di_list_all_configs_evt: DomainEvent, cache: CacheContext = None):
+        '''
+        Initialize the DI context.
+
+        :param di_list_all_configs_evt: The event to list all service configurations and constants.
+        :type di_list_all_configs_evt: DomainEvent
+        :param cache: The cache context to use for caching service providers.
+        :type cache: CacheContext
+        '''
+
+        # Assign the attributes.
+        self.list_all_configs_handler = di_list_all_configs_evt.execute
+        self.cache = cache if cache else CacheContext()
+
+    # * method: create_cache_key
+    def create_cache_key(self, flags: List[str] = None) -> str:
+        '''
+        Create a cache key for the service provider.
+
+        :param flags: The feature or data flags to use.
+        :type flags: List[str]
+        :return: The cache key.
+        :rtype: str
+        '''
+
+        # Create the cache key from the flags.
+        return f"feature_services{'_' + '_'.join(flags) if flags else ''}"
+
+    # * method: build_provider
+    def build_provider(self, flags: List[str] = []) -> ServiceProvider:
+        '''
+        Build and cache a service provider for the given flags.
+
+        :param flags: The feature or data flags to use.
+        :type flags: List[str]
+        :return: The service provider instance.
+        :rtype: ServiceProvider
+        '''
+
+        # Create the cache key from the flags.
+        cache_key = self.create_cache_key(flags)
+
+        # Return the cached provider if available.
+        cached_provider = self.cache.get(cache_key)
+        if cached_provider:
+            return cached_provider
+
+        # Get all service configurations and constants from the DI service.
+        configurations, constants = self.list_all_configs_handler()
+
+        # Load and parse constants from configurations and the top-level constants dict.
+        constants = self.load_constants(configurations, constants, flags)
+
+        # Resolve service types from configurations.
+        services = {}
+        for config in configurations:
+
+            # Get the dependency type based on the flags.
+            dep_type = self.get_configuration_type(config, *flags)
+
+            # If no type is found, raise an error.
+            if not dep_type:
+                RaiseError.execute(
+                    DEPENDENCY_TYPE_NOT_FOUND_ID,
+                    f'No dependency type found for service configuration {config.id} with flags {flags}.',
+                    configuration_id=config.id,
+                    flags=flags,
+                )
+
+            # Add the resolved type to the services dictionary.
+            services[config.id] = dep_type
+
+        # Merge services and constants and build the provider.
+        provider = DependenciesServiceProvider(
+            services={**services, **constants},
+            name=cache_key,
+        )
+
+        # Cache and return the provider.
+        self.cache.set(cache_key, provider)
+        return provider
+
+    # * method: get_dependency
+    def get_dependency(self, configuration_id: str, flags: List[str] = []) -> Any:
+        '''
+        Get a resolved service by its configuration ID.
+
+        :param configuration_id: The service configuration identifier.
+        :type configuration_id: str
+        :param flags: The feature or data flags to use.
+        :type flags: List[str]
+        :return: The resolved service instance.
+        :rtype: Any
+        '''
+
+        # Build (or retrieve) the service provider for these flags.
+        provider = self.build_provider(flags)
+
+        # Return the resolved service from the provider.
+        return provider.get_service(configuration_id)
+
+    # * method: get_configuration_type
+    def get_configuration_type(self, configuration: ServiceConfiguration, *flags) -> type:
+        '''
+        Resolve the implementation type for a service configuration.
+
+        Delegates to ServiceConfiguration.get_service_type() which checks
+        flagged dependencies first, then falls back to the default type.
+
+        :param configuration: The service configuration to resolve.
+        :type configuration: ServiceConfiguration
+        :param flags: The flags for the flagged dependency.
+        :type flags: Tuple[str, ...]
+        :return: The resolved type, or None.
+        :rtype: type
+        '''
+
+        # Delegate to the domain method for type resolution.
+        return configuration.get_service_type(*flags)
+
+    # * method: load_constants
+    def load_constants(self,
+            configurations: List[ServiceConfiguration] = [],
+            constants: Dict[str, str] = {},
+            flags: List[str] = [],
+        ) -> Dict[str, str]:
+        '''
+        Build the constants dict by parsing top-level constants and per-configuration parameters.
+
+        :param configurations: The list of service configurations.
+        :type configurations: List[ServiceConfiguration]
+        :param constants: The top-level constants dictionary.
+        :type constants: Dict[str, str]
+        :param flags: The feature or data flags to use.
+        :type flags: List[str]
+        :return: A dictionary of parsed constants.
+        :rtype: Dict[str, str]
+        '''
+
+        # Parse the top-level constants.
+        constants = {k: ParseParameter.execute(v) for k, v in constants.items()}
+
+        # Merge in per-configuration parameters (flagged or default).
+        for config in configurations:
+
+            # Check for a flagged dependency matching any of the provided flags.
+            dependency = config.get_dependency(*flags)
+
+            # Use flagged parameters if available; otherwise use the default parameters.
+            if dependency:
+                constants.update({k: ParseParameter.execute(v) for k, v in dependency.parameters.items()})
+            else:
+                constants.update({k: ParseParameter.execute(v) for k, v in config.parameters.items()})
+
+        # Return the merged constants dictionary.
+        return constants

--- a/tiferet/contexts/tests/test_di.py
+++ b/tiferet/contexts/tests/test_di.py
@@ -1,0 +1,357 @@
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+from typing import Tuple, List, Dict
+
+# ** app
+from ..di import DIContext
+from ...assets.exceptions import TiferetError
+from ...assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
+from ...di import ServiceProvider, DependenciesServiceProvider
+from ...domain.di import ServiceConfiguration, FlaggedDependency
+from ...domain.settings import DomainObject
+from ...events.di import ListAllSettings
+
+
+# *** classes
+
+# ** class: TestService
+class TestService():
+    '''
+    A mock service class for testing.
+    '''
+
+    # * attribute: test_config
+    test_config: str
+
+    # * attribute: param_config
+    param_config: str
+
+    # * attribute: flagged_config
+    flagged_config: str
+
+    def __init__(self, test_config: str, param_config: str = None, flagged_config: str = None):
+        '''Initialize the service with a test configuration.'''
+        self.test_config = test_config
+        self.param_config = param_config
+        self.flagged_config = flagged_config
+
+
+# *** fixtures
+
+# ** fixture: di_service_content
+@pytest.fixture
+def di_service_content() -> Tuple[List[ServiceConfiguration], Dict[str, str]]:
+    '''
+    Fixture to provide content for the DI service.
+    '''
+
+    # Create a list of service configurations.
+    configurations = [
+        DomainObject.new(
+            ServiceConfiguration,
+            id='test_service',
+            module_path='tiferet.contexts.tests.test_di',
+            class_name='TestService',
+            dependencies=[
+                DomainObject.new(
+                    FlaggedDependency,
+                    module_path='tiferet.contexts.tests.test_di',
+                    class_name='TestService',
+                    flag='test',
+                    parameters=dict(
+                        flagged_config='flagged_value',
+                    )
+                )
+            ],
+            parameters=dict(
+                param_config='param_value',
+            )
+        ),
+    ]
+
+    # Create a dictionary of constants.
+    constants = dict(
+        test_config='test_value'
+    )
+
+    # Return the configurations and constants.
+    return configurations, constants
+
+
+# ** fixture: di_list_all_configs_evt_mock
+@pytest.fixture
+def di_list_all_configs_evt_mock(di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
+    '''
+    Fixture to create a mock ListAllSettings event.
+
+    :param di_service_content: The content for the DI service.
+    :type di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]
+    :return: A mock ListAllSettings event.
+    :rtype: ListAllSettings
+    '''
+
+    # Create a mock ListAllSettings event.
+    evt = mock.Mock(spec=ListAllSettings)
+
+    # Mock the execute method to return the content.
+    evt.execute.return_value = di_service_content
+
+    # Return the mock event.
+    return evt
+
+
+# ** fixture: di_context
+@pytest.fixture
+def di_context(di_list_all_configs_evt_mock) -> DIContext:
+    '''
+    Fixture to create a DIContext with a mock DI service.
+
+    :param di_list_all_configs_evt_mock: The mock ListAllSettings event.
+    :type di_list_all_configs_evt_mock: mock.Mock
+    :return: A DIContext instance.
+    :rtype: DIContext
+    '''
+
+    # Return a DIContext instance.
+    return DIContext(di_list_all_configs_evt=di_list_all_configs_evt_mock)
+
+
+# ** fixture: provider
+@pytest.fixture
+def provider(di_context: DIContext) -> ServiceProvider:
+    '''
+    Fixture to build a service provider using the DIContext.
+
+    :param di_context: The DI context to use.
+    :type di_context: DIContext
+    :return: A ServiceProvider instance.
+    :rtype: ServiceProvider
+    '''
+
+    # Build the provider with no flags.
+    return di_context.build_provider()
+
+
+# *** tests
+
+# ** test: di_context_get_cache_key
+def test_di_context_get_cache_key(di_context: DIContext):
+    '''
+    Test the creation of a cache key in the DIContext.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    '''
+
+    # Test with no flags.
+    assert di_context.create_cache_key() == 'feature_services'
+
+    # Test with flags.
+    assert di_context.create_cache_key(flags=['test', 'test2']) == 'feature_services_test_test2'
+
+
+# ** test: di_context_build_provider
+def test_di_context_build_provider(di_context: DIContext):
+    '''
+    Test the building of a service provider in the DIContext.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    '''
+
+    # Build the provider with no flags.
+    provider = di_context.build_provider()
+
+    # Assert that the provider is not None and is a ServiceProvider.
+    assert provider
+    assert isinstance(provider, ServiceProvider)
+
+    # Get the test_service from the provider.
+    test_service = provider.get_service('test_service')
+
+    # Assert the service was resolved with default parameters.
+    assert test_service.test_config == 'test_value'
+    assert test_service.param_config == 'param_value'
+    assert test_service.flagged_config is None
+
+    # Assert that the provider is cached.
+    assert di_context.cache.get('feature_services') is provider
+
+    # Build the provider with flags.
+    flagged_provider = di_context.build_provider(flags=['test'])
+
+    # Assert the flagged provider is not None.
+    assert flagged_provider
+
+    # Get the test_service from the flagged provider.
+    flagged_service = flagged_provider.get_service('test_service')
+
+    # Assert the service was resolved with flagged parameters.
+    assert flagged_service.test_config == 'test_value'
+    assert flagged_service.param_config is None
+    assert flagged_service.flagged_config == 'flagged_value'
+
+    # Assert that the flagged provider is cached.
+    assert di_context.cache.get('feature_services_test') is flagged_provider
+
+
+# ** test: di_context_build_provider_with_missing_dependency_type
+def test_di_context_build_provider_with_missing_dependency_type(
+        di_context: DIContext,
+        di_list_all_configs_evt_mock,
+        di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
+    '''
+    Test building a provider with a missing dependency type raises an error.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    :param di_list_all_configs_evt_mock: The mock ListAllSettings event.
+    :param di_service_content: The content for the DI service.
+    :type di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]
+    '''
+
+    # Update the configuration to have no module_path and class_name.
+    configurations, constants = di_service_content
+    configurations[0].module_path = None
+    configurations[0].class_name = None
+
+    # Mock the execute method to return the updated configurations.
+    di_list_all_configs_evt_mock.execute.return_value = (configurations, constants)
+
+    # Attempt to build the provider and expect an error.
+    with pytest.raises(TiferetError) as exc_info:
+        di_context.build_provider(flags=['missing_flag'])
+
+    # Assert the correct error code and kwargs.
+    assert exc_info.value.error_code == DEPENDENCY_TYPE_NOT_FOUND_ID
+    assert exc_info.value.kwargs.get('configuration_id') == 'test_service'
+    assert exc_info.value.kwargs.get('flags') == ['missing_flag']
+
+
+# ** test: di_context_build_provider_with_cached_provider
+def test_di_context_build_provider_with_cached_provider(di_context: DIContext, provider: ServiceProvider):
+    '''
+    Test that build_provider returns the cached provider on subsequent calls.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    :param provider: The pre-built service provider fixture.
+    :type provider: ServiceProvider
+    '''
+
+    # Assert that a provider is cached.
+    assert di_context.cache.get('feature_services')
+
+    # Call build_provider again with no flags.
+    cached_provider = di_context.build_provider()
+
+    # Assert the same provider instance is returned.
+    assert cached_provider is provider
+
+
+# ** test: di_context_get_dependency
+def test_di_context_get_dependency(di_context: DIContext):
+    '''
+    Test retrieving a dependency from the DIContext.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    '''
+
+    # Retrieve the dependency.
+    service = di_context.get_dependency('test_service')
+
+    # Assert the service was resolved correctly.
+    assert service.test_config == 'test_value'
+    assert service.param_config == 'param_value'
+    assert service.flagged_config is None
+
+
+# ** test: di_context_get_configuration_type_success_default
+def test_di_context_get_configuration_type_success_default(
+        di_context: DIContext,
+        di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
+    '''
+    Test that get_configuration_type resolves the correct type with and without flags.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    :param di_service_content: The content for the DI service.
+    :type di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]
+    '''
+
+    # Unpack the service content.
+    configurations, _ = di_service_content
+    config = configurations[0]
+
+    # Resolve without flags — should return the default TestService.
+    dep_type = di_context.get_configuration_type(config)
+    assert dep_type is TestService
+
+    # Resolve with the test flag — should still return TestService (same class in fixture).
+    dep_type = di_context.get_configuration_type(config, 'test')
+    assert dep_type is TestService
+
+
+# ** test: di_context_get_configuration_type_none
+def test_di_context_get_configuration_type_none(di_context: DIContext):
+    '''
+    Test that get_configuration_type returns None when no type is found.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    '''
+
+    # Create a configuration with no default type and no matching dependencies.
+    config = DomainObject.new(
+        ServiceConfiguration,
+        id='no_type',
+        dependencies=[],
+    )
+
+    # Resolve without flags — should return None.
+    assert di_context.get_configuration_type(config) is None
+
+    # Resolve with an unknown flag — should return None.
+    assert di_context.get_configuration_type(config, 'missing_flag') is None
+
+
+# ** test: di_context_load_constants_with_flagged_dependencies
+def test_di_context_load_constants_with_flagged_dependencies(
+        di_context: DIContext,
+        di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
+    '''
+    Test the load_constants method with and without flags.
+
+    :param di_context: The DI context to test.
+    :type di_context: DIContext
+    :param di_service_content: The content for the DI service.
+    :type di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]
+    '''
+
+    # Unpack the service content.
+    configurations, constants = di_service_content
+
+    # Load constants without flags — uses default parameters.
+    constants_no_flags = di_context.load_constants(
+        configurations=configurations,
+        constants=constants,
+    )
+    assert constants_no_flags == {
+        'test_config': 'test_value',
+        'param_config': 'param_value',
+    }
+
+    # Load constants with the test flag — uses flagged parameters.
+    constants_with_flags = di_context.load_constants(
+        configurations=configurations,
+        constants=constants,
+        flags=['test'],
+    )
+    assert constants_with_flags == {
+        'test_config': 'test_value',
+        'flagged_config': 'flagged_value',
+    }

--- a/tiferet/domain/di.py
+++ b/tiferet/domain/di.py
@@ -2,6 +2,10 @@
 
 # *** imports
 
+# ** core
+from importlib import import_module
+from typing import Dict
+
 # ** app
 from .settings import (
     DomainObject,
@@ -128,4 +132,31 @@ class ServiceConfiguration(DomainObject):
                 return match
 
         # Return None if no dependency matches the flags.
+        return None
+
+    # * method: get_service_type
+    def get_service_type(self, *flags) -> type:
+        '''
+        Gets the service type based on the provided flags.
+
+        Checks flagged dependencies first (in flag priority order), then
+        falls back to the configuration\'s default module_path/class_name.
+
+        :param flags: The flags for the flagged dependency.
+        :type flags: Tuple[str, ...]
+        :return: The type of the service configuration.
+        :rtype: type
+        '''
+
+        # Check the flagged dependencies for the type first.
+        for flag in flags:
+            dependency = self.get_dependency(flag)
+            if dependency:
+                return getattr(import_module(dependency.module_path), dependency.class_name)
+
+        # Otherwise defer to an available default type.
+        if self.module_path and self.class_name:
+            return getattr(import_module(self.module_path), self.class_name)
+
+        # Return None if no type is found.
         return None

--- a/tiferet/domain/tests/test_di.py
+++ b/tiferet/domain/tests/test_di.py
@@ -199,3 +199,77 @@ def test_service_configuration_get_dependency_multiple_flags(
     dep_beta_first = service_configuration_multiple_deps.get_dependency('test_beta', 'test_alpha')
     assert dep_beta_first.flag == 'test_beta'
     assert dep_beta_first.class_name == 'TestDependencyBeta'
+
+
+# ** test: service_configuration_get_service_type_default
+def test_service_configuration_get_service_type_default(
+        service_configuration: ServiceConfiguration,
+    ) -> None:
+    '''
+    Test that get_service_type returns the default type when no flags match.
+
+    :param service_configuration: The ServiceConfiguration fixture.
+    :type service_configuration: ServiceConfiguration
+    '''
+
+    # Resolve with no flags — should return the default TestDependency.
+    resolved = service_configuration.get_service_type()
+
+    # Assert the default type is returned.
+    assert resolved is TestDependency
+
+
+# ** test: service_configuration_get_service_type_flagged
+def test_service_configuration_get_service_type_flagged(
+        service_configuration: ServiceConfiguration,
+    ) -> None:
+    '''
+    Test that get_service_type resolves the flagged dependency type when a matching flag is provided.
+
+    :param service_configuration: The ServiceConfiguration fixture.
+    :type service_configuration: ServiceConfiguration
+    '''
+
+    # Resolve with the test_alpha flag — should return TestDependencyAlpha.
+    resolved = service_configuration.get_service_type('test_alpha')
+
+    # Assert the flagged type takes priority over the default.
+    assert resolved is TestDependencyAlpha
+
+
+# ** test: service_configuration_get_service_type_no_match
+def test_service_configuration_get_service_type_no_match(
+        service_configuration_no_default_type: ServiceConfiguration,
+    ) -> None:
+    '''
+    Test that get_service_type returns None when no flag matches and there is no default.
+
+    :param service_configuration_no_default_type: ServiceConfiguration with no default type.
+    :type service_configuration_no_default_type: ServiceConfiguration
+    '''
+
+    # Resolve with an unknown flag and no default — should return None.
+    resolved = service_configuration_no_default_type.get_service_type('unknown_flag')
+
+    # Assert None is returned.
+    assert resolved is None
+
+
+# ** test: service_configuration_get_service_type_flag_priority
+def test_service_configuration_get_service_type_flag_priority(
+        service_configuration_multiple_deps: ServiceConfiguration,
+    ) -> None:
+    '''
+    Test that get_service_type respects flag priority order — first matching flag wins.
+
+    :param service_configuration_multiple_deps: ServiceConfiguration with two flagged overrides.
+    :type service_configuration_multiple_deps: ServiceConfiguration
+    '''
+
+    # test_alpha first — should resolve alpha.
+    resolved = service_configuration_multiple_deps.get_service_type('test_alpha', 'test_beta')
+    assert resolved is TestDependencyAlpha
+
+    # test_beta first — should resolve beta.
+    resolved = service_configuration_multiple_deps.get_service_type('test_beta', 'test_alpha')
+    assert resolved is TestDependencyBeta


### PR DESCRIPTION
## Summary

Introduces `DIContext` as the forward-compatible successor to `ContainerContext`, using the `ServiceProvider` pattern for all dependency resolution. Also adds `ServiceConfiguration.get_service_type()` to the domain layer.

## Changes

- **`domain/di.py`** — Add `ServiceConfiguration.get_service_type(*flags)`: checks flagged dependencies first, falls back to default `module_path/class_name`.
- **`contexts/di.py`** — New `DIContext`: builds and caches a `DependenciesServiceProvider` per flag set; `get_dependency` calls `provider.get_service(id)`. No commands or events used for injection.
- **`contexts/tests/test_di.py`** — 8 tests covering all `DIContext` methods.
- **`domain/tests/test_di.py`** — 4 new `get_service_type` tests (7 total).
- **`contexts/__init__.py`** — Export `DIContext`.
- **`assets/constants.py`** — Add `di_list_all_configs_evt` and `services` entries to `DEFAULT_SERVICES`.

## Design Note

`DIContext.build_provider()` returns a `ServiceProvider` (ABC), instantiated as `DependenciesServiceProvider`. The provider is cached by flag-derived key (`feature_services[_flag1_flag2...]`). `get_dependency` simply calls `provider.get_service()` — no injector commands involved.

## Acceptance Criteria

- [x] `DIContext` exported from `tiferet/contexts/__init__.py`
- [x] `pytest tiferet/contexts/tests/test_di.py` passes (8 tests)
- [x] `pytest tiferet/domain/tests/test_di.py` passes (7 tests)
- [x] `DEFAULT_SERVICES` contains `di_list_all_configs_evt` and `services` entries
- [x] `ServiceConfiguration.get_service_type()` resolves default and flagged types

Closes #681

Co-Authored-By: Oz <oz-agent@warp.dev>