### PR TITLE
Feature Context – Attribute ID Retirement and DIContext Integration (#682)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -15,14 +15,6 @@ DEFAULT_SERVICES = [
         },
     },
     {
-        'service_id': 'container_service',
-        'module_path': 'tiferet.repos.config.container',
-        'class_name': 'ContainerConfigurationRepository',
-        'parameters': {
-            'container_config_file': 'app/configs/container.yml',
-        },
-    },
-    {
         'service_id': 'error_service',
         'module_path': 'tiferet.repos.error',
         'class_name': 'ErrorYamlRepository',
@@ -52,24 +44,14 @@ DEFAULT_SERVICES = [
         'class_name': 'GetError',
     },
     {
-        'service_id': 'get_feature_cmd',
-        'module_path': 'tiferet.commands.feature',
+        'service_id': 'get_feature_evt',
+        'module_path': 'tiferet.events.feature',
         'class_name': 'GetFeature',
-    },
-    {
-        'service_id': 'container_list_all_cmd',
-        'module_path': 'tiferet.commands.container',
-        'class_name': 'ListAllSettings',
     },
     {
         'service_id': 'logging_service',
         'module_path': 'tiferet.handlers.logging',
         'class_name': 'LoggingHandler',
-    },
-    {
-        'service_id': 'container',
-        'module_path': 'tiferet.contexts.container',
-        'class_name': 'ContainerContext',
     },
     {
         'service_id': 'di_list_all_configs_evt',

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -4,7 +4,7 @@
 from typing import Callable
 
 # ** app
-from .container import ContainerContext
+from .di import DIContext
 from .cache import CacheContext
 from .request import RequestContext
 from ..assets.constants import (
@@ -12,21 +12,20 @@ from ..assets.constants import (
     REQUEST_NOT_FOUND_ID,
     PARAMETER_NOT_FOUND_ID
 )
-from ..commands import (
-    Command,
+from ..events import (
+    DomainEvent,
     RaiseError,
     ParseParameter
 )
-from ..commands.feature import GetFeature
-from ..models import Feature, FeatureCommand
+from ..domain import Feature, FeatureEvent
 
 # *** contexts
 
 # ** context: feature_context
 class FeatureContext(object):
 
-    # * attribute: container
-    container: ContainerContext
+    # * attribute: services
+    services: DIContext
 
     # * attribute: cache
     cache: CacheContext
@@ -34,62 +33,61 @@ class FeatureContext(object):
     # * attribute: get_feature_handler
     get_feature_handler: Callable
 
-    # * method: init
+    # * init
     def __init__(self,
-            get_feature_cmd: GetFeature,
-            container: ContainerContext,
+            get_feature_evt: DomainEvent,
+            services: DIContext,
             cache: CacheContext = None):
         '''
         Initialize the feature context.
 
-        :param get_feature_cmd: The command used to retrieve features.
-        :type get_feature_cmd: GetFeature
-        :param container: The container context for dependency injection.
-        :type container: ContainerContext
+        :param get_feature_evt: The event used to retrieve features.
+        :type get_feature_evt: DomainEvent
+        :param services: The DI context for dependency injection.
+        :type services: DIContext
         :param cache: The cache context to use for caching feature data.
         :type cache: CacheContext
         '''
 
         # Assign the attributes.
-        self.container = container
+        self.services = services
         self.cache = cache if cache else CacheContext()
-        self.get_feature_handler = get_feature_cmd.execute
+        self.get_feature_handler = get_feature_evt.execute
 
-    # * method: load_feature_command
-    def load_feature_command(self, feature_command: FeatureCommand, feature_flags: list[str] = None) -> Command:
+    # * method: load_feature_step
+    def load_feature_step(self, feature_event: FeatureEvent, feature_flags: list[str] = None) -> DomainEvent:
         '''
-        Load a feature command from the container using its attribute ID and
+        Load a feature event step from the DI context using its service ID and
         any configured flags.
 
-        :param feature_command: The feature command metadata describing the
-            container attribute and flags.
-        :type feature_command: FeatureCommand
+        :param feature_event: The feature event metadata describing the
+            service configuration and flags.
+        :type feature_event: FeatureEvent
         :param feature_flags: Optional list of flags from the parent feature.
         :type feature_flags: list[str]
-        :return: The command object.
-        :rtype: Command
+        :return: The resolved domain event.
+        :rtype: DomainEvent
         '''
 
-        # Resolve the attribute identifier for the command.
-        attribute_id = feature_command.attribute_id
+        # Resolve the service identifier for the event.
+        service_id = feature_event.service_id
 
-        # Combine flags: feature-level (higher priority) first, then command-level.
-        combined_flags = (feature_flags or []) + (feature_command.flags or [])
+        # Combine flags: feature-level (higher priority) first, then step-level.
+        combined_flags = (feature_flags or []) + (feature_event.flags or [])
 
-        # Attempt to retrieve the command from the container using the
-        # combined flags, if any.
+        # Attempt to retrieve the event from the DI context using the combined flags.
         try:
-            return self.container.get_dependency(
-                attribute_id,
+            return self.services.get_dependency(
+                service_id,
                 *combined_flags,
             )
-        
-        # If the command is not found, raise an error.
+
+        # If the event is not found, raise an error.
         except Exception as e:
             RaiseError.execute(
                 FEATURE_COMMAND_LOADING_FAILED_ID,
-                f'Failed to load feature command attribute: {attribute_id}. Ensure the container attributes is configured with the appropriate default settings/flags.',
-                attribute_id=attribute_id,
+                f'Failed to load feature step attribute: {service_id}. Ensure the container is configured with the appropriate default settings/flags.',
+                service_id=service_id,
                 exception=str(e)
             )
 
@@ -116,7 +114,7 @@ class FeatureContext(object):
         return feature
     # * method: handle_command
     def handle_command(self,
-        command: Command, 
+        command: DomainEvent,
         request: RequestContext,
         data_key: str = None,
         pass_on_error: bool = False,
@@ -154,13 +152,8 @@ class FeatureContext(object):
             # Set the result to None if passing on the error.
             result = None
 
-        # If a data key is provided, store the result in the request data.
-        if data_key:
-            request.data[data_key] = result
-
-        # Otherwise, set the result.
-        else:
-            request.result = result
+        # Store the result via the request context.
+        request.set_result(result, data_key)
 
     # * method: parse_request_parameter
     def parse_request_parameter(self, parameter: str, request: RequestContext = None) -> str:
@@ -215,27 +208,26 @@ class FeatureContext(object):
         # Load the feature by id, using the cache when possible.
         feature = self.load_feature(feature_id)
 
-        # Execute the feature by iterating over its configured commands.
-        for feature_command in feature.commands:
+        # Execute the feature by iterating over its configured steps.
+        for feature_event in feature.steps:
 
-            # Load the command dependency for this feature command, honoring
-            # any configured flags.
-            cmd = self.load_feature_command(feature_command, feature_flags=feature.flags)
+            # Load the event dependency for this step, honoring any configured flags.
+            cmd = self.load_feature_step(feature_event, feature_flags=feature.flags)
 
-            # Parse the command parameters.
+            # Parse the step parameters.
             params = {
                 param: self.parse_request_parameter(value, request)
-                for param, value in feature_command.parameters.items()
+                for param, value in feature_event.parameters.items()
             }
 
-            # Execute the command with the request data and parameters.
+            # Execute the step with the request data and parameters.
             self.handle_command(
                 cmd,
                 request,
-                data_key=feature_command.data_key,
-                pass_on_error=feature_command.pass_on_error,
+                data_key=feature_event.data_key,
+                pass_on_error=feature_event.pass_on_error,
                 **params,
-                container=self.container,
+                services=self.services,
                 cache=self.cache,
                 **kwargs
             )

--- a/tiferet/contexts/tests/test_feature.py
+++ b/tiferet/contexts/tests/test_feature.py
@@ -9,90 +9,89 @@ from unittest import mock
 
 # ** app
 from ..feature import (
-    ContainerContext,
+    DIContext,
     FeatureContext,
-    RequestContext
+    RequestContext,
 )
 from ...assets import TiferetError
-from ...commands import Command
-from ...commands.feature import GetFeature
-from ...models import (
-    ModelObject,
+from ...events import DomainEvent
+from ...domain import (
+    DomainObject,
     Feature,
-    FeatureCommand,
+    FeatureEvent,
 )
 
 # *** fixtures
 
-# ** fixture: get_feature_cmd
+# ** fixture: get_feature_evt
 @pytest.fixture
-def get_feature_cmd() -> GetFeature:
-    """Fixture to provide a mock GetFeature command instance."""
+def get_feature_evt() -> DomainEvent:
+    """Fixture to provide a mock GetFeature event instance."""
 
-    # Create a mock GetFeature command.
-    cmd = mock.Mock(spec=GetFeature)
+    # Create a mock GetFeature event.
+    evt = mock.Mock(spec=DomainEvent)
 
-    # Return the mock command instance.
-    return cmd
+    # Return the mock event instance.
+    return evt
 
-# ** fixture: container_context
+# ** fixture: services_context
 @pytest.fixture
-def container_context(test_command):
-    """Fixture to provide a mock container context."""
-    
-    # Create a mock container context.
-    container_context = mock.Mock(spec=ContainerContext)
+def services_context(test_command):
+    """Fixture to provide a mock DI context."""
 
-    # Set the container service to return the test command when requested.
-    container_context.get_dependency.return_value = test_command
-    
-    # Return the mock container context.
-    return container_context
+    # Create a mock DI context.
+    services_context = mock.Mock(spec=DIContext)
+
+    # Set the DI service to return the test command when requested.
+    services_context.get_dependency.return_value = test_command
+
+    # Return the mock DI context.
+    return services_context
 
 # ** fixture: feature_context
 @pytest.fixture
-def feature_context(get_feature_cmd, container_context):
+def feature_context(get_feature_evt, services_context):
     """Fixture to provide an instance of FeatureContext."""
 
-    # Create an instance of FeatureContext with the mock GetFeature command and container context.
+    # Create an instance of FeatureContext with the mock event and DI context.
     return FeatureContext(
-        get_feature_cmd=get_feature_cmd,
-        container=container_context
+        get_feature_evt=get_feature_evt,
+        services=services_context
     )
 
 # ** fixture: test_command
 @pytest.fixture
 def test_command():
 
-    class TestCommand(Command):
-        """A mock command for testing purposes."""
-        
+    class TestEvent(DomainEvent):
+        """A mock domain event for testing purposes."""
+
         def execute(self, key: str, param: str = None, **kwargs) -> Any:
             """Mock execute method that returns a test response."""
-            
+
             # Verify that the request exists.
             self.verify(key, 'KEY_NOT_FOUND', 'No key provided for command execution.')
-            
+
             # Mock response data.
             if not param:
                 return {"status": "success", "data": {"key": key}}
             return {"status": "success", "data": {"key": key, "param": param}}
-        
-    # Return an instance of the mock command.
-    return TestCommand()
+
+    # Return an instance of the mock event.
+    return TestEvent()
 
 # ** fixture: feature
 @pytest.fixture
 def feature():
 
-    return ModelObject.new(
+    return DomainObject.new(
         Feature,
         id='test_group.test_feature',
         group_id='test_group',
         feature_key='test_feature',
         name='Test Feature',
         description='A feature for testing purposes.',
-        commands=[]
+        steps=[]
     )
 
 # *** tests
@@ -143,7 +142,7 @@ def test_feature_context_parse_request_parameter_not_found(feature_context):
 def test_feature_context_parse_request_parameter_delegates_to_parse_parameter(feature_context, monkeypatch):
     """Test that non-request parameters delegate to ParseParameter.execute."""
 
-    from ...commands import static as static_commands
+    from ...events import static as static_events
 
     called = {}
 
@@ -151,7 +150,7 @@ def test_feature_context_parse_request_parameter_delegates_to_parse_parameter(fe
         called['parameter'] = parameter
         return 'parsed-value'
 
-    monkeypatch.setattr(static_commands.ParseParameter, 'execute', staticmethod(fake_execute))
+    monkeypatch.setattr(static_events.ParseParameter, 'execute', staticmethod(fake_execute))
 
     # Non-request parameter should be delegated to ParseParameter.execute.
     result = feature_context.parse_request_parameter('$env.MY_VAR', RequestContext(data={}))
@@ -159,130 +158,121 @@ def test_feature_context_parse_request_parameter_delegates_to_parse_parameter(fe
     assert result == 'parsed-value'
     assert called['parameter'] == '$env.MY_VAR'
 
-# ** test: feature_context_load_feature_command_with_combined_flags
-def test_feature_context_load_feature_command_with_combined_flags(feature_context, container_context, test_command):
-    """Test loading a feature command combining feature and command flags with correct priority."""
+# ** test: feature_context_load_feature_step_with_combined_flags
+def test_feature_context_load_feature_step_with_combined_flags(feature_context, services_context, test_command):
+    """Test loading a feature step combining feature and step flags with correct priority."""
 
     feature_flags = ['feature_flag_1', 'feature_flag_2']
-    
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
         flags=['command_flag_1', 'command_flag_2'],
     )
 
-    # Load the feature command using the feature context, passing the feature flags.
-    command = feature_context.load_feature_command(feature_command, feature_flags=feature_flags)
+    command = feature_context.load_feature_step(feature_event, feature_flags=feature_flags)
 
-    # Assert that the loaded command is the same as the test command and that
-    # flags were forwarded to the container dependency resolution in the correct order:
-    # Feature flags first, then command flags.
     assert command == test_command
-    container_context.get_dependency.assert_called_once_with(
-        'test_command', 
-        'feature_flag_1', 
-        'feature_flag_2', 
-        'command_flag_1', 
+    services_context.get_dependency.assert_called_once_with(
+        'test_command',
+        'feature_flag_1',
+        'feature_flag_2',
+        'command_flag_1',
         'command_flag_2'
     )
 
 
-# ** test: feature_context_load_feature_command_only_feature_flags
-def test_feature_context_load_feature_command_only_feature_flags(feature_context, container_context, test_command):
-    """Test loading a feature command with only feature flags."""
+# ** test: feature_context_load_feature_step_only_feature_flags
+def test_feature_context_load_feature_step_only_feature_flags(feature_context, services_context, test_command):
+    """Test loading a feature step with only feature flags."""
 
     feature_flags = ['feature_flag']
-    
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
         flags=[],
     )
 
-    command = feature_context.load_feature_command(feature_command, feature_flags=feature_flags)
+    command = feature_context.load_feature_step(feature_event, feature_flags=feature_flags)
 
     assert command == test_command
-    container_context.get_dependency.assert_called_once_with('test_command', 'feature_flag')
+    services_context.get_dependency.assert_called_once_with('test_command', 'feature_flag')
 
-# ** test: feature_context_load_feature_command_only_command_flags
-def test_feature_context_load_feature_command_only_command_flags(feature_context, container_context, test_command):
-    """Test loading a feature command with only command flags."""
+# ** test: feature_context_load_feature_step_only_command_flags
+def test_feature_context_load_feature_step_only_command_flags(feature_context, services_context, test_command):
+    """Test loading a feature step with only step flags."""
 
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
         flags=['command_flag'],
     )
 
-    command = feature_context.load_feature_command(feature_command)
+    command = feature_context.load_feature_step(feature_event)
 
     assert command == test_command
-    container_context.get_dependency.assert_called_once_with('test_command', 'command_flag')
+    services_context.get_dependency.assert_called_once_with('test_command', 'command_flag')
 
-# ** test: feature_context_load_feature_command_with_flags
-def test_feature_context_load_feature_command_with_flags(feature_context, container_context, test_command):
-    """Test loading a feature command that includes flags for dependency resolution."""
+# ** test: feature_context_load_feature_step_with_flags
+def test_feature_context_load_feature_step_with_flags(feature_context, services_context, test_command):
+    """Test loading a feature step that includes flags for dependency resolution."""
 
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
         flags=['flag1', 'flag2'],
     )
 
-    # Load the feature command using the feature context.
-    command = feature_context.load_feature_command(feature_command)
+    command = feature_context.load_feature_step(feature_event)
 
-    # Assert that the loaded command is the same as the test command and that
-    # flags were forwarded to the container dependency resolution.
     assert command == test_command
-    container_context.get_dependency.assert_called_once_with('test_command', 'flag1', 'flag2')
+    services_context.get_dependency.assert_called_once_with('test_command', 'flag1', 'flag2')
 
 
-# ** test: feature_context_load_feature_command_without_flags
-def test_feature_context_load_feature_command_without_flags(feature_context, container_context, test_command):
-    """Test loading a feature command when no flags are configured."""
+# ** test: feature_context_load_feature_step_without_flags
+def test_feature_context_load_feature_step_without_flags(feature_context, services_context, test_command):
+    """Test loading a feature step when no flags are configured."""
 
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
     )
 
-    command = feature_context.load_feature_command(feature_command)
+    command = feature_context.load_feature_step(feature_event)
 
     assert command == test_command
-    container_context.get_dependency.assert_called_once_with('test_command')
+    services_context.get_dependency.assert_called_once_with('test_command')
 
 
-# ** test: feature_context_load_feature_command_failed
-def test_feature_context_load_feature_command_failed(feature_context, container_context):
-    """Test loading a feature command that does not exist in the FeatureContext."""
-    
-    # Add a side effect to the container context to raise an exception when trying to get a non-existent command.
-    container_context.get_dependency.side_effect = TiferetError(
+# ** test: feature_context_load_feature_step_failed
+def test_feature_context_load_feature_step_failed(feature_context, services_context):
+    """Test loading a feature step that does not exist in the DIContext."""
+
+    # Add a side effect to raise an exception when the service is not found.
+    services_context.get_dependency.side_effect = TiferetError(
         'TEST_ERROR',
-        'Feature command not found in container: non_existent_command',
+        'Feature command not found in services: non_existent_command',
     )
 
-    feature_command: FeatureCommand = ModelObject.new(
-        FeatureCommand,
+    feature_event: FeatureEvent = DomainObject.new(
+        FeatureEvent,
         name='Missing Command',
-        attribute_id='non_existent_command',
+        service_id='non_existent_command',
         flags=['flagX'],
     )
 
-    # Attempt to load a non-existent feature command.
     with pytest.raises(TiferetError) as exc_info:
-        feature_context.load_feature_command(feature_command)
-    
-    # Assert that the exception message is as expected.
+        feature_context.load_feature_step(feature_event)
+
     assert exc_info.value.error_code == 'FEATURE_COMMAND_LOADING_FAILED'
-    assert exc_info.value.kwargs.get('attribute_id') == 'non_existent_command'
-    assert 'Failed to load feature command attribute: non_existent_command' in str(exc_info.value)
+    assert exc_info.value.kwargs.get('service_id') == 'non_existent_command'
+    assert 'Failed to load feature step attribute: non_existent_command' in str(exc_info.value)
 
 # ** test: feature_context_handle_command
 def test_feature_context_handle_command(feature_context, test_command):
@@ -340,16 +330,17 @@ def test_feature_context_handle_command_with_pass_on_error(feature_context, test
     assert not request.handle_response()
 
 # ** test: feature_context_execute_feature
-def test_feature_context_execute_feature(feature_context, get_feature_cmd, feature):
+def test_feature_context_execute_feature(feature_context, get_feature_evt, feature):
 
-    # Add a standard feature command with no data key or pass on error.
-    feature.add_command(
+    # Add a standard feature step with no data key or pass on error.
+    feature.steps.append(DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
-    )
+        service_id='test_command',
+    ))
 
-    # Set the feature as the GetFeature command's return value.
-    get_feature_cmd.execute.return_value = feature
+    # Set the feature as the GetFeature event's return value.
+    get_feature_evt.execute.return_value = feature
 
     # Create a mock request.
     request = RequestContext(data={"key": "value"})
@@ -357,71 +348,67 @@ def test_feature_context_execute_feature(feature_context, get_feature_cmd, featu
     # Execute the feature using the feature context.
     feature_context.execute_feature(feature.id, request)
 
-    # Assert that the load_feature_command was called with the feature flags.
-    # Note: feature fixture has empty flags by default, so we expect None or [] depending on impl,
-    # but more importantly, we want to ensure execute_feature passes feature.flags.
-    # We can inspect the call to load_feature_command if we mock it, or rely on the fact that
-    # integration logic is covered by the unit tests above.
-    
     # Assert that the request handled the response correctly.
     assert request.handle_response() == {"status": "success", "data": {"key": "value"}}
 
-    # Assert that the GetFeature command was invoked once for this feature id.
-    get_feature_cmd.execute.assert_called_once_with(id=feature.id)
+    # Assert that the GetFeature event was invoked once for this feature id.
+    get_feature_evt.execute.assert_called_once_with(id=feature.id)
 
 # ** test: feature_context_execute_feature_with_request_parameter
-def test_feature_context_execute_feature_with_request_parameter(feature_context, get_feature_cmd, feature):
+def test_feature_context_execute_feature_with_request_parameter(feature_context, get_feature_evt, feature):
     """Test executing a feature with a request parameter in the FeatureContext."""
-    
-    # Add a standard feature command with a data key.
-    feature.add_command(
+
+    # Add a feature step with a data key and request parameter.
+    feature.steps.append(DomainObject.new(
+        FeatureEvent,
         name='Test Command',
-        attribute_id='test_command',
+        service_id='test_command',
         parameters=dict(
             param='$r.key',
         ),
         data_key='response_data',
-    )
+    ))
 
-    # Set the feature as the GetFeature command's return value.
-    get_feature_cmd.execute.return_value = feature
+    # Set the feature as the GetFeature event's return value.
+    get_feature_evt.execute.return_value = feature
 
     # Create a mock request.
     request = RequestContext(data={"key": "value"})
 
     # Execute the feature using the feature context with a data key.
-    feature_context.cache.clear()  # Clear the cache to ensure fresh execution.
+    feature_context.cache.clear()
     feature_context.execute_feature(feature.id, request)
 
     # Assert that the response is stored in the request data under the specified key.
     assert request.data.get('response_data') == {"status": "success", "data": {"key": "value", "param": "value"}}
 
-    # Assert that the GetFeature command was invoked once for this feature id.
-    get_feature_cmd.execute.assert_called_once_with(id=feature.id)
+    # Assert that the GetFeature event was invoked once for this feature id.
+    get_feature_evt.execute.assert_called_once_with(id=feature.id)
 
 # ** test: feature_context_execute_feature_with_pass_on_error
-def test_feature_context_execute_feature_with_pass_on_error(feature_context, get_feature_cmd, feature):
+def test_feature_context_execute_feature_with_pass_on_error(feature_context, get_feature_evt, feature):
     """Test executing a feature with pass_on_error in the FeatureContext."""
-    
-    # Add a standard feature command and enable pass_on_error.
-    feature_command = feature.add_command(
-        name='Test Command',
-        attribute_id='test_command',
-    )
-    feature_command.pass_on_error = True
 
-    # Set the feature as the GetFeature command's return value.
-    get_feature_cmd.execute.return_value = feature
+    # Add a feature step with pass_on_error enabled.
+    feature.steps.append(DomainObject.new(
+        FeatureEvent,
+        name='Test Command',
+        service_id='test_command',
+        pass_on_error=True,
+    ))
+
+    # Set the feature as the GetFeature event's return value.
+    get_feature_evt.execute.return_value = feature
 
     # Create a mock request that will raise an error.
     request = RequestContext(data={'key': None})
 
     # Execute the feature using the feature context.
-    feature_context.cache.clear()  # Clear the cache to ensure fresh execution.
+    feature_context.cache.clear()
     feature_context.execute_feature(feature.id, request)
 
     # Assert that the request handled the error without raising an exception.
     assert not request.handle_response()
 
-    # Assert that the GetFeature command was invoked once for this feature id.
-    get_feature_cmd.execute.assert_called_once_with(id=feature.id)
+    # Assert that the GetFeature event was invoked once for this feature id.
+    get_feature_evt.execute.assert_called_once_with(id=feature.id)

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -45,18 +45,10 @@ class FeatureEvent(FeatureStep):
     '''
 
     # * attribute: service_id
-    # + todo: set to required when attribute_id is removed
     service_id = StringType(
+        required=True,
         metadata=dict(
             description='The service configuration ID for the feature event.'
-        )
-    )
-
-    # * attribute: attribute_id
-    # - obsolete: replaced by service_id
-    attribute_id = StringType(
-        metadata=dict(
-            description='The container attribute ID for the feature event.'
         )
     )
 

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -263,19 +263,18 @@ class FeatureAggregate(Feature, Aggregate):
     def add_step(
         self,
         name: str,
-        service_id: str = None,
+        service_id: str,
         parameters: Dict[str, Any] | None = None,
         data_key: str | None = None,
         pass_on_error: bool = False,
         position: int | None = None,
-        attribute_id: str = None,
     ) -> FeatureEvent:
         '''
         Add a feature event step using raw attributes.
 
         :param name: Step name.
         :type name: str
-        :param service_id: Service configuration ID (primary).
+        :param service_id: Service configuration ID.
         :type service_id: str
         :param parameters: Optional parameters dictionary.
         :type parameters: dict | None
@@ -285,20 +284,14 @@ class FeatureAggregate(Feature, Aggregate):
         :type pass_on_error: bool
         :param position: Insertion position (None to append).
         :type position: int | None
-        :param attribute_id: Deprecated fallback for service_id.
-        :type attribute_id: str
         :return: Created FeatureEvent instance.
         :rtype: FeatureEvent
         '''
-
-        # Resolve service_id from the primary or deprecated fallback.
-        service_id = service_id or attribute_id
 
         # Create the feature event from raw attributes.
         step = FeatureEventAggregate.new(
             name=name,
             service_id=service_id,
-            attribute_id=service_id,
             parameters=parameters or {},
             data_key=data_key,
             pass_on_error=pass_on_error,

--- a/tiferet/repos/tests/test_feature.py
+++ b/tiferet/repos/tests/test_feature.py
@@ -34,7 +34,7 @@ FEATURE_DATA: Dict[str, Dict] = {
                 'commands': [
                     {
                         'name': 'Test Command',
-                        'attribute_id': 'test.attribute',
+                        'service_id': 'test.attribute',
                         'params': {
                             'key': 'value'
                         }


### PR DESCRIPTION
## Summary

Completes the forward-compatible DI migration at the feature execution layer. Replaces `ContainerContext` with `DIContext`, retires `attribute_id` from `FeatureEvent` in favour of the now-required `service_id`, and migrates `FeatureContext` to iterate over `feature.steps` using `load_feature_step`.

## Changes

- **`contexts/feature.py`** — Replace `container: ContainerContext` with `services: DIContext`; `get_feature_cmd` → `get_feature_evt: DomainEvent`; `load_feature_command` → `load_feature_step` (uses `service_id`); `feature.commands` → `feature.steps`; `container=self.container` → `services=self.services`; use `request.set_result()`.
- **`domain/feature.py`** — `FeatureEvent.service_id` made `required=True`; `attribute_id` field removed entirely.
- **`mappers/feature.py`** — Remove `attribute_id` param and fallback from `FeatureAggregate.add_step()`; `service_id` is now required positional arg.
- **`assets/constants.py`** — Remove `container_service`, `container_list_all_cmd`, `container` from `DEFAULT_SERVICES`; rename `get_feature_cmd` → `get_feature_evt`.
- **`contexts/tests/test_feature.py`** — Forward-compatible imports; `DIContext`/`DomainEvent` fixtures; renamed to `load_feature_step` tests; `execute_feature` tests use `feature.steps`.
- **`repos/tests/test_feature.py`** — `attribute_id` → `service_id` in `FEATURE_DATA` fixture.

## Acceptance Criteria

- [x] `pytest tiferet/contexts/tests/test_feature.py` passes
- [x] `pytest tiferet/domain/tests/test_feature.py` passes
- [x] `pytest tiferet/mappers/tests/test_feature.py` passes
- [x] `pytest tiferet/repos/tests/test_feature.py` passes
- [x] No references to `attribute_id` in `domain/feature.py` or `mappers/feature.py`
- [x] No `container_service`, `container_list_all_cmd`, or `container` in `DEFAULT_SERVICES`
- [x] `FeatureContext.__init__` accepts `get_feature_evt: DomainEvent` and `services: DIContext`

Closes #682

Co-Authored-By: Oz <oz-agent@warp.dev>