### PR TITLE
Contexts – CLI Context: Forward-Compatible Refactor and DomainEvent Integration (#685)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -54,6 +54,24 @@ DEFAULT_SERVICES = [
         'class_name': 'LoggingHandler',
     },
     {
+        'service_id': 'cli_service',
+        'module_path': 'tiferet.repos.cli',
+        'class_name': 'CliYamlRepository',
+        'parameters': {
+            'cli_yaml_file': 'app/configs/cli.yml',
+        },
+    },
+    {
+        'service_id': 'list_commands_evt',
+        'module_path': 'tiferet.events.cli',
+        'class_name': 'ListCliCommands',
+    },
+    {
+        'service_id': 'get_parent_args_evt',
+        'module_path': 'tiferet.events.cli',
+        'class_name': 'GetParentArguments',
+    },
+    {
         'service_id': 'di_list_all_configs_evt',
         'module_path': 'tiferet.events.di',
         'class_name': 'ListAllSettings',

--- a/tiferet/contexts/cli.py
+++ b/tiferet/contexts/cli.py
@@ -2,10 +2,12 @@
 
 # ** core
 import sys
+import argparse
+from typing import Dict, Any, Callable
 
 # ** app
 from .app import *
-from ..handlers.cli import CliService
+from ..domain import CliCommand
 
 # *** contexts
 
@@ -16,13 +18,22 @@ class CliContext(AppInterfaceContext):
     It provides methods to handle command line arguments, commands, and their execution.
     '''
 
-    # * attribute: cli_service
-    cli_service: CliService
+    # * attribute: list_cli_commands_handler
+    list_cli_commands_handler: Callable
+
+    # * attribute: get_parent_args_handler
+    get_parent_args_handler: Callable
 
     # * init
-    def __init__(self, interface_id: str, features: FeatureContext, errors: ErrorContext, logging: LoggingContext, cli_service: CliService):
+    def __init__(self,
+                 interface_id: str,
+                 features: FeatureContext,
+                 errors: ErrorContext,
+                 logging: LoggingContext,
+                 list_commands_evt: DomainEvent,
+                 get_parent_args_evt: DomainEvent):
         '''
-        Initialize the CLI context with a CLI service.
+        Initialize the CLI context with command handlers.
 
         :param interface_id: The unique identifier for the CLI interface.
         :type interface_id: str
@@ -32,12 +43,15 @@ class CliContext(AppInterfaceContext):
         :type errors: ErrorContext
         :param logging: The logging context.
         :type logging: LoggingContext
-        :param cli_service: The CLI service to use.
-        :type cli_service: CliService
+        :param list_commands_evt: Event to list all CLI commands.
+        :type list_commands_evt: DomainEvent
+        :param get_parent_args_evt: Event to get parent arguments.
+        :type get_parent_args_evt: DomainEvent
         '''
 
-        # Set the CLI service.
-        self.cli_service = cli_service
+        # Set the command handlers.
+        self.list_cli_commands_handler = list_commands_evt.execute
+        self.get_parent_args_handler = get_parent_args_evt.execute
 
         # Initialize the base class with the interface ID, features, and errors.
         super().__init__(
@@ -46,6 +60,93 @@ class CliContext(AppInterfaceContext):
             errors=errors,
             logging=logging
         )
+
+    # * method: get_commands
+    def get_commands(self) -> Dict[str, CliCommand]:
+        '''
+        Get all commands available in the CLI mapped by their group keys.
+
+        :return: A dictionary of CLI commands mapped by their group keys.
+        :rtype: Dict[str, CliCommand]
+        '''
+
+        # Retrieve the commands via the list commands handler.
+        cli_commands = self.list_cli_commands_handler()
+
+        # Create a map of commands by their group keys.
+        command_map = {}
+        for command in cli_commands:
+            if command.group_key not in command_map:
+                command_map[command.group_key] = [command]
+            else:
+                command_map[command.group_key].append(command)
+
+        # Return the command map.
+        return command_map
+
+    # * method: parse_arguments
+    def parse_arguments(self, cli_commands: Dict[str, CliCommand]) -> Dict[str, Any]:
+        '''
+        Parse the command line arguments for a list of CLI commands.
+
+        :param cli_commands: The CLI commands to parse arguments for.
+        :type cli_commands: Dict[str, CliCommand]
+        :return: A dictionary of parsed arguments.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Retrieve the parent arguments via the get parent args handler.
+        parent_arguments = self.get_parent_args_handler()
+
+        # Create an argument parser.
+        parser = argparse.ArgumentParser()
+
+        # Add command subparsers for the command group.
+        group_subparsers = parser.add_subparsers(dest='group')
+
+        # Loop through the command map and create a parser for each command.
+        for group_key in cli_commands:
+            group_subparser = group_subparsers.add_parser(
+                group_key,
+                help=f'Commands for the {group_key} group.'
+            )
+            cli_group_commands = cli_commands[group_key]
+            cmd_subparsers = group_subparser.add_subparsers(dest='command')
+
+            for cli_command in cli_group_commands:
+                cli_command_parser = cmd_subparsers.add_parser(
+                    cli_command.key,
+                    help=cli_command.description
+                )
+
+                for argument in cli_command.arguments:
+                    args = dict(
+                        help=argument.description,
+                        type=argument.get_type(),
+                        default=argument.default,
+                        nargs=argument.nargs,
+                        choices=argument.choices,
+                        action=argument.action
+                    )
+                    if argument.required is not None:
+                        args['required'] = argument.required
+                    cli_command_parser.add_argument(*argument.name_or_flags, **args)
+
+                for argument in parent_arguments:
+                    if not cli_command.has_argument(argument.name_or_flags):
+                        cli_command_parser.add_argument(
+                            *argument.name_or_flags,
+                            help=argument.description,
+                            type=argument.get_type(),
+                            default=argument.default,
+                            required=argument.required,
+                            nargs=argument.nargs,
+                            choices=argument.choices,
+                            action=argument.action
+                        )
+
+        # Return the parsed arguments as a dictionary.
+        return vars(parser.parse_args())
 
     # * method: parse_request
     def parse_request(self) -> RequestContext:
@@ -56,11 +157,11 @@ class CliContext(AppInterfaceContext):
         :rtype: RequestContext
         '''
 
-        # Retrieve the command map from the CLI service.
-        cli_commands = self.cli_service.get_commands()
+        # Retrieve the command map via get_commands.
+        cli_commands = self.get_commands()
 
-        # Parse the command line arguments for the CLI command.
-        data = self.cli_service.parse_arguments(cli_commands)
+        # Parse the command line arguments.
+        data = self.parse_arguments(cli_commands)
 
         # Fashion the feature id from the command group and key.
         feature_id = '{}.{}'.format(

--- a/tiferet/contexts/tests/test_cli.py
+++ b/tiferet/contexts/tests/test_cli.py
@@ -8,53 +8,58 @@ import pytest
 from unittest import mock
 
 # ** app
-from ..cli import CliContext, CliService
+from ..cli import CliContext
 from ..app import FeatureContext, ErrorContext, LoggingContext, TiferetError, RequestContext
-from ...models.cli import *
+from ...domain.cli import CliCommand, CliArgument
+from ...domain.settings import DomainObject
+from ...events.cli import ListCliCommands, GetParentArguments
 
 # *** fixtures
 
-# ** fixture: cli_commands
+# ** fixture: cli_command_list
 @pytest.fixture
-def cli_commands():
+def cli_command_list():
     """
     Fixture to create a list of mock CLI commands.
     """
-    return {
-        'test-group': [
-            CliCommand.new(
-                group_key='test-group',
-                key='test-feature',
-                name='Test Feature Command',
-                description='A test feature command.',
-                arguments=[
-                    ModelObject.new(
-                        CliArgument,
-                        name_or_flags=['--arg1', '-a'],
-                        description='Test argument 1',
-                        required=True,
-                        type='str',
-                        default='default_value',
-                    )
-                ]
-            )
-        ]
-    }
+    return [
+        CliCommand.new(
+            group_key='test-group',
+            key='test-feature',
+            name='Test Feature Command',
+            description='A test feature command.',
+            arguments=[
+                DomainObject.new(
+                    CliArgument,
+                    name_or_flags=['--arg1', '-a'],
+                    description='Test argument 1',
+                    required=True,
+                    type='str',
+                    default='default_value',
+                )
+            ]
+        )
+    ]
 
-# ** fixture: cli_service
+# ** fixture: list_commands_evt
 @pytest.fixture
-def cli_service(cli_commands):
+def list_commands_evt(cli_command_list):
     """
-    Fixture to create a mock CLI service.
+    Fixture to create a mock ListCliCommands event.
     """
-    cli_service = mock.create_autospec(CliService)
-    cli_service.get_commands.return_value = cli_commands
-    cli_service.parse_arguments.return_value = dict(
-        group='test-group',
-        command='test-feature',
-        arg1='default_value'
-    )
-    return cli_service
+    evt = mock.Mock(spec=ListCliCommands)
+    evt.execute.return_value = cli_command_list
+    return evt
+
+# ** fixture: get_parent_args_evt
+@pytest.fixture
+def get_parent_args_evt():
+    """
+    Fixture to create a mock GetParentArguments event.
+    """
+    evt = mock.Mock(spec=GetParentArguments)
+    evt.execute.return_value = []
+    return evt
 
 # ** fixture: feature_context
 @pytest.fixture
@@ -89,25 +94,64 @@ def logging_context():
 
 # ** fixture: cli_context
 @pytest.fixture
-def cli_context(cli_service, feature_context, error_context, logging_context):
+def cli_context(list_commands_evt, get_parent_args_evt, feature_context, error_context, logging_context):
     """
-    Fixture to create a CLI context with the provided CLI service, feature context, error context, and logging context.
+    Fixture to create a CLI context with command handlers, feature context, error context, and logging context.
     """
     return CliContext(
         interface_id='test_cli',
         features=feature_context,
         errors=error_context,
-        cli_service=cli_service,
-        logging=logging_context
+        logging=logging_context,
+        list_commands_evt=list_commands_evt,
+        get_parent_args_evt=get_parent_args_evt
     )
 
 # *** tests
 
+# ** test: cli_context_get_commands
+def test_cli_context_get_commands(cli_context, list_commands_evt, cli_command_list):
+    """
+    Test the get_commands method of the CLI context.
+    """
+    # Get the commands.
+    command_map = cli_context.get_commands()
+
+    # Check that the list_cli_commands_handler was called.
+    list_commands_evt.execute.assert_called_once()
+
+    # Check the command map structure.
+    assert 'test-group' in command_map
+    assert len(command_map['test-group']) == 1
+    assert command_map['test-group'][0].key == 'test-feature'
+
+# ** test: cli_context_parse_arguments
+def test_cli_context_parse_arguments(cli_context, cli_command_list, monkeypatch):
+    """
+    Test the parse_arguments method of the CLI context.
+    """
+    # Create a command map from the command list.
+    command_map = {'test-group': cli_command_list}
+
+    # Mock sys.argv to simulate command line arguments.
+    monkeypatch.setattr('sys.argv', ['prog', 'test-group', 'test-feature', '--arg1', 'test_value'])
+
+    # Parse the arguments.
+    parsed_args = cli_context.parse_arguments(command_map)
+
+    # Check parsed arguments.
+    assert parsed_args['group'] == 'test-group'
+    assert parsed_args['command'] == 'test-feature'
+    assert parsed_args['arg1'] == 'test_value'
+
 # ** test: cli_context_parse_request
-def test_cli_context_parse_request(cli_context):
+def test_cli_context_parse_request(cli_context, monkeypatch):
     """
     Test the parse_request method of the CLI context.
     """
+    # Mock sys.argv to simulate command line arguments.
+    monkeypatch.setattr('sys.argv', ['prog', 'test-group', 'test-feature', '--arg1', 'default_value'])
+
     # Parse the request.
     request = cli_context.parse_request()
 
@@ -126,7 +170,7 @@ def test_cli_context_parse_request(cli_context):
     assert request.headers['command_key'] == 'test-feature'
 
 # ** test: cli_context_run
-def test_cli_context_run(cli_context, logging_context):
+def test_cli_context_run(cli_context, logging_context, monkeypatch):
     """
     Test the run method of the CLI context.
 
@@ -135,6 +179,9 @@ def test_cli_context_run(cli_context, logging_context):
     :param logging_context: The mock LoggingContext instance.
     :type logging_context: LoggingContext
     """
+    # Mock sys.argv to simulate command line arguments.
+    monkeypatch.setattr('sys.argv', ['prog', 'test-group', 'test-feature', '--arg1', 'default_value'])
+
     # Run the CLI context.
     result = cli_context.run()
 
@@ -155,19 +202,24 @@ def test_cli_context_run(cli_context, logging_context):
     logger.error.assert_not_called()
 
 # ** test: cli_context_run_with_parse_request_error
-def test_cli_context_run_with_parse_request_error(cli_context, cli_service, logging_context):
+def test_cli_context_run_with_parse_request_error(cli_context, get_parent_args_evt, logging_context, monkeypatch):
     """
     Test the run method of the CLI context when there is an error in parsing the request.
 
     :param cli_context: The CliContext instance.
     :type cli_context: CliContext
-    :param cli_service: The mock CliService instance.
-    :type cli_service: CliService
+    :param get_parent_args_evt: The mock GetParentArguments event.
+    :type get_parent_args_evt: GetParentArguments
     :param logging_context: The mock LoggingContext instance.
     :type logging_context: LoggingContext
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :type monkeypatch: pytest.MonkeyPatch
     """
-    # Mock the parse_arguments method to raise an exception.
-    cli_service.parse_arguments.side_effect = Exception("Parsing error")
+    # Mock the get_parent_args_handler to raise an exception.
+    get_parent_args_evt.execute.side_effect = Exception("Parsing error")
+
+    # Mock sys.argv to simulate command line arguments.
+    monkeypatch.setattr('sys.argv', ['prog', 'test-group', 'test-feature', '--arg1', 'default_value'])
 
     # Run the CLI context and capture the output.
     with pytest.raises(SystemExit) as exc_info:
@@ -183,7 +235,7 @@ def test_cli_context_run_with_parse_request_error(cli_context, cli_service, logg
     logger.error.assert_called_once_with('Error parsing CLI request: Parsing error')
 
 # ** test: cli_context_run_with_feature_error
-def test_cli_context_run_with_feature_error(cli_context, feature_context, error_context, logging_context):
+def test_cli_context_run_with_feature_error(cli_context, feature_context, error_context, logging_context, monkeypatch):
     """
     Test the run method of the CLI context when there is an error in executing the feature.
 
@@ -195,7 +247,12 @@ def test_cli_context_run_with_feature_error(cli_context, feature_context, error_
     :type error_context: ErrorContext
     :param logging_context: The mock LoggingContext instance.
     :type logging_context: LoggingContext
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :type monkeypatch: pytest.MonkeyPatch
     """
+    # Mock sys.argv to simulate command line arguments.
+    monkeypatch.setattr('sys.argv', ['prog', 'test-group', 'test-feature', '--arg1', 'default_value'])
+
     # Mock the execute_feature method to raise a TiferetError.
     feature_context.execute_feature.side_effect = TiferetError(
         'FEATURE_EXECUTION_FAILED',


### PR DESCRIPTION
## Summary

Rewrites `CliContext` to use the `DomainEvent` base-type convention, replacing the legacy `CliService` handler injection with two injected `DomainEvent` instances. The `get_commands()` and `parse_arguments()` methods are inlined into the context, and `DEFAULT_SERVICES` is updated to register the three new CLI service entries.

## Changes

- **`contexts/cli.py`** — Replace `cli_service: CliService` with `list_commands_evt: DomainEvent` and `get_parent_args_evt: DomainEvent`; bound attribute named `list_cli_commands_handler`; add `get_commands()` and `parse_arguments()` methods; update `parse_request()` to call them directly.
- **`contexts/tests/test_cli.py`** — Forward-compatible imports (`CliCommand`, `DomainObject`, `ListCliCommands`, `GetParentArguments`); flat `cli_command_list` fixture; `list_commands_evt`/`get_parent_args_evt` fixtures; add `test_cli_context_get_commands` and `test_cli_context_parse_arguments`; add `monkeypatch` for `sys.argv` across all applicable tests (6 total).
- **`assets/constants.py`** — Add `cli_service` (→ `CliYamlRepository`), `list_commands_evt` (→ `ListCliCommands`), `get_parent_args_evt` (→ `GetParentArguments`) to `DEFAULT_SERVICES`.

## Deviation

- `list_commands_handler` attribute renamed to `list_cli_commands_handler` per human clarification during implementation.

## Acceptance Criteria

- [x] `CliContext.__init__` accepts `list_commands_evt` and `get_parent_args_evt`
- [x] `pytest tiferet/contexts/tests/test_cli.py` passes (6 tests)
- [x] `DEFAULT_SERVICES` contains `cli_service`, `list_commands_evt`, `get_parent_args_evt`
- [x] No imports from `tiferet.handlers.cli` remain in `contexts/cli.py`

Closes #685

Co-Authored-By: Oz <oz-agent@warp.dev>