### PR TITLE
Contexts – Logging Context: Forward-Compatible Refactor and DomainEvent Integration (#684)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -49,9 +49,9 @@ DEFAULT_SERVICES = [
         'class_name': 'GetFeature',
     },
     {
-        'service_id': 'logging_service',
-        'module_path': 'tiferet.handlers.logging',
-        'class_name': 'LoggingHandler',
+        'service_id': 'logging_list_all_evt',
+        'module_path': 'tiferet.events.logging',
+        'class_name': 'ListAllLoggingConfigs',
     },
     {
         'service_id': 'cli_service',

--- a/tiferet/assets/logging.py
+++ b/tiferet/assets/logging.py
@@ -1,0 +1,77 @@
+# *** configs
+
+# ** config: default_formatters
+DEFAULT_FORMATTERS = [
+    dict(
+        id='default',
+        name='Default Formatter',
+        description='The default logging formatter.',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+]
+
+# ** config: default_handlers
+DEFAULT_HANDLERS = [
+    dict(
+        id='default_root',
+        name='Default Root Handler',
+        description='The default root logging handler.',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='WARNING',
+        formatter='default',
+        stream='ext://sys.stderr'
+    ),
+    dict(
+        id='default',
+        name='Default Handler',
+        description='The default logging handler.',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='INFO',
+        formatter='default',
+        stream='ext://sys.stdout'
+    ),
+    dict(
+        id='debug',
+        name='Debug Handler',
+        description='A handler for debugging purposes.',
+        module_path='logging',
+        class_name='StreamHandler',
+        level='DEBUG',
+        formatter='default',
+        stream='ext://sys.stdout'
+    )
+]
+
+# ** config: default_loggers
+DEFAULT_LOGGERS = [
+    dict(
+        id='root',
+        name='Default Root Logger',
+        description='The default logging configuration.',
+        level='WARNING',
+        handlers=['default_root'],
+        propagate=False,
+        is_root=True
+    ),
+    dict(
+        id='default',
+        name='Default Logger',
+        description='The default logging configuration.',
+        level='INFO',
+        handlers=['default'],
+        propagate=True,
+        is_root=False
+    ),
+    dict(
+        id='debug',
+        name='Debug Logger',
+        description='A logger for debugging purposes.',
+        level='DEBUG',
+        handlers=['debug'],
+        propagate=True,
+        is_root=False
+    )
+]

--- a/tiferet/contexts/logging.py
+++ b/tiferet/contexts/logging.py
@@ -2,74 +2,154 @@
 
 # ** core
 import logging
+import logging.config
+from typing import Dict, Any, List, Callable
 
 # ** app
-from ..configs.logging import *
-from ..models.logging import *
-from ..handlers.logging import LoggingService
+from ..assets.logging import *
+from ..domain import (
+    DomainObject,
+    Formatter,
+    Handler,
+    Logger,
+)
+from ..events import DomainEvent, RaiseError, a
 
 # *** contexts
 
 # ** context: logging_context
 class LoggingContext(object):
 
-    # * attribute: logging_service
-    logging_service: LoggingService
+    # * attribute: list_all_handler
+    list_all_handler: Callable
 
     # * attribute: logger_id
     logger_id: str
 
-    def __init__(self, logging_service: LoggingService, logger_id: str):
+    # * init
+    def __init__(self, logging_list_all_evt: DomainEvent, logger_id: str):
         '''
         Initialize the logging context.
 
-        :param logging_service: The logging service to use for managing logger configurations.
-        :type logging_service: LoggingService
+        :param logging_list_all_evt: The event to list all logging configurations.
+        :type logging_list_all_evt: DomainEvent
         :param logger_id: The ID of the logger configuration to create.
         :type logger_id: str
         '''
-        self.logging_service = logging_service
+
+        # Bind the list all handler and store the logger ID.
+        self.list_all_handler = logging_list_all_evt.execute
         self.logger_id = logger_id
 
+    # * method: format_config
+    def format_config(self,
+                      formatters: List[Formatter],
+                      handlers: List[Handler],
+                      loggers: List[Logger],
+                      version: int = 1,
+                      disable_existing_loggers: bool = False) -> Dict[str, Any]:
+        '''
+        Format logging configurations into a dictionary suitable for logging.config.dictConfig.
+
+        :param formatters: List of formatter entities.
+        :type formatters: List[Formatter]
+        :param handlers: List of handler entities.
+        :type handlers: List[Handler]
+        :param loggers: List of logger entities.
+        :type loggers: List[Logger]
+        :param version: Logging configuration version (default 1).
+        :type version: int
+        :param disable_existing_loggers: Whether to disable existing loggers (default False).
+        :type disable_existing_loggers: bool
+        :return: Dictionary configuration for logging.config.dictConfig.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Return the formatted configuration dictionary.
+        return dict(
+            version=version,
+            disable_existing_loggers=disable_existing_loggers,
+            formatters={formatter.id: formatter.format_config() for formatter in formatters},
+            handlers={handler.id: handler.format_config() for handler in handlers},
+            loggers={logger.id: logger.format_config() for logger in loggers if not logger.is_root},
+            root=next((logger.format_config() for logger in loggers if logger.is_root), None)
+        )
+
+    # * method: create_logger
+    def create_logger(self, logger_id: str, logging_config: Dict[str, Any]) -> logging.Logger:
+        '''
+        Create a logger instance for the specified logger ID.
+
+        :param logger_id: The ID of the logger configuration to create.
+        :type logger_id: str
+        :param logging_config: The logging configuration dictionary.
+        :type logging_config: Dict[str, Any]
+        :return: The native logger instance.
+        :rtype: logging.Logger
+        '''
+
+        # Configure the logging system with the formatted configurations.
+        try:
+            logging.config.dictConfig(logging_config)
+        except Exception as e:
+            RaiseError.execute(
+                a.const.LOGGING_CONFIG_FAILED_ID,
+                f'Failed to configure logging: {e}.',
+                exception=str(e)
+            )
+
+        # Return the logger instance by its ID.
+        try:
+            logger = logging.getLogger(logger_id)
+        except Exception as e:
+            RaiseError.execute(
+                a.const.LOGGER_CREATION_FAILED_ID,
+                f'Failed to create logger with ID {logger_id}: {e}.',
+                logger_id=logger_id,
+                exception=str(e)
+            )
+
+        # Return the logger.
+        return logger
+
+    # * method: build_logger
     def build_logger(self) -> logging.Logger:
         '''
         Build a logger instance for the specified logger ID.
 
-        :param logger_id: The ID of the logger configuration to create.
-        :type logger_id: str
         :return: The native logger instance.
         :rtype: logging.Logger
         '''
 
         # List all formatter, handler, and logger configurations.
-        formatters, handlers, loggers = self.logging_service.list_all()
+        formatters, handlers, loggers = self.list_all_handler()
 
         # Set the default configurations if not provided.
         if not formatters:
-            formatters = [ModelObject.new(
+            formatters = [DomainObject.new(
                 Formatter,
                 **data
             ) for data in DEFAULT_FORMATTERS]
         if not handlers:
-            handlers = [ModelObject.new(
+            handlers = [DomainObject.new(
                 Handler,
                 **data
             ) for data in DEFAULT_HANDLERS]
         if not loggers:
-            loggers = [ModelObject.new(
+            loggers = [DomainObject.new(
                 Logger,
                 **data
             ) for data in DEFAULT_LOGGERS]
 
         # Format the configurations into a dictionary.
-        config = self.logging_service.format_config(
+        config = self.format_config(
             formatters=formatters,
             handlers=handlers,
             loggers=loggers
         )
 
-        # Create the logger using the logging service.
-        return self.logging_service.create_logger(
+        # Create the logger using the create_logger method.
+        return self.create_logger(
             logger_id=self.logger_id,
             logging_config=config
         )

--- a/tiferet/contexts/tests/test_logging.py
+++ b/tiferet/contexts/tests/test_logging.py
@@ -8,10 +8,10 @@ from unittest import mock
 
 # ** app
 from ..logging import *
-from ...configs import TiferetError
-from ...configs.logging import *
-from ...models.logging import *
-from ...handlers.logging import LoggingService
+from ...assets import TiferetError
+from ...assets.logging import DEFAULT_FORMATTERS, DEFAULT_HANDLERS, DEFAULT_LOGGERS
+from ...domain.logging import Formatter, Handler, Logger
+from ...domain.settings import DomainObject
 
 
 # *** fixtures
@@ -23,7 +23,7 @@ def formatter():
     '''
     Fixture to create a Formatter instance.
     '''
-    return ModelObject.new(
+    return DomainObject.new(
         Formatter,
         id='simple',
         name='Simple Formatter',
@@ -39,7 +39,7 @@ def handler(formatter):
     '''
     Fixture to create a Handler instance.
     '''
-    return ModelObject.new(
+    return DomainObject.new(
         Handler,
         id='console',
         name='Console Handler',
@@ -58,7 +58,7 @@ def logger_root(handler):
     '''
     Fixture to create a root Logger instance.
     '''
-    return ModelObject.new(
+    return DomainObject.new(
         Logger,
         id='root',
         name='',
@@ -70,32 +70,24 @@ def logger_root(handler):
     )
 
 
-# ** fixture: logging_service
+# ** fixture: logging_list_all_evt
 @pytest.fixture
-def logging_service(formatter, handler, logger_root):
+def logging_list_all_evt(formatter, handler, logger_root):
     '''
-    Fixture to create a mocked LoggingService instance.
+    Fixture to create a mocked ListAllLoggingConfigs event instance.
     '''
-    service = mock.Mock(spec=LoggingService)
-    service.list_all.return_value = ([formatter], [handler], [logger_root])
-    service.format_config.return_value = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {'simple': formatter.format_config()},
-        'handlers': {'root': handler.format_config()},
-        'root': logger_root.format_config()
-    }
-    service.create_logger.return_value = mock.Mock(spec=logging.Logger)
-    return service
+    evt = mock.Mock()
+    evt.execute.return_value = ([formatter], [handler], [logger_root])
+    return evt
 
 
 # ** fixture: logging_context
 @pytest.fixture
-def logging_context(logging_service):
+def logging_context(logging_list_all_evt):
     '''
     Fixture to create a LoggingContext instance.
     '''
-    return LoggingContext(logging_service=logging_service, logger_id='root')
+    return LoggingContext(logging_list_all_evt=logging_list_all_evt, logger_id='root')
 
 
 # ** fixture: default_configs
@@ -118,14 +110,14 @@ def default_configs():
             'description': 'A default logging handler.',
             'module_path': 'logging',
             'class_name': 'NullHandler',
-            'level': 'NOTSET',
+            'level': 'INFO',
             'formatter': 'default'
         }],
         'DEFAULT_LOGGERS': [{
             'id': 'root',
             'name': '',
             'description': 'Default root logger.',
-            'level': 'NOTSET',
+            'level': 'INFO',
             'handlers': ['default'],
             'propagate': False,
             'is_root': True
@@ -137,74 +129,173 @@ def default_configs():
 
 
 # ** test: logging_context_build_logger_success
-def test_logging_context_build_logger_success(logging_context, logging_service, formatter, handler, logger_root):
+def test_logging_context_build_logger_success(logging_context, logging_list_all_evt, formatter, handler, logger_root):
     '''
     Test successful logger creation by LoggingContext with provided configurations.
     '''
+
     # Call build_logger to create a logger.
     logger = logging_context.build_logger()
 
-
     # Assert that the logger is created and methods are called.
     assert isinstance(logger, logging.Logger)
-    logging_service.list_all.assert_called_once()
-    logging_service.format_config.assert_called_once_with(
+    logging_list_all_evt.execute.assert_called_once()
+    assert logger.name == 'root'
+
+
+# ** test: logging_context_build_logger_default_configs
+def test_logging_context_build_logger_default_configs(logging_context, logging_list_all_evt, default_configs):
+    '''
+    Test LoggingContext build_logger using default configurations.
+    '''
+
+    # Mock empty configurations from logging_list_all_evt.
+    logging_list_all_evt.execute.return_value = ([], [], [])
+
+    # Mock default configurations.
+    with mock.patch('tiferet.contexts.logging.DEFAULT_FORMATTERS', default_configs['DEFAULT_FORMATTERS']):
+        with mock.patch('tiferet.contexts.logging.DEFAULT_HANDLERS', default_configs['DEFAULT_HANDLERS']):
+            with mock.patch('tiferet.contexts.logging.DEFAULT_LOGGERS', default_configs['DEFAULT_LOGGERS']):
+                logger = logging_context.build_logger()
+
+    # Assert that default configurations are used.
+    assert isinstance(logger, logging.Logger)
+    logging_list_all_evt.execute.assert_called_once()
+    assert logger.name == 'root'
+
+
+# ** test: logging_context_format_config_success
+def test_logging_context_format_config_success(logging_context, formatter, handler, logger_root):
+    '''
+    Test LoggingContext format_config successfully formats logging configurations.
+    '''
+
+    # Call format_config to format the configurations.
+    config = logging_context.format_config(
         formatters=[formatter],
         handlers=[handler],
         loggers=[logger_root]
     )
-    logging_service.create_logger.assert_called_once_with(
-        logger_id='root',
-        logging_config=logging_service.format_config.return_value
+
+    # Assert the configuration structure.
+    assert config['version'] == 1
+    assert config['disable_existing_loggers'] is False
+    assert 'formatters' in config
+    assert 'handlers' in config
+    assert 'root' in config
+    assert formatter.id in config['formatters']
+    assert handler.id in config['handlers']
+    assert config['root'] == logger_root.format_config()
+
+
+# ** test: logging_context_format_config_non_root_logger
+def test_logging_context_format_config_non_root_logger(logging_context, formatter, handler):
+    '''
+    Test LoggingContext format_config with non-root logger.
+    '''
+
+    # Create a non-root logger.
+    non_root_logger = DomainObject.new(
+        Logger,
+        id='app',
+        name='app',
+        description='Application logger.',
+        level='INFO',
+        handlers=[handler.id],
+        propagate=True,
+        is_root=False
     )
 
+    # Call format_config.
+    config = logging_context.format_config(
+        formatters=[formatter],
+        handlers=[handler],
+        loggers=[non_root_logger]
+    )
 
-# ** test: logging_context_build_logger_default_configs
-def test_logging_context_build_logger_default_configs(logging_context, logging_service, default_configs):
+    # Assert non-root logger is in loggers section.
+    assert 'loggers' in config
+    assert non_root_logger.id in config['loggers']
+    assert config['root'] is None
+
+
+# ** test: logging_context_create_logger_success
+def test_logging_context_create_logger_success(logging_context, formatter, handler, logger_root):
     '''
-    Test LoggingContext build_logger using default configurations.
+    Test LoggingContext create_logger successfully creates a logger.
     '''
-    # Mock empty configurations from logging_service.
-    logging_service.list_all.return_value = ([], [], [])
 
+    # Format the configurations.
+    config = logging_context.format_config(
+        formatters=[formatter],
+        handlers=[handler],
+        loggers=[logger_root]
+    )
 
-    # Mock default configurations.
-    with mock.patch('tiferet.configs.logging.DEFAULT_FORMATTERS', default_configs['DEFAULT_FORMATTERS']):
-        with mock.patch('tiferet.configs.logging.DEFAULT_HANDLERS', default_configs['DEFAULT_HANDLERS']):
-            with mock.patch('tiferet.configs.logging.DEFAULT_LOGGERS', default_configs['DEFAULT_LOGGERS']):
-                logger = logging_context.build_logger()
+    # Create the logger.
+    logger = logging_context.create_logger(
+        logger_id='root',
+        logging_config=config
+    )
 
-
-    # Assert that default configurations are used.
+    # Assert logger is created.
     assert isinstance(logger, logging.Logger)
-    logging_service.list_all.assert_called_once()
-    logging_service.format_config.assert_called_once()
-    logging_service.create_logger.assert_called_once_with(
-        logger_id='root',
-        logging_config=logging_service.format_config.return_value
-    )
+    assert logger.name == 'root'
+
+
+# ** test: logging_context_create_logger_invalid_config
+def test_logging_context_create_logger_invalid_config(logging_context):
+    '''
+    Test LoggingContext create_logger with invalid configuration.
+    '''
+
+    # Create an invalid configuration.
+    invalid_config = {
+        'version': 1,
+        'formatters': {},
+        'handlers': {
+            'invalid': {
+                'class': 'InvalidHandlerClass',
+                'level': 'INFO'
+            }
+        },
+        'root': {
+            'level': 'DEBUG',
+            'handlers': ['invalid']
+        }
+    }
+
+    # Call create_logger with invalid config.
+    with pytest.raises(TiferetError) as exc_info:
+        logging_context.create_logger(
+            logger_id='root',
+            logging_config=invalid_config
+        )
+
+    # Assert that the correct error is raised.
+    assert exc_info.value.error_code == 'LOGGING_CONFIG_FAILED'
 
 
 # ** test: logging_context_build_logger_error
-def test_logging_context_build_logger_error(logging_context, logging_service):
+def test_logging_context_build_logger_error(logging_context, logging_list_all_evt):
     '''
-    Test LoggingContext build_logger with invalid logger ID.
+    Test LoggingContext build_logger with configurations that fail dictConfig.
     '''
-    # Mock create_logger to raise an error.
-    logging_service.create_logger.side_effect = TiferetError(
-        'LOGGER_CREATION_FAILED',
-        'Failed to create logger with ID invalid: Logger not found.',
-        'invalid', 
-        'Logger not found'
+
+    # Mock list_all to return invalid configurations that will fail.
+    invalid_formatter = DomainObject.new(
+        Formatter,
+        id='invalid',
+        name='Invalid Formatter',
+        description='An invalid formatter.',
+        format='%(invalid)s',
+        datefmt=None
     )
+    logging_list_all_evt.execute.return_value = ([invalid_formatter], [], [])
 
-
-    # Call build_logger with an invalid logger ID.
-    logging_context.logger_id = 'invalid'
+    # Call build_logger with invalid configurations.
     with pytest.raises(TiferetError) as exc_info:
         logging_context.build_logger()
 
-
     # Assert that the correct error is raised.
-    assert exc_info.value.error_code == 'LOGGER_CREATION_FAILED'
-    assert 'Failed to create logger with ID invalid' in str(exc_info.value)
+    assert exc_info.value.error_code == 'LOGGING_CONFIG_FAILED'


### PR DESCRIPTION
## Summary

Refactors `LoggingContext` to use the `DomainEvent` base-type convention, replacing `LoggingService` handler injection with a single `logging_list_all_evt` event. `format_config()` and `create_logger()` are moved from the handler layer into the context itself.

## Changes

- **`tiferet/assets/logging.py`** (new) — Default logging constants (`DEFAULT_FORMATTERS`, `DEFAULT_HANDLERS`, `DEFAULT_LOGGERS`) ported from v2.0-proto to match the proto import path used by `contexts/logging.py`.
- **`contexts/logging.py`** — Replace `logging_service: LoggingService` with `logging_list_all_evt: DomainEvent`; bind `list_all_handler`; inline `format_config()` and `create_logger()`; import from `assets.logging` and `domain`.
- **`contexts/tests/test_logging.py`** — Forward-compatible imports; `logging_list_all_evt` fixture; 4 new tests (`format_config_success`, `format_config_non_root_logger`, `create_logger_success`, `create_logger_invalid_config`); 7 total.
- **`assets/constants.py`** — Rename `logging_service` (→ `LoggingHandler`) to `logging_list_all_evt` (→ `ListAllLoggingConfigs`) in `DEFAULT_SERVICES`.

## Deviation

- `tiferet/assets/logging.py` ported early from v2.0-proto (originally scoped to a separate story) to align with the proto's import path convention (`from ..assets.logging import *`).

## Acceptance Criteria

- [x] `LoggingContext.__init__` accepts `logging_list_all_evt: DomainEvent`
- [x] `pytest tiferet/contexts/tests/test_logging.py` passes (7 tests)
- [x] No imports from `tiferet.handlers.logging` remain in `contexts/logging.py`
- [x] `DEFAULT_SERVICES` contains `logging_list_all_evt`

Closes #684

Co-Authored-By: Oz <oz-agent@warp.dev>