### PR TITLE
Contexts – Error Context: Forward-Compatible Refactor and DomainEvent Integration (#683)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -39,8 +39,8 @@ DEFAULT_SERVICES = [
         },
     },
     {
-        'service_id': 'get_error_cmd',
-        'module_path': 'tiferet.commands.error',
+        'service_id': 'get_error_evt',
+        'module_path': 'tiferet.events.error',
         'class_name': 'GetError',
     },
     {

--- a/tiferet/contexts/error.py
+++ b/tiferet/contexts/error.py
@@ -4,16 +4,14 @@
 from typing import Any, Callable, Dict
 
 # ** app
-from .cache import CacheContext
 from ..assets import (
-    TiferetError, 
+    TiferetError,
     TiferetAPIError,
     ERROR_NOT_FOUND_ID,
     DEFAULT_ERRORS
 )
-from ..models import Error
-from ..commands.error import GetError
-from ..configs import TiferetError as LegacyTiferetError
+from ..domain import Error
+from ..events import DomainEvent
 
 # *** contexts
 
@@ -23,22 +21,20 @@ class ErrorContext(object):
     The error context object.
     '''
 
-    # * attribute: error_service
+    # * attribute: get_error_handler
     get_error_handler: Callable
 
-    # * method: init
-    def __init__(self, get_error_cmd: GetError):
+    # * init
+    def __init__(self, get_error_evt: DomainEvent):
         '''
         Initialize the error context.
 
-        :param get_error_cmd: The command to get an error by id.
-        :type get_error_cmd: GetError
-        :param cache: The cache context to use for caching error data.
-        :type cache: CacheContext
+        :param get_error_evt: The event to get an error by id.
+        :type get_error_evt: DomainEvent
         '''
 
         # Assign the attributes.
-        self.get_error_handler = get_error_cmd.execute
+        self.get_error_handler = get_error_evt.execute
     
     # * method: get_error_by_code
     def get_error_by_code(self, error_code: str) -> Error:
@@ -69,37 +65,25 @@ class ErrorContext(object):
         return error
 
     # * method: handle_error
-    def handle_error(self, exception: TiferetError | LegacyTiferetError, lang: str = 'en_US') -> Dict[str, Any]:
+    def handle_error(self, exception: TiferetError, lang: str = 'en_US') -> Dict[str, Any]:
         '''
         Format and return the structured error response dictionary.
         Does not raise — raising is now handled by the calling context.
 
         :param exception: The exception to handle.
-        :type exception: TiferetError | LegacyTiferetError
+        :type exception: TiferetError
         :param lang: The language to use for the error message.
         :type lang: str
         :return: The formatted error response dictionary.
         :rtype: Dict[str, Any]
         '''
 
-        # Raise the exception if it is not a Tiferet error.
-        if not isinstance(exception, (TiferetError, LegacyTiferetError)):
+        # Raise the exception if it is not a TiferetError.
+        if not isinstance(exception, TiferetError):
             raise exception
 
         # Get the error by its code from the error service.
         error = self.get_error_by_code(exception.error_code)
-        
-        # Format the error response.
-        if isinstance(exception, LegacyTiferetError):
-            error_message = error.format_message(
-                lang,
-                *exception.args
-            )
-        else:
-            error_message = error.format_message(
-                lang,
-                **exception.kwargs
-            )
 
         # Return the formatted response dictionary (no raise).
         return error.format_response(lang=lang, **exception.kwargs)

--- a/tiferet/contexts/tests/test_error.py
+++ b/tiferet/contexts/tests/test_error.py
@@ -6,55 +6,56 @@ from unittest import mock
 
 # ** app
 from ...assets import (
-    TiferetError, 
+    TiferetError,
     TiferetAPIError,
     DEFAULT_ERRORS,
     ERROR_NOT_FOUND_ID
 )
 from ..error import ErrorContext
-from ...models import Error
-from ...commands.error import GetError
+from ...domain import Error
+from ...events import DomainEvent
+from ...events.error import GetError
 
 # *** fixtures
 
-# ** fixture: get_error_cmd_mock
+# ** fixture: get_error_evt_mock
 @pytest.fixture
-def get_error_cmd_mock() -> GetError:
+def get_error_evt_mock() -> DomainEvent:
     '''
-    Fixture to create a mock GetError command.
+    Fixture to create a mock GetError event.
 
-    :return: A mock GetError command.
-    :rtype: mock.Mock
+    :return: A mock GetError event.
+    :rtype: DomainEvent
     '''
 
-    # Return the mocked GetError command.
+    # Return the mocked GetError event (spec kept as GetError for method signature).
     return mock.Mock(spec=GetError)
 
 # ** fixture: error_context
 @pytest.fixture
-def error_context(get_error_cmd_mock: GetError):
+def error_context(get_error_evt_mock: DomainEvent):
     '''
     Fixture to create a new ErrorContext object.
     '''
-    
-    # Create an instance of ErrorContext with the mock error service.
-    return ErrorContext(get_error_cmd=get_error_cmd_mock)
+
+    # Create an instance of ErrorContext with the mock event.
+    return ErrorContext(get_error_evt=get_error_evt_mock)
 
 # *** tests
 
 # ** test: error_context_get_error_by_code
-def test_error_context_get_error_by_code(get_error_cmd_mock: GetError, error_context: ErrorContext):
+def test_error_context_get_error_by_code(get_error_evt_mock: DomainEvent, error_context: ErrorContext):
     '''
     Test retrieving an error by its code from the ErrorContext.
 
-    :param get_error_cmd_mock: The mocked GetError command.
-    :type get_error_cmd_mock: GetError
+    :param get_error_evt_mock: The mocked GetError event.
+    :type get_error_evt_mock: DomainEvent
     :param error_context: The error context to test.
     :type error_context: ErrorContext
     '''
 
     # Mock the get_error_handler to return a sample Error.
-    get_error_cmd_mock.execute.return_value = Error.new(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
+    get_error_evt_mock.execute.return_value = Error.new(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
     
     error = error_context.get_error_by_code(ERROR_NOT_FOUND_ID)
     


### PR DESCRIPTION
## Summary

Refactors `ErrorContext` to use the `DomainEvent` base-type convention and cleans up legacy references. A focused, three-file change.

## Changes

- **`contexts/error.py`** — Replace `get_error_cmd: GetError` with `get_error_evt: DomainEvent`; fix artifact comments (`# * attribute: error_service` → `get_error_handler`, `# * method: init` → `# * init`); remove `LegacyTiferetError` union type and dual-path formatting from `handle_error()`; update imports to forward-compatible packages.
- **`contexts/tests/test_error.py`** — Rename `get_error_cmd_mock` → `get_error_evt_mock` (`DomainEvent`); update `error_context` constructor call; forward-compatible imports.
- **`assets/constants.py`** — Rename `get_error_cmd` → `get_error_evt` (→ `tiferet.events.error.GetError`) in `DEFAULT_SERVICES`.

## Acceptance Criteria

- [x] `ErrorContext.__init__` accepts `get_error_evt: DomainEvent`
- [x] `pytest tiferet/contexts/tests/test_error.py` passes (3 tests)
- [x] No references to `get_error_cmd` remain in `contexts/error.py` or `DEFAULT_SERVICES`
- [x] No imports from `tiferet.commands.error` remain in `contexts/error.py`

Closes #683

Co-Authored-By: Oz <oz-agent@warp.dev>