### PR TITLE
Docs/Packaging – v2.0.0a7 Release Updates (#688)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Tiferet Framework (v1.9.x)
+# AGENTS.md — Tiferet Framework (v2.0.0a7)
 
 ## Project Overview
 
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a6`
+- **Version:** `2.0.0a7`
 
 ## Architecture
 
@@ -19,9 +19,10 @@ The codebase maintains a **dual-package structure**: legacy packages from v1.x c
 tiferet/
 ├── assets/               # Constants, exceptions (TiferetError), shared config
 ├── commands/             # Legacy: Command base class
-├── contexts/             # Runtime orchestration (AppManager, Feature, Error, CLI, etc.)
+├── contexts/             # Runtime orchestration (AppManager, DIContext, Feature, Error, CLI, Logging)
 ├── contracts/            # Legacy: Service/Repository contracts
 ├── data/                 # Legacy: DataObject
+├── di/                   # App-level DI: ServiceProvider, DependenciesServiceProvider
 ├── domain/               # Forward: DomainObject
 ├── events/               # Forward: DomainEvent
 ├── handlers/             # Handler implementations
@@ -56,13 +57,16 @@ tiferet/
 
 1. `App()` (alias for `AppManagerContext`) loads settings.
 2. `app.run(interface_id, feature_id, data={})` loads the interface via `AppInterfaceContext`.
-3. `FeatureContext.execute_feature()` loads the feature config, resolves commands from the container, and executes them sequentially.
-4. Each command is a `DomainEvent` (or legacy `Command`) subclass that receives injected services and performs domain logic.
+3. `FeatureContext.execute_feature()` loads the feature config, resolves services from `DIContext`, and executes them sequentially.
+4. Each step is a `DomainEvent` subclass that receives injected services and performs domain logic.
 5. Results flow back through `RequestContext` and `handle_response()`.
 
 ### Dependency Injection
 
-Tiferet uses the `dependencies` library for runtime DI. Injectors are created per app interface in `AppManagerContext.load_app_instance()`. Container attributes are defined in `app/configs/container.yml` and resolved via `ContainerContext`.
+Tiferet uses a two-layer DI architecture:
+
+- **App-level DI** (`tiferet/di/`) — `ServiceProvider` ABC and `DependenciesServiceProvider` concrete implementation. Backs `AppManagerContext.load_app_instance()`: assembles the full interface dependency graph (contexts, repos, events) via `AppInterface.get_service_type_mapping()` and resolves `AppInterfaceContext` via `service_provider.get_service('app_context')`.
+- **Feature-level DI** (`tiferet/contexts/di.py` — `DIContext`) — Builds and caches a `DependenciesServiceProvider` per flag set from `ServiceConfiguration` objects loaded by `DIYamlRepository`. `FeatureContext` calls `DIContext.get_dependency(service_id, *flags)` to resolve each feature step.
 
 ## Structured Code Style
 
@@ -211,9 +215,9 @@ See [docs/core/repos.md](docs/core/repos.md) for structured code design and [doc
 
 Applications are configured via YAML files in `app/configs/`:
 
-- `app.yml` — Interface definitions (name, module_path, class_name, attributes)
-- `container.yml` — Dependency injection container attributes (module_path, class_name, parameters)
-- `feature.yml` — Feature workflows (steps with service_id, parameters, data_key; `attribute_id` supported as deprecated fallback)
+- `app.yml` — Interface definitions (name, module_path, class_name, service dependencies)
+- `di.yml` — Feature-level DI service configurations (module_path, class_name, parameters, flagged dependencies)
+- `feature.yml` — Feature workflows (steps with service_id, parameters, data_key)
 - `error.yml` — Error definitions with multilingual messages
 - `cli.yml` — CLI command definitions with arguments
 - `logging.yml` — Logging formatters, handlers, loggers
@@ -282,7 +286,10 @@ The following forward-compatible packages are successors to legacy packages. New
 - `tiferet/events/settings.py` — `DomainEvent` base class (execute, verify, parameters_required, handle)
 - `tiferet/mappers/settings.py` — `Aggregate` and `TransferObject` base classes
 - `tiferet/interfaces/settings.py` — `Service` (ABC) base class
+- `tiferet/di/settings.py` — `ServiceProvider` ABC
+- `tiferet/di/dependencies.py` — `DependenciesServiceProvider` (app-level DI)
 - `tiferet/contexts/app.py` — `AppManagerContext` and `AppInterfaceContext`
+- `tiferet/contexts/di.py` — `DIContext` (feature-level DI)
 - `tiferet/contexts/feature.py` — `FeatureContext` (feature execution engine)
 - `tiferet/assets/constants.py` — Error codes and default configuration
 - `tiferet/assets/exceptions.py` — `TiferetError` and `TiferetAPIError`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ include = [
     "tiferet.commands",
     "tiferet.configs",
     "tiferet.contexts",
+    "tiferet.di",
     "tiferet.contracts",
     "tiferet.data",
     "tiferet.handlers",

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -50,4 +50,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a6'
+__version__ = '2.0.0a7'

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -23,11 +23,11 @@ DEFAULT_SERVICES = [
         },
     },
     {
-        'service_id': 'logging_repo',
-        'module_path': 'tiferet.proxies.yaml.logging',
-        'class_name': 'LoggingYamlProxy',
+        'service_id': 'logging_service',
+        'module_path': 'tiferet.repos.logging',
+        'class_name': 'LoggingYamlRepository',
         'parameters': {
-            'logging_config_file': 'app/configs/logging.yml',
+            'logging_yaml_file': 'app/configs/logging.yml',
         },
     },
     {

--- a/tiferet/assets/tests/test_calc.yml
+++ b/tiferet/assets/tests/test_calc.yml
@@ -1,4 +1,4 @@
-attrs:
+services:
   add_number_cmd:
     class_name: TestAddNumber
     module_path: tiferet.tests_int
@@ -23,31 +23,31 @@ features:
   test_calc:
     add_number:
       commands:
-      - attribute_id: add_number_cmd
+      - service_id: add_number_cmd
         name: Add Number Command
       description: Adds two numbers.
       name: Add Number Feature
     subtract_number:
       commands:
-      - attribute_id: subtract_number_cmd
+      - service_id: subtract_number_cmd
         name: Subtract Number Command
       description: Subtracts two numbers.
       name: Subtract Number Feature
     multiply_number:
       commands:
-      - attribute_id: multiply_number_cmd
+      - service_id: multiply_number_cmd
         name: Multiply Number Command
       description: Multiplies two numbers.
       name: Multiply Number Feature
     divide_number:
       commands:
-      - attribute_id: divide_number_cmd
+      - service_id: divide_number_cmd
         name: Divide Number Command
       description: Divides two numbers.
       name: Divide Number Feature
     square_number:
       commands:
-      - attribute_id: multiply_number_cmd
+      - service_id: multiply_number_cmd
         name: Square Number Command
         params:
           b: $r.a
@@ -68,14 +68,14 @@ interfaces:
         class_name: ErrorYamlRepository
         params:
           error_yaml_file: tiferet/assets/tests/test_calc.yml
-      container_service:
-        module_path: tiferet.repos.config.container
-        class_name: ContainerConfigurationRepository
+      di_service:
+        module_path: tiferet.repos.di
+        class_name: DIYamlRepository
         params:
-          container_config_file: tiferet/assets/tests/test_calc.yml
-      logging_repo:
-        module_path: tiferet.proxies.yaml.logging
-        class_name: LoggingYamlProxy
+          di_yaml_file: tiferet/assets/tests/test_calc.yml
+      logging_service:
+        module_path: tiferet.repos.logging
+        class_name: LoggingYamlRepository
         params:
-          logging_config_file: tiferet/assets/tests/test_calc.yml
+          logging_yaml_file: tiferet/assets/tests/test_calc.yml
 logging: {}

--- a/tiferet/tests_int/test_main.py
+++ b/tiferet/tests_int/test_main.py
@@ -6,10 +6,6 @@ import pytest
 # ** app
 from .. import App, TiferetAPIError
 
-pytestmark = pytest.mark.skip(reason='Integration tests require full forward-compatible stack (#682+)')
-
-# *** fixtures
-
 # ** fixture: app_context
 @pytest.fixture
 def app_context():


### PR DESCRIPTION
## Summary

Delivers the final v2.0.0a7 release updates: version bump, packaging, documentation, test fixture fixes, and integration test restoration.

## Changes

- **`tiferet/__init__.py`** — `__version__` bumped to `2.0.0a7`.
- **`pyproject.toml`** — `tiferet.di` added to `tool.setuptools.packages.find.include`.
- **`AGENTS.md`** — Version `2.0.0a7`, branch `main`, `di/` added to directory tree, Runtime Flow and Dependency Injection sections updated (`DIContext`, `ServiceProvider`), `di.yml` added to Configuration, `tiferet/di/` entries added to Key Files.
- **`assets/constants.py`** — `DEFAULT_SERVICES`: renamed `logging_repo` → `logging_service` pointing to `LoggingYamlRepository` (fix: `ListAllLoggingConfigs` needs `logging_service` injected).
- **`assets/tests/test_calc.yml`** — Full forward-compatible rewrite: `services:` key for DI, `service_id:` in feature steps, interface overrides pointing to `feature_service`, `error_service`, `di_service`, `logging_service` repos.
- **`tests_int/test_main.py`** — `pytestmark = skip` removed; all 6 integration tests now pass.

## Result

**1,281 passed, 18 skipped** — integration tests fully restored with the complete forward-compatible stack.

Closes #688

Co-Authored-By: Oz <oz-agent@warp.dev>