### PR TITLE
Constants + Events - default constants merge support (#713)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -3,6 +3,14 @@
 # *** imports
 
 # *** constants (app)
+# ** constant: default_constants
+DEFAULT_CONSTANTS = {
+    'cli_yaml_file': 'config.yml',
+    'di_yaml_file': 'config.yml',
+    'error_yaml_file': 'config.yml',
+    'logging_yaml_file': 'config.yml',
+    'feature_yaml_file': 'config.yml',
+}
 
 # ** constant: default_services
 DEFAULT_SERVICES = [
@@ -10,33 +18,21 @@ DEFAULT_SERVICES = [
         'service_id': 'di_service',
         'module_path': 'tiferet.repos.di',
         'class_name': 'DIYamlRepository',
-        'parameters': {
-            'di_yaml_file': 'app/configs/di.yml',
-        },
     },
     {
         'service_id': 'error_service',
         'module_path': 'tiferet.repos.error',
         'class_name': 'ErrorYamlRepository',
-        'parameters': {
-            'error_yaml_file': 'app/configs/error.yml',
-        },
     },
     {
         'service_id': 'logging_service',
         'module_path': 'tiferet.repos.logging',
         'class_name': 'LoggingYamlRepository',
-        'parameters': {
-            'logging_yaml_file': 'app/configs/logging.yml',
-        },
     },
     {
         'service_id': 'feature_service',
         'module_path': 'tiferet.repos.feature',
         'class_name': 'FeatureYamlRepository',
-        'parameters': {
-            'feature_yaml_file': 'app/configs/feature.yml',
-        },
     },
     {
         'service_id': 'get_error_evt',
@@ -57,9 +53,6 @@ DEFAULT_SERVICES = [
         'service_id': 'cli_service',
         'module_path': 'tiferet.repos.cli',
         'class_name': 'CliYamlRepository',
-        'parameters': {
-            'cli_yaml_file': 'app/configs/cli.yml',
-        },
     },
     {
         'service_id': 'list_commands_evt',

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -23,7 +23,7 @@ class AddAppInterface(DomainEvent):
     # * init
     def __init__(self, app_service: AppService):
         '''
-        Initialize the AddAppInterface command.
+        Initialize the AddAppInterface event.
 
         :param app_service: The application service used to persist app interfaces.
         :type app_service: AppService
@@ -111,7 +111,7 @@ class GetAppInterface(DomainEvent):
     # * init
     def __init__(self, app_service: AppService) -> None:
         '''
-        Initialize the GetAppInterface command.
+        Initialize the GetAppInterface event.
 
         :param app_service: The app service used to retrieve interfaces.
         :type app_service: AppService
@@ -122,15 +122,24 @@ class GetAppInterface(DomainEvent):
 
     # * method: execute
     @DomainEvent.parameters_required(['interface_id'])
-    def execute(self, interface_id: str, default_services: List[AppServiceDependency] = [], **kwargs) -> AppInterface:
+    def execute(
+            self,
+            interface_id: str,
+            default_services: List[AppServiceDependency] | None = None,
+            default_constants: Dict[str, str] | None = None,
+            **kwargs,
+        ) -> AppInterface:
         '''
-        Execute the command to load the application interface.
+        Execute the event to load the application interface.
 
         :param interface_id: The ID of the application interface to load.
         :type interface_id: str
         :param default_services: A list of AppServiceDependency objects to merge
             into the interface for any service_id not already present.
-        :type default_services: List[AppServiceDependency]
+        :type default_services: List[AppServiceDependency] | None
+        :param default_constants: A mapping of default constants to merge into the
+            interface for any key not already present.
+        :type default_constants: Dict[str, str] | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The loaded application interface.
@@ -149,6 +158,12 @@ class GetAppInterface(DomainEvent):
                 interface_id=interface_id,
             )
 
+        # Ensure the interface is mutable before applying service/constant merges.
+        if not isinstance(interface, AppInterfaceAggregate):
+            interface = AppInterfaceAggregate.new(
+                app_interface_data=interface.to_primitive(),
+            )
+
         # Merge default services into the interface for any service_id not already present.
         if default_services:
 
@@ -164,6 +179,21 @@ class GetAppInterface(DomainEvent):
                         class_name=dep.class_name,
                         parameters=dep.parameters,
                     )
+                    existing_ids.add(dep.service_id)
+
+        # Merge default constants only for keys that do not already exist.
+        if default_constants:
+
+            # Create a set of missing constants that are not already defined.
+            missing_constants = {
+                key: value
+                for key, value in default_constants.items()
+                if key not in interface.constants
+            }
+
+            # Apply only missing constants, preserving user-defined constants.
+            if missing_constants:
+                interface.set_constants(missing_constants)
 
         # Return the loaded application interface.
         return interface

--- a/tiferet/events/tests/test_app.py
+++ b/tiferet/events/tests/test_app.py
@@ -209,6 +209,125 @@ class TestGetAppInterface(ServiceEventTestBase):
         # Assert that the returned interface matches the expected app interface.
         assert result == app_interface
 
+    # * method: test_merges_missing_default_services_only
+    def test_merges_missing_default_services_only(self, mock_dependencies, app_interface):
+        '''
+        Test that default services are merged only when service_id is missing.
+        '''
+
+        # Configure the service mock to return the app interface.
+        mock_dependencies['app_service'].get.return_value = app_interface
+
+        # Create default services with one duplicate and one missing service_id.
+        default_services = [
+            DomainObject.new(
+                AppServiceDependency,
+                service_id='test_service',
+                module_path='ignored.module',
+                class_name='IgnoredClass',
+                parameters={'ignored': 'value'},
+            ),
+            DomainObject.new(
+                AppServiceDependency,
+                service_id='new_service',
+                module_path='new.module',
+                class_name='NewClass',
+                parameters={'new': 'value'},
+            ),
+        ]
+
+        # Execute the event with default services.
+        result = self.handle(
+            mock_dependencies,
+            default_services=default_services,
+        )
+
+        # Assert the existing dependency remains and only the missing dependency is added.
+        assert result.get_service('test_service').module_path == 'test_module_path'
+        assert result.get_service('new_service').module_path == 'new.module'
+        assert len(result.services) == 2
+
+    # * method: test_merges_missing_default_constants_only
+    def test_merges_missing_default_constants_only(self, mock_dependencies, app_interface):
+        '''
+        Test that default constants are merged without overwriting existing values.
+        '''
+
+        # Configure the service mock to return the app interface.
+        mock_dependencies['app_service'].get.return_value = app_interface
+
+        # Seed interface constants with an existing key that should be preserved.
+        app_interface.constants = {
+            'di_yaml_file': 'custom.yml',
+            'custom_key': 'custom_value',
+        }
+
+        # Execute the event with default constants.
+        result = self.handle(
+            mock_dependencies,
+            default_constants={
+                'di_yaml_file': 'config.yml',
+                'feature_yaml_file': 'config.yml',
+            },
+        )
+
+        # Assert existing keys are preserved and missing keys are added.
+        assert result.constants['di_yaml_file'] == 'custom.yml'
+        assert result.constants['feature_yaml_file'] == 'config.yml'
+        assert result.constants['custom_key'] == 'custom_value'
+
+    # * method: test_converts_to_aggregate_and_merges_services_and_constants
+    def test_converts_to_aggregate_and_merges_services_and_constants(self, mock_dependencies):
+        '''
+        Test aggregate conversion before applying default services and constants.
+        '''
+
+        # Configure the service mock to return a plain AppInterface domain object.
+        domain_interface = DomainObject.new(
+            AppInterface,
+            id='test.interface',
+            name='Test Interface',
+            module_path='tiferet.contexts.app',
+            class_name='AppContext',
+            services=[
+                DomainObject.new(
+                    AppServiceDependency,
+                    service_id='existing_service',
+                    module_path='existing.module',
+                    class_name='ExistingClass',
+                    parameters={},
+                ),
+            ],
+            constants={'di_yaml_file': 'custom.yml'},
+        )
+        mock_dependencies['app_service'].get.return_value = domain_interface
+
+        # Execute the event with both defaults provided.
+        result = self.handle(
+            mock_dependencies,
+            interface_id='test.interface',
+            default_services=[
+                DomainObject.new(
+                    AppServiceDependency,
+                    service_id='new_service',
+                    module_path='new.module',
+                    class_name='NewClass',
+                    parameters={'key': 'value'},
+                ),
+            ],
+            default_constants={
+                'di_yaml_file': 'config.yml',
+                'feature_yaml_file': 'config.yml',
+            },
+        )
+
+        # Assert conversion to aggregate and correct merge behavior.
+        assert isinstance(result, AppInterfaceAggregate)
+        assert result.get_service('existing_service') is not None
+        assert result.get_service('new_service') is not None
+        assert result.constants['di_yaml_file'] == 'custom.yml'
+        assert result.constants['feature_yaml_file'] == 'config.yml'
+
 
 # ** test: TestListAppInterfaces
 class TestListAppInterfaces(DomainEventTestBase):


### PR DESCRIPTION
## Summary
- add `DEFAULT_CONSTANTS` mapping YAML configuration keys to consolidated `config.yml`
- simplify `DEFAULT_SERVICES` by removing hardcoded per-service `parameters`
- update `GetAppInterface` to support `default_constants` with missing-key-only merge semantics
- ensure `GetAppInterface` converts to `AppInterfaceAggregate` before mutating defaults
- add event tests covering missing-only service merge, missing-only constants merge, and aggregate conversion path

Closes #713

Co-Authored-By: Oz <oz-agent@warp.dev>