### PR TITLE
Domain - AppServiceDependency and AppInterface service provider support (#714)

### DIFF
--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -39,3 +39,7 @@ from .logging import (
     Handler,
     Logger,
 )
+from ..di import (
+    ServiceProvider,
+    DependenciesServiceProvider,
+)

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -14,6 +14,7 @@ from .settings import (
     DictType,
     ModelType,
 )
+from ..di import ServiceProvider
 
 # *** models
 
@@ -55,6 +56,18 @@ class AppServiceDependency(DomainObject):
             description='The parameters for the application dependency.'
         ),
     )
+
+    # * method: get_service_type
+    def get_service_type(self) -> type:
+        '''
+        Get the service type for this app service dependency.
+
+        :return: The service type.
+        :rtype: type
+        '''
+
+        # Import and return the service class type.
+        return getattr(import_module(self.module_path), self.class_name)
 
 
 # ** model: app_interface
@@ -138,6 +151,22 @@ class AppInterface(DomainObject):
         ),
     )
 
+    # * attribute: service_provider_path
+    service_provider_path = StringType(
+        default='tiferet.di.dependencies',
+        metadata=dict(
+            description='The module path for the service provider to use for this dependency.'
+        ),
+    )
+
+    # * attribute: service_provider_class_name
+    service_provider_class_name = StringType(
+        default='DependenciesServiceProvider',
+        metadata=dict(
+            description='The class name for the service provider to use for this dependency.'
+        ),
+    )
+
     # * method: get_service
     def get_service(self, service_id: str) -> AppServiceDependency:
         '''
@@ -176,12 +205,30 @@ class AppInterface(DomainObject):
 
         # Add the remaining app context service dependencies and parameters.
         for dep in self.services:
-            dependencies[dep.service_id] = getattr(
-                import_module(dep.module_path),
-                dep.class_name,
-            )
+            dependencies[dep.service_id] = dep.get_service_type()
             for param, value in dep.parameters.items():
                 dependencies[param] = value
 
         # Return the assembled dependencies mapping.
         return dependencies
+
+    # * method: create_service_provider
+    def create_service_provider(self) -> ServiceProvider:
+        '''
+        Create a service provider for this app interface.
+
+        :return: A configured service provider instance.
+        :rtype: ServiceProvider
+        '''
+
+        # Build the service type mapping for this interface.
+        type_map = self.get_service_type_mapping()
+
+        # Resolve the configured service provider class.
+        provider_class = getattr(
+            import_module(self.service_provider_path),
+            self.service_provider_class_name,
+        )
+
+        # Create and return the configured service provider instance.
+        return provider_class(services=type_map)

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -11,6 +11,10 @@ from ..app import (
     AppInterface,
     AppServiceDependency,
 )
+from ...di import (
+    ServiceProvider,
+    DependenciesServiceProvider,
+)
 
 # *** fixtures
 
@@ -175,3 +179,70 @@ def test_app_interface_get_service_type_mapping_no_services() -> None:
     assert 'interface_id' in mapping
     assert 'logger_id' in mapping
     assert len(mapping) == 3
+
+
+# ** test: app_service_dependency_get_service_type
+def test_app_service_dependency_get_service_type(resolvable_app_dependency: AppServiceDependency) -> None:
+    '''
+    Test that AppServiceDependency.get_service_type resolves the configured class type.
+
+    :param resolvable_app_dependency: An AppServiceDependency with a real module path.
+    :type resolvable_app_dependency: AppServiceDependency
+    '''
+
+    # Resolve the service type from the dependency.
+    service_type = resolvable_app_dependency.get_service_type()
+
+    # Assert the resolved type matches the expected class.
+    from tiferet.contexts.app import AppInterfaceContext
+    assert service_type is AppInterfaceContext
+
+
+# ** test: app_interface_service_provider_defaults
+def test_app_interface_service_provider_defaults() -> None:
+    '''
+    Test default service provider metadata values on AppInterface.
+    '''
+
+    # Create an AppInterface with minimal required data.
+    interface = DomainObject.new(
+        AppInterface,
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppInterfaceContext',
+        services=[],
+    )
+
+    # Assert default provider module path and class name values.
+    assert interface.service_provider_path == 'tiferet.di.dependencies'
+    assert interface.service_provider_class_name == 'DependenciesServiceProvider'
+
+
+# ** test: app_interface_create_service_provider
+def test_app_interface_create_service_provider(resolvable_app_dependency: AppServiceDependency) -> None:
+    '''
+    Test that AppInterface.create_service_provider returns a configured provider instance.
+
+    :param resolvable_app_dependency: An AppServiceDependency with a real module path.
+    :type resolvable_app_dependency: AppServiceDependency
+    '''
+
+    # Create an AppInterface with a resolvable service dependency.
+    interface = DomainObject.new(
+        AppInterface,
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppInterfaceContext',
+        services=[resolvable_app_dependency],
+    )
+
+    # Create the provider from the interface.
+    provider = interface.create_service_provider()
+
+    # Assert the provider is correctly created and populated.
+    assert isinstance(provider, ServiceProvider)
+    assert isinstance(provider, DependenciesServiceProvider)
+    assert 'app_context' in provider.services
+    assert 'resolvable_service' in provider.services


### PR DESCRIPTION
## Summary
- add `AppServiceDependency.get_service_type()` to centralize dependency type resolution
- add `service_provider_path` and `service_provider_class_name` attributes to `AppInterface` with defaults
- add `AppInterface.create_service_provider()` to instantiate the configured provider
- update `AppInterface.get_service_type_mapping()` to delegate service resolution to dependency models
- re-export `ServiceProvider` and `DependenciesServiceProvider` from `tiferet.domain`
- expand domain tests for service type resolution, provider defaults, and provider creation

Closes #714

Co-Authored-By: Oz <oz-agent@warp.dev>