### PR TITLE
Contexts - DIContext service provider refactor (#715)

### DIFF
--- a/tiferet/contexts/di.py
+++ b/tiferet/contexts/di.py
@@ -6,8 +6,11 @@ from typing import Callable, Any, List, Dict
 # ** app
 from .cache import CacheContext
 from ..assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
-from ..di import ServiceProvider, DependenciesServiceProvider
-from ..domain.di import ServiceConfiguration
+from ..domain import (
+    ServiceProvider,
+    DependenciesServiceProvider,
+    ServiceConfiguration,
+)
 from ..events import DomainEvent, RaiseError, ParseParameter
 
 
@@ -25,8 +28,15 @@ class DIContext(object):
     # * attribute: list_all_configs_handler
     list_all_configs_handler: Callable
 
+    # * attribute: create_service_provider
+    create_service_provider: Callable
+
     # * init
-    def __init__(self, di_list_all_configs_evt: DomainEvent, cache: CacheContext = None):
+    def __init__(self,
+            di_list_all_configs_evt: DomainEvent,
+            cache: CacheContext = None,
+            create_service_provider: Callable = None,
+        ):
         '''
         Initialize the DI context.
 
@@ -34,11 +44,37 @@ class DIContext(object):
         :type di_list_all_configs_evt: DomainEvent
         :param cache: The cache context to use for caching service providers.
         :type cache: CacheContext
+        :param create_service_provider: Optional factory for creating service providers.
+        :type create_service_provider: Callable | None
         '''
 
         # Assign the attributes.
         self.list_all_configs_handler = di_list_all_configs_evt.execute
         self.cache = cache if cache else CacheContext()
+        self.create_service_provider = create_service_provider if create_service_provider else self._default_service_provider
+
+    # * method: _default_service_provider (static)
+    @staticmethod
+    def _default_service_provider(type_map: Dict[str, type] = None, **constants) -> ServiceProvider:
+        '''
+        Create the default service provider for DI context resolution.
+
+        :param type_map: Mapping of service IDs to dependency types.
+        :type type_map: Dict[str, type]
+        :param constants: Constant values to register in the provider.
+        :type constants: dict
+        :return: A configured service provider.
+        :rtype: ServiceProvider
+        '''
+
+        # Create a provider seeded with service dependency types.
+        provider = DependenciesServiceProvider(services=type_map or {})
+
+        # Add constants to the provider for constructor injection.
+        provider.add_constants(constants)
+
+        # Return the configured provider.
+        return provider
 
     # * method: create_cache_key
     def create_cache_key(self, flags: List[str] = None) -> str:
@@ -46,7 +82,7 @@ class DIContext(object):
         Create a cache key for the service provider.
 
         :param flags: The feature or data flags to use.
-        :type flags: List[str]
+        :type flags: List[str] | None
         :return: The cache key.
         :rtype: str
         '''
@@ -54,16 +90,18 @@ class DIContext(object):
         # Create the cache key from the flags.
         return f"feature_services{'_' + '_'.join(flags) if flags else ''}"
 
-    # * method: build_provider
-    def build_provider(self, flags: List[str] = []) -> ServiceProvider:
+    # * method: build_service_provider
+    def build_service_provider(self, flags: List[str] = None) -> ServiceProvider:
         '''
         Build and cache a service provider for the given flags.
 
         :param flags: The feature or data flags to use.
-        :type flags: List[str]
+        :type flags: List[str] | None
         :return: The service provider instance.
         :rtype: ServiceProvider
         '''
+        # Normalize optional flags.
+        flags = flags if flags else []
 
         # Create the cache key from the flags.
         cache_key = self.create_cache_key(flags)
@@ -77,10 +115,14 @@ class DIContext(object):
         configurations, constants = self.list_all_configs_handler()
 
         # Load and parse constants from configurations and the top-level constants dict.
-        constants = self.load_constants(configurations, constants, flags)
+        constants = self.load_constants(
+            configurations=configurations,
+            constants=constants,
+            flags=flags,
+        )
 
         # Resolve service types from configurations.
-        services = {}
+        type_map = {}
         for config in configurations:
 
             # Get the dependency type based on the flags.
@@ -95,13 +137,13 @@ class DIContext(object):
                     flags=flags,
                 )
 
-            # Add the resolved type to the services dictionary.
-            services[config.id] = dep_type
+            # Add the resolved type to the service type mapping.
+            type_map[config.id] = dep_type
 
-        # Merge services and constants and build the provider.
-        provider = DependenciesServiceProvider(
-            services={**services, **constants},
-            name=cache_key,
+        # Build the service provider using the configured factory.
+        provider = self.create_service_provider(
+            type_map=type_map,
+            **constants,
         )
 
         # Cache and return the provider.
@@ -109,20 +151,20 @@ class DIContext(object):
         return provider
 
     # * method: get_dependency
-    def get_dependency(self, configuration_id: str, flags: List[str] = []) -> Any:
+    def get_dependency(self, configuration_id: str, flags: List[str] = None) -> Any:
         '''
         Get a resolved service by its configuration ID.
 
         :param configuration_id: The service configuration identifier.
         :type configuration_id: str
         :param flags: The feature or data flags to use.
-        :type flags: List[str]
+        :type flags: List[str] | None
         :return: The resolved service instance.
         :rtype: Any
         '''
 
         # Build (or retrieve) the service provider for these flags.
-        provider = self.build_provider(flags)
+        provider = self.build_service_provider(flags)
 
         # Return the resolved service from the provider.
         return provider.get_service(configuration_id)
@@ -148,23 +190,27 @@ class DIContext(object):
 
     # * method: load_constants
     def load_constants(self,
-            configurations: List[ServiceConfiguration] = [],
-            constants: Dict[str, str] = {},
-            flags: List[str] = [],
-        ) -> Dict[str, str]:
+            configurations: List[ServiceConfiguration] = None,
+            constants: Dict[str, Any] = None,
+            flags: List[str] = None,
+        ) -> Dict[str, Any]:
         '''
         Build the constants dict by parsing top-level constants and per-configuration parameters.
 
         :param configurations: The list of service configurations.
-        :type configurations: List[ServiceConfiguration]
+        :type configurations: List[ServiceConfiguration] | None
         :param constants: The top-level constants dictionary.
-        :type constants: Dict[str, str]
+        :type constants: Dict[str, Any] | None
         :param flags: The feature or data flags to use.
-        :type flags: List[str]
+        :type flags: List[str] | None
         :return: A dictionary of parsed constants.
-        :rtype: Dict[str, str]
+        :rtype: Dict[str, Any]
         '''
 
+        # Normalize optional inputs.
+        configurations = configurations if configurations else []
+        constants = constants if constants else {}
+        flags = flags if flags else []
         # Parse the top-level constants.
         constants = {k: ParseParameter.execute(v) for k, v in constants.items()}
 

--- a/tiferet/contexts/tests/test_di.py
+++ b/tiferet/contexts/tests/test_di.py
@@ -7,10 +7,15 @@ from typing import Tuple, List, Dict
 
 # ** app
 from ..di import DIContext
+from ..cache import CacheContext
 from ...assets.exceptions import TiferetError
 from ...assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
-from ...di import ServiceProvider, DependenciesServiceProvider
-from ...domain.di import ServiceConfiguration, FlaggedDependency
+from ...domain import (
+    ServiceProvider,
+    DependenciesServiceProvider,
+    ServiceConfiguration,
+    FlaggedDependency,
+)
 from ...domain.settings import DomainObject
 from ...events.di import ListAllSettings
 
@@ -116,7 +121,10 @@ def di_context(di_list_all_configs_evt_mock) -> DIContext:
     '''
 
     # Return a DIContext instance.
-    return DIContext(di_list_all_configs_evt=di_list_all_configs_evt_mock)
+    return DIContext(
+        di_list_all_configs_evt=di_list_all_configs_evt_mock,
+        cache=CacheContext(cache={}),
+    )
 
 
 # ** fixture: provider
@@ -132,7 +140,7 @@ def provider(di_context: DIContext) -> ServiceProvider:
     '''
 
     # Build the provider with no flags.
-    return di_context.build_provider()
+    return di_context.build_service_provider()
 
 
 # *** tests
@@ -152,9 +160,55 @@ def test_di_context_get_cache_key(di_context: DIContext):
     # Test with flags.
     assert di_context.create_cache_key(flags=['test', 'test2']) == 'feature_services_test_test2'
 
+# ** test: di_context_default_service_provider_factory
+def test_di_context_default_service_provider_factory():
+    '''
+    Test the default DIContext service provider factory.
+    '''
 
-# ** test: di_context_build_provider
-def test_di_context_build_provider(di_context: DIContext):
+    # Build a provider with a type map and injected constants.
+    provider = DIContext._default_service_provider(
+        type_map={'test_service': TestService},
+        test_config='factory_value',
+    )
+
+    # Assert the provider type and service resolution behavior.
+    assert isinstance(provider, ServiceProvider)
+    resolved_service = provider.get_service('test_service')
+    assert resolved_service.test_config == 'factory_value'
+
+
+# ** test: di_context_custom_service_provider_factory
+def test_di_context_custom_service_provider_factory(di_list_all_configs_evt_mock):
+    '''
+    Test that DIContext uses a custom service provider factory when injected.
+    '''
+
+    # Create a custom factory mock and provider return value.
+    provider = DependenciesServiceProvider()
+    create_factory = mock.Mock(return_value=provider)
+
+    # Create context with custom provider factory and build provider.
+    context = DIContext(
+        di_list_all_configs_evt=di_list_all_configs_evt_mock,
+        cache=CacheContext(cache={}),
+        create_service_provider=create_factory,
+    )
+    result = context.build_service_provider()
+
+    # Assert custom factory was called with expected type map/constants.
+    create_factory.assert_called_once()
+    kwargs = create_factory.call_args.kwargs
+    assert kwargs['type_map']['test_service'] is TestService
+    assert kwargs['test_config'] == 'test_value'
+    assert kwargs['param_config'] == 'param_value'
+
+    # Assert the factory output provider is used and returned.
+    assert result is provider
+
+
+# ** test: di_context_build_service_provider
+def test_di_context_build_service_provider(di_context: DIContext):
     '''
     Test the building of a service provider in the DIContext.
 
@@ -163,7 +217,7 @@ def test_di_context_build_provider(di_context: DIContext):
     '''
 
     # Build the provider with no flags.
-    provider = di_context.build_provider()
+    provider = di_context.build_service_provider()
 
     # Assert that the provider is not None and is a ServiceProvider.
     assert provider
@@ -181,7 +235,7 @@ def test_di_context_build_provider(di_context: DIContext):
     assert di_context.cache.get('feature_services') is provider
 
     # Build the provider with flags.
-    flagged_provider = di_context.build_provider(flags=['test'])
+    flagged_provider = di_context.build_service_provider(flags=['test'])
 
     # Assert the flagged provider is not None.
     assert flagged_provider
@@ -198,8 +252,8 @@ def test_di_context_build_provider(di_context: DIContext):
     assert di_context.cache.get('feature_services_test') is flagged_provider
 
 
-# ** test: di_context_build_provider_with_missing_dependency_type
-def test_di_context_build_provider_with_missing_dependency_type(
+# ** test: di_context_build_service_provider_with_missing_dependency_type
+def test_di_context_build_service_provider_with_missing_dependency_type(
         di_context: DIContext,
         di_list_all_configs_evt_mock,
         di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
@@ -223,7 +277,7 @@ def test_di_context_build_provider_with_missing_dependency_type(
 
     # Attempt to build the provider and expect an error.
     with pytest.raises(TiferetError) as exc_info:
-        di_context.build_provider(flags=['missing_flag'])
+        di_context.build_service_provider(flags=['missing_flag'])
 
     # Assert the correct error code and kwargs.
     assert exc_info.value.error_code == DEPENDENCY_TYPE_NOT_FOUND_ID
@@ -231,10 +285,10 @@ def test_di_context_build_provider_with_missing_dependency_type(
     assert exc_info.value.kwargs.get('flags') == ['missing_flag']
 
 
-# ** test: di_context_build_provider_with_cached_provider
-def test_di_context_build_provider_with_cached_provider(di_context: DIContext, provider: ServiceProvider):
+# ** test: di_context_build_service_provider_with_cached_provider
+def test_di_context_build_service_provider_with_cached_provider(di_context: DIContext, provider: ServiceProvider):
     '''
-    Test that build_provider returns the cached provider on subsequent calls.
+    Test that build_service_provider returns the cached provider on subsequent calls.
 
     :param di_context: The DI context to test.
     :type di_context: DIContext
@@ -245,8 +299,8 @@ def test_di_context_build_provider_with_cached_provider(di_context: DIContext, p
     # Assert that a provider is cached.
     assert di_context.cache.get('feature_services')
 
-    # Call build_provider again with no flags.
-    cached_provider = di_context.build_provider()
+    # Call build_service_provider again with no flags.
+    cached_provider = di_context.build_service_provider()
 
     # Assert the same provider instance is returned.
     assert cached_provider is provider


### PR DESCRIPTION
## Summary
- refactor `DIContext` to use service-provider terminology with `build_service_provider`
- add `_default_service_provider` factory and injectable `create_service_provider` constructor parameter
- move provider imports to `tiferet.domain` exports
- expand `load_constants` signature/default handling and keep flagged dependency precedence behavior
- route `get_dependency` through the new provider-building flow
- update DI context tests for renamed API and provider-factory behavior
- isolate cache objects in tests to prevent cross-test cache contamination

Closes #715

`Co-Authored-By: Oz <oz-agent@warp.dev>`