### PR TITLE
Docs/Packaging/Tests – v2.0.0a9 Updates (#717)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Tiferet Framework (v2.0.0a8)
+# AGENTS.md — Tiferet Framework (v2.0.0a9)
 
 ## Project Overview
 
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a8`
+- **Version:** `2.0.0a9`
 
 ## Architecture
 
@@ -18,7 +18,8 @@ The v2.0 codebase is a clean, single-layer architecture. All legacy packages hav
 ```
 tiferet/
 ├── assets/               # Constants, exceptions (TiferetError), shared config
-├── contexts/             # Runtime orchestration (AppManager, DIContext, Feature, Error, CLI, Logging)
+├── builders/             # AppBuilder and top-level runtime orchestration
+├── contexts/             # Runtime orchestration (AppInterface, DIContext, Feature, Error, CLI, Logging)
 ├── di/                   # App-level DI: ServiceProvider, DependenciesServiceProvider
 ├── domain/               # DomainObject base class and domain modules
 ├── events/               # DomainEvent base class and domain event modules
@@ -41,17 +42,28 @@ tiferet/
 
 ### Runtime Flow
 
-1. `App()` (alias for `AppManagerContext`) loads settings.
-2. `app.run(interface_id, feature_id, data={})` loads the interface via `AppInterfaceContext`.
-3. `FeatureContext.execute_feature()` loads the feature config, resolves services from `DIContext`, and executes them sequentially.
-4. Each step is a `DomainEvent` subclass that receives injected services and performs domain logic.
-5. Results flow back through `RequestContext` and `handle_response()`.
+1. `App()` (alias for `AppBuilder`) is initialized.
+2. `app.load_app_service(...)` loads the app repository service (typically `AppYamlRepository`).
+3. `app.run(interface_id, feature_id, data={})` resolves the interface via `GetAppInterface` and builds an `AppInterfaceContext`.
+4. `FeatureContext.execute_feature()` loads the feature config, resolves services from `DIContext`, and executes them sequentially.
+5. Each step is a `DomainEvent` subclass that receives injected services and performs domain logic.
+6. Results flow back through `RequestContext` and `handle_response()`.
+
+### Builders
+
+- `AppBuilder` is defined in `tiferet/builders/main.py`.
+- It is the primary public orchestration entry point and is exported as `App` from `tiferet/__init__.py`.
+- Core responsibilities:
+  - Loading the app service (`load_app_service`)
+  - Injecting default services and constants (`load_default_services`, `DEFAULT_CONSTANTS`)
+  - Resolving interface contexts (`load_interface`)
+  - Delegating feature execution (`run`)
 
 ### Dependency Injection
 
 Tiferet uses a two-layer DI architecture:
 
-- **App-level DI** (`tiferet/di/`) — `ServiceProvider` ABC and `DependenciesServiceProvider` concrete implementation. Backs `AppManagerContext.load_app_instance()`: assembles the full interface dependency graph (contexts, repos, events) via `AppInterface.get_service_type_mapping()` and resolves `AppInterfaceContext` via `service_provider.get_service('app_context')`.
+- **App-level DI** (`tiferet/di/`) — `ServiceProvider` ABC and `DependenciesServiceProvider` concrete implementation. Backs `AppBuilder.load_app_instance()`: assembles the full interface dependency graph (contexts, repos, events) via `AppInterface.get_service_type_mapping()` and resolves `AppInterfaceContext` via `service_provider.get_service('app_context')`.
 - **Feature-level DI** (`tiferet/contexts/di.py` — `DIContext`) — Builds and caches a `DependenciesServiceProvider` per flag set from `ServiceConfiguration` objects loaded by `DIYamlRepository`. `FeatureContext` calls `DIContext.get_dependency(service_id, *flags)` to resolve each feature step.
 
 ## Structured Code Style
@@ -199,14 +211,14 @@ See [docs/core/repos.md](docs/core/repos.md) for structured code design and [doc
 
 ## Configuration
 
-Applications are configured via YAML files in `app/configs/`:
+Applications are configured in a consolidated root `config.yml` file:
 
-- `app.yml` — Interface definitions (name, module_path, class_name, service dependencies)
-- `di.yml` — Feature-level DI service configurations (module_path, class_name, parameters, flagged dependencies)
-- `feature.yml` — Feature workflows (steps with service_id, parameters, data_key)
-- `error.yml` — Error definitions with multilingual messages
-- `cli.yml` — CLI command definitions with arguments
-- `logging.yml` — Logging formatters, handlers, loggers
+- `interfaces` — Interface definitions (name, module_path, class_name, service dependencies)
+- `services` — Feature-level DI service configurations (module_path, class_name, parameters, flagged dependencies)
+- `features` — Feature workflows (commands with service_id, parameters, and data mapping)
+- `errors` — Error definitions with multilingual messages
+- `cli` — CLI command definitions with arguments
+- `logging` — Logging formatters, handlers, loggers
 
 ## Testing
 
@@ -237,7 +249,7 @@ Current utilities:
 The top-level `tiferet/__init__.py` exports:
 
 **Core:**
-- `App` (alias for `AppManagerContext`)
+- `App` (alias for `AppBuilder`)
 - `TiferetError`, `TiferetAPIError`
 
 **Domain:**
@@ -264,7 +276,8 @@ The top-level `tiferet/__init__.py` exports:
 - `tiferet/interfaces/settings.py` — `Service` (ABC) base class
 - `tiferet/di/settings.py` — `ServiceProvider` ABC
 - `tiferet/di/dependencies.py` — `DependenciesServiceProvider` (app-level DI)
-- `tiferet/contexts/app.py` — `AppManagerContext` and `AppInterfaceContext`
+- `tiferet/builders/main.py` — `AppBuilder` (public app orchestration entry point)
+- `tiferet/contexts/app.py` — `AppInterfaceContext`
 - `tiferet/contexts/di.py` — `DIContext` (feature-level DI)
 - `tiferet/contexts/feature.py` — `FeatureContext` (feature execution engine)
 - `tiferet/assets/constants.py` — Error codes and default configuration

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@
 Inspired by the Kabbalistic principle of harmony and beauty in balance, Tiferet helps you turn complex business logic into maintainable, configuration-driven applications — where purpose, structure, and execution feel naturally aligned.
 
 ### At a glance
-
+- Builders-first app entry point via `AppBuilder` (exported as `App`)  
 - Domain events as the core unit of behavior  
 - YAML for features, workflows, dependency injection, errors, CLI commands  
 - Clean layering: domain objects • aggregates • transfer objects • services  
 - Structured, multilingual errors built-in  
 - Easy to extend to CLI, web, scripts, TUI, …
-
-Current status: **2.0.0a8** (pre-release – actively evolving toward stable v2)
+Current status: **2.0.0a9** (pre-release – actively evolving toward stable v2)
 
 ## Quick Start – Add two numbers in ~3 minutes
 
@@ -31,8 +30,9 @@ Create these files in your project folder:
 **demo.py**
 ```python
 from tiferet import App
-
-app = App()                     # loads configs from app/configs/ by default
+app = App().load_app_service(
+    app_yaml_file="config.yml"
+)                               # App is the AppBuilder alias
 
 result = app.run(
     interface_id="basic_calc",
@@ -42,30 +42,24 @@ result = app.run(
 
 print(f"19 + 23 = {result}")    # → 42
 ```
-
-**app/configs/app.yml**
+**config.yml**
 ```yaml
 interfaces:
   basic_calc:
     name: Basic Calculator
-```
+    description: Basic calculator interface
 
-**app/configs/feature.yml**
-```yaml
+services:
+  add_number_event:
+    module_path: app.events.calc
+    class_name: AddNumber
+
 features:
   calc:
     add:
       name: Add Numbers
       commands:
         - service_id: add_number_event
-```
-
-**app/configs/di.yml**
-```yaml
-services:
-  add_number_event:
-    module_path: app.events.calc
-    class_name: AddNumber
 ```
 
 **app/events/calc.py**  
@@ -106,11 +100,12 @@ You should see:
 
 **Core architecture**  
 - [Code Style & Artifact Comments](docs/core/code_style.md)  
+- [Builders (AppBuilder)](docs/core/builders.md)  
 - [Domain Objects](docs/core/domain.md)  
 - [Domain Events](docs/core/events.md)  
 - [Aggregates & Transfer Objects (Mappers)](docs/core/mappers.md)  
 - [Service Interfaces](docs/core/interfaces.md)  
-- [Contexts](docs/core/contexts.md)  
+- [Dependency Injection (ServiceProvider)](docs/core/di.md)  
 - [Repositories](docs/core/repos.md)  
 - [Utilities (File/Yaml/Json/Csv/Sqlite)](docs/core/utils.md)
 

--- a/docs/core/builders.md
+++ b/docs/core/builders.md
@@ -1,0 +1,137 @@
+# Builders in Tiferet
+
+Builders are a core component of the Tiferet framework in v2.0+. They serve as the primary public entry point for applications, providing a clean, high-level API for loading services, preparing defaults, resolving interfaces, and executing features.
+
+While contexts define the runtime shape and behavior of an individual interface, builders orchestrate the overall application lifecycle and wiring. They replace previous direct usage of lower-level contexts for application initialization.
+
+## What is a Builder?
+
+A builder in Tiferet is a class that encapsulates the initialization and orchestration logic required to prepare and run an application interface. Builders are intentionally thin: they focus on service loading, default configuration injection, dependency wiring, and delegation to the appropriate `AppInterfaceContext`.
+
+The canonical implementation is `AppBuilder` in `tiferet/builders/main.py`.
+
+### Role in the Architecture
+
+Builders sit at the highest level of the application graph:
+
+- They load the application service (typically a repository)
+- They prepare default services and constants from `assets.constants`
+- They resolve interfaces via domain events (`GetAppInterface`)
+- They wire the dependency injection container
+- They delegate feature execution to the resolved `AppInterfaceContext`
+
+This design keeps application code simple while maintaining full extensibility and testability.
+
+## Types of Builders
+
+Tiferet currently defines one primary builder:
+
+- **High-level builder**: `AppBuilder` — used for general script, CLI, and custom interfaces.
+
+Future specialized builders may include:
+
+- `CliBuilder` — optimized for pure CLI applications with argument parsing
+- `WebBuilder` — for web framework integration (Flask, FastAPI, etc.)
+- `TestBuilder` — for integration and unit testing with mocked services
+
+## Structured Code Design of Builders
+
+Builders follow Tiferet’s standard artifact comment structure.
+
+### Artifact Comments
+
+Builders are organized under the `# *** builders` top-level comment, with individual builders under `# ** builder: <snake_case_name>`. Within each builder:
+
+- `# * attribute: <name>` — instance attributes (with type hints)
+- `# * init` — constructor
+- `# * method: <name>` — methods (including static factory methods)
+
+**Spacing rules:**
+
+- One empty line between `# *** builders` and first `# ** builder`
+- One empty line between each `# *` section
+- One empty line after docstrings and between code snippets
+
+## Writing Builders
+
+### Creating a New Builder
+
+1. Place the class under `# *** builders` in an appropriate module (for example, `tiferet/builders/main.py`).
+2. Use `# ** builder: <snake_case_name>`.
+3. Implement the standard lifecycle:
+   - `__init__`
+   - `create_service_provider` (static factory)
+   - `load_app_service`
+   - `load_default_services`
+   - `load_app_instance`
+   - `load_interface`
+   - `run` (high-level entry point)
+
+### Key Patterns
+
+**Method chaining**  
+`load_app_service()` returns `self` to support fluent usage:
+
+```python
+builder = AppBuilder().load_app_service(...)
+```
+
+**Default configuration injection**  
+Builders automatically inject `DEFAULT_SERVICES` and `DEFAULT_CONSTANTS` via `GetAppInterface`:
+
+```python
+app_interface = DomainEvent.handle(
+    GetAppInterface,
+    ...,
+    default_services=default_services,
+    default_constants=a.const.DEFAULT_CONSTANTS,
+)
+```
+
+**Service provider registration**  
+The builder’s static factory is registered so contexts can create scoped providers:
+
+```python
+dependencies['create_service_provider'] = self.create_service_provider
+```
+
+**Defensive service lookup**  
+Always check the cache before using the app service:
+
+```python
+app_service = self.cache.get(APP_SERVICE_KEY)
+if not app_service:
+    RaiseError.execute(...)
+```
+
+## Testing Builders
+
+Builder tests use `pytest` with `unittest.mock`. Focus on:
+
+- Proper initialization of cache and service provider
+- Correct loading of the app service
+- Delegation to `GetAppInterface` with defaults injected
+- Validation of the resolved `AppInterfaceContext`
+- High-level `run()` behavior
+
+## Best Practices
+
+- Keep builders **thin** — they should orchestrate, not implement domain logic.
+- Always validate the resolved context type in `load_interface`.
+- Use `RaiseError.execute()` for all error paths with proper constants.
+- Support method chaining where it improves developer experience.
+- Register `create_service_provider` so contexts remain decoupled from the builder.
+
+## Conclusion
+
+Builders provide a clean, high-level API for initializing and running Tiferet applications. They encapsulate service loading, default configuration, and interface resolution while delegating execution to `AppInterfaceContext`. Their structured design ensures consistency, forward-compatibility, and extensibility.
+
+Explore source in `tiferet/builders/` and tests in `tiferet/builders/tests/` for implementation details.
+
+## Related Documentation
+
+- [docs/guides/builders.md](../guides/builders.md) — builder strategies and patterns
+- [docs/core/di.md](../core/di.md) — dependency injection and service provider design
+- [docs/core/events.md](../core/events.md) — domain event design and usage
+- [docs/guides/domain/app.md](../guides/domain/app.md) — application interface and service configuration guide
+- [docs/core/code_style.md](../core/code_style.md) — artifact comments and formatting

--- a/docs/guides/builders.md
+++ b/docs/guides/builders.md
@@ -1,0 +1,183 @@
+# Builders – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/builders/`  
+**Version:** 2.0.0a9
+
+## Overview
+
+Builders are the top-level orchestration layer in Tiferet v2.0+. They serve as the primary public entry point for applications, replacing direct usage of `AppManagerContext`.
+
+A builder is responsible for:
+
+- Loading the application service (repository)
+- Preparing default services and constants
+- Resolving interfaces via domain events
+- Wiring dependency injection
+- Executing features through the resolved interface context
+
+The canonical example is `AppBuilder` in `tiferet/builders/main.py`.
+
+## Role of Builders in the Architecture
+
+Builders sit at the highest level of the runtime graph. They are what application code interacts with directly:
+
+```python
+from tiferet import App
+
+builder = App()
+builder.load_app_service(...)          # optional custom service
+result = builder.run("basic_calc", "calc.add", data={"a": 5, "b": 3})
+```
+
+Key responsibilities:
+
+- **Initialization** — cache and service provider setup
+- **Service loading** — dynamic import of the app service (usually a repository)
+- **Default configuration** — injecting `DEFAULT_SERVICES` and `DEFAULT_CONSTANTS`
+- **Interface resolution** — calling `GetAppInterface` and validating the result
+- **Execution** — delegating to `AppInterfaceContext.run()`
+
+Builders are intentionally **thin** — they coordinate rather than implement business logic.
+
+## The AppBuilder Pattern
+
+`AppBuilder` follows a clear, reusable pattern:
+
+### 1. Initialization
+
+```python
+def __init__(self):
+    self.cache = {}
+    self.service_provider = self.create_service_provider()
+```
+
+### 2. Service Provider Factory
+
+A static factory allows downstream contexts to create providers consistently:
+
+```python
+@staticmethod
+def create_service_provider(
+    provider_type: type = DependenciesServiceProvider,
+    type_map: Dict[str, type] = None,
+    **constants
+) -> ServiceProvider:
+    ...
+```
+
+This is registered in the DI container so contexts can create scoped providers.
+
+### 3. Loading the App Service
+
+```python
+def load_app_service(self, module_path=..., class_name=..., **parameters) -> 'AppBuilder':
+    ...
+    self.cache[APP_SERVICE_KEY] = app_service
+    return self   # supports chaining
+```
+
+### 4. Loading Default Services and Constants
+
+```python
+def load_default_services(self) -> List[AppServiceDependency]:
+    return [
+        DomainObject.new(AppServiceDependency, **data, validate=False)
+        for data in a.const.DEFAULT_SERVICES
+    ]
+```
+
+Constants are passed via `default_constants=a.const.DEFAULT_CONSTANTS` to `GetAppInterface`.
+
+### 5. Interface Resolution Flow
+
+```python
+def load_interface(self, interface_id: str) -> AppInterfaceContext:
+    app_service = self.cache[APP_SERVICE_KEY]
+    default_services = self.load_default_services()
+
+    app_interface = DomainEvent.handle(
+        GetAppInterface,
+        dependencies={'app_service': app_service},
+        interface_id=interface_id,
+        default_services=default_services,
+        default_constants=a.const.DEFAULT_CONSTANTS,
+    )
+
+    return self.load_app_instance(app_interface)
+```
+
+### 6. High-level Run Method
+
+```python
+def run(self, interface_id: str, feature_id: str, headers=None, data=None, **kwargs):
+    context = self.load_interface(interface_id)
+    return context.run(feature_id, headers or {}, data or {}, **kwargs)
+```
+
+## When to Create a New Builder
+
+Create a new builder when you need a specialized entry point:
+
+- `CliBuilder` — for CLI-only applications with argument parsing
+- `WebBuilder` — for Flask/FastAPI integration
+- `TestBuilder` — for integration testing with mocked services
+
+If you find yourself repeating the same loading and wiring logic in multiple scripts, extract it into a dedicated builder.
+
+## Builder vs Context
+
+| Concern | Builder | Context |
+| --- | --- | --- |
+| Public API | Yes (`App().run(...)`) | Internal (used by builder) |
+| Service loading | Yes | No |
+| Default config injection | Yes | No |
+| Feature execution | Delegates to interface context | Yes (`execute_feature`, `run`) |
+| Lifecycle | Application-level | Per-interface |
+
+Builders are **application-level**; contexts are **interface-level**.
+
+## Best Practices
+
+### 1. Method Chaining
+
+`load_app_service()` returns `self` to support fluent usage:
+
+```python
+builder = App().load_app_service(...)
+```
+
+### 2. Defensive Service Lookup
+
+Always check the cache before using `app_service`:
+
+```python
+app_service = self.cache.get(APP_SERVICE_KEY)
+if not app_service:
+    RaiseError.execute(...)
+```
+
+### 3. Consistent Error Handling
+
+Use framework constants and `RaiseError.execute()` for all failure paths.
+
+### 4. Keep Builders Thin
+
+Builders should **not** contain domain logic — only orchestration, wiring, and delegation.
+
+### 5. Register `create_service_provider`
+
+Always register the builder’s static factory so contexts can create scoped providers:
+
+```python
+dependencies['create_service_provider'] = self.create_service_provider
+```
+
+## Related Documentation
+
+- [docs/core/builders.md](../core/builders.md) — detailed `AppBuilder` implementation reference
+- [docs/guides/domain/app.md](../guides/domain/app.md) — application-level configuration and runtime orchestration
+- [docs/guides/events/app.md](../guides/events/app.md) — app event usage in interface resolution
+- [docs/core/di.md](../core/di.md) — dependency injection and service provider architecture
+- [docs/core/code_style.md](../core/code_style.md) — artifact comments and formatting

--- a/docs/tutorial/basic_calculator/01-setup-and-entry-points.md
+++ b/docs/tutorial/basic_calculator/01-setup-and-entry-points.md
@@ -28,8 +28,8 @@ Create an empty folder called `basic-calculator` (or whatever name you like) and
 basic-calculator/
 ├── basic_calc.py               # ← our simple test runner
 ├── calc_cli.py                 # ← the cool CLI version
+├── config.yml                  # ← all app configuration lives here
 └── app/
-    ├── configs/                # ← all YAML files live here later
     ├── events/                 # ← domain events go here
     │   ├── __init__.py
     │   └── calc.py
@@ -37,8 +37,9 @@ basic-calculator/
         ├── __init__.py
         └── calc.py
 ```
+In Tiferet v2.0, configuration is consolidated into a single root `config.yml` file, which replaces the older split `app/configs/*.yml` layout.
 
-Don't worry about filling them yet — we'll get there step by step.
+Don't worry about filling everything yet — we'll get there step by step.
 
 ### 1.3 The two main entry points (what you'll run)
 
@@ -49,7 +50,7 @@ These are the files people will actually use. Let's look at them now so you know
 ```python
 from tiferet import App, TiferetError
 
-app = App()  # loads everything from app/configs/
+app = App().load_app_service(app_yaml_file="config.yml")
 
 # Some fun test cases
 tests = [
@@ -96,8 +97,8 @@ Error: Invalid number: 'hello'
 ```python
 from tiferet import App
 
-app = App()
-cli = app.load_interface("calc_cli")   # connects to cli.yml config
+app = App().load_app_service(app_yaml_file="config.yml")
+cli = app.load_interface("calc_cli")   # reads the CLI settings from root config.yml
 
 if __name__ == "__main__":
     cli.run()
@@ -116,7 +117,7 @@ python calc_cli.py calc divide 10 0
 # → Error: Cannot divide by zero
 ```
 
-Pretty neat, right? These two files are the "front door" — everything else we build (events, utils, configs) is just to make these work beautifully.
+Pretty neat, right? These two files are the "front door" — everything else we build (events, utils, and config.yml) is just to make these work beautifully.
 
 No pressure — we're just looking ahead.  
 In the next step we'll start writing the actual math operations.

--- a/docs/tutorial/basic_calculator/04-configurations.md
+++ b/docs/tutorial/basic_calculator/04-configurations.md
@@ -1,32 +1,20 @@
 # Step 4: Configurations
 
 We've got the math events and a nice validation utility — now it's time to make everything come alive through configuration.  
-In Tiferet, YAML files are the "wiring diagram": they tell the framework what events exist, how features map to them, and what errors look like.
+In Tiferet v2.0, everything is consolidated into a single root `config.yml` file. This one file defines interfaces, dependency mappings, features, and errors.
 
-We'll go through each file one by one, explaining what it does and why each piece matters.
+### 4.1 config.yml – The complete wiring diagram
 
-### 4.1 app/configs/app.yml – Application interfaces
+Create `config.yml` in your project root (next to `basic_calc.py` and `calc_cli.py`).
 
-This file defines the "entry points" or interfaces your app exposes. For now we'll just set up the basic script interface — we'll add the CLI interface in Step 6.
-
-**app/configs/app.yml**
+**config.yml**
 
 ```yaml
 interfaces:
   basic_calc:
     name: Basic Calculator
     description: Simple arithmetic operations via script or direct call
-```
 
-- `basic_calc`: our simple script interface (uses default Tiferet behavior — no custom context needed)
-
-### 4.2 app/configs/container.yml – Dependency injection
-
-This maps event names to actual Python classes so Tiferet can instantiate them when needed.
-
-**app/configs/container.yml**
-
-```yaml
 attrs:
   add_event:
     module_path: app.events.calc
@@ -43,17 +31,7 @@ attrs:
   exp_event:
     module_path: app.events.calc
     class_name: Exponentiate
-```
 
-These are the "service names" our features will reference later.
-
-### 4.3 app/configs/feature.yml – Workflow orchestration
-
-This defines the actual calculator features and which event(s) they run.
-
-**app/configs/feature.yml**
-
-```yaml
 features:
   calc:
     add:
@@ -93,19 +71,7 @@ features:
         - attribute_id: exp_event
           params:
             b: 0.5    # fixed exponent for square root (a^(1/2))
-```
 
-- Each sub-key under `calc` is a feature ID (e.g., `calc.add`)
-- `commands` lists the events to run (we only need one per feature here)
-- `attribute_id` matches the names we defined in `container.yml`
-
-### 4.4 app/configs/error.yml – Structured error messages
-
-This defines user-friendly, multilingual error messages.
-
-**app/configs/error.yml**
-
-```yaml
 errors:
   INVALID_INPUT:
     name: Invalid Input
@@ -120,21 +86,25 @@ errors:
         text: "Cannot divide by zero"
 ```
 
-- Keys match the `error_code` strings we use in `RaiseError.execute(...)` and `CalcUtil`
-- Supports multiple languages (we'll stick to `en_US` for now)
-- `{value}` is a placeholder filled from the keyword arguments passed to `RaiseError`
+### 4.2 How to read this file
 
-### 4.5 Quick recap
+- `interfaces` defines the app entry points (`basic_calc` now, `calc_cli` in Step 6)
+- `attrs` maps friendly names to domain event classes
+- `features` defines workflows (for example, `calc.add` → `add_event`)
+- `errors` defines structured response messages
 
-- `app.yml`: defines interfaces (script for now, CLI in Step 6)
-- `container.yml`: maps Python classes to injectable names
-- `feature.yml`: defines workflows (feature → event)
-- `error.yml`: provides nice error messages
+This gives Tiferet everything it needs to execute features and format errors from one configuration source.
 
-All these files work together so Tiferet knows:  
-"When someone runs `calc.add`, instantiate `AddNumber` from `app.events.calc`, run it, and format any errors nicely."
+### 4.3 Quick recap
 
-No code changes needed here — just YAML.
+All configuration now lives in root `config.yml`:
+
+- Interface definition
+- Domain event dependency mapping
+- Feature workflow wiring
+- Error message definitions
+
+No code changes needed here — just YAML in one place.
 
 → Ready to see it all run?  
 Head to **[Step 5: Running the Script Runner](05-running-the-script.md)**

--- a/docs/tutorial/basic_calculator/06-cli-interface.md
+++ b/docs/tutorial/basic_calculator/06-cli-interface.md
@@ -3,11 +3,11 @@
 We've got a working calculator through the script runner — now let's make it feel like a real tool people can use from the terminal.  
 Enter the command-line interface (CLI): fast, scriptable, and perfect for quick calculations.
 
-### 6.1 Add the CLI config file
+### 6.1 Add the CLI config section
 
-Create this file to tell Tiferet how to parse commands like `calc add 19 23`.
+In Tiferet v2.0, CLI definitions live in root `config.yml`. Add this section to tell Tiferet how to parse commands like `calc add 19 23`.
 
-**app/configs/cli.yml**
+**config.yml** (add this section)
 
 ```yaml
 cli:
@@ -87,11 +87,11 @@ cli:
 Each command needs `group_key`, `key`, and `name` — Tiferet uses these to build the argument parser and map commands to features.  
 The `args` list defines the positional arguments that get passed as `data` to your events.
 
-### 6.2 Update app.yml to add the CLI interface
+### 6.2 Update config.yml to add the CLI interface
 
-Now we need to tell Tiferet about the CLI interface. Update `app/configs/app.yml` to add the `calc_cli` entry:
+Now we need to tell Tiferet about the CLI interface. In the same root `config.yml`, update the `interfaces` block to add `calc_cli`:
 
-**app/configs/app.yml** (updated)
+**config.yml** (interfaces section)
 
 ```yaml
 interfaces:
@@ -104,16 +104,10 @@ interfaces:
     description: Command-line interface for calculator operations
     module_path: tiferet.contexts.cli
     class_name: CliContext
-    attrs:
-      cli_service:
-        module_path: tiferet.repos.cli
-        class_name: CliYamlRepository
-        params:
-          cli_yaml_file: app/configs/cli.yml
 ```
 
-- `calc_cli` tells Tiferet to use the built-in `CliContext` for command-line handling
-- `cli_service` points to `CliYamlRepository`, which reads command definitions from `cli.yml`
+- `calc_cli` tells Tiferet to use the built-in `CliContext` for command-line handling.
+- CLI command definitions are read from the `cli` section in the same root `config.yml`.
 
 ### 6.3 The CLI entry point script
 
@@ -122,9 +116,9 @@ interfaces:
 ```python
 from tiferet import App
 
-app = App()  # loads all configs as usual
+app = App().load_app_service(app_yaml_file="config.yml")
 
-# Load the CLI interface we defined in app.yml
+# Load the CLI interface we defined in config.yml
 cli = app.load_interface("calc_cli")
 
 if __name__ == "__main__":
@@ -132,7 +126,7 @@ if __name__ == "__main__":
 ```
 
 That's it — super short!  
-`app.load_interface("calc_cli")` pulls in `CliContext` from `app.yml`, which reads `cli.yml` for command definitions.
+`app.load_interface("calc_cli")` pulls in `CliContext` from root `config.yml`, which also contains the CLI command definitions.
 
 ### 6.4 Run and play with it
 
@@ -184,7 +178,7 @@ Want to run it as just `calc add 19 23` instead of `python calc_cli.py ...`?
 - No extra code for argument parsing — YAML does it
 - Same events power both script and CLI
 - Errors are consistent and friendly across interfaces
-- Easy to extend: add more commands by editing `cli.yml` and `feature.yml`
+- Easy to extend: add more commands by editing `config.yml`
 
 You've now got a complete, dual-mode calculator: script for automation/testing, CLI for everyday use.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ where = ["."]
 include = [
     "tiferet",
     "tiferet.assets",
+    "tiferet.builders",
     "tiferet.contexts",
     "tiferet.di",
     "tiferet.interfaces",

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -50,4 +50,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a8'
+__version__ = '2.0.0a9'

--- a/tiferet/tests_int/test_main.py
+++ b/tiferet/tests_int/test_main.py
@@ -6,15 +6,14 @@ import pytest
 # ** app
 from .. import App, TiferetAPIError
 
+# *** fixtures
+
 # ** fixture: app_context
 @pytest.fixture
 def app_context():
-
-    return App(settings=dict(
-        app_repo_params=dict(
-            app_yaml_file='tiferet/assets/tests/test_calc.yml'
-        )
-    ))
+    return App().load_app_service(
+        app_yaml_file='tiferet/assets/tests/test_calc.yml',
+    )
 
 # ** fixture: basic_calc
 @pytest.fixture


### PR DESCRIPTION
## Summary
- migrate `tiferet/tests_int/test_main.py` to the AppBuilder flow (`App().load_app_service(...)`)
- add builder documentation files: `docs/core/builders.md` and `docs/guides/builders.md`
- update tutorial steps 01/04/06 to reference consolidated root `config.yml` and AppBuilder-style initialization
- refresh `README.md` and `AGENTS.md` for builders-first architecture and config consolidation
- bump package version to `2.0.0a9` and include `tiferet.builders` in packaging

## Validation
- `/Users/ashatz/Documents/GitHub/tiferet/.venv/bin/pytest /Users/ashatz/Documents/GitHub/tiferet/tiferet/tests_int/test_main.py`
- `/Users/ashatz/Documents/GitHub/tiferet/.venv/bin/pytest /Users/ashatz/Documents/GitHub/tiferet/tiferet`

## Artifacts
- Conversation: https://app.warp.dev/conversation/40ab9149-0a31-4cdd-b52e-65774767fb97
- Plan: https://app.warp.dev/drive/notebook/q9oAc5WHEYFvRBcEtNbOvY

Co-Authored-By: Oz <oz-agent@warp.dev>