### PR TITLE
Tests – Contexts: Update ModelObject Terminology to DomainObject in test_request.py

### DIFF
--- a/tiferet/contexts/tests/test_request.py
+++ b/tiferet/contexts/tests/test_request.py
@@ -85,16 +85,16 @@ def test_request_context_handle_response_data(request_context):
     # Check that the response is as expected.
     assert response == {'key': 'value'}
 
-# ** test: request_context_handle_response_model_object
-def test_request_context_handle_response_model_object(request_context):
+# ** test: request_context_handle_response_domain_object
+def test_request_context_handle_response_domain_object(request_context):
     """
-    Test handling a response that is a ModelObject in the RequestContext.
+    Test handling a response that is a DomainObject in the RequestContext.
 
     :param request_context: The RequestContext instance.
     :type request_context: RequestContext
     """
 
-    # Create a ModelObject to simulate a response.
+    # Create a DomainObject to simulate a response.
     class Data(DomainObject):
 
         key = StringType(
@@ -102,13 +102,13 @@ def test_request_context_handle_response_model_object(request_context):
             required=True
         )
 
-    # Set the request context result to a ModelObject.
+    # Set the request context result to a DomainObject.
     request_context.result = DomainObject.new(Data, key='value')
 
-    # Handle the response with a ModelObject.
+    # Handle the response with a DomainObject.
     response = request_context.handle_response()
 
-    # Check that the response is a ModelObject and has the expected data.
+    # Check that the response is a DomainObject and has the expected data.
     assert isinstance(response, DomainObject)
     assert response.key == 'value'
 
@@ -131,16 +131,16 @@ def test_request_context_handle_response_list(request_context):
     assert isinstance(response, list)
     assert response == ['item1', 'item2', 'item3']
 
-# ** test: request_context_handle_response_model_list
-def test_request_context_handle_response_model_list(request_context):
+# ** test: request_context_handle_response_domain_object_list
+def test_request_context_handle_response_domain_object_list(request_context):
     """
-    Test handling a response that is a list of ModelObjects in the RequestContext.
+    Test handling a response that is a list of DomainObjects in the RequestContext.
 
     :param request_context: The RequestContext instance.
     :type request_context: RequestContext
     """
 
-    # Create a ModelObject to simulate a response.
+    # Create a DomainObject to simulate a response.
     class Item(DomainObject):
 
         name = StringType(
@@ -148,16 +148,16 @@ def test_request_context_handle_response_model_list(request_context):
             required=True
         )
 
-    # Set the request context result to a list of ModelObjects.
+    # Set the request context result to a list of DomainObjects.
     request_context.result = [
         DomainObject.new(Item, name='item1'),
         DomainObject.new(Item, name='item2')
     ]
 
-    # Handle the response with a list of ModelObjects.
+    # Handle the response with a list of DomainObjects.
     response = request_context.handle_response()
 
-    # Check that the response is a list and contains ModelObjects with expected names.
+    # Check that the response is a list and contains DomainObjects with expected names.
     assert isinstance(response, list)
     assert len(response) == 2
     assert response[0].name == 'item1'


### PR DESCRIPTION
## Summary

Updates outdated `ModelObject` terminology to `DomainObject` in `tiferet/contexts/tests/test_request.py`, aligning the module with the v2.0 naming conventions (`ModelObject` → `DomainObject`, `tiferet/entities/` → `tiferet/domain/`). No production source or behavior is changed.

Closes #730.

## Changes

- Renamed `test_request_context_handle_response_model_object` → `test_request_context_handle_response_domain_object` (and `# ** test:` artifact comment).
- Renamed `test_request_context_handle_response_model_list` → `test_request_context_handle_response_domain_object_list` (and `# ** test:` artifact comment).
- Updated docstrings and inline comments in both tests to reference `DomainObject`/`DomainObjects` in place of `ModelObject`/`ModelObjects`.
- Verified no `ModelObject` references remain in the file.

## Verification

- `pytest tiferet/contexts/tests/test_request.py -v` — all 8 tests pass.

## Acceptance Criteria

1. ✅ All 8 tests in `tiferet/contexts/tests/test_request.py` pass.
2. ✅ No references to `ModelObject` remain in `tiferet/contexts/tests/test_request.py`.
3. ✅ Test function names and artifact comments use `domain_object` in place of `model_object`/`model_list`.
4. ✅ Changes committed to the feature branch and pushed to the remote.

---

[Warp conversation](https://app.warp.dev/conversation/cbc84bfd-106a-4196-827f-d7a813b8120f)

Co-Authored-By: Oz <oz-agent@warp.dev>