### PR TITLE
Docs/Utils Guides – Update branch references and version metadata (#735)

### DIFF
--- a/docs/guides/utils/csv.md
+++ b/docs/guides/utils/csv.md
@@ -276,9 +276,9 @@ def test_import_csv_records_file_not_found(tmp_path):
 
 ## Related Documentation
 
-- [docs/guides/utils/file.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/guides/utils/file.md) — FileLoader guide (parent class)
-- [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/guides/utils/yaml.md) — YamlLoader guide (sibling utility)
-- [docs/guides/utils/json.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/guides/utils/json.md) — JsonLoader guide (sibling utility)
-- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/core/code_style.md) — Artifact comment & formatting rules
-- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/core/events.md) — Domain event patterns & testing
+- [docs/guides/utils/file.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/file.md) — FileLoader guide (parent class)
+- [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/yaml.md) — YamlLoader guide (sibling utility)
+- [docs/guides/utils/json.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/json.md) — JsonLoader guide (sibling utility)
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
 ```

--- a/docs/guides/utils/file.md
+++ b/docs/guides/utils/file.md
@@ -7,7 +7,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Date:** March 01, 2026  
-**Version:** 2.0.0a0 (v2.0-proto)
+**Version:** 2.0.0a0
 
 ## Overview
 

--- a/docs/guides/utils/json.md
+++ b/docs/guides/utils/json.md
@@ -225,8 +225,8 @@ def test_load_json_config_file_not_found(tmp_path):
 
 ## Related Documentation
 
-- [docs/guides/utils/file.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/guides/utils/file.md) — FileLoader guide (parent class)
-- [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/guides/utils/yaml.md) — YamlLoader guide (sibling utility)
-- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/core/code_style.md) — Artifact comment & formatting rules
-- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/core/events.md) — Domain event patterns & testing
+- [docs/guides/utils/file.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/file.md) — FileLoader guide (parent class)
+- [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/yaml.md) — YamlLoader guide (sibling utility)
+- [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
 ```


### PR DESCRIPTION
## Summary

Implements [#735](https://github.com/greatstrength/tiferet/issues/735) — targeted documentation housekeeping on three guide files in `docs/guides/utils/` for the v2.0.0a10 release.

## Changes

- **`docs/guides/utils/csv.md`** — Replaced every `v2.0a1-release` URL in the Related Documentation section with `main` (links to `file.md`, `yaml.md`, `json.md`, `code_style.md`, `events.md`).
- **`docs/guides/utils/json.md`** — Replaced every `v2.0a1-release` URL in the Related Documentation section with `main` (links to `file.md`, `yaml.md`, `code_style.md`, `events.md`).
- **`docs/guides/utils/file.md`** — Updated version metadata line from `**Version:** 2.0.0a0 (v2.0-proto)` to `**Version:** 2.0.0a0`.

No other content (overview, examples, methods, errors, etc.) is altered.

## Acceptance Criteria

- [x] `docs/guides/utils/csv.md` contains no remaining occurrences of `v2.0a1-release`.
- [x] `docs/guides/utils/json.md` contains no remaining occurrences of `v2.0a1-release`.
- [x] `docs/guides/utils/file.md` version metadata reads exactly `**Version:** 2.0.0a0`.
- [x] `grep -R "v2.0a1-release" docs/guides/utils/` returns no matches.
- [x] No other content in the three files is altered.
- [x] Feature branch follows naming convention; PR targets `v2.0a10-release`.

## Notes

Backward-compatible documentation-only change — no impact on framework runtime, public API, or tests.

Conversation: https://app.warp.dev/conversation/92df80e9-8d15-40f6-bdad-cb455fe356f7

Co-Authored-By: Oz <oz-agent@warp.dev>