### PR TITLE
Docs/Tutorial – Sync pages 04 and 06 from v2.0-proto (#736)

### DIFF
--- a/docs/tutorial/basic_calculator/04-configurations.md
+++ b/docs/tutorial/basic_calculator/04-configurations.md
@@ -10,11 +10,14 @@ Create `config.yml` in your project root (next to `basic_calc.py` and `calc_cli.
 **config.yml**
 
 ```yaml
+# Application interfaces
 interfaces:
   basic_calc:
     name: Basic Calculator
     description: Simple arithmetic operations via script or direct call
 
+# Dependency injection mappings
+# These map friendly names (used in features) to actual Python classes
 attrs:
   add_event:
     module_path: app.events.calc
@@ -30,48 +33,50 @@ attrs:
     class_name: DivideNumber
   exp_event:
     module_path: app.events.calc
-    class_name: Exponentiate
+    class_name: ExponentiateNumber
 
+# Feature workflows
 features:
   calc:
     add:
       name: Addition
       description: Add two numbers
-      commands:
+      steps:
         - attribute_id: add_event
 
     subtract:
       name: Subtraction
       description: Subtract second number from first
-      commands:
+      steps:
         - attribute_id: subtract_event
 
     multiply:
       name: Multiplication
       description: Multiply two numbers
-      commands:
+      steps:
         - attribute_id: multiply_event
 
     divide:
       name: Division
       description: Divide first number by second
-      commands:
+      steps:
         - attribute_id: divide_event
 
     exp:
       name: Exponentiation
       description: Raise first number to the power of second
-      commands:
+      steps:
         - attribute_id: exp_event
 
     sqrt:
       name: Square Root
       description: Calculates the square root of a number
-      commands:
+      steps:
         - attribute_id: exp_event
           params:
             b: 0.5    # fixed exponent for square root (a^(1/2))
 
+# Structured error messages
 errors:
   INVALID_INPUT:
     name: Invalid Input
@@ -86,25 +91,25 @@ errors:
         text: "Cannot divide by zero"
 ```
 
-### 4.2 How to read this file
+### 4.2 Why a single config.yml?
 
-- `interfaces` defines the app entry points (`basic_calc` now, `calc_cli` in Step 6)
-- `attrs` maps friendly names to domain event classes
-- `features` defines workflows (for example, `calc.add` → `add_event`)
-- `errors` defines structured response messages
-
-This gives Tiferet everything it needs to execute features and format errors from one configuration source.
+- **Simpler structure** — No more hunting through multiple files.
+- **Easier to manage** — Everything related to how the app behaves is in one place.
+- **Still fully flexible** — You can define multiple interfaces, complex features, and rich error handling.
+- Tiferet automatically loads `config.yml` from the project root when you create `App()`.
 
 ### 4.3 Quick recap
 
-All configuration now lives in root `config.yml`:
+In this single `config.yml` file we defined:
 
-- Interface definition
-- Domain event dependency mapping
-- Feature workflow wiring
-- Error message definitions
+- **Interfaces** (`basic_calc`) — the entry point for our script runner
+- **Dependency mappings** (`attrs`) — links friendly names like `add_event` to the actual Python classes in `app/events/calc.py`
+- **Features** (`calc.add`, `calc.sqrt`, etc.) — defines the workflows and which event to run for each operation
+- **Errors** — user-friendly, structured error messages with support for multiple languages
 
-No code changes needed here — just YAML in one place.
+When you run `app = App()`, Tiferet reads this `config.yml` and wires everything together automatically.
+
+No code changes needed here — just this one YAML file.
 
 → Ready to see it all run?  
 Head to **[Step 5: Running the Script Runner](05-running-the-script.md)**

--- a/docs/tutorial/basic_calculator/06-cli-interface.md
+++ b/docs/tutorial/basic_calculator/06-cli-interface.md
@@ -10,6 +10,9 @@ In Tiferet v2.0, CLI definitions live in root `config.yml`. Add this section to 
 **config.yml** (add this section)
 
 ```yaml
+# ... (previous interfaces, attrs, features, and errors sections remain above)
+
+# CLI command definitions
 cli:
   cmds:
     calc:


### PR DESCRIPTION
## Summary

Implements [#736](https://github.com/greatstrength/tiferet/issues/736) — verbatim sync of two Basic Calculator tutorial pages from the authoritative `v2.0-proto` branch into `v2.0a10-release`.

## Changes

- **`docs/tutorial/basic_calculator/04-configurations.md`** — Replaced with the `v2.0-proto` version. Brings the consolidated `config.yml` narrative (single-file `interfaces` / `services` / `features` / `errors` / `cli` layout), the `commands` → `steps` feature-step terminology, and the `ExponentiateNumber` event-class rename onto the release branch.
- **`docs/tutorial/basic_calculator/06-cli-interface.md`** — Replaced with the `v2.0-proto` version, applying the same terminology and structural updates.

No manual edits were applied after the copy. Both files are byte-identical to their `v2.0-proto` counterparts.

## Procedure

```bash
git checkout v2.0-proto -- \
    docs/tutorial/basic_calculator/04-configurations.md \
    docs/tutorial/basic_calculator/06-cli-interface.md

git diff v2.0-proto -- \
    docs/tutorial/basic_calculator/04-configurations.md \
    docs/tutorial/basic_calculator/06-cli-interface.md
# (no output)
```

## Acceptance Criteria

- [x] `04-configurations.md` is byte-identical to its `v2.0-proto` counterpart.
- [x] `06-cli-interface.md` is byte-identical to its `v2.0-proto` counterpart.
- [x] `git diff v2.0-proto -- <both files>` produces no output.
- [x] No other files modified.
- [x] Feature branch follows naming convention; PR targets `v2.0a10-release`.

## Notes

Documentation-only change — no runtime, API, or test impact.

Conversation: https://app.warp.dev/conversation/92df80e9-8d15-40f6-bdad-cb455fe356f7

Co-Authored-By: Oz <oz-agent@warp.dev>