### PR TITLE
Contexts – App & Feature: Add kwargs to AppInterfaceContext Methods and Correct DomainEvent Type Annotation (#737)

### DIFF
--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -54,7 +54,7 @@ class AppInterfaceContext(object):
         self.logging = logging
 
     # * method: parse_request
-    def parse_request(self, headers: Dict[str, str] = {}, data: Dict[str, Any] = {}, feature_id: str = None) -> RequestContext:
+    def parse_request(self, headers: Dict[str, str] = {}, data: Dict[str, Any] = {}, feature_id: str = None, **kwargs) -> RequestContext:
         '''
         Parse the incoming request.
 
@@ -64,6 +64,8 @@ class AppInterfaceContext(object):
         :type data: dict
         :param feature_id: The feature identifier if provided.
         :type feature_id: str
+        :kwargs: Additional keyword arguments.
+        :type kwargs: dict
         :return: The parsed request as a request context.
         :rtype: RequestContext
         '''
@@ -86,7 +88,7 @@ class AppInterfaceContext(object):
     # * method: execute_feature
     def execute_feature(self, feature_id: str, request: RequestContext, **kwargs):
         '''
-        Execute the feature context.
+        Execute the feature request.
 
         :param feature_id: The feature identifier.
         :type feature_id: str
@@ -105,12 +107,14 @@ class AppInterfaceContext(object):
         self.features.execute_feature(feature_id, request, **kwargs)
 
     # * method: handle_error
-    def handle_error(self, error: Exception) -> Any:
+    def handle_error(self, error: Exception, **kwargs) -> Any:
         '''
         Handle the error by formatting it via ErrorContext and raising TiferetAPIError.
 
         :param error: The error to handle.
         :type error: Exception
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
         :return: The error response.
         :rtype: Any
         '''
@@ -130,12 +134,14 @@ class AppInterfaceContext(object):
         raise TiferetAPIError(**formatted_error)
 
     # * method: handle_response
-    def handle_response(self, request: RequestContext) -> Any:
+    def handle_response(self, request: RequestContext, **kwargs) -> Any:
         '''
         Handle the response from the request.
 
         :param request: The request context.
         :type request: RequestContext
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
         :return: The response.
         :rtype: Any
         '''
@@ -184,7 +190,7 @@ class AppInterfaceContext(object):
         # Handle error and return response if triggered.
         except TiferetError as e:
             logger.error(f'Error executing feature {feature_id}: {str(e)}')
-            return self.handle_error(e)
+            return self.handle_error(e, **kwargs)
 
         # Calculate execution duration in milliseconds.
         duration_ms = round((time.perf_counter() - start_time) * 1000)

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -124,7 +124,7 @@ class FeatureContext(object):
         Handle the execution of a command with the provided request and command-handling options.
         
         :param command: The command to execute.
-        :type command: Command
+        :type command: DomainEvent
         :param request: The request context object.
         :type request: RequestContext
         :param debug: Debug flag.


### PR DESCRIPTION
Closes #737.

## Summary

Minor cleanup on two context modules to align the `v2.0a10-release` state with the authoritative `v2.0-proto` state.

### `tiferet/contexts/app.py` — `AppInterfaceContext`
- Added `**kwargs` to `parse_request`, `handle_error`, and `handle_response` for forward-compatible request-flow passthrough.
- Propagated `**kwargs` from the `run()` `try`/`except` branch into the `handle_error(e, **kwargs)` call.
- Reworded the `execute_feature` docstring summary from `Execute the feature context.` to `Execute the feature request.`.
- Documented the new `**kwargs` parameter in the updated docstrings.

### `tiferet/contexts/feature.py` — `FeatureContext`
- Corrected the `handle_command` docstring `:type command:` annotation from `Command` to `DomainEvent`.

## Acceptance Criteria
1. ✅ `parse_request`, `handle_error`, and `handle_response` accept `**kwargs` and document the parameter.
2. ✅ `execute_feature` docstring summary reads `Execute the feature request.`.
3. ✅ The `except` branch calls `self.handle_error(e, **kwargs)`.
4. ✅ `handle_command` docstring documents `:type command: DomainEvent`.
5. ✅ `git diff v2.0-proto -- tiferet/contexts/app.py tiferet/contexts/feature.py` shows no remaining content drift in the affected methods.
6. ✅ Full test suite passes: `704 passed, 11 skipped` via `pytest tiferet/`.
7. ✅ Feature branch follows the project naming convention; PR targets `v2.0a10-release`.

## Non-Functional
- Backward-compatible: existing callers that do not pass extra keyword arguments remain unaffected.
- Adheres to Tiferet's structured code style (artifact comments, spacing, RST docstring formatting).
- No new dependencies, imports, or modules introduced.

---

Conversation: https://app.warp.dev/conversation/dff5b4cf-321a-4dac-ac02-e26ef81d4fae

Co-Authored-By: Oz <oz-agent@warp.dev>