### PR TITLE
Contexts – DI: Remove Obsolete `get_configuration_type` and Sync ServiceConfiguration `get_service_type` Tests

### DIFF
--- a/tiferet/contexts/di.py
+++ b/tiferet/contexts/di.py
@@ -126,7 +126,7 @@ class DIContext(object):
         for config in configurations:
 
             # Get the dependency type based on the flags.
-            dep_type = self.get_configuration_type(config, *flags)
+            dep_type = config.get_service_type(*flags)
 
             # If no type is found, raise an error.
             if not dep_type:
@@ -168,25 +168,6 @@ class DIContext(object):
 
         # Return the resolved service from the provider.
         return provider.get_service(configuration_id)
-
-    # * method: get_configuration_type
-    def get_configuration_type(self, configuration: ServiceConfiguration, *flags) -> type:
-        '''
-        Resolve the implementation type for a service configuration.
-
-        Delegates to ServiceConfiguration.get_service_type() which checks
-        flagged dependencies first, then falls back to the default type.
-
-        :param configuration: The service configuration to resolve.
-        :type configuration: ServiceConfiguration
-        :param flags: The flags for the flagged dependency.
-        :type flags: Tuple[str, ...]
-        :return: The resolved type, or None.
-        :rtype: type
-        '''
-
-        # Delegate to the domain method for type resolution.
-        return configuration.get_service_type(*flags)
 
     # * method: load_constants
     def load_constants(self,

--- a/tiferet/contexts/tests/test_di.py
+++ b/tiferet/contexts/tests/test_di.py
@@ -324,55 +324,6 @@ def test_di_context_get_dependency(di_context: DIContext):
     assert service.flagged_config is None
 
 
-# ** test: di_context_get_configuration_type_success_default
-def test_di_context_get_configuration_type_success_default(
-        di_context: DIContext,
-        di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]):
-    '''
-    Test that get_configuration_type resolves the correct type with and without flags.
-
-    :param di_context: The DI context to test.
-    :type di_context: DIContext
-    :param di_service_content: The content for the DI service.
-    :type di_service_content: Tuple[List[ServiceConfiguration], Dict[str, str]]
-    '''
-
-    # Unpack the service content.
-    configurations, _ = di_service_content
-    config = configurations[0]
-
-    # Resolve without flags — should return the default TestService.
-    dep_type = di_context.get_configuration_type(config)
-    assert dep_type is TestService
-
-    # Resolve with the test flag — should still return TestService (same class in fixture).
-    dep_type = di_context.get_configuration_type(config, 'test')
-    assert dep_type is TestService
-
-
-# ** test: di_context_get_configuration_type_none
-def test_di_context_get_configuration_type_none(di_context: DIContext):
-    '''
-    Test that get_configuration_type returns None when no type is found.
-
-    :param di_context: The DI context to test.
-    :type di_context: DIContext
-    '''
-
-    # Create a configuration with no default type and no matching dependencies.
-    config = DomainObject.new(
-        ServiceConfiguration,
-        id='no_type',
-        dependencies=[],
-    )
-
-    # Resolve without flags — should return None.
-    assert di_context.get_configuration_type(config) is None
-
-    # Resolve with an unknown flag — should return None.
-    assert di_context.get_configuration_type(config, 'missing_flag') is None
-
-
 # ** test: di_context_load_constants_with_flagged_dependencies
 def test_di_context_load_constants_with_flagged_dependencies(
         di_context: DIContext,


### PR DESCRIPTION
## Summary

Implements [#738](https://github.com/greatstrength/tiferet/issues/738). Performs targeted cleanup on the DI context and verifies parity of `ServiceConfiguration.get_service_type` test coverage with `v2.0-proto`.

## Changes

### `tiferet/contexts/di.py`
- Removed the obsolete `DIContext.get_configuration_type` method (a thin pass-through to `ServiceConfiguration.get_service_type`).
- Updated the single call site in `DIContext.build_service_provider` to invoke `config.get_service_type(*flags)` directly.

### `tiferet/contexts/tests/test_di.py`
- Removed the two obsolete context-level tests:
  - `test_di_context_get_configuration_type_success_default`
  - `test_di_context_get_configuration_type_none`

### `tiferet/domain/tests/test_di.py`
- Verified the four `ServiceConfiguration.get_service_type` tests (`_default`, `_flagged`, `_no_match`, `_flag_priority`) are already present on the implementing branch and match the `v2.0-proto` versions verbatim. No additions required per the TRD's no-duplicates rule.

## Verification
- `grep -rn "get_configuration_type" tiferet/` → no matches.
- `pytest tiferet/contexts/tests/test_di.py tiferet/domain/tests/test_di.py` → 15 passed.
- `pytest tiferet/` → **702 passed, 11 skipped**.

## Acceptance Criteria
- [x] `tiferet/contexts/di.py` no longer contains `get_configuration_type` or any reference to it.
- [x] `DIContext.build_service_provider` calls `config.get_service_type(*flags)` directly.
- [x] Two obsolete context-level tests removed.
- [x] Domain-level `get_service_type` tests match `v2.0-proto` content; no duplicates.
- [x] `pytest tiferet/contexts/tests/test_di.py` and `pytest tiferet/domain/tests/test_di.py` pass.
- [x] Full test suite passes.
- [x] `grep -rn "get_configuration_type" tiferet/` returns no matches.
- [x] Feature branch follows naming convention; PR targets `v2.0a10-release`.

Closes #738.

---

Conversation: https://app.warp.dev/conversation/2d8df5fa-9a3d-4e64-a103-af3e81cc0d42

Co-Authored-By: Oz <oz-agent@warp.dev>