### PR TITLE
Release – Bump Version to 2.0.0a10 and Confirm DomainEvent / DomainObject Exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Tiferet Framework (v2.0.0a9)
+# AGENTS.md — Tiferet Framework (v2.0.0a10)
 
 ## Project Overview
 
@@ -7,7 +7,7 @@
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0a9`
+- **Version:** `2.0.0a10`
 
 ## Architecture
 
@@ -18,8 +18,8 @@ The v2.0 codebase is a clean, single-layer architecture. All legacy packages hav
 ```
 tiferet/
 ├── assets/               # Constants, exceptions (TiferetError), shared config
-├── builders/             # AppBuilder and top-level runtime orchestration
-├── contexts/             # Runtime orchestration (AppInterface, DIContext, Feature, Error, CLI, Logging)
+├── builders/             # AppBuilder, CliBuilder and top-level runtime orchestration
+├── contexts/             # Runtime orchestration (AppInterface, DIContext, Feature, Error, Logging)
 ├── di/                   # App-level DI: ServiceProvider, DependenciesServiceProvider
 ├── domain/               # DomainObject base class and domain modules
 ├── events/               # DomainEvent base class and domain event modules
@@ -58,6 +58,14 @@ tiferet/
   - Injecting default services and constants (`load_default_services`, `DEFAULT_CONSTANTS`)
   - Resolving interface contexts (`load_interface`)
   - Delegating feature execution (`run`)
+- `CliBuilder` is defined in `tiferet/builders/cli.py` and is exported as `CLI` from `tiferet/__init__.py`.
+- It extends `AppBuilder` to provide an argparse-based CLI build procedure on top of the inherited app-service / interface-loading machinery.
+- Build procedure:
+  - `get_commands()` resolves and groups `CliCommand` objects by `group_key` via the `list_commands_evt` service.
+  - `get_parent_arguments()` resolves parent-level CLI arguments via the `get_parent_args_evt` service.
+  - `build_parser(cli_commands, parent_arguments)` composes the root `argparse.ArgumentParser`, group/command subparsers, and command/parent arguments.
+  - `run(interface_id, argv=None)` loads the interface context, builds the parser, parses argv (exits 2 on parse errors), derives `feature_id` and `headers` from the parsed group/command, dispatches to `interface_context.run(...)` (exits 1 on `TiferetAPIError`), and prints the response.
+- CLI interfaces resolve to the default `AppInterfaceContext`; `CliContext` has been retired and `tiferet/contexts/cli.py` no longer exists.
 
 ### Dependency Injection
 
@@ -250,6 +258,7 @@ The top-level `tiferet/__init__.py` exports:
 
 **Core:**
 - `App` (alias for `AppBuilder`)
+- `CLI` (alias for `CliBuilder`)
 - `TiferetError`, `TiferetAPIError`
 
 **Domain:**
@@ -277,6 +286,7 @@ The top-level `tiferet/__init__.py` exports:
 - `tiferet/di/settings.py` — `ServiceProvider` ABC
 - `tiferet/di/dependencies.py` — `DependenciesServiceProvider` (app-level DI)
 - `tiferet/builders/main.py` — `AppBuilder` (public app orchestration entry point)
+- `tiferet/builders/cli.py` — `CliBuilder` (CLI orchestration entry point, exported as `CLI`)
 - `tiferet/contexts/app.py` — `AppInterfaceContext`
 - `tiferet/contexts/di.py` — `DIContext` (feature-level DI)
 - `tiferet/contexts/feature.py` — `FeatureContext` (feature execution engine)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inspired by the Kabbalistic principle of harmony and beauty in balance, Tiferet 
 - Clean layering: domain objects • aggregates • transfer objects • services  
 - Structured, multilingual errors built-in  
 - Easy to extend to CLI, web, scripts, TUI, …
-Current status: **2.0.0a9** (pre-release – actively evolving toward stable v2)
+Current status: **2.0.0a10** (pre-release – actively evolving toward stable v2)
 
 ## Quick Start – Add two numbers in ~3 minutes
 

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -51,4 +51,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0a9'
+__version__ = '2.0.0a10'


### PR DESCRIPTION
## Summary

Implements [#739](https://github.com/greatstrength/tiferet/issues/739) — bumps the framework version to `2.0.0a10` and confirms that the top-level public exports for `DomainEvent` (from `tiferet.events`) and `DomainObject` (from `tiferet.domain`) are present in `tiferet/__init__.py`. Supporting documentation (`README.md` and `AGENTS.md`) is updated to reflect the new version. While verifying `AGENTS.md` for the version bump, the doc was also brought up to date with the rest of the closed v2.0.0a10 milestone work (notably the `CliBuilder` / `CLI` promotion from #729).

## Changes

- **`tiferet/__init__.py`** — `__version__` bumped from `2.0.0a9` to `2.0.0a10`. `DomainObject` and `DomainEvent` re-exports verified.
- **`README.md`** — Current-status line updated to `2.0.0a10`.
- **`AGENTS.md`**:
  - Heading and `**Version:**` bullet updated to `v2.0.0a10` / `2.0.0a10`.
  - Layer Overview: `builders/` comment now lists both `AppBuilder` and `CliBuilder`; `contexts/` comment no longer lists `CLI` (since `CliContext` was retired in #729).
  - Builders section: added a full `CliBuilder` description (file location, `CLI` export, `get_commands` / `get_parent_arguments` / `build_parser` / `run` build procedure, exit-code conventions, default-`AppInterfaceContext` resolution).
  - Package Exports: added `CLI` (alias for `CliBuilder`) under Core.
  - Key Files for Orientation: added `tiferet/builders/cli.py — CliBuilder`.

## Verification

- `python -c "import tiferet; print(tiferet.__version__)"` → `2.0.0a10`.
- `from tiferet import DomainEvent, DomainObject` imports successfully.
- `grep -n "2\.0\.0a9" tiferet/__init__.py README.md AGENTS.md` returns no matches.
- `pytest tiferet/` → 702 passed, 11 skipped.

## Acceptance Criteria

All eight acceptance criteria from the TRD have been met:

1. ✅ `tiferet.__version__` reports `2.0.0a10`.
2. ✅ `from tiferet import DomainEvent, DomainObject` imports successfully.
3. ✅ No `2.0.0a9` references remain in `tiferet/__init__.py`, `README.md`, or `AGENTS.md`.
4. ✅ `README.md` current-status line updated.
5. ✅ `AGENTS.md` heading and `**Version:**` bullet updated.
6. ✅ Full test suite passes.
7. ✅ Only the three target files were modified for the version bump (`AGENTS.md` includes the additional CliBuilder catch-up identified during verification).
8. ✅ Feature branch follows the project naming convention; PR targets `v2.0a10-release`.

## Related

- Issue: #739
- Milestone: [v2.0.0a10](https://github.com/greatstrength/tiferet/milestone/24) (description updated to enumerate all 10 contained issues)
- Conversation: https://app.warp.dev/conversation/116851cb-1724-4043-8aa6-04cf9e56482f

Co-Authored-By: Oz <oz-agent@warp.dev>
