### PR TITLE
Packaging – Replace schematics with Pydantic v2 (#745)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "BSD-3-Clause" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "schematics>=2.1.1",
+    "pydantic>=2.6",
     "pyyaml>=6.0.1",
     "dependencies>=7.7.0"
 ]

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -9,16 +9,7 @@ try:
     from .assets import TiferetError, TiferetAPIError
     from .builders import AppBuilder as App
     from .builders import CliBuilder as CLI
-    from .domain import (
-        DomainObject,
-        StringType,
-        IntegerType,
-        BooleanType,
-        FloatType,
-        ListType,
-        DictType,
-        ModelType,
-    )
+    from .domain import DomainObject
     from .events import (
         DomainEvent,
         ParseParameter,

--- a/tiferet/contexts/di.py
+++ b/tiferet/contexts/di.py
@@ -6,11 +6,8 @@ from typing import Callable, Any, List, Dict
 # ** app
 from .cache import CacheContext
 from ..assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
-from ..domain import (
-    ServiceProvider,
-    DependenciesServiceProvider,
-    ServiceConfiguration,
-)
+from ..di import ServiceProvider, DependenciesServiceProvider
+from ..domain import ServiceConfiguration
 from ..events import DomainEvent, RaiseError, ParseParameter
 
 

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -3,16 +3,7 @@
 # *** imports
 
 # ** app
-from .settings import (
-    DomainObject,
-    StringType,
-    IntegerType,
-    FloatType,
-    BooleanType,
-    ListType,
-    DictType,
-    ModelType,
-)
+from .settings import DomainObject
 from .app import (
     AppInterface,
     AppServiceDependency,
@@ -38,8 +29,4 @@ from .logging import (
     Formatter,
     Handler,
     Logger,
-)
-from ..di import (
-    ServiceProvider,
-    DependenciesServiceProvider,
 )

--- a/tiferet/domain/settings.py
+++ b/tiferet/domain/settings.py
@@ -3,109 +3,25 @@
 # *** imports
 
 # ** infra
-from schematics import Model, types as t
+from pydantic import BaseModel, ConfigDict
 
 # *** classes
 
-# ** class: string_type
-class StringType(t.StringType):
-    '''
-    A string type.
-    '''
-
-    pass
-
-# ** class: integer_type
-class IntegerType(t.IntType):
-    '''
-    An integer type.
-    '''
-
-    pass
-
-# ** class: float_type
-class FloatType(t.FloatType):
-    '''
-    A float type.
-    '''
-
-    pass
-
-# ** class: boolean_type
-class BooleanType(t.BooleanType):
-    '''
-    A boolean type.
-    '''
-
-    pass
-
-# ** class: list_type
-class ListType(t.ListType):
-    '''
-    A list type.
-    '''
-
-    pass
-
-# ** class: dict_type
-class DictType(t.DictType):
-    '''
-    A dictionary type.
-    '''
-
-    pass
-
-# ** class: model_type
-class ModelType(t.ModelType):
-    '''
-    A model type.
-    '''
-
-    pass
-
 # ** class: domain_object
-class DomainObject(Model):
+class DomainObject(BaseModel):
     '''
-    A domain model object.
+    The base domain model object for Tiferet, backed by Pydantic v2.
+
+    Subclasses declare fields with idiomatic ``name: T = Field(...)`` annotations.
+    Domain objects are intended to be read-only at the base level; mutation logic
+    lives on Aggregate subclasses in :mod:`tiferet.mappers`.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        model_type: type,
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'DomainObject':
-        '''
-        Initializes a new domain object.
-
-        :param model_type: The type of domain object to create.
-        :type model_type: type
-        :param validate: True to validate the domain object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the domain object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new domain object.
-        :rclass: DomainObject
-        '''
-
-        # Create a new domain object.
-        domain_object: DomainObject = model_type(dict(
-            **kwargs
-        ), strict=strict)
-
-        # Validate if specified.
-        if validate:
-            domain_object.validate()
-
-        # Return the new domain object.
-        return domain_object
-
-    # * method: validate
-    def validate(self, **kwargs):
-
-        # Override to disable strict mode by default.
-        return super().validate(False, True, None, **kwargs)
+    # * attribute: model_config
+    model_config = ConfigDict(
+        extra='forbid',
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        coerce_numbers_to_str=True,
+    )


### PR DESCRIPTION
## Summary

Implements the first story of the v2.0.0b1 release: swaps the `schematics` dependency for `pydantic` and removes the schematics type-wrapper layer.

## Changes

- **`pyproject.toml`** — Replace `schematics>=2.1.1` with `pydantic>=2.6`.
- **`tiferet/domain/settings.py`** — Remove seven type-wrapper classes (`StringType`, `IntegerType`, `FloatType`, `BooleanType`, `ListType`, `DictType`, `ModelType`). Replace `DomainObject(schematics.Model)` with a minimal `DomainObject(pydantic.BaseModel)` stub using `ConfigDict`.
- **`tiferet/domain/__init__.py`** — Remove type-wrapper re-exports from `.settings`; remove stale `ServiceProvider`/`DependenciesServiceProvider` re-export from `..di`.
- **`tiferet/__init__.py`** — Simplify domain import block to `from .domain import DomainObject` only.
- **`tiferet/contexts/di.py`** — Fix import of `ServiceProvider`/`DependenciesServiceProvider` to source from `..di` instead of `..domain` (no longer re-exported there).

## Breaking Changes

This is an intentional breaking change. Domain modules (`app.py`, `cli.py`, `di.py`, `error.py`, `feature.py`, `logging.py`) still import the removed schematics type wrappers from `.settings`. These will be resolved in subsequent stories (Phase 2–4, stories #4–9) as each module is migrated to native Pydantic field declarations.

## Acceptance Criteria (this story)

- [x] `pyproject.toml` lists `pydantic>=2.6` and does not list `schematics`.
- [x] `tiferet/domain/settings.py` contains only the `DomainObject` class extending `pydantic.BaseModel` with the specified `ConfigDict`; no type-wrapper classes exist.
- [x] `tiferet/domain/__init__.py` imports `DomainObject` from `.settings` without type wrappers; duplicate DI import removed.
- [x] `tiferet/__init__.py` imports `DomainObject` from `.domain` without type wrappers.
- [ ] `from tiferet import DomainObject` — passes after stories #4–9 migrate domain modules.
- [ ] `from tiferet.domain.settings import DomainObject` — passes after stories #4–9 migrate domain modules.
- [x] Importing removed symbols (`from tiferet import StringType`) raises `ImportError`.

Resolves #745

---
[Warp conversation](https://app.warp.dev/conversation/be9cd694-5e8a-43e2-8c2c-42137e354c34)

Co-Authored-By: Oz <oz-agent@warp.dev>