### PR TITLE
Domain – Migrate DomainObject Base Class Tests to Pydantic v2 (#746)

### DIFF
--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -4,29 +4,36 @@
 
 # ** app
 from .settings import DomainObject
-from .app import (
-    AppInterface,
-    AppServiceDependency,
-)
-from .di import (
-    FlaggedDependency,
-    ServiceConfiguration,
-)
-from .cli import (
-    CliArgument,
-    CliCommand,
-)
-from .error import (
-    Error,
-    ErrorMessage,
-)
-from .feature import (
-    Feature,
-    FeatureStep,
-    FeatureEvent,
-)
-from .logging import (
-    Formatter,
-    Handler,
-    Logger,
-)
+
+# Concrete domain modules are guarded during the Pydantic v2 migration.
+# Modules that still reference removed Schematics type wrappers will raise
+# ImportError until migrated in subsequent stories (#4-9).
+try:
+    from .app import (
+        AppInterface,
+        AppServiceDependency,
+    )
+    from .di import (
+        FlaggedDependency,
+        ServiceConfiguration,
+    )
+    from .cli import (
+        CliArgument,
+        CliCommand,
+    )
+    from .error import (
+        Error,
+        ErrorMessage,
+    )
+    from .feature import (
+        Feature,
+        FeatureStep,
+        FeatureEvent,
+    )
+    from .logging import (
+        Formatter,
+        Handler,
+        Logger,
+    )
+except ImportError:
+    pass

--- a/tiferet/domain/tests/test_settings.py
+++ b/tiferet/domain/tests/test_settings.py
@@ -4,32 +4,28 @@
 
 # ** infra
 import pytest
+from pydantic import Field, ValidationError
 
 # ** app
-from ..settings import (
-    DomainObject,
-    StringType,
-)
+from ..settings import DomainObject
 
 # *** fixtures
 
 # ** fixture: test_domain_object
 @pytest.fixture
-def test_domain_object() -> DomainObject:
+def test_domain_object() -> type:
     '''
     Fixture for a basic DomainObject subclass.
 
     :return: The DomainObject subclass.
-    :rtype: DomainObject
+    :rtype: type
     '''
 
-    # Define a simple DomainObject subclass.
+    # Define a simple DomainObject subclass with one required field.
     class TestDomainObject(DomainObject):
-        attribute = StringType(
-            required=True,
-            metadata=dict(
-                description='The attribute.'
-            ),
+        attribute: str = Field(
+            ...,
+            description='The attribute.',
         )
 
     # Return the class.
@@ -37,18 +33,46 @@ def test_domain_object() -> DomainObject:
 
 # *** tests
 
-# ** test: domain_object_new
-def test_domain_object_new(test_domain_object: DomainObject):
+# ** test: domain_object_construct
+def test_domain_object_construct(test_domain_object: type):
     '''
-    Test the DomainObject.new method.
+    Test direct construction of a DomainObject subclass.
 
     :param test_domain_object: The DomainObject subclass to test.
-    :type test_domain_object: DomainObject
+    :type test_domain_object: type
     '''
 
-    # Create a new domain object using the fixture.
-    domain_object = DomainObject.new(test_domain_object, attribute='test')
+    # Construct via the standard Pydantic constructor.
+    domain_object = test_domain_object(attribute='test')
 
     # Assert the domain object is valid.
     assert isinstance(domain_object, test_domain_object)
     assert domain_object.attribute == 'test'
+
+# ** test: domain_object_strict_extra_field
+def test_domain_object_strict_extra_field(test_domain_object: type):
+    '''
+    Test that DomainObject rejects unknown fields under ``extra='forbid'``.
+
+    :param test_domain_object: The DomainObject subclass to test.
+    :type test_domain_object: type
+    '''
+
+    # Constructing with an unknown field should raise.
+    with pytest.raises(ValidationError):
+        test_domain_object(attribute='test', unknown='nope')
+
+# ** test: domain_object_validate_assignment
+def test_domain_object_validate_assignment(test_domain_object: type):
+    '''
+    Test that DomainObject re-validates on attribute assignment.
+
+    :param test_domain_object: The DomainObject subclass to test.
+    :type test_domain_object: type
+    '''
+
+    # Construct and then assign an invalid type to the attribute. A list is
+    # not coercible to ``str`` even with ``coerce_numbers_to_str=True``.
+    domain_object = test_domain_object(attribute='test')
+    with pytest.raises(ValidationError):
+        domain_object.attribute = ['not', 'a', 'string']


### PR DESCRIPTION
## Summary

Rewrites `tiferet/domain/tests/test_settings.py` to validate the Pydantic v2-backed `DomainObject` base class introduced in #745.

### Changes

- **`tiferet/domain/tests/test_settings.py`** — Replaced `StringType`/`DomainObject.new()` with `pydantic.Field`/`ValidationError`. Added three tests: `test_domain_object_construct`, `test_domain_object_strict_extra_field`, `test_domain_object_validate_assignment`.
- **`tiferet/domain/__init__.py`** — Added `try/except ImportError` guard around concrete domain module imports that still reference removed Schematics type wrappers (pending migration in stories #4–9).

### Test Results

`pytest tiferet/domain/tests/test_settings.py` — 3 passed, 0 failures.

Resolves #746

---
[Warp conversation](https://app.warp.dev/conversation/4520d979-47b7-4d5f-bf54-48061c5be5c0)

Co-Authored-By: Oz <oz-agent@warp.dev>