### PR TITLE
Mappers – Migrate Aggregate and TransferObject Base Classes to Pydantic v2 (#747)

### DIFF
--- a/tiferet/mappers/__init__.py
+++ b/tiferet/mappers/__init__.py
@@ -7,36 +7,43 @@ from .settings import (
     Aggregate,
     TransferObject,
 )
-from .app import (
-    AppInterfaceAggregate,
-    AppInterfaceYamlObject,
-)
-from .di import (
-    ServiceConfigurationAggregate,
-    ServiceConfigurationYamlObject,
-)
-from .cli import (
-    CliArgumentAggregate,
-    CliCommandAggregate,
-    CliCommandYamlObject,
-)
-from .error import (
-    ErrorAggregate,
-    ErrorYamlObject,
-    ErrorMessageYamlObject,
-)
-from .feature import (
-    FeatureAggregate,
-    FeatureYamlObject,
-    FeatureEventAggregate,
-    FeatureEventYamlObject,
-)
-from .logging import (
-    FormatterAggregate,
-    FormatterYamlObject,
-    HandlerAggregate,
-    HandlerYamlObject,
-    LoggerAggregate,
-    LoggerYamlObject,
-    LoggingSettingsYamlObject,
-)
+
+# Concrete mapper modules are guarded during the Pydantic v2 migration.
+# Modules that still reference removed Schematics type wrappers will raise
+# ImportError until migrated in subsequent stories (#11-16).
+try:
+    from .app import (
+        AppInterfaceAggregate,
+        AppInterfaceYamlObject,
+    )
+    from .di import (
+        ServiceConfigurationAggregate,
+        ServiceConfigurationYamlObject,
+    )
+    from .cli import (
+        CliArgumentAggregate,
+        CliCommandAggregate,
+        CliCommandYamlObject,
+    )
+    from .error import (
+        ErrorAggregate,
+        ErrorYamlObject,
+        ErrorMessageYamlObject,
+    )
+    from .feature import (
+        FeatureAggregate,
+        FeatureYamlObject,
+        FeatureEventAggregate,
+        FeatureEventYamlObject,
+    )
+    from .logging import (
+        FormatterAggregate,
+        FormatterYamlObject,
+        HandlerAggregate,
+        HandlerYamlObject,
+        LoggerAggregate,
+        LoggerYamlObject,
+        LoggingSettingsYamlObject,
+    )
+except ImportError:
+    pass

--- a/tiferet/mappers/settings.py
+++ b/tiferet/mappers/settings.py
@@ -3,12 +3,13 @@
 # *** imports
 
 # ** core
-from typing import Any
+from typing import Any, ClassVar, Dict
 
 # ** infra
-from schematics.models import Model
+from pydantic import BaseModel, ConfigDict
 
 # ** app
+from ..domain import DomainObject
 from ..events import RaiseError, a
 
 # *** constants
@@ -22,215 +23,129 @@ DEFAULT_CLASS_NAME = 'AppInterfaceContext'
 # *** classes
 
 # ** class: aggregate
-class Aggregate(Model):
+class Aggregate(DomainObject):
     '''
-    A data representation of an aggregate object.
+    A mutable, validated representation of a domain aggregate.
+
+    Aggregates inherit the strict ``extra='forbid'`` and ``validate_assignment=True``
+    config from :class:`DomainObject`. Mutation goes through :meth:`set_attribute`
+    for an explicit existence check, but any direct ``setattr`` will still trigger
+    Pydantic field validation.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        aggregate_type: type,
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'Aggregate':
-        '''
-        Initializes a new aggregate object.
-
-        :param aggregate_type: The type of aggregate object to create.
-        :type aggregate_type: type
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new aggregate object.
-        :rtype: Aggregate
-        '''
-
-        # Create a new aggregate object.
-        aggregate_object: Aggregate = aggregate_type(dict(
-            **kwargs
-        ), strict=strict)
-
-        # Validate if specified.
-        if validate:
-            aggregate_object.validate()
-
-        # Return the new aggregate object.
-        return aggregate_object
 
     # * method: set_attribute
     def set_attribute(self, attribute: str, value: Any) -> None:
         '''
-        Update an attribute on the aggregate object.
-
-        Raises an error if the attribute does not exist on the instance.
+        Update an attribute on the aggregate, raising an error if it is unknown.
 
         :param attribute: The attribute name to update.
         :type attribute: str
-        :param value: The new value.
+        :param value: The new value to assign.
         :type value: Any
         :return: None
         :rtype: None
         '''
 
-        # Check if the attribute exists on the aggregate instance.
-        # If the attribute does not exist, raise an error.
-        if not hasattr(self, attribute):
+        # Reject unknown attribute names by raising a structured error.
+        if attribute not in type(self).model_fields:
             RaiseError.execute(
                 error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
                 attribute=attribute,
             )
 
-        # Apply the update to the attribute.
+        # Apply the update; validate_assignment=True triggers field validation.
         setattr(self, attribute, value)
 
-        # Perform final aggregate validation.
-        self.validate()
-
 # ** class: transfer_object
-class TransferObject(Model):
+class TransferObject(DomainObject):
     '''
-    A data representation object.
+    A serialization and mapping layer for domain data.
+
+    TransferObjects use a lenient config (``extra='ignore'``, ``validate_assignment=False``)
+    so that unknown or extra fields in external data sources (e.g. YAML) are silently
+    dropped rather than raising validation errors.
+
+    Subclasses declare a ``_ROLES`` ClassVar mapping role names to ``model_dump`` kwargs
+    for role-based serialization via :meth:`to_primitive`.
     '''
 
-    # ** method: map
-    def map(self,
-            type: Aggregate,
-            role: str = 'to_model',
-            validate: bool = True,
-            **kwargs
-            ) -> Aggregate:
+    # * attribute: model_config
+    model_config = ConfigDict(
+        extra='ignore',
+        populate_by_name=True,
+        validate_assignment=False,
+        arbitrary_types_allowed=True,
+        coerce_numbers_to_str=True,
+    )
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {}
+
+    # * method: to_primitive
+    def to_primitive(self, role: str = None, **overrides) -> Dict[str, Any]:
         '''
-        Maps the model data to a model object.
+        Serialize the transfer object to a dictionary, optionally applying role-specific kwargs.
 
-        :param type: The type of aggregate object to map to.
-        :type type: type
-        :param role: The role for the mapping.
+        :param role: The serialization role to apply.
         :type role: str
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param kwargs: Additional keyword arguments for mapping.
-        :type kwargs: dict
-        :return: A new aggregate object.
+        :param overrides: Additional keyword arguments passed to ``model_dump``.
+        :type overrides: dict
+        :return: The serialized dictionary.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Start with the default kwargs.
+        kwargs: Dict[str, Any] = {'exclude_none': True}
+
+        # Merge role-specific kwargs if the role is known.
+        if role and role in type(self)._ROLES:
+            kwargs.update(type(self)._ROLES[role])
+
+        # Apply caller overrides last so they always win.
+        kwargs.update(overrides)
+
+        # Delegate to Pydantic model_dump.
+        return self.model_dump(**kwargs)
+
+    # * method: map
+    def map(self, target: type, **overrides) -> 'Aggregate':
+        '''
+        Map the transfer object to an aggregate instance.
+
+        :param target: The aggregate class to construct.
+        :type target: type
+        :param overrides: Additional keyword arguments merged into the data.
+        :type overrides: dict
+        :return: A new aggregate instance.
         :rtype: Aggregate
         '''
 
-        # Get primitive of the model data and merge with the keyword arguments.
-        # Give priority to the keyword arguments.
-        data_object = self.to_primitive(role=role)
-        for key, value in kwargs.items():
-            data_object[key] = value
+        # Serialize via the to_model role and merge overrides.
+        data = self.to_primitive(role='to_model')
+        data.update(overrides)
 
-        # Map the data object to an aggregate object.
-        # Attempt to create a new aggregate object with a custom factory method.
-        # If the factory method does not exist, employ the standard method.
-        try:
-            aggregate_object = type.new(**data_object, strict=False)
-        except Exception:
-            aggregate_object = Aggregate.new(type, **data_object, strict=False)
+        # Construct the target aggregate.
+        return target(**data)
 
-        # Validate if specified.
-        if validate:
-            aggregate_object.validate()
-
-        # Return the aggregate object.
-        return aggregate_object
-
-    # ** method: from_model
-    @staticmethod
-    def from_model(
-        transfer_obj: 'TransferObject',
-        aggregate: Aggregate,
-        validate: bool = True,
-        **kwargs
-    ) -> 'TransferObject':
+    # * method: from_model
+    @classmethod
+    def from_model(cls, model: BaseModel, **overrides) -> 'TransferObject':
         '''
-        Initializes a new data object from a model object.
+        Create a transfer object from a domain model or aggregate.
 
-        :param transfer_obj: The type of transfer object to map from.
-        :type transfer_obj: type
-        :param aggregate: The aggregate object to map from.
-        :type aggregate: Aggregate
-        :param validate: True to validate the data object.
-        :type validate: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
+        :param model: The source model instance.
+        :type model: BaseModel
+        :param overrides: Additional keyword arguments that take priority.
+        :type overrides: dict
         :return: A new transfer object.
         :rtype: TransferObject
         '''
 
-        # Convert the aggregate object to a primitive dictionary and merge with the keyword arguments.
-        # Give priority to the keyword arguments.
-        aggregate_data = aggregate.to_primitive()
-        for key, value in kwargs.items():
-            aggregate_data[key] = value
+        # Dump the model to a dict using canonical field names.
+        data = model.model_dump(by_alias=False)
 
-        # Create a new transfer object.
-        data_object = transfer_obj(dict(
-            **aggregate_data
-        ), strict=False)
+        # Apply overrides so they take priority.
+        data.update(overrides)
 
-        # Validate the data object if specified.
-        if validate:
-            data_object.validate()
-
-        # Return the data object.
-        return data_object
-
-    # ** method: from_data
-    @staticmethod
-    def from_data(
-        data: type,
-        **kwargs
-    ) -> 'TransferObject':
-        '''
-        Initializes a new transfer object from a dictionary.
-
-        :param data: The type of transfer object to map from.
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new transfer object.
-        :rtype: TransferObject
-        '''
-
-        # Create a new transfer object.
-        return data(dict(**kwargs), strict=False)
-
-    # ** method: allow
-    @staticmethod
-    def allow(*args) -> Any:
-        '''
-        Creates a whitelist transform for data mapping.
-
-        :param args: Fields to allow in the transform.
-        :type args: tuple
-        :return: The whitelist transform.
-        :rtype: Any
-        '''
-
-        # Create a whitelist transform.
-        # Create a wholelist transform if no arguments are specified.
-        from schematics.transforms import whitelist, wholelist
-        if args:
-            return whitelist(*args)
-        return wholelist()
-
-    # ** method: deny
-    @staticmethod
-    def deny(*args) -> Any:
-        '''
-        Creates a blacklist transform for data mapping.
-
-        :param args: Fields to deny in the transform.
-        :type args: tuple
-        :return: The blacklist transform.
-        :rtype: Any
-        '''
-
-        # Create a blacklist transform.
-        from schematics.transforms import blacklist
-        return blacklist(*args)
+        # Construct and return the transfer object.
+        return cls.model_validate(data)

--- a/tiferet/mappers/tests/settings.py
+++ b/tiferet/mappers/tests/settings.py
@@ -140,7 +140,7 @@ class AggregateTestBase(MapperAssertions):
     # * method: make_aggregate
     def make_aggregate(self, data: dict = None) -> Aggregate:
         '''
-        Create an aggregate from data. Override for custom new() signatures.
+        Create an aggregate from data. Override for custom constructor signatures.
 
         :param data: The data to create from (defaults to self.sample_data).
         :type data: dict
@@ -148,8 +148,8 @@ class AggregateTestBase(MapperAssertions):
         :rtype: Aggregate
         '''
 
-        # Create an aggregate using the standard Aggregate.new factory.
-        return Aggregate.new(self.aggregate_cls, **(data or self.sample_data))
+        # Create an aggregate using the standard Pydantic constructor.
+        return self.aggregate_cls(**(data or self.sample_data))
 
     # * fixture: aggregate
     @pytest.fixture
@@ -230,7 +230,7 @@ class TransferObjectTestBase(MapperAssertions):
     def make_aggregate(self, data: dict = None) -> Aggregate:
         '''
         Create an aggregate for from_model / round_trip tests.
-        Override for custom new() signatures.
+        Override for custom constructor signatures.
 
         :param data: The data to create from (defaults to self.aggregate_sample_data).
         :type data: dict
@@ -238,8 +238,8 @@ class TransferObjectTestBase(MapperAssertions):
         :rtype: Aggregate
         '''
 
-        # Create an aggregate using the standard Aggregate.new factory.
-        return Aggregate.new(self.aggregate_cls, **(data or self.aggregate_sample_data))
+        # Create an aggregate using the standard Pydantic constructor.
+        return self.aggregate_cls(**(data or self.aggregate_sample_data))
 
     # * fixture: aggregate
     @pytest.fixture
@@ -258,7 +258,7 @@ class TransferObjectTestBase(MapperAssertions):
     # * method: test_map
     def test_map(self):
         '''
-        Verify TransferObject.from_data -> map() produces a valid aggregate.
+        Verify TransferObject construction -> map() produces a valid aggregate.
         '''
 
         # Skip if no transfer class is defined.
@@ -266,7 +266,7 @@ class TransferObjectTestBase(MapperAssertions):
             pytest.skip("transfer_cls not defined")
 
         # Create a transfer object from YAML-format sample data.
-        yaml_obj = TransferObject.from_data(self.transfer_cls, **self.sample_data)
+        yaml_obj = self.transfer_cls.model_validate(self.sample_data)
 
         # Map to an aggregate.
         mapped = yaml_obj.map(**self.map_kwargs)
@@ -285,7 +285,7 @@ class TransferObjectTestBase(MapperAssertions):
         if not self.transfer_cls:
             pytest.skip("transfer_cls not defined")
 
-        # Convert the aggregate to a transfer object.
+        # Convert the aggregate to a transfer object using the classmethod.
         yaml_obj = self.transfer_cls.from_model(aggregate)
 
         # Assert the result is the correct type.

--- a/tiferet/mappers/tests/test_settings.py
+++ b/tiferet/mappers/tests/test_settings.py
@@ -4,13 +4,10 @@
 
 # ** infra
 import pytest
-from unittest import mock
+from pydantic import Field, ValidationError
 
 # ** app
-from ...domain import (
-    DomainObject,
-    StringType,
-)
+from ...domain import DomainObject
 from ..settings import Aggregate, TransferObject
 from ...assets import TiferetError
 
@@ -21,182 +18,127 @@ from ...assets import TiferetError
 def test_aggregate() -> type:
     '''
     Provides a fixture for a test Aggregate class.
-    
+
     :return: The Aggregate subclass.
     :rtype: type
     '''
-    
+
     class TestAggregate(Aggregate):
         '''
         A test Aggregate for testing purposes.
         '''
-        
-        id = StringType(
-            required=True,
-            metadata=dict(
-                description='The unique identifier.'
-            )
-        )
-        
-        name = StringType(
-            required=True,
-            metadata=dict(
-                description='The name of the aggregate.'
-            )
-        )
-    
-    return TestAggregate
 
-# ** fixture: mock_model
-@pytest.fixture
-def mock_model() -> DomainObject:
-    '''
-    Provides a fixture for a mocked DomainObject instance.
-    
-    :return: The mocked DomainObject instance.
-    :rtype: DomainObject
-    '''
-    
-    # Create a mocked DomainObject instance.
-    model = mock.Mock(spec=DomainObject)
-    model.to_primitive.return_value = {
-        'id': 'test_id',
-        'name': 'Test Model'
-    }
-    model.validate.return_value = None
-    
-    # Return the mocked model.
-    return model
+        id: str = Field(
+            ...,
+            description='The unique identifier.',
+        )
+
+        name: str = Field(
+            ...,
+            description='The name of the aggregate.',
+        )
+
+    return TestAggregate
 
 # ** fixture: test_data_object
 @pytest.fixture
-def test_data_object() -> TransferObject:
+def test_data_object(test_aggregate: type) -> type:
     '''
-    Provides a fixture for a TransferObject instance.
-    
-    :return: The TransferObject instance.
-    :rtype: TransferObject
+    Provides a fixture for a TransferObject subclass with _ROLES.
+
+    :param test_aggregate: The Aggregate subclass used as the map target.
+    :type test_aggregate: type
+    :return: The TransferObject subclass.
+    :rtype: type
     '''
-    
+
     class TestDataObject(TransferObject):
         '''
         A test TransferObject for testing purposes.
         '''
 
-        class Options:
-            '''
-            Options for the test TransferObject.
-            '''
+        _ROLES = {
+            'to_data': {'exclude': {'id'}},
+            'to_model': {},
+        }
 
-            serialize_when_none = False
-            roles = {
-                'to_data': TransferObject.allow('id', 'name'),
-                'to_model': TransferObject.allow('id', 'name')
-            }
-        
-        id = StringType(
-            required=True,
-            metadata=dict(
-                description='The unique identifier for the data object.'
-            )
+        id: str = Field(
+            ...,
+            description='The unique identifier for the data object.',
         )
 
-        name = StringType(
-            required=True,
-            metadata=dict(
-                description='The name of the data object.'
-            )
+        name: str = Field(
+            ...,
+            description='The name of the data object.',
         )
 
     return TestDataObject
 
+# ** fixture: source_model
+@pytest.fixture
+def source_model() -> DomainObject:
+    '''
+    Provides a real DomainObject instance for from_model tests.
+
+    :return: A DomainObject instance.
+    :rtype: DomainObject
+    '''
+
+    # Define a simple source model.
+    class SourceModel(DomainObject):
+        id: str = Field(...)
+        name: str = Field(...)
+
+    # Return an instance with sample data.
+    return SourceModel(id='test_id', name='Test Model')
+
 # *** tests
 
-# ** test: aggregate_new
-def test_aggregate_new(test_aggregate: type):
+# ** test: aggregate_construct
+def test_aggregate_construct(test_aggregate: type):
     '''
-    Test the Aggregate.new factory method.
-    
+    Test direct construction of an Aggregate subclass.
+
     :param test_aggregate: The Aggregate subclass to test.
     :type test_aggregate: type
     '''
-    
-    # Create a new aggregate instance.
-    aggregate = Aggregate.new(
-        test_aggregate,
-        id='test_id',
-        name='Test Aggregate'
-    )
-    
+
+    # Construct via the standard Pydantic constructor.
+    aggregate = test_aggregate(id='test_id', name='Test Aggregate')
+
     # Assert the aggregate is correctly instantiated.
     assert isinstance(aggregate, test_aggregate)
     assert aggregate.id == 'test_id'
     assert aggregate.name == 'Test Aggregate'
 
-# ** test: aggregate_new_no_validation
-def test_aggregate_new_no_validation(test_aggregate: type):
+# ** test: aggregate_extra_field_rejected
+def test_aggregate_extra_field_rejected(test_aggregate: type):
     '''
-    Test the Aggregate.new factory method without validation.
-    
-    :param test_aggregate: The Aggregate subclass to test.
-    :type test_aggregate: type
-    '''
-    
-    # Create a new aggregate instance without validation.
-    aggregate = Aggregate.new(
-        test_aggregate,
-        validate=False,
-        id='test_id',
-        name='Test Aggregate'
-    )
-    
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(aggregate, test_aggregate)
-    assert aggregate.id == 'test_id'
-    assert aggregate.name == 'Test Aggregate'
+    Test that Aggregate rejects unknown fields under ``extra='forbid'``.
 
-# ** test: aggregate_new_not_strict
-def test_aggregate_new_not_strict(test_aggregate: type):
-    '''
-    Test the Aggregate.new factory method with strict=False.
-    
     :param test_aggregate: The Aggregate subclass to test.
     :type test_aggregate: type
     '''
-    
-    # Create a new aggregate instance in non-strict mode.
-    aggregate = Aggregate.new(
-        test_aggregate,
-        strict=False,
-        id='test_id',
-        name='Test Aggregate',
-        extra_field='ignored'
-    )
-    
-    # Assert the aggregate is correctly instantiated.
-    assert isinstance(aggregate, test_aggregate)
-    assert aggregate.id == 'test_id'
-    assert aggregate.name == 'Test Aggregate'
+
+    # Constructing with an unknown field should raise.
+    with pytest.raises(ValidationError):
+        test_aggregate(id='test_id', name='Test', extra_field='nope')
 
 # ** test: aggregate_set_attribute_success
 def test_aggregate_set_attribute_success(test_aggregate: type):
     '''
     Test setting a valid attribute on an Aggregate instance.
-    
+
     :param test_aggregate: The Aggregate subclass to test.
     :type test_aggregate: type
     '''
-    
+
     # Create an aggregate instance.
-    aggregate = Aggregate.new(
-        test_aggregate,
-        id='test_id',
-        name='Original Name'
-    )
-    
+    aggregate = test_aggregate(id='test_id', name='Original Name')
+
     # Update the name attribute.
     aggregate.set_attribute('name', 'Updated Name')
-    
+
     # Assert the attribute was updated.
     assert aggregate.name == 'Updated Name'
 
@@ -204,189 +146,138 @@ def test_aggregate_set_attribute_success(test_aggregate: type):
 def test_aggregate_set_attribute_invalid(test_aggregate: type):
     '''
     Test setting an invalid attribute raises TiferetError.
-    
+
     :param test_aggregate: The Aggregate subclass to test.
     :type test_aggregate: type
     '''
-    
+
     # Create an aggregate instance.
-    aggregate = Aggregate.new(
-        test_aggregate,
-        id='test_id',
-        name='Test Name'
-    )
-    
+    aggregate = test_aggregate(id='test_id', name='Test Name')
+
     # Attempt to set an invalid attribute.
     with pytest.raises(TiferetError) as exc_info:
         aggregate.set_attribute('invalid_attribute', 'value')
-    
+
     # Assert the correct error is raised.
     assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
 
-# ** test: data_object_from_data
-def test_data_object_from_data(test_data_object: type):
+# ** test: aggregate_set_attribute_validates_assignment
+def test_aggregate_set_attribute_validates_assignment(test_aggregate: type):
     '''
-    Test the creation of a TransferObject from a dictionary.
+    Test that set_attribute triggers Pydantic validate_assignment on invalid type.
+
+    :param test_aggregate: The Aggregate subclass to test.
+    :type test_aggregate: type
+    '''
+
+    # Create an aggregate instance.
+    aggregate = test_aggregate(id='test_id', name='Test Name')
+
+    # Assigning a non-coercible type should raise ValidationError.
+    with pytest.raises(ValidationError):
+        aggregate.set_attribute('name', ['not', 'a', 'string'])
+
+# ** test: transfer_object_from_data
+def test_transfer_object_from_data(test_data_object: type):
+    '''
+    Test the creation of a TransferObject via model_validate.
 
     :param test_data_object: The TransferObject subclass to test.
     :type test_data_object: type
     '''
-    
-    # Create a TransferObject from data.
-    data_object = TransferObject.from_data(
-        test_data_object,
+
+    # Create a TransferObject using model_validate.
+    data_object = test_data_object.model_validate(dict(
         id='test_id',
-        name='Test Data'
-    )
-    
+        name='Test Data',
+    ))
+
     # Assert the attributes are correctly set.
     assert isinstance(data_object, test_data_object)
-    assert data_object.to_primitive() == {'id': 'test_id', 'name': 'Test Data'}
+    assert data_object.id == 'test_id'
+    assert data_object.name == 'Test Data'
 
 # ** test: transfer_object_from_model
-def test_transfer_object_from_model(mock_model, test_data_object):
+def test_transfer_object_from_model(source_model: DomainObject, test_data_object: type):
     '''
     Test the creation of a TransferObject from a DomainObject.
-    
-    :param mock_model: The mocked DomainObject instance.
-    :type mock_model: DomainObject
+
+    :param source_model: The source DomainObject instance.
+    :type source_model: DomainObject
     :param test_data_object: The TransferObject subclass to test.
     :type test_data_object: type
     '''
-    
+
     # Create a TransferObject from the model.
-    data_object = TransferObject.from_model(
-        test_data_object,
-        mock_model
-    )
-    
+    data_object = test_data_object.from_model(source_model)
+
     # Assert the data object is valid.
     assert isinstance(data_object, test_data_object)
-    assert data_object.to_primitive() == {'id': 'test_id', 'name': 'Test Model'}
+    assert data_object.id == 'test_id'
+    assert data_object.name == 'Test Model'
 
-# ** test: transfer_object_from_model_with_kwargs
-def test_transfer_object_from_model_with_kwargs(mock_model, test_data_object):
+# ** test: transfer_object_from_model_with_overrides
+def test_transfer_object_from_model_with_overrides(source_model: DomainObject, test_data_object: type):
     '''
-    Test the creation of a TransferObject from a DomainObject with additional keyword arguments.
-    
-    :param mock_model: The mocked DomainObject instance.
-    :type mock_model: DomainObject
+    Test that from_model overrides take priority over model data.
+
+    :param source_model: The source DomainObject instance.
+    :type source_model: DomainObject
     :param test_data_object: The TransferObject subclass to test.
     :type test_data_object: type
     '''
-    
-    # Create a TransferObject from the model with additional attributes.
-    data_object = TransferObject.from_model(
-        test_data_object,
-        mock_model,
-        name='Overridden Name',
-    )
-    
-    # Assert the data object is valid and includes the extra attribute.
+
+    # Create a TransferObject from the model with an override.
+    data_object = test_data_object.from_model(source_model, name='Overridden Name')
+
+    # Assert the override takes priority.
     assert isinstance(data_object, test_data_object)
-    assert data_object.to_primitive() == {'id': 'test_id', 'name': 'Overridden Name'}
-    
+    assert data_object.id == 'test_id'
+    assert data_object.name == 'Overridden Name'
 
-# ** test: data_object_map_custom_new
-def test_transfer_object_map_custom_new(test_data_object: type):
+# ** test: transfer_object_map
+def test_transfer_object_map(test_data_object: type, test_aggregate: type):
     '''
-    Test mapping a TransferObject to a DomainObject with a custom new method.
-    
-    :param test_data_object: The TransferObject subclass type.
+    Test mapping a TransferObject to an Aggregate.
+
+    :param test_data_object: The TransferObject subclass to test.
     :type test_data_object: type
+    :param test_aggregate: The Aggregate subclass to map to.
+    :type test_aggregate: type
     '''
-    
+
     # Create a TransferObject instance.
-    data_object = TransferObject.from_data(
-        test_data_object,
-        id='test_id',
-        name='Test Data'
-    )
+    data_object = test_data_object(id='test_id', name='Test Data')
 
-    # Mock a DomainObject class with a custom new method.
-    mock_model_type = mock.Mock()
-    mock_model_instance = mock.Mock(spec=DomainObject)
-    mock_model_instance.validate.return_value = None
-    mock_model_type.new.return_value = mock_model_instance
-    
-    # Map the DataObject to the model.
-    result = data_object.map(type=mock_model_type, role='to_model', validate=True)
-    
-    # Assert the mapped object is valid.
-    assert result == mock_model_instance
-    mock_model_type.new.assert_called_once_with(id='test_id', name='Test Data', strict=False)
-    mock_model_instance.validate.assert_called_once()
+    # Map to an aggregate.
+    result = data_object.map(target=test_aggregate)
 
-# ** test: data_object_map_fallback_new
-def test_data_object_map_fallback_new(test_data_object: type):
+    # Assert the mapped aggregate is valid.
+    assert isinstance(result, test_aggregate)
+    assert result.id == 'test_id'
+    assert result.name == 'Test Data'
+
+# ** test: transfer_object_to_primitive_with_role
+def test_transfer_object_to_primitive_with_role(test_data_object: type):
     '''
-    Test mapping a DataObject to a DomainObject using the fallback DomainObject.new.
-    
-    :param test_data_object: The DataObject subclass type.
+    Test to_primitive with _ROLES role resolution, exclude behavior, and unknown-role fallback.
+
+    :param test_data_object: The TransferObject subclass to test.
     :type test_data_object: type
     '''
 
     # Create a TransferObject instance.
-    data_object = TransferObject.from_data(
-        test_data_object,
-        id='test_id',
-        name='Test Data'
-    )
-    
-    # Mock a DomainObject class without a custom new method.
-    mock_model_type = mock.Mock()
-    mock_model_type.new.side_effect = AttributeError
-    mock_aggregate_instance = mock.Mock(spec=Aggregate)
-    mock_aggregate_instance.validate.return_value = None
-    with mock.patch.object(Aggregate, 'new', return_value=mock_aggregate_instance) as mock_new:
-        result = data_object.map(type=mock_model_type, role='to_model', validate=True)
-    
-    # Assert the mapped object is valid.
-    assert result == mock_aggregate_instance
-    mock_new.assert_called_once_with(mock_model_type, id='test_id', name='Test Data', strict=False)
-    mock_aggregate_instance.validate.assert_called_once()
+    data_object = test_data_object(id='test_id', name='Test Data')
 
-# ** test: data_object_allow_with_args
-def test_data_object_allow_with_args():
-    '''
-    Test the allow method with specific fields.
-    '''
-    
-    # Create a whitelist transform with fields.
-    transform = TransferObject.allow('id', 'name')
-    
-    # Assert the transform is a whitelist.
-    from schematics.transforms import Role
-    assert isinstance(transform, Role)
-    assert transform.fields == set(['id', 'name'])
-    assert transform.function.__name__ == 'whitelist'
+    # to_data role should exclude 'id'.
+    to_data = data_object.to_primitive(role='to_data')
+    assert 'id' not in to_data
+    assert to_data['name'] == 'Test Data'
 
-# ** test: data_object_allow_no_args
-def test_data_object_allow_no_args():
-    '''
-    Test the allow method with no arguments.
-    '''
-    
-    # Create a wholelist transform with no fields.
-    transform = TransferObject.allow()
-    
-    # Assert the transform is a wholelist.
-    from schematics.transforms import Role
-    assert isinstance(transform, Role)
-    assert transform.fields == set()
-    assert transform.function.__name__ == 'wholelist'
+    # to_model role should include all fields.
+    to_model = data_object.to_primitive(role='to_model')
+    assert to_model == {'id': 'test_id', 'name': 'Test Data'}
 
-# ** test: data_object_deny
-def test_data_object_deny():
-    '''
-    Test the deny method with specific fields.
-    '''
-    
-    # Create a blacklist transform with fields.
-    transform = TransferObject.deny('id', 'name')
-    
-    # Assert the transform is a blacklist.
-    from schematics.transforms import Role
-    assert isinstance(transform, Role)
-    assert transform.fields == set(['id', 'name'])
-    assert transform.function.__name__ == 'blacklist'
+    # Unknown role should fall back to defaults (exclude_none only).
+    fallback = data_object.to_primitive(role='unknown_role')
+    assert fallback == {'id': 'test_id', 'name': 'Test Data'}


### PR DESCRIPTION
## Summary

Migrates the two mapper base classes — `Aggregate` and `TransferObject` — from schematics to Pydantic v2, and rewrites their tests and shared test harness.

### Changes

**`tiferet/mappers/settings.py`**
- `Aggregate` now extends `DomainObject` (Pydantic v2). `Aggregate.new()` removed; consumers use the standard Pydantic constructor. `set_attribute` checks `model_fields` and relies on `validate_assignment=True`.
- `TransferObject` extends `DomainObject` with lenient `ConfigDict(extra='ignore', validate_assignment=False)`. Schematics-era `allow()`, `deny()`, `from_data()`, and `class Options` removed. Role-based serialization replaced by `_ROLES` ClassVar + `to_primitive(role)`. `map()` and `from_model()` simplified.

**`tiferet/mappers/tests/test_settings.py`**
- 10 Pydantic v2 tests replacing 12 schematics-era tests. New tests include `aggregate_extra_field_rejected`, `aggregate_set_attribute_validates_assignment`, and `transfer_object_to_primitive_with_role`.

**`tiferet/mappers/tests/settings.py`**
- Test harness updated: `Aggregate.new()` → direct Pydantic constructor, `TransferObject.from_data()` → `model_validate()`.

**`tiferet/mappers/__init__.py`**
- Added `try/except ImportError` guard for concrete mapper modules still referencing schematics (pending stories #11–16).

### Test Results

`pytest tiferet/mappers/tests/test_settings.py` — 10 passed, 0 failures.

Resolves #747

---
[Warp conversation](https://app.warp.dev/conversation/4520d979-47b7-4d5f-bf54-48061c5be5c0)

Co-Authored-By: Oz <oz-agent@warp.dev>