### PR TITLE
Domain – Migrate Error Domain to Pydantic v2

### DIFF
--- a/tiferet/domain/error.py
+++ b/tiferet/domain/error.py
@@ -3,15 +3,13 @@
 # *** imports
 
 # ** core
-from typing import Any, Dict, List
+from typing import Any, List
+
+# ** infra
+from pydantic import Field, model_validator
 
 # ** app
-from .settings import (
-    DomainObject,
-    StringType,
-    ListType,
-    ModelType,
-)
+from .settings import DomainObject
 
 # *** models
 
@@ -22,20 +20,10 @@ class ErrorMessage(DomainObject):
     '''
 
     # * attribute: lang
-    lang = StringType(
-        required=True,
-        metadata=dict(
-            description='The language of the error message text.'
-        ),
-    )
+    lang: str = Field(..., description='The language of the error message text.')
 
     # * attribute: text
-    text = StringType(
-        required=True,
-        metadata=dict(
-            description='The error message text.'
-        ),
-    )
+    text: str = Field(..., description='The error message text.')
 
     # * method: format
     def format(self, **kwargs) -> str:
@@ -63,74 +51,40 @@ class Error(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the error.'
-        ),
-    )
+    id: str = Field(..., description='The unique identifier of the error.')
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the error.'
-        ),
-    )
+    name: str = Field(..., description='The name of the error.')
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the error.'
-        ),
-    )
+    description: str | None = Field(default=None, description='The description of the error.')
 
     # * attribute: error_code
-    error_code = StringType(
-        metadata=dict(
-            description='The unique code of the error.'
-        ),
-    )
+    error_code: str | None = Field(default=None, description='The unique code of the error.')
 
     # * attribute: message
-    message = ListType(
-        ModelType(ErrorMessage),
-        required=True,
-        metadata=dict(
-            description='The error message translations for the error.'
-        ),
-    )
+    message: List[ErrorMessage] = Field(default_factory=list, description='The error message translations for the error.')
 
-    # * method: new
-    @staticmethod
-    def new(name: str, id: str, message: List[Dict[str, str]] = [], **kwargs) -> 'Error':
+    # * method: _derive_error_code (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def _derive_error_code(cls, data: Any) -> Any:
         '''
-        Initializes a new Error object.
+        Derive ``error_code`` from ``id`` when not explicitly provided.
 
-        :param name: The name of the error.
-        :type name: str
-        :param id: The unique identifier for the error.
-        :type id: str
-        :param message: The error message translations for the error.
-        :type message: list
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new Error object.
-        :rtype: Error
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The (possibly augmented) input data.
+        :rtype: Any
         '''
 
-        # Set the error code as the id upper cased.
-        error_code = id.upper().replace(' ', '_')
+        # Only mutate dict-shaped inputs; pass other shapes through unchanged.
+        if isinstance(data, dict) and not data.get('error_code') and data.get('id'):
+            data = dict(data)
+            data['error_code'] = str(data['id']).upper().replace(' ', '_')
 
-        # Create and return a new Error object.
-        return DomainObject.new(
-            Error,
-            id=id,
-            name=name,
-            error_code=error_code,
-            message=message,
-            **kwargs,
-        )
+        # Return the (possibly augmented) input data.
+        return data
 
     # * method: format_message
     def format_message(self, lang: str = 'en_US', **kwargs) -> str:

--- a/tiferet/domain/tests/test_error.py
+++ b/tiferet/domain/tests/test_error.py
@@ -6,7 +6,6 @@
 import pytest
 
 # ** app
-from ..settings import DomainObject
 from ..error import (
     Error,
     ErrorMessage,
@@ -25,11 +24,7 @@ def error_message() -> ErrorMessage:
     '''
 
     # Create and return a new ErrorMessage.
-    return DomainObject.new(
-        ErrorMessage,
-        lang='en_US',
-        text='An error occurred.',
-    )
+    return ErrorMessage(lang='en_US', text='An error occurred.')
 
 # ** fixture: formatted_error_message
 @pytest.fixture
@@ -42,11 +37,7 @@ def formatted_error_message() -> ErrorMessage:
     '''
 
     # Create and return a new ErrorMessage with a format placeholder.
-    return DomainObject.new(
-        ErrorMessage,
-        lang='en_US',
-        text='An error occurred: {error}',
-    )
+    return ErrorMessage(lang='en_US', text='An error occurred: {error}')
 
 # ** fixture: error
 @pytest.fixture
@@ -60,8 +51,8 @@ def error(error_message: ErrorMessage) -> Error:
     :rtype: Error
     '''
 
-    # Create and return a new Error via the custom factory.
-    return Error.new(
+    # Create and return a new Error via direct construction.
+    return Error(
         id='TEST_ERROR',
         name='Test Error',
         message=[error_message],
@@ -80,7 +71,7 @@ def error_with_formatted_message(formatted_error_message: ErrorMessage) -> Error
     '''
 
     # Create and return a new Error with a formatted message.
-    return Error.new(
+    return Error(
         id='TEST_FORMATTED_ERROR',
         name='Test Formatted Error',
         message=[formatted_error_message],
@@ -88,10 +79,10 @@ def error_with_formatted_message(formatted_error_message: ErrorMessage) -> Error
 
 # *** tests
 
-# ** test: error_new
-def test_error_new(error: Error) -> None:
+# ** test: error_construction_derives_error_code
+def test_error_construction_derives_error_code(error: Error) -> None:
     '''
-    Test that Error.new() sets id, name, error_code, and message correctly.
+    Test that constructing an Error derives error_code from id via the model validator.
 
     :param error: The Error fixture.
     :type error: Error


### PR DESCRIPTION
## Summary

Migrates `ErrorMessage` and `Error` domain objects from schematics type declarations to idiomatic Pydantic v2 field annotations.

### Changes
- **`tiferet/domain/error.py`**: Replaced schematics `StringType`/`ListType`/`ModelType` with Pydantic `Field(...)` annotations. Replaced `Error.new()` static factory with `@model_validator(mode='before')` that auto-derives `error_code` from `id`.
- **`tiferet/domain/tests/test_error.py`**: Updated all fixtures to use direct Pydantic constructors. Renamed `test_error_new` → `test_error_construction_derives_error_code`.

All 6 tests pass.

Closes #748

---
[Warp conversation](https://app.warp.dev/conversation/44320255-01c3-4afa-bed4-72b6bdb737c7)

Co-Authored-By: Oz <oz-agent@warp.dev>