### PR TITLE
Domain – Migrate Feature Domain to Pydantic v2

### DIFF
--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -2,15 +2,14 @@
 
 # *** imports
 
+# ** core
+from typing import Any, Dict, List, Literal
+
+# ** infra
+from pydantic import Field, model_validator
+
 # ** app
-from .settings import (
-    DomainObject,
-    StringType,
-    BooleanType,
-    ListType,
-    DictType,
-    ModelType,
-)
+from .settings import DomainObject
 
 # *** models
 
@@ -21,21 +20,10 @@ class FeatureStep(DomainObject):
     '''
 
     # * attribute: type
-    type = StringType(
-        choices=['event'],
-        default='event',
-        metadata=dict(
-            description='The type of the feature step.'
-        )
-    )
+    type: Literal['event'] = Field(default='event', description='The type of the feature step.')
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the feature step.'
-        )
-    )
+    name: str = Field(..., description='The name of the feature step.')
 
 
 # ** model: feature_event
@@ -45,53 +33,22 @@ class FeatureEvent(FeatureStep):
     '''
 
     # * attribute: service_id
-    service_id = StringType(
-        required=True,
-        metadata=dict(
-            description='The service configuration ID for the feature event.'
-        )
-    )
+    service_id: str = Field(..., description='The service configuration ID for the feature event.')
 
     # * attribute: flags
-    flags = ListType(
-        StringType(),
-        default=[],
-        metadata=dict(
-            description='List of feature flags that activate this event.'
-        )
-    )
+    flags: List[str] = Field(default_factory=list, description='List of feature flags that activate this event.')
 
     # * attribute: parameters
-    parameters = DictType(
-        StringType(),
-        default={},
-        metadata=dict(
-            description='The custom parameters for the feature event.'
-        )
-    )
+    parameters: Dict[str, str] = Field(default_factory=dict, description='The custom parameters for the feature event.')
 
     # * attribute: return_to_data (obsolete)
-    return_to_data = BooleanType(
-        default=False,
-        metadata=dict(
-            description='Whether to return the feature event result to the feature data context.'
-        )
-    )
+    return_to_data: bool = Field(default=False, description='Whether to return the feature event result to the feature data context.')
 
     # * attribute: data_key
-    data_key = StringType(
-        metadata=dict(
-            description='The data key to store the feature event result in if Return to Data is True.'
-        )
-    )
+    data_key: str | None = Field(default=None, description='The data key to store the feature event result in if Return to Data is True.')
 
     # * attribute: pass_on_error
-    pass_on_error = BooleanType(
-        default=False,
-        metadata=dict(
-            description='Whether to pass on the error if the feature event fails.'
-        )
-    )
+    pass_on_error: bool = Field(default=False, description='Whether to pass on the error if the feature event fails.')
 
 
 # ** model: feature
@@ -101,70 +58,72 @@ class Feature(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the feature.'
-        )
-    )
+    id: str = Field(..., description='The unique identifier of the feature.')
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the feature.'
-        )
-    )
+    name: str = Field(..., description='The name of the feature.')
 
     # * attribute: flags
-    flags = ListType(
-        StringType(),
-        default=[],
-        metadata=dict(
-            description='List of feature flags that activate this entire feature.'
-        )
-    )
+    flags: List[str] = Field(default_factory=list, description='List of feature flags that activate this entire feature.')
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the feature.'
-        )
-    )
+    description: str | None = Field(default=None, description='The description of the feature.')
 
     # * attribute: group_id
-    group_id = StringType(
-        required=True,
-        metadata=dict(
-            description='The context group identifier for the feature.'
-        )
-    )
+    group_id: str = Field(..., description='The context group identifier for the feature.')
 
     # * attribute: feature_key
-    feature_key = StringType(
-        required=True,
-        metadata=dict(
-            description='The key of the feature.'
-        )
-    )
+    feature_key: str = Field(..., description='The key of the feature.')
 
     # * attribute: steps
-    steps = ListType(
-        ModelType(FeatureEvent),
-        default=[],
-        metadata=dict(
-            description='The step workflow for the feature.'
-        )
-    )
+    steps: List[FeatureEvent] = Field(default_factory=list, description='The step workflow for the feature.')
 
     # * attribute: log_params
-    log_params = DictType(
-        StringType(),
-        default={},
-        metadata=dict(
-            description='The parameters to log for the feature.'
-        )
-    )
+    log_params: Dict[str, str] = Field(default_factory=dict, description='The parameters to log for the feature.')
+
+    # * method: _derive_keys (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def _derive_keys(cls, data: Any) -> Any:
+        '''
+        Derive ``id``, ``group_id``, ``feature_key``, and ``description`` from
+        whichever inputs are provided so callers may supply any consistent subset.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The (possibly augmented) input data.
+        :rtype: Any
+        '''
+
+        # Only mutate dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        # Derive group_id and feature_key from id when id is dotted.
+        if (
+            data.get('id')
+            and '.' in str(data['id'])
+            and (not data.get('group_id') or not data.get('feature_key'))
+        ):
+            group_id, feature_key = str(data['id']).split('.', 1)
+            data.setdefault('group_id', group_id)
+            data.setdefault('feature_key', feature_key)
+
+        # Derive feature_key from name (snake-case) when missing.
+        if data.get('name') and not data.get('feature_key'):
+            data['feature_key'] = str(data['name']).lower().replace(' ', '_')
+
+        # Derive id from group_id and feature_key when missing.
+        if not data.get('id') and data.get('group_id') and data.get('feature_key'):
+            data['id'] = f"{data['group_id']}.{data['feature_key']}"
+
+        # Default description to name when missing.
+        if data.get('name') and not data.get('description'):
+            data['description'] = data['name']
+
+        # Return the (possibly augmented) input data.
+        return data
 
     # * method: get_step
     def get_step(self, position: int) -> FeatureStep | None:

--- a/tiferet/domain/tests/test_feature.py
+++ b/tiferet/domain/tests/test_feature.py
@@ -6,7 +6,6 @@
 import pytest
 
 # ** app
-from ..settings import DomainObject
 from ..feature import (
     Feature,
     FeatureStep,
@@ -26,8 +25,7 @@ def feature() -> Feature:
     '''
 
     # Create and return a new Feature.
-    return DomainObject.new(
-        Feature,
+    return Feature(
         id='test_group.test_feature',
         name='Test Feature',
         group_id='test_group',
@@ -45,8 +43,7 @@ def test_feature_step_type_defaults_to_event() -> None:
     '''
 
     # Create a FeatureEvent with minimal required fields.
-    event = DomainObject.new(
-        FeatureEvent,
+    event = FeatureEvent(
         name='Test Event',
         service_id='test_event_service',
     )
@@ -54,9 +51,9 @@ def test_feature_step_type_defaults_to_event() -> None:
     # Assert type defaults to 'event'.
     assert event.type == 'event'
 
-    # Serialize via to_primitive() and reload.
-    primitive = event.to_primitive()
-    reloaded = DomainObject.new(FeatureEvent, **primitive)
+    # Serialize via model_dump() and reload.
+    primitive = event.model_dump()
+    reloaded = FeatureEvent(**primitive)
 
     # Assert type is preserved through round-trip.
     assert reloaded.type == 'event'
@@ -68,8 +65,7 @@ def test_feature_event_flags_creation_and_round_trip() -> None:
     '''
 
     # Create a FeatureEvent with flags.
-    event = DomainObject.new(
-        FeatureEvent,
+    event = FeatureEvent(
         name='Flagged Event',
         service_id='flagged_event_service',
         flags=['flag1', 'flag2'],
@@ -78,9 +74,9 @@ def test_feature_event_flags_creation_and_round_trip() -> None:
     # Assert flags are set correctly.
     assert event.flags == ['flag1', 'flag2']
 
-    # Serialize via to_primitive() and reload.
-    primitive = event.to_primitive()
-    reloaded = DomainObject.new(FeatureEvent, **primitive)
+    # Serialize via model_dump() and reload.
+    primitive = event.model_dump()
+    reloaded = FeatureEvent(**primitive)
 
     # Assert flags are preserved through round-trip.
     assert reloaded.flags == ['flag1', 'flag2']
@@ -95,13 +91,11 @@ def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
     '''
 
     # Create two FeatureEvent steps.
-    step_0 = DomainObject.new(
-        FeatureEvent,
+    step_0 = FeatureEvent(
         name='Step Zero',
         service_id='step_zero_service',
     )
-    step_1 = DomainObject.new(
-        FeatureEvent,
+    step_1 = FeatureEvent(
         name='Step One',
         service_id='step_one_service',
     )


### PR DESCRIPTION
## Summary

Migrates `FeatureStep`, `FeatureEvent`, and `Feature` domain objects from schematics type declarations to idiomatic Pydantic v2 field annotations.

### Changes
- **`tiferet/domain/feature.py`**: Replaced all schematics types with Pydantic `Field(...)` annotations. Replaced `StringType(choices=[...])` with `Literal['event']` for `FeatureStep.type`. Added `_derive_keys` `@model_validator(mode='before')` on `Feature` for automatic key derivation (`id`, `group_id`, `feature_key`, `description`).
- **`tiferet/domain/tests/test_feature.py`**: Updated all fixtures/instantiations to direct Pydantic constructors. Replaced `to_primitive()` with `model_dump()` in round-trip tests.

All 3 tests pass.

Closes #749

---
[Warp conversation](https://app.warp.dev/conversation/44320255-01c3-4afa-bed4-72b6bdb737c7)

Co-Authored-By: Oz <oz-agent@warp.dev>