### PR TITLE
Domain – Migrate App Domain to Pydantic v2 (#750)

### DIFF
--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -4,17 +4,14 @@
 
 # ** core
 from importlib import import_module
-from typing import Dict
+from typing import Dict, List
+
+# ** infra
+from pydantic import Field
 
 # ** app
-from .settings import (
-    DomainObject,
-    StringType,
-    ListType,
-    DictType,
-    ModelType,
-)
 from ..di import ServiceProvider
+from .settings import DomainObject
 
 # *** models
 
@@ -25,36 +22,27 @@ class AppServiceDependency(DomainObject):
     '''
 
     # * attribute: service_id
-    service_id = StringType(
-        required=True,
-        metadata=dict(
-            description='The service id for the application dependency.'
-        ),
+    service_id: str = Field(
+        ...,
+        description='The service id for the application dependency.',
     )
 
     # * attribute: module_path
-    module_path = StringType(
-        required=True,
-        metadata=dict(
-            description='The module path for the app dependency.'
-        ),
+    module_path: str = Field(
+        ...,
+        description='The module path for the app dependency.',
     )
 
     # * attribute: class_name
-    class_name = StringType(
-        required=True,
-        metadata=dict(
-            description='The class name for the app dependency.'
-        ),
+    class_name: str = Field(
+        ...,
+        description='The class name for the app dependency.',
     )
 
     # * attribute: parameters
-    parameters = DictType(
-        StringType,
-        default={},
-        metadata=dict(
-            description='The parameters for the application dependency.'
-        ),
+    parameters: Dict[str, str] = Field(
+        default_factory=dict,
+        description='The parameters for the application dependency.',
     )
 
     # * method: get_service_type
@@ -77,105 +65,80 @@ class AppInterface(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier for the application interface.'
-        ),
+    id: str = Field(
+        ...,
+        description='The unique identifier for the application interface.',
     )
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the application interface.'
-        ),
+    name: str = Field(
+        ...,
+        description='The name of the application interface.',
     )
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the application interface.'
-        ),
+    description: str | None = Field(
+        default=None,
+        description='The description of the application interface.',
     )
 
     # * attribute: module_path
-    module_path = StringType(
-        required=True,
-        metadata=dict(
-            description='The module path for the application instance context.'
-        ),
+    module_path: str = Field(
+        ...,
+        description='The module path for the application instance context.',
     )
 
     # * attribute: class_name
-    class_name = StringType(
-        required=True,
-        metadata=dict(
-            description='The class name for the application instance context.'
-        ),
-    )
-
-    # * attribute: logger_id
-    logger_id = StringType(
-        default='default',
-        metadata=dict(
-            description='The logger ID for the application instance.'
-        ),
-    )
-
-    # * attribute: flags
-    flags = ListType(
-        StringType(),
-        default=['default'],
-        metadata=dict(
-            description='The flags for the application interface.'
-        ),
-    )
-
-    # * attribute: services
-    services = ListType(
-        ModelType(AppServiceDependency),
-        required=True,
-        default=[],
-        metadata=dict(
-            description='The application instance service dependencies.'
-        ),
-    )
-
-    # * attribute: constants
-    constants = DictType(
-        StringType,
-        default={},
-        metadata=dict(
-            description='The application dependency constants.'
-        ),
+    class_name: str = Field(
+        ...,
+        description='The class name for the application instance context.',
     )
 
     # * attribute: service_provider_path
-    service_provider_path = StringType(
+    service_provider_path: str = Field(
         default='tiferet.di.dependencies',
-        metadata=dict(
-            description='The module path for the service provider to use for this dependency.'
-        ),
+        description='The module path for the service provider to use for this dependency.',
     )
 
     # * attribute: service_provider_class_name
-    service_provider_class_name = StringType(
+    service_provider_class_name: str = Field(
         default='DependenciesServiceProvider',
-        metadata=dict(
-            description='The class name for the service provider to use for this dependency.'
-        ),
+        description='The class name for the service provider to use for this dependency.',
+    )
+
+    # * attribute: logger_id
+    logger_id: str = Field(
+        default='default',
+        description='The logger ID for the application instance.',
+    )
+
+    # * attribute: flags
+    flags: List[str] = Field(
+        default_factory=lambda: ['default'],
+        description='The flags for the application interface.',
+    )
+
+    # * attribute: services
+    services: List[AppServiceDependency] = Field(
+        default_factory=list,
+        description='The application instance service dependencies.',
+    )
+
+    # * attribute: constants
+    constants: Dict[str, str] = Field(
+        default_factory=dict,
+        description='The application dependency constants.',
     )
 
     # * method: get_service
-    def get_service(self, service_id: str) -> AppServiceDependency:
+    def get_service(self, service_id: str) -> AppServiceDependency | None:
         '''
         Get the service dependency by service id.
 
         :param service_id: The service id of the service dependency.
         :type service_id: str
-        :return: The service dependency.
-        :rtype: AppServiceDependency
+        :return: The matching service dependency, or ``None``.
+        :rtype: AppServiceDependency | None
         '''
 
         # Get the service dependency by service id.
@@ -191,7 +154,7 @@ class AppInterface(DomainObject):
         '''
 
         # Retrieve the app context dependency, interface id, and logger id.
-        dependencies = dict(
+        dependencies: Dict[str, type] = dict(
             app_context=getattr(
                 import_module(self.module_path),
                 self.class_name,

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -29,9 +29,7 @@ def app_dependency() -> AppServiceDependency:
     '''
 
     # Create and return a new AppServiceDependency.
-    return DomainObject.new(
-        AppServiceDependency,
-        service_id='test_service',
+    return AppServiceDependency(service_id='test_service',
         module_path='test_module_path',
         class_name='test_class_name',
         parameters={'param1': 'value1', 'param2': 'value2'},
@@ -49,9 +47,7 @@ def resolvable_app_dependency() -> AppServiceDependency:
     '''
 
     # Use a real module path so import_module resolves correctly.
-    return DomainObject.new(
-        AppServiceDependency,
-        service_id='resolvable_service',
+    return AppServiceDependency(service_id='resolvable_service',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',
         parameters={'param1': 'value1'},
@@ -70,9 +66,7 @@ def app_interface(app_dependency: AppServiceDependency) -> AppInterface:
     '''
 
     # Create and return a new AppInterface.
-    return DomainObject.new(
-        AppInterface,
-        id='test',
+    return AppInterface(id='test',
         name='Test App',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',
@@ -127,9 +121,7 @@ def test_app_interface_get_service_type_mapping(resolvable_app_dependency: AppSe
     '''
 
     # Create an AppInterface with a resolvable service dependency.
-    interface = DomainObject.new(
-        AppInterface,
-        id='test',
+    interface = AppInterface(id='test',
         name='Test App',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',
@@ -162,9 +154,7 @@ def test_app_interface_get_service_type_mapping_no_services() -> None:
     '''
 
     # Create an AppInterface with no services.
-    interface = DomainObject.new(
-        AppInterface,
-        id='empty',
+    interface = AppInterface(id='empty',
         name='Empty App',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',
@@ -205,9 +195,7 @@ def test_app_interface_service_provider_defaults() -> None:
     '''
 
     # Create an AppInterface with minimal required data.
-    interface = DomainObject.new(
-        AppInterface,
-        id='test',
+    interface = AppInterface(id='test',
         name='Test App',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',
@@ -229,9 +217,7 @@ def test_app_interface_create_service_provider(resolvable_app_dependency: AppSer
     '''
 
     # Create an AppInterface with a resolvable service dependency.
-    interface = DomainObject.new(
-        AppInterface,
-        id='test',
+    interface = AppInterface(id='test',
         name='Test App',
         module_path='tiferet.contexts.app',
         class_name='AppInterfaceContext',


### PR DESCRIPTION
## Summary

Migrates `AppServiceDependency` and `AppInterface` in `tiferet/domain/app.py` from schematics type declarations to idiomatic Pydantic v2 `Field(...)` annotations. Updates all test fixtures and inline constructions in `tiferet/domain/tests/test_app.py` to use direct Pydantic constructors.

## Changes

### `tiferet/domain/app.py`
- Replaced all schematics type attributes (`StringType`, `ListType`, `DictType`, `ModelType`) with Pydantic `Field(...)` annotations
- Removed duplicate `service_provider_path` / `service_provider_class_name` attribute declarations
- Removed duplicate `from ..di import ServiceProvider` import
- Updated `get_service()` return type to `AppServiceDependency | None`
- Added `Dict[str, type]` annotation to `dependencies` local in `get_service_type_mapping()`
- Reordered imports: `pydantic.Field` under `# ** infra`, removed schematics type imports

### `tiferet/domain/tests/test_app.py`
- Replaced all `DomainObject.new(Type, ...)` calls with direct Pydantic constructors in fixtures and inline test constructions

## Test Results
- 3/7 tests pass (the ones that don't trigger the `tiferet.contexts` import chain)
- 4 tests fail due to a pre-existing import chain issue: `contexts/logging.py` imports `Formatter`/`Handler`/`Logger` from `tiferet.domain`, but `domain/logging.py` still uses schematics types (migration tracked in a separate story)
- On the base branch, 0/7 tests could even be collected since `domain/app.py` imported non-existent schematics types

Closes #750

---
[Warp conversation](https://app.warp.dev/conversation/41816633-b37b-47a1-a7f3-e02bb36e8d9b)

Co-Authored-By: Oz <oz-agent@warp.dev>