### PR TITLE
Domain – Migrate Logging Domain to Pydantic v2 (#753)

### DIFF
--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -4,36 +4,29 @@
 
 # ** app
 from .settings import DomainObject
-
-# Concrete domain modules are guarded during the Pydantic v2 migration.
-# Modules that still reference removed Schematics type wrappers will raise
-# ImportError until migrated in subsequent stories (#4-9).
-try:
-    from .app import (
-        AppInterface,
-        AppServiceDependency,
-    )
-    from .di import (
-        FlaggedDependency,
-        ServiceConfiguration,
-    )
-    from .cli import (
-        CliArgument,
-        CliCommand,
-    )
-    from .error import (
-        Error,
-        ErrorMessage,
-    )
-    from .feature import (
-        Feature,
-        FeatureStep,
-        FeatureEvent,
-    )
-    from .logging import (
-        Formatter,
-        Handler,
-        Logger,
-    )
-except ImportError:
-    pass
+from .app import (
+    AppInterface,
+    AppServiceDependency,
+)
+from .di import (
+    FlaggedDependency,
+    ServiceConfiguration,
+)
+from .cli import (
+    CliArgument,
+    CliCommand,
+)
+from .error import (
+    Error,
+    ErrorMessage,
+)
+from .feature import (
+    Feature,
+    FeatureStep,
+    FeatureEvent,
+)
+from .logging import (
+    Formatter,
+    Handler,
+    Logger,
+)

--- a/tiferet/domain/logging.py
+++ b/tiferet/domain/logging.py
@@ -1,17 +1,15 @@
-"""Tiferet Domain Logging"""
+"""Tiferet Logging Domain Models"""
 
 # *** imports
 
 # ** core
-from typing import Any, Dict
+from typing import Any, Dict, List, Literal
+
+# ** infra
+from pydantic import Field
 
 # ** app
-from .settings import (
-    DomainObject,
-    StringType,
-    BooleanType,
-    ListType,
-)
+from .settings import DomainObject
 
 # *** models
 
@@ -22,41 +20,33 @@ class Formatter(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the formatter.'
-        )
+    id: str = Field(
+        ...,
+        description='The unique identifier of the formatter.',
     )
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the formatter.'
-        )
+    name: str = Field(
+        ...,
+        description='The name of the formatter.',
     )
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the formatter.'
-        )
+    description: str | None = Field(
+        default=None,
+        description='The description of the formatter.',
     )
 
     # * attribute: format
-    format = StringType(
-        required=True,
-        metadata=dict(
-            description='The format string for log messages.'
-        )
+    format: str = Field(
+        ...,
+        description='The format string for log messages.',
     )
 
     # * attribute: datefmt
-    datefmt = StringType(
-        metadata=dict(
-            description='The date format for log timestamps.'
-        )
+    datefmt: str | None = Field(
+        default=None,
+        description='The date format for log timestamps.',
     )
 
     # * method: format_config
@@ -71,9 +61,8 @@ class Formatter(DomainObject):
         # Return the formatter configuration.
         return {
             'format': self.format,
-            'datefmt': self.datefmt
+            'datefmt': self.datefmt,
         }
-
 
 # ** model: handler
 class Handler(DomainObject):
@@ -82,73 +71,57 @@ class Handler(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the handler.'
-        )
+    id: str = Field(
+        ...,
+        description='The unique identifier of the handler.',
     )
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the handler.'
-        )
+    name: str = Field(
+        ...,
+        description='The name of the handler.',
     )
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the handler.'
-        )
+    description: str | None = Field(
+        default=None,
+        description='The description of the handler.',
     )
 
     # * attribute: module_path
-    module_path = StringType(
-        required=True,
-        metadata=dict(
-            description='The module path for the handler class.'
-        )
+    module_path: str = Field(
+        ...,
+        description='The module path for the handler class.',
     )
 
     # * attribute: class_name
-    class_name = StringType(
-        required=True,
-        metadata=dict(
-            description='The class name of the handler.'
-        )
+    class_name: str = Field(
+        ...,
+        description='The class name of the handler.',
     )
 
     # * attribute: level
-    level = StringType(
-        required=True,
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        metadata=dict(
-            description='The logging level for the handler (e.g., INFO, DEBUG).'
-        )
+    level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = Field(
+        ...,
+        description='The logging level for the handler (e.g., INFO, DEBUG).',
     )
 
     # * attribute: formatter
-    formatter = StringType(
-        required=True,
-        metadata=dict(
-            description='The id of the formatter to use.'
-        )
+    formatter: str = Field(
+        ...,
+        description='The id of the formatter to use.',
     )
 
     # * attribute: stream
-    stream = StringType(
-        metadata=dict(
-            description='The stream for StreamHandler (e.g., ext://sys.stdout).'
-        )
+    stream: str | None = Field(
+        default=None,
+        description='The stream for StreamHandler (e.g., ext://sys.stdout).',
     )
 
     # * attribute: filename
-    filename = StringType(
-        metadata=dict(
-            description='The file path for FileHandler (e.g., app.log).'
-        )
+    filename: str | None = Field(
+        default=None,
+        description='The file path for FileHandler (e.g., app.log).',
     )
 
     # * method: format_config
@@ -164,7 +137,7 @@ class Handler(DomainObject):
         config = {
             'class': f'{self.module_path}.{self.class_name}',
             'level': self.level,
-            'formatter': self.formatter
+            'formatter': self.formatter,
         }
 
         # Add optional attributes if they are set.
@@ -176,7 +149,6 @@ class Handler(DomainObject):
         # Return the handler configuration.
         return config
 
-
 # ** model: logger
 class Logger(DomainObject):
     '''
@@ -184,60 +156,45 @@ class Logger(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the logger.'
-        )
+    id: str = Field(
+        ...,
+        description='The unique identifier of the logger.',
     )
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the logger.'
-        )
+    name: str = Field(
+        ...,
+        description='The name of the logger.',
     )
 
     # * attribute: description
-    description = StringType(
-        metadata=dict(
-            description='The description of the logger.'
-        )
+    description: str | None = Field(
+        default=None,
+        description='The description of the logger.',
     )
 
     # * attribute: level
-    level = StringType(
-        required=True,
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        metadata=dict(
-            description='The logging level for the logger (e.g., DEBUG, WARNING).'
-        )
+    level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = Field(
+        ...,
+        description='The logging level for the logger (e.g., DEBUG, WARNING).',
     )
 
     # * attribute: handlers
-    handlers = ListType(
-        StringType(),
-        default=[],
-        metadata=dict(
-            description='List of handler ids for the logger.'
-        )
+    handlers: List[str] = Field(
+        default_factory=list,
+        description='List of handler ids for the logger.',
     )
 
     # * attribute: propagate
-    propagate = BooleanType(
+    propagate: bool = Field(
         default=False,
-        metadata=dict(
-            description='Whether to propagate messages to parent loggers.'
-        )
+        description='Whether to propagate messages to parent loggers.',
     )
 
     # * attribute: is_root
-    is_root = BooleanType(
+    is_root: bool = Field(
         default=False,
-        metadata=dict(
-            description='Whether this is the root logger.'
-        )
+        description='Whether this is the root logger.',
     )
 
     # * method: format_config
@@ -253,5 +210,5 @@ class Logger(DomainObject):
         return {
             'level': self.level,
             'handlers': self.handlers,
-            'propagate': self.propagate
+            'propagate': self.propagate,
         }

--- a/tiferet/domain/tests/test_logging.py
+++ b/tiferet/domain/tests/test_logging.py
@@ -26,9 +26,7 @@ def formatter() -> Formatter:
     '''
 
     # Create and return a new Formatter.
-    return DomainObject.new(
-        Formatter,
-        id='simple',
+    return Formatter(id='simple',
         name='Simple Formatter',
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S',
@@ -45,9 +43,7 @@ def handler() -> Handler:
     '''
 
     # Create and return a new Handler.
-    return DomainObject.new(
-        Handler,
-        id='console',
+    return Handler(id='console',
         name='Console Handler',
         module_path='logging',
         class_name='StreamHandler',
@@ -67,9 +63,7 @@ def handler_no_optional() -> Handler:
     '''
 
     # Create and return a new Handler without optional attributes.
-    return DomainObject.new(
-        Handler,
-        id='bare',
+    return Handler(id='bare',
         name='Bare Handler',
         module_path='logging',
         class_name='StreamHandler',
@@ -88,9 +82,7 @@ def logger() -> Logger:
     '''
 
     # Create and return a new Logger.
-    return DomainObject.new(
-        Logger,
-        id='app',
+    return Logger(id='app',
         name='App Logger',
         level='DEBUG',
         handlers=['console'],
@@ -108,9 +100,7 @@ def logger_empty_handlers() -> Logger:
     '''
 
     # Create and return a new Logger with empty handlers.
-    return DomainObject.new(
-        Logger,
-        id='root',
+    return Logger(id='root',
         name='Root Logger',
         level='WARNING',
         handlers=[],
@@ -143,9 +133,7 @@ def test_formatter_format_config_no_datefmt() -> None:
     '''
 
     # Create a Formatter without datefmt.
-    formatter = DomainObject.new(
-        Formatter,
-        id='minimal',
+    formatter = Formatter(id='minimal',
         name='Minimal Formatter',
         format='%(message)s',
     )


### PR DESCRIPTION
## Summary

Migrates `Formatter`, `Handler`, and `Logger` in `tiferet/domain/logging.py` from schematics type declarations to idiomatic Pydantic v2 `Field(...)` annotations. Also removes the `try/except` import guard from `tiferet/domain/__init__.py` since all domain modules are now fully migrated to Pydantic v2.

## Changes

### `tiferet/domain/logging.py`
- Replaced all schematics type attributes with Pydantic `Field(...)` annotations
- `Handler.level` and `Logger.level` use `Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']`
- Optional string attributes (`description`, `datefmt`, `stream`, `filename`) are `str | None` with `default=None`
- `handlers` uses `default_factory=list`; `propagate` and `is_root` use `default=False`
- Added trailing commas to dict literals in all `format_config()` methods
- Removed stray blank lines between model classes

### `tiferet/domain/tests/test_logging.py`
- Replaced all 6 `DomainObject.new(Type, ...)` calls with direct Pydantic constructors

### `tiferet/domain/__init__.py`
- **Removed the `try/except ImportError` guard** around all domain module imports — all domain modules are now migrated to Pydantic v2 and import cleanly
- This also unblocks the 4 previously-failing `test_app.py` tests (which depended on the `contexts` → `domain.logging` import chain)

## Test Results
- **6/6 logging tests pass**, 0 failures
- **7/7 app tests now pass** (previously 4 failed due to the import chain)

## Deviations vs TRD
- Removed the `try/except` import guard from `domain/__init__.py` (not in TRD scope, but necessary since this was the last blocking domain module)

Closes #753

---
[Warp conversation](https://app.warp.dev/conversation/41816633-b37b-47a1-a7f3-e02bb36e8d9b)

Co-Authored-By: Oz <oz-agent@warp.dev>