### PR TITLE
Mappers – Migrate Error Mappers to Pydantic v2

### DIFF
--- a/tiferet/mappers/error.py
+++ b/tiferet/mappers/error.py
@@ -3,14 +3,15 @@
 # *** imports
 
 # ** core
-from typing import Dict, Any
+from typing import Any, ClassVar, Dict, List
+
+# ** infra
+from pydantic import Field
 
 # ** app
 from ..domain import (
     Error,
     ErrorMessage,
-    ListType,
-    ModelType,
 )
 from .settings import (
     Aggregate,
@@ -25,34 +26,6 @@ class ErrorAggregate(Error, Aggregate):
     An aggregate representation of an error.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'ErrorAggregate':
-        '''
-        Initializes a new error aggregate.
-
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new error aggregate.
-        :rtype: ErrorAggregate
-        '''
-
-        # Create a new error aggregate from the provided data.
-        return Aggregate.new(
-            ErrorAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
-        )
-
     # * method: rename
     def rename(self, new_name: str) -> None:
         '''
@@ -64,11 +37,8 @@ class ErrorAggregate(Error, Aggregate):
         :rtype: None
         '''
 
-        # Update the name.
+        # Update the name; validate_assignment=True handles re-validation.
         self.name = new_name
-
-        # Perform final aggregate validation.
-        self.validate()
 
     # * method: set_message
     def set_message(self, lang: str, text: str) -> None:
@@ -89,15 +59,8 @@ class ErrorAggregate(Error, Aggregate):
                 msg.text = text
                 return
 
-        # If not, create a new ErrorMessage object and add it to the message list.
-        from ..domain import DomainObject
-        self.message.append(
-            DomainObject.new(
-                ErrorMessage,
-                lang=lang,
-                text=text
-            )
-        )
+        # If not, create a new ErrorMessage and add it via list reassignment.
+        self.message = self.message + [ErrorMessage(lang=lang, text=text)]
 
     # * method: remove_message
     def remove_message(self, lang: str) -> None:
@@ -110,8 +73,9 @@ class ErrorAggregate(Error, Aggregate):
         :rtype: None
         '''
 
-        # Filter out the message with the specified language.
+        # Filter out the message with the specified language via list reassignment.
         self.message = [msg for msg in self.message if msg.lang != lang]
+
 
 # ** mapper: error_message_yaml_object
 class ErrorMessageYamlObject(ErrorMessage, TransferObject):
@@ -119,55 +83,25 @@ class ErrorMessageYamlObject(ErrorMessage, TransferObject):
     A YAML data representation of an error message object.
     '''
 
-    class Options():
-        '''
-        The options for the error message data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny(),
-            'to_data.yaml': TransferObject.deny(),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {},
+        'to_data.yaml': {'by_alias': True},
+    }
 
     # * method: map
-    def map(self, **kwargs) -> ErrorMessage:
+    def map(self, **overrides) -> ErrorMessage:
         '''
         Maps the error message data to an error message object.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new error message object.
         :rtype: ErrorMessage
         '''
 
         # Map to the error message object.
-        return super().map(
-            ErrorMessage,
-            **self.to_primitive('to_model'),
-            **kwargs
-        )
-
-    # * method: from_model
-    @staticmethod
-    def from_model(error_message: ErrorMessage, **kwargs) -> 'ErrorMessageYamlObject':
-        '''
-        Creates an ErrorMessageYamlObject from an ErrorMessage model.
-
-        :param error_message: The error message model.
-        :type error_message: ErrorMessage
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new ErrorMessageYamlObject.
-        :rtype: ErrorMessageYamlObject
-        '''
-
-        # Create a new ErrorMessageYamlObject from the model.
-        return TransferObject.from_model(
-            ErrorMessageYamlObject,
-            error_message,
-            **kwargs,
-        )
+        return super().map(ErrorMessage, **overrides)
 
 
 # ** mapper: error_yaml_object
@@ -176,67 +110,57 @@ class ErrorYamlObject(Error, TransferObject):
     A YAML data representation of an error object.
     '''
 
-    class Options():
-        '''
-        The options for the error data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('message'),
-            'to_data.yaml': TransferObject.deny('id'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'message'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+    }
 
     # * attribute: message
-    message = ListType(
-        ModelType(ErrorMessageYamlObject),
-        required=True,
-        metadata=dict(
-            description='The error messages.'
-        )
+    message: List[ErrorMessageYamlObject] = Field(
+        default_factory=list,
+        description='The error messages.',
     )
 
     # * method: map
-    def map(self, **kwargs) -> ErrorAggregate:
+    def map(self, **overrides) -> ErrorAggregate:
         '''
         Maps the error data to an error aggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new error aggregate.
         :rtype: ErrorAggregate
         '''
 
-        # Map the error data.
+        # Map the error data with nested message conversion.
         return super().map(
             ErrorAggregate,
             message=[msg.map() for msg in self.message],
-            **self.to_primitive('to_model'),
-            **kwargs
+            **overrides,
         )
 
     # * method: from_model
-    @staticmethod
-    def from_model(error: Error, **kwargs) -> 'ErrorYamlObject':
+    @classmethod
+    def from_model(cls, error: Error, **overrides) -> 'ErrorYamlObject':
         '''
         Creates an ErrorYamlObject from an Error model.
 
         :param error: The error model.
         :type error: Error
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new ErrorYamlObject.
         :rtype: ErrorYamlObject
         '''
 
         # Create a new ErrorYamlObject from the model, converting
         # the message list into ErrorMessageYamlObject instances.
-        return TransferObject.from_model(
-            ErrorYamlObject,
+        return super().from_model(
             error,
             message=[
-                TransferObject.from_model(ErrorMessageYamlObject, msg)
+                ErrorMessageYamlObject.from_model(msg)
                 for msg in error.message
             ],
-            **kwargs,
+            **overrides,
         )

--- a/tiferet/mappers/tests/test_error.py
+++ b/tiferet/mappers/tests/test_error.py
@@ -4,12 +4,10 @@
 
 # ** app
 from ...domain import (
-    DomainObject,
     Error,
     ErrorMessage,
 )
 from ...events import a
-from ..settings import TransferObject
 from ..error import (
     ErrorAggregate,
     ErrorYamlObject,
@@ -162,11 +160,11 @@ class TestErrorYamlObject(TransferObjectTestBase):
     # ** test: from_data
     def test_from_data(self):
         '''
-        Test that from_data() initializes scalar fields and nested ErrorMessageYamlObject instances.
+        Test that model_validate() initializes scalar fields and nested ErrorMessageYamlObject instances.
         '''
 
         # Create a YAML object from sample data.
-        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+        yaml_obj = ErrorYamlObject.model_validate(self.sample_data)
 
         # Assert scalar fields.
         assert yaml_obj.name == 'TEST_ERROR'
@@ -185,7 +183,7 @@ class TestErrorYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object and serialize.
-        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+        yaml_obj = ErrorYamlObject.model_validate(self.sample_data)
         primitive = yaml_obj.to_primitive('to_data.yaml')
 
         # Assert id is excluded.
@@ -206,7 +204,7 @@ class TestErrorYamlObject(TransferObjectTestBase):
         '''
 
         # Create YAML object and map.
-        yaml_obj = TransferObject.from_data(ErrorYamlObject, **self.sample_data)
+        yaml_obj = ErrorYamlObject.model_validate(self.sample_data)
         mapped = yaml_obj.map()
 
         # Assert messages are ErrorMessage instances.
@@ -250,14 +248,14 @@ class TestErrorYamlObject(TransferObjectTestBase):
             assert restored.lang == original.lang
             assert restored.text == original.text
 
-    # ** test: from_model_via_error_new
-    def test_from_model_via_error_new(self):
+    # ** test: from_model_via_error_constructor
+    def test_from_model_via_error_constructor(self):
         '''
-        Test that from_model() works with an Error.new() factory-created model with multilingual messages.
+        Test that from_model() works with a directly constructed Error model with multilingual messages.
         '''
 
-        # Create an Error model via the domain factory.
-        error = Error.new(
+        # Create an Error model via the direct constructor.
+        error = Error(
             id='test_error',
             name='Test Error',
             message=[
@@ -286,10 +284,8 @@ def test_error_message_yaml_object_map():
     '''
 
     # Create from data and map.
-    yaml_obj = TransferObject.from_data(
-        ErrorMessageYamlObject,
-        lang='en',
-        text='Test message',
+    yaml_obj = ErrorMessageYamlObject.model_validate(
+        dict(lang='en', text='Test message'),
     )
     msg = yaml_obj.map()
 
@@ -305,9 +301,8 @@ def test_error_message_yaml_object_from_model():
     Test that ErrorMessageYamlObject can be created from an ErrorMessage domain object.
     '''
 
-    # Create an ErrorMessage via DomainObject.new.
-    model = DomainObject.new(
-        ErrorMessage,
+    # Create an ErrorMessage via direct constructor.
+    model = ErrorMessage(
         lang='es',
         text='Mensaje de prueba',
     )


### PR DESCRIPTION
Closes #754

Migrates `tiferet/mappers/error.py` and its tests from schematics conventions to Pydantic v2 mapper base classes.

### Changes
- **ErrorAggregate**: Removed `new()` factory and explicit `self.validate()` calls. Mutation methods use direct assignment and list reassignment with `validate_assignment=True`.
- **ErrorMessageYamlObject**: Replaced `class Options` with `_ROLES` ClassVar. Simplified `map()`. Removed `from_model()` (inherited classmethod suffices).
- **ErrorYamlObject**: Replaced `class Options` with `_ROLES` ClassVar. Redeclared `message` field with `Field(default_factory=list)`. Converted `from_model` to `@classmethod`.
- **Tests**: Replaced `TransferObject.from_data()` → `model_validate()`, `Error.new()` → `Error()`, `DomainObject.new(ErrorMessage)` → `ErrorMessage()`.

All 20 tests passing.

---
[Warp conversation](https://app.warp.dev/conversation/d1c29ae9-e027-4b7f-aa05-3eef95dd183a)

Co-Authored-By: Oz <oz-agent@warp.dev>