### PR TITLE
Mappers – Migrate Feature Mappers to Pydantic v2

### DIFF
--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -3,19 +3,17 @@
 # *** imports
 
 # ** core
-from typing import Dict, Any, List
+from typing import Any, ClassVar, Dict, List
+
+# ** infra
+from pydantic import AliasChoices, Field
 
 # ** app
 from ..domain import (
     Feature,
     FeatureStep,
     FeatureEvent,
-    ListType,
-    ModelType,
-    DictType,
-    StringType,
 )
-from ..events import RaiseError, a
 from .settings import (
     Aggregate,
     TransferObject,
@@ -28,34 +26,6 @@ class FeatureEventAggregate(FeatureEvent, Aggregate):
     '''
     An aggregate representation of a feature event.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'FeatureEventAggregate':
-        '''
-        Initializes a new feature event aggregate.
-
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new feature event aggregate.
-        :rtype: FeatureEventAggregate
-        '''
-
-        # Create a new feature event aggregate from the provided data.
-        return Aggregate.new(
-            FeatureEventAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
-        )
 
     # * method: set_pass_on_error
     def set_pass_on_error(self, value: Any) -> None:
@@ -112,13 +82,18 @@ class FeatureEventAggregate(FeatureEvent, Aggregate):
         :rtype: None
         '''
 
-        # Delegate to specialized helpers for parameters and pass_on_error.
+        # Delegate to set_parameters for the parameters attribute.
         if attribute == 'parameters':
             self.set_parameters(value)
-        elif attribute == 'pass_on_error':
+            return
+
+        # Delegate to set_pass_on_error for the pass_on_error attribute.
+        if attribute == 'pass_on_error':
             self.set_pass_on_error(value)
-        else:
-            setattr(self, attribute, value)
+            return
+
+        # Delegate to the base Aggregate for all other attributes.
+        super().set_attribute(attribute, value)
 
 
 # ** mapper: feature_event_yaml_object
@@ -127,137 +102,57 @@ class FeatureEventYamlObject(FeatureEvent, TransferObject):
     A YAML data representation of a feature event object.
     '''
 
-    class Options():
-        '''
-        The options for the feature event data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('type'),
-            'to_data.yaml': TransferObject.deny('type'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'type'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'type'}},
+    }
 
     # * attribute: parameters
-    parameters = DictType(
-        StringType(),
-        default={},
-        serialized_name='params',
-        deserialize_from=['params', 'parameters'],
-        metadata=dict(
-            description='The parameters for the feature event.'
-        )
+    parameters: Dict[str, str] = Field(
+        default_factory=dict,
+        serialization_alias='params',
+        validation_alias=AliasChoices('params', 'parameters'),
+        description='The parameters for the feature event.',
     )
 
     # * method: map
-    def map(self, **kwargs) -> FeatureEvent:
+    def map(self, **overrides) -> FeatureEventAggregate:
         '''
-        Maps the feature event data to a feature event object.
+        Maps the feature event data to a feature event aggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new feature event object.
-        :rtype: FeatureEvent
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new feature event aggregate.
+        :rtype: FeatureEventAggregate
         '''
 
         # Map to the feature event aggregate.
-        return super().map(
-            FeatureEventAggregate,
-            parameters=self.parameters,
-            **self.to_primitive('to_model'),
-            **kwargs
-        )
+        return super().map(FeatureEventAggregate, **overrides)
 
     # * method: from_model
-    @staticmethod
-    def from_model(feature_event: FeatureEvent, **kwargs) -> 'FeatureEventYamlObject':
+    @classmethod
+    def from_model(cls, feature_event: FeatureEvent, **overrides) -> 'FeatureEventYamlObject':
         '''
         Creates a FeatureEventYamlObject from a FeatureEvent model.
 
         :param feature_event: The feature event model.
         :type feature_event: FeatureEvent
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new FeatureEventYamlObject.
         :rtype: FeatureEventYamlObject
         '''
 
         # Create a new FeatureEventYamlObject from the model.
-        return TransferObject.from_model(
-            FeatureEventYamlObject,
-            feature_event,
-            **kwargs,
-        )
+        return super().from_model(feature_event, **overrides)
+
 
 # ** mapper: feature_aggregate
 class FeatureAggregate(Feature, Aggregate):
     '''
     An aggregate representation of a feature.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        name: str = None,
-        group_id: str = None,
-        feature_key: str = None,
-        id: str = None,
-        description: str = None,
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'FeatureAggregate':
-        '''
-        Initializes a new feature aggregate.
-
-        :param name: The name of the feature.
-        :type name: str
-        :param group_id: The context group identifier of the feature.
-        :type group_id: str
-        :param feature_key: The key of the feature.
-        :type feature_key: str
-        :param id: The identifier of the feature.
-        :type id: str
-        :param description: The description of the feature.
-        :type description: str
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new feature aggregate.
-        :rtype: FeatureAggregate
-        '''
-
-        # Derive group_id and feature_key from id if provided.
-        if id and '.' in id and (not group_id or not feature_key):
-            group_id, feature_key = id.split('.', 1)
-
-        # Set the feature key as the snake case of the name if not provided.
-        if name and not feature_key:
-            feature_key = name.lower().replace(' ', '_')
-
-        # Feature ID is the group ID and feature key separated by a period.
-        if not id and group_id and feature_key:
-            id = f'{group_id}.{feature_key}'
-
-        # Set the description as the name if not provided.
-        if name and not description:
-            description = name
-
-        # Create a new feature aggregate from the provided data.
-        return Aggregate.new(
-            FeatureAggregate,
-            validate=validate,
-            strict=strict,
-            id=id,
-            name=name,
-            group_id=group_id,
-            feature_key=feature_key,
-            description=description,
-            **kwargs
-        )
 
     # * method: add_step
     def add_step(
@@ -289,7 +184,7 @@ class FeatureAggregate(Feature, Aggregate):
         '''
 
         # Create the feature event from raw attributes.
-        step = FeatureEventAggregate.new(
+        step = FeatureEventAggregate(
             name=name,
             service_id=service_id,
             parameters=parameters or {},
@@ -297,11 +192,13 @@ class FeatureAggregate(Feature, Aggregate):
             pass_on_error=pass_on_error,
         )
 
-        # Add the feature event step to the feature.
+        # Copy steps to a local list, insert or append, then reassign.
+        steps = list(self.steps)
         if position is not None:
-            self.steps.insert(position, step)
+            steps.insert(position, step)
         else:
-            self.steps.append(step)
+            steps.append(step)
+        self.steps = steps
 
         return step
 
@@ -339,11 +236,15 @@ class FeatureAggregate(Feature, Aggregate):
         if not isinstance(position, int) or position < 0:
             return None
 
-        # Attempt to remove and return the step at the specified index.
+        # Copy steps to a local list, pop, then reassign.
+        steps = list(self.steps)
         try:
-            return self.steps.pop(position)
+            removed = steps.pop(position)
         except IndexError:
             return None
+        self.steps = steps
+
+        return removed
 
     # * method: reorder_step
     def reorder_step(self, current_position: int, new_position: int) -> FeatureStep | None:
@@ -359,20 +260,22 @@ class FeatureAggregate(Feature, Aggregate):
         :rtype: FeatureStep | None
         '''
 
-        # Attempt to remove the step at the current position.
+        # Copy steps to a local list and attempt to pop the current position.
+        steps = list(self.steps)
         try:
-            step = self.steps.pop(current_position)
+            step = steps.pop(current_position)
         except (IndexError, TypeError):
             return None
 
         # Clamp the new position index to the valid range.
         if new_position < 0:
             new_position = 0
-        if new_position > len(self.steps):
-            new_position = len(self.steps)
+        if new_position > len(steps):
+            new_position = len(steps)
 
-        # Insert the step at the clamped position and return it.
-        self.steps.insert(new_position, step)
+        # Insert the step at the clamped position, reassign, and return it.
+        steps.insert(new_position, step)
+        self.steps = steps
 
         return step
 
@@ -387,10 +290,8 @@ class FeatureAggregate(Feature, Aggregate):
         :rtype: None
         '''
 
+        # Update the name; validate_assignment=True handles re-validation.
         self.name = name
-
-        # Perform final aggregate validation.
-        self.validate()
 
     # * method: set_description
     def set_description(self, description: str | None) -> None:
@@ -403,6 +304,7 @@ class FeatureAggregate(Feature, Aggregate):
         :rtype: None
         '''
 
+        # Update the description.
         self.description = description
 
 
@@ -412,65 +314,61 @@ class FeatureYamlObject(Feature, TransferObject):
     A YAML data representation of a feature object.
     '''
 
-    class Options():
-        '''
-        The options for the feature data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('steps'),
-            'to_data.yaml': TransferObject.deny('feature_key', 'group_id', 'id'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'steps'}},
+        'to_data.yaml': {
+            'by_alias': True,
+            'exclude': {'feature_key', 'group_id', 'id'},
+        },
+    }
 
     # * attribute: steps
-    steps = ListType(
-        ModelType(FeatureEventYamlObject),
-        deserialize_from=['handlers', 'functions', 'commands', 'steps'],
-        default=[],
+    steps: List[FeatureEventYamlObject] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
+        description='The step workflow for the feature.',
     )
 
     # * method: map
-    def map(self, **kwargs) -> FeatureAggregate:
+    def map(self, **overrides) -> FeatureAggregate:
         '''
         Maps the feature data to a feature aggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new feature aggregate.
         :rtype: FeatureAggregate
         '''
 
-        # Map the feature data.
+        # Map the feature data with nested step conversion.
         return super().map(
             FeatureAggregate,
             steps=[step.map() for step in (self.steps or [])],
-            **self.to_primitive('to_model'),
-            **kwargs
+            **overrides,
         )
 
     # * method: from_model
-    @staticmethod
-    def from_model(feature: Feature, **kwargs) -> 'FeatureYamlObject':
+    @classmethod
+    def from_model(cls, feature: Feature, **overrides) -> 'FeatureYamlObject':
         '''
         Creates a FeatureYamlObject from a Feature model.
 
         :param feature: The feature model.
         :type feature: Feature
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new FeatureYamlObject.
         :rtype: FeatureYamlObject
         '''
 
         # Create a new FeatureYamlObject from the model, converting
         # the steps list into FeatureEventYamlObject instances.
-        return TransferObject.from_model(
-            FeatureYamlObject,
+        return super().from_model(
             feature,
             steps=[
-                TransferObject.from_model(FeatureEventYamlObject, step)
+                FeatureEventYamlObject.from_model(step)
                 for step in feature.steps
             ],
-            **kwargs,
+            **overrides,
         )

--- a/tiferet/mappers/tests/test_feature.py
+++ b/tiferet/mappers/tests/test_feature.py
@@ -3,9 +3,8 @@
 # *** imports
 
 # ** app
-from ...domain import DomainObject, FeatureEvent
+from ...domain import FeatureEvent
 from ...events import a
-from ..settings import TransferObject
 from ..feature import (
     FeatureEventAggregate,
     FeatureEventYamlObject,
@@ -185,11 +184,11 @@ class TestFeatureAggregate(AggregateTestBase):
     # * method: make_aggregate
     def make_aggregate(self, data: dict = None) -> FeatureAggregate:
         '''
-        Override to use FeatureAggregate.new() custom factory.
+        Override to use FeatureAggregate constructor with derivation.
         '''
 
-        # Create an aggregate using the custom factory.
-        return FeatureAggregate.new(**(data or self.sample_data))
+        # Create an aggregate using the direct constructor.
+        return FeatureAggregate(**(data or self.sample_data))
 
     # *** domain-specific tests
 
@@ -354,20 +353,20 @@ class TestFeatureYamlObject(TransferObjectTestBase):
     # * method: make_aggregate
     def make_aggregate(self, data: dict = None) -> FeatureAggregate:
         '''
-        Override to use FeatureAggregate.new() custom factory.
+        Override to use direct constructors for aggregate and steps.
         '''
 
-        # Create an aggregate using the custom factory.
+        # Create an aggregate using the direct constructor.
         data = data or self.aggregate_sample_data
 
         # Build steps as FeatureEventAggregate instances.
         steps = [
-            FeatureEventAggregate.new(**step)
+            FeatureEventAggregate(**step)
             for step in data.get('steps', [])
         ]
 
         # Create the feature aggregate with mapped steps.
-        return FeatureAggregate.new(
+        return FeatureAggregate(
             **{k: v for k, v in data.items() if k != 'steps'},
             steps=steps,
         )
@@ -390,9 +389,8 @@ class TestFeatureYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object and map it.
-        yaml_obj = TransferObject.from_data(
-            FeatureEventYamlObject,
-            **self.feature_event_sample_data,
+        yaml_obj = FeatureEventYamlObject.model_validate(
+            self.feature_event_sample_data,
         )
         event = yaml_obj.map()
 
@@ -411,12 +409,11 @@ class TestFeatureYamlObject(TransferObjectTestBase):
         '''
 
         # Create YAML object using the 'params' alias.
-        yaml_obj = TransferObject.from_data(
-            FeatureEventYamlObject,
+        yaml_obj = FeatureEventYamlObject.model_validate(dict(
             name='Alias Event',
             service_id='alias_handler',
             params={'alias_key': 'value'},
-        )
+        ))
         event = yaml_obj.map()
 
         # Verify aliased parameters were deserialized correctly.
@@ -428,9 +425,8 @@ class TestFeatureYamlObject(TransferObjectTestBase):
         Test that FeatureEventYamlObject can be created from a FeatureEvent model.
         '''
 
-        # Create a FeatureEvent model.
-        model = DomainObject.new(
-            FeatureEvent,
+        # Create a FeatureEvent model via direct constructor.
+        model = FeatureEvent(
             name='Test Event',
             service_id='test_event_handler',
             parameters={'key': 'value'},


### PR DESCRIPTION
Closes #755

Migrates `tiferet/mappers/feature.py` and its tests from schematics conventions to Pydantic v2 mapper base classes.

### Changes
- **FeatureEventAggregate**: Removed `new()` factory. Restructured `set_attribute` with early returns for `parameters`/`pass_on_error`, delegating to `super().set_attribute()` for standard attributes.
- **FeatureAggregate**: Removed `new()` factory (derivation now in `Feature._derive_keys` from #749). `add_step`/`remove_step`/`reorder_step` use list copy-and-reassign for validation. `rename` no longer calls `self.validate()`.
- **FeatureEventYamlObject**: `_ROLES` ClassVar, `serialization_alias='params'` + `AliasChoices` for `parameters`, `@classmethod from_model`.
- **FeatureYamlObject**: `_ROLES` ClassVar, `AliasChoices` for `steps` (backward-compatible deserialization), `@classmethod from_model`.
- **Tests**: Replaced `new()` → direct constructors, `TransferObject.from_data()` → `model_validate()`, `DomainObject.new()` → direct constructors.

All 24 tests passing.

---
[Warp conversation](https://app.warp.dev/conversation/d1c29ae9-e027-4b7f-aa05-3eef95dd183a)

Co-Authored-By: Oz <oz-agent@warp.dev>