### PR TITLE
Mappers – Migrate App Mappers to Pydantic v2

### DIFF
--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -3,16 +3,15 @@
 # *** imports
 
 # ** core
-from typing import Dict, Any
+from typing import Any, ClassVar, Dict, List
+
+# ** infra
+from pydantic import AliasChoices, Field
 
 # ** app
 from ..domain import (
     AppServiceDependency,
     AppInterface,
-    DomainObject,
-    StringType,
-    DictType,
-    ModelType,
 )
 from ..events import RaiseError, a
 from .settings import (
@@ -30,40 +29,14 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
     An aggregate representation of an app interface contract.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        app_interface_data: Dict[str, Any],
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'AppInterfaceAggregate':
-        '''
-        Initializes a new app interface aggregate.
-
-        :param app_interface_data: The data to create the app interface aggregate from.
-        :type app_interface_data: dict
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new app interface aggregate.
-        :rtype: AppInterfaceAggregate
-        '''
-
-        # Create a new app interface aggregate from the provided app interface data.
-        return Aggregate.new(
-            AppInterfaceAggregate,
-            validate=validate,
-            strict=strict,
-            **app_interface_data,
-            **kwargs
-        )
-
     # * method: add_service
-    def add_service(self, module_path: str, class_name: str, service_id: str, parameters: Dict[str, str] = {}) -> None:
+    def add_service(
+        self,
+        module_path: str,
+        class_name: str,
+        service_id: str,
+        parameters: Dict[str, str] | None = None,
+    ) -> None:
         '''
         Add a service dependency to the app interface.
 
@@ -74,26 +47,29 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         :param service_id: The id for the service dependency.
         :type service_id: str
         :param parameters: Additional parameters for the service dependency.
-        :type parameters: dict
+        :type parameters: Dict[str, str] | None
         :return: None
         :rtype: None
         '''
 
         # Create a new AppServiceDependency object.
-        dependency = DomainObject.new(
-            AppServiceDependency,
+        dependency = AppServiceDependency(
             module_path=module_path,
             class_name=class_name,
             service_id=service_id,
-            parameters=parameters,
+            parameters=parameters or {},
         )
 
-        # Add the service dependency to the list of services.
-        self.services.append(dependency)
+        # Add the service dependency via list reassignment.
+        self.services = list(self.services) + [dependency]
 
     # * method: remove_service
     # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
-    def remove_service(self, service_id: str = None, attribute_id: str = None) -> AppServiceDependency:
+    def remove_service(
+        self,
+        service_id: str | None = None,
+        attribute_id: str | None = None,
+    ) -> AppServiceDependency | None:
         '''
         Remove and return a service dependency by its service_id (idempotent).
 
@@ -101,21 +77,24 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         If no matching service dependency exists, no action is taken (silent success).
 
         :param service_id: The service_id of the service dependency to remove.
-        :type service_id: str
+        :type service_id: str | None
         :param attribute_id: Deprecated alias for service_id.
-        :type attribute_id: str
+        :type attribute_id: str | None
         :return: The removed AppServiceDependency or None.
-        :rtype: AppServiceDependency
+        :rtype: AppServiceDependency | None
         '''
 
         # Fall back to attribute_id if service_id is not provided.
         if service_id is None and attribute_id is not None:
             service_id = attribute_id
 
-        # Iterate over services and remove the first match by service_id.
-        for index, dep in enumerate(self.services):
+        # Work on a local copy; reassign only when a match is found.
+        services = list(self.services)
+        for index, dep in enumerate(services):
             if dep.service_id == service_id:
-                return self.services.pop(index)
+                removed = services.pop(index)
+                self.services = services
+                return removed
 
         # If no service dependency matches, return None without modifying the list.
         return None
@@ -124,11 +103,11 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
     # + todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
     def set_service(
         self,
-        service_id: str = None,
-        module_path: str = None,
-        class_name: str = None,
-        parameters: Dict[str, Any] = None,
-        attribute_id: str = None,
+        service_id: str | None = None,
+        module_path: str | None = None,
+        class_name: str | None = None,
+        parameters: Dict[str, Any] | None = None,
+        attribute_id: str | None = None,
     ) -> None:
         '''
         Set or update a service dependency by service_id (PUT semantics).
@@ -142,15 +121,15 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
           - Create new AppServiceDependency and append to services.
 
         :param service_id: The service dependency identifier.
-        :type service_id: str
+        :type service_id: str | None
         :param module_path: The module path.
-        :type module_path: str
+        :type module_path: str | None
         :param class_name: The class name.
-        :type class_name: str
+        :type class_name: str | None
         :param parameters: New parameters (None to clear).
-        :type parameters: Dict[str, Any]
+        :type parameters: Dict[str, Any] | None
         :param attribute_id: Deprecated alias for service_id.
-        :type attribute_id: str
+        :type attribute_id: str | None
         :return: None
         :rtype: None
         '''
@@ -173,23 +152,23 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
 
             # Otherwise merge and then remove keys whose value is None.
             else:
-                dep.parameters.update(parameters)
+                merged = dict(dep.parameters or {})
+                merged.update(parameters)
                 dep.parameters = {
                     key: value
-                    for key, value in dep.parameters.items()
+                    for key, value in merged.items()
                     if value is not None
                 }
 
-        # If the service dependency does not exist, create a new one and append.
+        # If the service dependency does not exist, create a new one and reassign.
         else:
-            new_dep = DomainObject.new(
-                AppServiceDependency,
+            new_dep = AppServiceDependency(
                 service_id=service_id,
                 module_path=module_path,
                 class_name=class_name,
                 parameters=parameters or {},
             )
-            self.services.append(new_dep)
+            self.services = list(self.services) + [new_dep]
 
     # * method: set_constants
     def set_constants(self, constants: Dict[str, Any] | None = None) -> None:
@@ -205,15 +184,16 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
         # Clear all constants when None is provided.
         if constants is None:
             self.constants = {}
+            return
 
-        # Otherwise merge new constants and remove keys with None value.
-        else:
-            self.constants.update(constants)
-            self.constants = {
-                key: value
-                for key, value in self.constants.items()
-                if value is not None
-            }
+        # Merge new constants and remove keys with None value.
+        merged = dict(self.constants or {})
+        merged.update(constants)
+        self.constants = {
+            key: value
+            for key, value in merged.items()
+            if value is not None
+        }
 
     # * method: set_attribute
     def set_attribute(self, attribute: str, value: Any) -> None:
@@ -259,11 +239,8 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
                     attribute=attribute,
                 )
 
-        # Apply the update to the attribute.
+        # Apply the update; validate_assignment=True handles re-validation.
         setattr(self, attribute, value)
-
-        # Perform final aggregate validation.
-        self.validate()
 
 
 # ** mapper: app_service_dependency_yaml_object
@@ -272,56 +249,63 @@ class AppServiceDependencyYamlObject(AppServiceDependency, TransferObject):
     A YAML data representation of an app service dependency object.
     '''
 
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'parameters', 'service_id'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'service_id'}},
+    }
+
     # * attribute: service_id
-    service_id = StringType(
-        metadata=dict(
-            description='The service id for the application dependency that is not required for assembly.'
-        ),
+    service_id: str | None = Field(
+        default=None,
+        description='The service id for the application dependency that is not required for assembly.',
     )
 
     # * attribute: parameters
-    parameters = DictType(
-        StringType,
-        default={},
-        serialized_name='params',
-        deserialize_from=['params', 'parameters'],
-        metadata=dict(
-            description='The parameters for the application dependency that are not required for assembly.'
-        ),
+    parameters: Dict[str, str] = Field(
+        default_factory=dict,
+        serialization_alias='params',
+        validation_alias=AliasChoices('params', 'parameters'),
+        description='The parameters for the application dependency that are not required for assembly.',
     )
 
-    class Options():
-        '''
-        The options for the app dependency data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('parameters', 'service_id'),
-            'to_data.yaml': TransferObject.deny('service_id'),
-        }
-
     # * method: map
-    def map(self, service_id: str, **kwargs) -> AppServiceDependency:
+    def map(self, service_id: str, **overrides) -> AppServiceDependency:
         '''
         Maps the app service dependency data to an app service dependency object.
 
         :param service_id: The id for the app service dependency.
         :type service_id: str
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new app service dependency object.
         :rtype: AppServiceDependency
         '''
 
-        # Map to the app service dependency object.
+        # Map to the app service dependency object, injecting service_id and parameters.
         return super().map(
             AppServiceDependency,
             service_id=service_id,
-            parameters=self.parameters,
-            **self.to_primitive('to_model'),
-            **kwargs
+            parameters=dict(self.parameters or {}),
+            **overrides,
         )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, dependency: AppServiceDependency, **overrides) -> 'AppServiceDependencyYamlObject':
+        '''
+        Creates an AppServiceDependencyYamlObject from an AppServiceDependency model.
+
+        :param dependency: The app service dependency model.
+        :type dependency: AppServiceDependency
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new AppServiceDependencyYamlObject.
+        :rtype: AppServiceDependencyYamlObject
+        '''
+
+        # Create a new AppServiceDependencyYamlObject from the model.
+        return super().from_model(dependency, **overrides)
 
 
 # ** mapper: app_interface_yaml_object
@@ -330,103 +314,86 @@ class AppInterfaceYamlObject(AppInterface, TransferObject):
     A YAML data representation of an app interface settings object.
     '''
 
-    class Options():
-        '''
-        The options for the app interface data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
-            'to_data.yaml': TransferObject.deny('id'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'services', 'constants', 'module_path', 'class_name'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+    }
 
     # * attribute: module_path
-    module_path = StringType(
+    module_path: str = Field(
         default=DEFAULT_MODULE_PATH,
-        serialized_name='module',
-        deserialize_from=['module_path', 'module'],
-        metadata=dict(
-            description='The app context module path for the app settings.'
-        ),
+        serialization_alias='module',
+        validation_alias=AliasChoices('module_path', 'module'),
+        description='The app context module path for the app settings.',
     )
 
     # * attribute: class_name
-    class_name = StringType(
+    class_name: str = Field(
         default=DEFAULT_CLASS_NAME,
-        serialized_name='class',
-        deserialize_from=['class_name', 'class'],
-        metadata=dict(
-            description='The class name for the app context.'
-        ),
+        serialization_alias='class',
+        validation_alias=AliasChoices('class_name', 'class'),
+        description='The class name for the app context.',
     )
 
     # * attribute: services
-    services = DictType(
-        ModelType(AppServiceDependencyYamlObject),
-        default={},
-        serialized_name='attrs',
-        deserialize_from=['attrs', 'services', 'dependencies', 'attributes'],
-        metadata=dict(
-            description='The app instance service dependencies.'
-        ),
+    services: Dict[str, AppServiceDependencyYamlObject] = Field(
+        default_factory=dict,
+        serialization_alias='attrs',
+        validation_alias=AliasChoices('attrs', 'services', 'dependencies', 'attributes'),
+        description='The app instance service dependencies.',
     )
 
     # * attribute: constants
-    constants = DictType(
-        StringType,
-        default={},
-        serialized_name='const',
-        deserialize_from=['constants', 'const'],
-        metadata=dict(
-            description='The constants for the app settings.'
-        ),
+    constants: Dict[str, str] = Field(
+        default_factory=dict,
+        serialization_alias='const',
+        validation_alias=AliasChoices('constants', 'const'),
+        description='The constants for the app settings.',
     )
 
     # * method: map
-    def map(self, **kwargs) -> AppInterfaceAggregate:
+    def map(self, **overrides) -> AppInterfaceAggregate:
         '''
         Maps the app interface data to an app interface aggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new app interface aggregate.
         :rtype: AppInterfaceAggregate
         '''
 
-        # Map the app interface data to an app interface aggregate.
+        # Map the app interface data with dict→list conversion for services.
         return super().map(
             AppInterfaceAggregate,
             module_path=self.module_path,
             class_name=self.class_name,
-            services=[dep.map(service_id=dep_id) for dep_id, dep in self.services.items()],
-            constants=self.constants,
-            **self.to_primitive('to_model'),
-            **kwargs
+            services=[dep.map(service_id=dep_id) for dep_id, dep in (self.services or {}).items()],
+            constants=dict(self.constants or {}),
+            **overrides,
         )
 
     # * method: from_model
-    @staticmethod
-    def from_model(app_interface: AppInterfaceAggregate, **kwargs) -> 'AppInterfaceYamlObject':
+    @classmethod
+    def from_model(cls, app_interface: AppInterface, **overrides) -> 'AppInterfaceYamlObject':
         '''
-        Creates an AppInterfaceYamlObject from an AppInterfaceAggregate model.
+        Creates an AppInterfaceYamlObject from an AppInterface model.
 
         :param app_interface: The app interface model.
-        :type app_interface: AppInterfaceAggregate
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :type app_interface: AppInterface
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new AppInterfaceYamlObject.
         :rtype: AppInterfaceYamlObject
         '''
 
         # Create a new AppInterfaceYamlObject from the model, converting
         # the services list into a dictionary keyed by service_id.
-        return TransferObject.from_model(
-            AppInterfaceYamlObject,
+        return super().from_model(
             app_interface,
             services={
-                dep.service_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
+                dep.service_id: AppServiceDependencyYamlObject.from_model(dep)
                 for dep in app_interface.services
             },
-            **kwargs,
+            **overrides,
         )

--- a/tiferet/mappers/tests/test_app.py
+++ b/tiferet/mappers/tests/test_app.py
@@ -6,9 +6,9 @@
 import pytest
 
 # ** app
-from ...domain import AppServiceDependency, DomainObject
+from ...domain import AppServiceDependency
 from ...assets import TiferetError, const
-from ..settings import TransferObject, DEFAULT_MODULE_PATH, DEFAULT_CLASS_NAME
+from ..settings import DEFAULT_MODULE_PATH, DEFAULT_CLASS_NAME
 from ..app import (
     AppInterfaceAggregate,
     AppInterfaceYamlObject,
@@ -121,12 +121,12 @@ class TestAppInterfaceAggregate(AggregateTestBase):
     # * method: make_aggregate
     def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
         '''
-        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        Override to use AppInterfaceAggregate direct constructor.
         '''
 
-        # Create an aggregate using the custom factory.
-        return AppInterfaceAggregate.new(
-            app_interface_data=(data if data is not None else self.sample_data).copy()
+        # Create an aggregate using the direct constructor.
+        return AppInterfaceAggregate(
+            **(data if data is not None else self.sample_data)
         )
 
     # *** fixtures
@@ -151,7 +151,7 @@ class TestAppInterfaceAggregate(AggregateTestBase):
             data.update(overrides)
 
             # Create and return the aggregate.
-            return AppInterfaceAggregate.new(app_interface_data=data)
+            return AppInterfaceAggregate(**data)
 
         return factory
 
@@ -221,8 +221,7 @@ class TestAppInterfaceAggregate(AggregateTestBase):
 
         # Build services from the initial ids.
         services = [
-            DomainObject.new(
-                AppServiceDependency,
+            AppServiceDependency(
                 service_id=aid,
                 module_path=f"mod.{aid}",
                 class_name=f"{aid.capitalize()}Class",
@@ -344,12 +343,12 @@ class TestAppInterfaceYamlObject(TransferObjectTestBase):
     # * method: make_aggregate
     def make_aggregate(self, data: dict = None) -> AppInterfaceAggregate:
         '''
-        Override to use AppInterfaceAggregate.new(app_interface_data=...) signature.
+        Override to use AppInterfaceAggregate direct constructor.
         '''
 
-        # Create an aggregate using the custom factory.
-        return AppInterfaceAggregate.new(
-            app_interface_data=(data if data is not None else self.aggregate_sample_data).copy()
+        # Create an aggregate using the direct constructor.
+        return AppInterfaceAggregate(
+            **(data if data is not None else self.aggregate_sample_data)
         )
 
     # *** child mapper: AppServiceDependencyYamlObject
@@ -368,9 +367,8 @@ class TestAppInterfaceYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object and map it.
-        yaml_obj = TransferObject.from_data(
-            AppServiceDependencyYamlObject,
-            **self.dependency_sample_data,
+        yaml_obj = AppServiceDependencyYamlObject.model_validate(
+            self.dependency_sample_data,
         )
         dep = yaml_obj.map(service_id='injected_svc')
 
@@ -384,16 +382,15 @@ class TestAppInterfaceYamlObject(TransferObjectTestBase):
     # ** test: app_service_dependency_yaml_aliasing_params
     def test_app_service_dependency_yaml_aliasing_params(self):
         '''
-        Test that the "params" serialized_name alias is correctly deserialized.
+        Test that the "params" alias is correctly deserialized.
         '''
 
         # Create YAML object using the 'params' alias.
-        yaml_obj = TransferObject.from_data(
-            AppServiceDependencyYamlObject,
+        yaml_obj = AppServiceDependencyYamlObject.model_validate(dict(
             module_path='alias.test.mod',
             class_name='AliasImpl',
             params={'alias_key': 'value'},
-        )
+        ))
         dep = yaml_obj.map(service_id='aliased_dep')
 
         # Verify aliased parameters were deserialized correctly.
@@ -406,13 +403,12 @@ class TestAppInterfaceYamlObject(TransferObjectTestBase):
         '''
 
         # Create YAML object with fields that should be excluded.
-        yaml_obj = TransferObject.from_data(
-            AppServiceDependencyYamlObject,
+        yaml_obj = AppServiceDependencyYamlObject.model_validate(dict(
             module_path='ex.test.mod',
             class_name='ExcludeTest',
             parameters={'secret': 'dontleak'},
             service_id='should_ignore',
-        )
+        ))
         primitive = yaml_obj.to_primitive('to_model')
 
         # Verify excluded fields are absent.


### PR DESCRIPTION
Closes #756

Migrates `tiferet/mappers/app.py` and its tests from schematics conventions to Pydantic v2 mapper base classes.

### Changes
- **AppInterfaceAggregate**: Removed `new()` factory. `add_service`/`remove_service`/`set_service` use `AppServiceDependency(...)` and list reassignment. `set_constants` uses `merged = dict(...)` pattern with early return. `set_attribute` removes trailing `self.validate()`.
- **AppServiceDependencyYamlObject**: `_ROLES` ClassVar, `service_id` optional (`str | None`), `parameters` with `serialization_alias='params'` + `AliasChoices`, new `@classmethod from_model`.
- **AppInterfaceYamlObject**: `_ROLES` ClassVar, `serialization_alias`/`AliasChoices` for `module_path`, `class_name`, `services`, `constants`. Dict↔list conversion preserved in `map()`/`from_model()`. `@classmethod from_model`.
- **Tests**: Replaced `new()` → direct constructors, `TransferObject.from_data()` → `model_validate()`, `DomainObject.new()` → direct constructors.

All 25 tests passing.

---
[Warp conversation](https://app.warp.dev/conversation/d1c29ae9-e027-4b7f-aa05-3eef95dd183a)

Co-Authored-By: Oz <oz-agent@warp.dev>