### PR TITLE
Mappers – Migrate CLI Mappers to Pydantic v2

### DIFF
--- a/tiferet/mappers/cli.py
+++ b/tiferet/mappers/cli.py
@@ -3,22 +3,15 @@
 # *** imports
 
 # ** core
-from typing import Dict, Any, List
+from typing import Any, ClassVar, Dict, List
+
+# ** infra
+from pydantic import AliasChoices, Field
 
 # ** app
-from ..domain import (
-    CliCommand,
-    CliArgument,
-    DomainObject,
-    StringType,
-    ListType,
-    ModelType,
-)
+from ..domain import CliArgument, CliCommand
 from ..events import RaiseError, a
-from .settings import (
-    Aggregate,
-    TransferObject,
-)
+from .settings import Aggregate, TransferObject
 
 # *** mappers
 
@@ -27,34 +20,6 @@ class CliArgumentAggregate(CliArgument, Aggregate):
     '''
     An aggregate representation of a CLI argument.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'CliArgumentAggregate':
-        '''
-        Initializes a new CLI argument aggregate.
-
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new CLI argument aggregate.
-        :rtype: CliArgumentAggregate
-        '''
-
-        # Create a new CLI argument aggregate from the provided data.
-        return Aggregate.new(
-            CliArgumentAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
-        )
 
     # * method: set_attribute
     def set_attribute(self, attribute: str, value: Any) -> None:
@@ -91,46 +56,14 @@ class CliArgumentAggregate(CliArgument, Aggregate):
                 supported=', '.join(sorted(supported)),
             )
 
-        # Apply the update to the attribute.
+        # Apply the update; validate_assignment=True triggers field validation.
         setattr(self, attribute, value)
-
-        # Perform final aggregate validation.
-        self.validate()
-
 
 # ** mapper: cli_command_aggregate
 class CliCommandAggregate(CliCommand, Aggregate):
     '''
     An aggregate representation of a CLI command.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'CliCommandAggregate':
-        '''
-        Initializes a new CLI command aggregate.
-
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode for the aggregate object.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new CLI command aggregate.
-        :rtype: CliCommandAggregate
-        '''
-
-        # Create a new CLI command aggregate from the provided CLI command data.
-        return Aggregate.new(
-            CliCommandAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
-        )
 
     # * method: add_argument
     def add_argument(self,
@@ -141,7 +74,7 @@ class CliCommandAggregate(CliCommand, Aggregate):
             default: str = None,
             choices: list = None,
             nargs: str = None,
-            action: str = None
+            action: str = None,
         ) -> None:
         '''
         Add an argument to the command.
@@ -166,21 +99,26 @@ class CliCommandAggregate(CliCommand, Aggregate):
         :rtype: None
         '''
 
-        # Create a new CliArgument instance using DomainObject.new.
-        argument = DomainObject.new(
-            CliArgument,
-            name_or_flags=name_or_flags,
-            description=description,
-            type=type,
-            required=required,
-            default=default,
-            choices=choices,
-            nargs=nargs,
-            action=action
-        )
+        # Build the kwargs for the argument, omitting any None values so
+        # CliArgument's defaults (e.g. type='str') are preserved.
+        argument_kwargs = {
+            k: v
+            for k, v in dict(
+                name_or_flags=name_or_flags,
+                description=description,
+                type=type,
+                required=required,
+                default=default,
+                choices=choices,
+                nargs=nargs,
+                action=action,
+            ).items()
+            if v is not None
+        }
 
-        # Append the argument to the command's arguments list.
-        self.arguments.append(argument)
+        # Create the argument and reassign so validate_assignment=True triggers validation.
+        argument = CliArgument(**argument_kwargs)
+        self.arguments = list(self.arguments) + [argument]
 
     # * method: set_attribute
     def set_attribute(self, attribute: str, value: Any) -> None:
@@ -214,12 +152,8 @@ class CliCommandAggregate(CliCommand, Aggregate):
                 supported=', '.join(sorted(supported)),
             )
 
-        # Apply the update to the attribute.
+        # Apply the update; validate_assignment=True triggers field validation.
         setattr(self, attribute, value)
-
-        # Perform final aggregate validation.
-        self.validate()
-
 
 # ** mapper: cli_command_yaml_object
 class CliCommandYamlObject(CliCommand, TransferObject):
@@ -227,95 +161,52 @@ class CliCommandYamlObject(CliCommand, TransferObject):
     A YAML data representation of a CLI command object.
     '''
 
-    class Options():
-        '''
-        The options for the CLI command data.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('arguments'),
-            'to_data.yaml': TransferObject.deny('id', 'arguments'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'arguments'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+    }
 
     # * attribute: arguments
-    arguments = ListType(
-        ModelType(CliArgument),
-        default=[],
-        deserialize_from=['args', 'arguments'],
-        serialized_name='args',
-        metadata={
-            'description': 'The list of arguments for the CLI command.'
-        },
+    arguments: List[CliArgument] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices('args', 'arguments'),
+        serialization_alias='args',
+        description='The list of arguments for the CLI command.',
     )
 
-    # * method: to_primitive
-    def to_primitive(self, role='to_data.yaml', **kwargs) -> Dict[str, Any]:
-        '''
-        Converts the CLI command data to a primitive dictionary representation.
-
-        :param role: The role to use for the conversion.
-        :type role: str
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A primitive dictionary representation of the CLI command data.
-        :rtype: dict
-        '''
-
-        # Convert the CLI command data to a primitive dictionary, converting
-        # the arguments list into dictionaries as well.
-        return dict(
-            **super().to_primitive(role=role, **kwargs),
-            args=[
-                arg.to_primitive()
-                for arg in self.arguments
-            ]
-        )
-
     # * method: map
-    def map(self, **kwargs) -> CliCommandAggregate:
+    def map(self, **overrides) -> CliCommandAggregate:
         '''
         Maps the CLI command data to a CLI command aggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new CLI command aggregate.
+        :param overrides: Additional field overrides.
+        :type overrides: dict
+        :return: A new CliCommandAggregate instance.
         :rtype: CliCommandAggregate
         '''
 
-        # Map the CLI command data.
+        # Pass arguments back as primitives so the aggregate validates them
+        # under its canonical schema.
         return super().map(
             CliCommandAggregate,
-            arguments=[
-                arg.to_primitive()
-                for arg in self.arguments
-            ],
-            **self.to_primitive('to_model'),
-            **kwargs
+            arguments=[arg.model_dump() for arg in self.arguments],
+            **overrides,
         )
 
     # * method: from_model
-    @staticmethod
-    def from_model(cli_command: CliCommand, **kwargs) -> 'CliCommandYamlObject':
+    @classmethod
+    def from_model(cls, cli_command: CliCommand, **overrides) -> 'CliCommandYamlObject':
         '''
         Creates a CliCommandYamlObject from a CliCommand model.
 
-        :param cli_command: The CLI command model.
+        :param cli_command: The CLI command model to copy from.
         :type cli_command: CliCommand
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new CliCommandYamlObject.
+        :param overrides: Additional field overrides.
+        :type overrides: dict
+        :return: A new CliCommandYamlObject instance.
         :rtype: CliCommandYamlObject
         '''
 
-        # Create a new CliCommandYamlObject from the model, converting
-        # the arguments list into primitive dictionaries.
-        return TransferObject.from_model(
-            CliCommandYamlObject,
-            cli_command,
-            arguments=[
-                arg.to_primitive()
-                for arg in cli_command.arguments
-            ],
-            **kwargs,
-        )
+        # Delegate to the base mapper.
+        return super().from_model(cli_command, **overrides)

--- a/tiferet/mappers/tests/test_cli.py
+++ b/tiferet/mappers/tests/test_cli.py
@@ -5,7 +5,6 @@
 # ** app
 from ...domain import CliArgument, CliCommand, DomainObject
 from ...events import a
-from ..settings import TransferObject
 from ..cli import CliArgumentAggregate, CliCommandAggregate, CliCommandYamlObject
 from .settings import AggregateTestBase, TransferObjectTestBase
 
@@ -191,7 +190,7 @@ class TestCliCommandAggregate(AggregateTestBase):
         '''
 
         # Create an aggregate with no arguments.
-        aggregate = CliCommandAggregate.new(
+        aggregate = CliCommandAggregate(
             id='calc.divide',
             name='Divide Number Command',
             key='divide',
@@ -256,10 +255,9 @@ class TestCliCommandYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object using the 'args' alias.
-        yaml_obj = TransferObject.from_data(
-            CliCommandYamlObject,
+        yaml_obj = CliCommandYamlObject.model_validate(dict(
             **self.sample_data,
-        )
+        ))
 
         # Assert the arguments were correctly deserialized.
         assert len(yaml_obj.arguments) == 2
@@ -275,10 +273,9 @@ class TestCliCommandYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object and serialize to primitive.
-        yaml_obj = TransferObject.from_data(
-            CliCommandYamlObject,
+        yaml_obj = CliCommandYamlObject.model_validate(dict(
             **self.sample_data,
-        )
+        ))
         primitive = yaml_obj.to_primitive('to_data.yaml')
 
         # Assert 'id' is excluded and 'args' is present with full dicts.
@@ -299,10 +296,9 @@ class TestCliCommandYamlObject(TransferObjectTestBase):
         '''
 
         # Create a YAML object and serialize with to_model role.
-        yaml_obj = TransferObject.from_data(
-            CliCommandYamlObject,
+        yaml_obj = CliCommandYamlObject.model_validate(dict(
             **self.sample_data,
-        )
+        ))
         primitive = yaml_obj.to_primitive('to_model')
 
         # Assert 'arguments' is excluded and other fields are retained.
@@ -319,15 +315,13 @@ class TestCliCommandYamlObject(TransferObjectTestBase):
         '''
 
         # Create a CliCommand domain object using the factory method.
-        cli_command = CliCommand.new(
+        cli_command = CliCommand(
             group_key='calc',
             key='subtract',
             name='Subtract Number Command',
             description='Subtracts one number from another.',
             arguments=[
-                DomainObject.new(
-                    CliArgument,
-                    name_or_flags=['a'],
+                CliArgument(name_or_flags=['a'],
                     description='The number to subtract from.',
                 ),
             ],


### PR DESCRIPTION
## Summary

Migrates the three CLI mapper classes in `tiferet/mappers/cli.py` and their tests from schematics to Pydantic v2.

### Changes
- **CliArgumentAggregate**: Removed `new()` factory; removed trailing `self.validate()` from `set_attribute`.
- **CliCommandAggregate**: Removed `new()` factory; `add_argument` filters `None` kwargs to preserve `CliArgument` defaults, uses `CliArgument(**kwargs)` + list reassignment; removed trailing `self.validate()`.
- **CliCommandYamlObject**: `_ROLES` ClassVar (no longer excludes `arguments` in `to_data.yaml`), `arguments` field with `AliasChoices`/`serialization_alias`, removed custom `to_primitive` override, `map()` uses `arg.model_dump()`, `@classmethod from_model` delegating to `super()`.
- **Tests**: `TransferObject.from_data` → `model_validate`, `new()` → direct constructors, `DomainObject.new()`/`CliCommand.new()` → direct constructors.

All 25 tests pass.

Closes #758

---
[Warp conversation](https://app.warp.dev/conversation/8f468eb2-19de-4202-ab96-6362140bdc2b)

Co-Authored-By: Oz <oz-agent@warp.dev>