### PR TITLE
Repos – Update All Repositories for Pydantic v2 Mapper APIs (#760)

### DIFF
--- a/tiferet/repos/app.py
+++ b/tiferet/repos/app.py
@@ -8,7 +8,6 @@ from typing import List
 # ** app
 from ..interfaces import AppService
 from ..mappers import (
-    TransferObject,
     AppInterfaceAggregate,
     AppInterfaceYamlObject,
 )
@@ -93,10 +92,8 @@ class AppYamlRepository(AppService):
             return None
 
         # Map the data to an AppInterfaceAggregate and return it.
-        return TransferObject.from_data(
-            AppInterfaceYamlObject,
-            id=id,
-            **interface_data,
+        return AppInterfaceYamlObject.model_validate(
+            {**interface_data, 'id': id}
         ).map()
 
     # * method: list
@@ -118,10 +115,8 @@ class AppYamlRepository(AppService):
 
         # Map each interface entry to an AppInterfaceAggregate.
         return [
-            TransferObject.from_data(
-                AppInterfaceYamlObject,
-                id=interface_id,
-                **interface_data,
+            AppInterfaceYamlObject.model_validate(
+                {**interface_data, 'id': interface_id}
             ).map()
             for interface_id, interface_data in interfaces_data.items()
         ]

--- a/tiferet/repos/cli.py
+++ b/tiferet/repos/cli.py
@@ -8,7 +8,6 @@ from typing import List
 # ** app
 from ..interfaces import CliService
 from ..mappers import (
-    TransferObject,
     CliArgumentAggregate,
     CliCommandAggregate,
     CliCommandYamlObject,
@@ -89,10 +88,8 @@ class CliYamlRepository(CliService):
             return None
 
         # Map the data to a CliCommandAggregate and return it.
-        return TransferObject.from_data(
-            CliCommandYamlObject,
-            id=id,
-            **cmd_data,
+        return CliCommandYamlObject.model_validate(
+            {**cmd_data, 'id': id}
         ).map()
 
     # * method: list
@@ -116,10 +113,8 @@ class CliYamlRepository(CliService):
         result = []
         for group_key, commands in cmds_data.items():
             for command_key, command_data in commands.items():
-                cmd = TransferObject.from_data(
-                    CliCommandYamlObject,
-                    id=f'{group_key}.{command_key}',
-                    **command_data,
+                cmd = CliCommandYamlObject.model_validate(
+                    {**command_data, 'id': f'{group_key}.{command_key}'}
                 ).map()
                 result.append(cmd)
 
@@ -205,7 +200,7 @@ class CliYamlRepository(CliService):
         ).load(
             start_node=lambda data: data.get('cli', {}).get('parent_args', []),
             data_factory=lambda args: [
-                CliArgumentAggregate.new(**arg)
+                CliArgumentAggregate(**arg)
                 for arg in args
             ],
         )
@@ -232,7 +227,7 @@ class CliYamlRepository(CliService):
 
         # Set the parent_args section to the serialized argument list.
         full_data.setdefault('cli', {})['parent_args'] = [
-            {k: v for k, v in arg.to_primitive().items() if v is not None}
+            {k: v for k, v in arg.model_dump().items() if v is not None}
             for arg in parent_arguments
         ]
 

--- a/tiferet/repos/di.py
+++ b/tiferet/repos/di.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Tuple
 # ** app
 from ..interfaces import DIService
 from ..mappers import (
-    TransferObject,
     ServiceConfigurationAggregate,
     ServiceConfigurationYamlObject,
 )
@@ -95,10 +94,8 @@ class DIYamlRepository(DIService):
             return None
 
         # Map the data to a ServiceConfigurationAggregate.
-        configuration = TransferObject.from_data(
-            ServiceConfigurationYamlObject,
-            id=configuration_id,
-            **config_data,
+        configuration = ServiceConfigurationYamlObject.model_validate(
+            {**config_data, 'id': configuration_id}
         ).map()
 
         # If a flag is provided, filter the configuration by flag.
@@ -132,10 +129,8 @@ class DIYamlRepository(DIService):
 
         # Map each service entry to a ServiceConfigurationAggregate.
         configurations = [
-            TransferObject.from_data(
-                ServiceConfigurationYamlObject,
-                id=config_id,
-                **config_data,
+            ServiceConfigurationYamlObject.model_validate(
+                {**config_data, 'id': config_id}
             ).map()
             for config_id, config_data in full_data.get('services', {}).items()
         ]

--- a/tiferet/repos/error.py
+++ b/tiferet/repos/error.py
@@ -8,7 +8,6 @@ from typing import List
 # ** app
 from ..interfaces import ErrorService
 from ..mappers import (
-    TransferObject,
     ErrorAggregate,
     ErrorYamlObject,
 )
@@ -93,10 +92,8 @@ class ErrorYamlRepository(ErrorService):
             return None
 
         # Map the data to an ErrorAggregate and return it.
-        return TransferObject.from_data(
-            ErrorYamlObject,
-            id=id,
-            **error_data,
+        return ErrorYamlObject.model_validate(
+            {**error_data, 'id': id}
         ).map()
 
     # * method: list
@@ -118,10 +115,8 @@ class ErrorYamlRepository(ErrorService):
 
         # Map each error entry to an ErrorAggregate.
         return [
-            TransferObject.from_data(
-                ErrorYamlObject,
-                id=error_id,
-                **error_data,
+            ErrorYamlObject.model_validate(
+                {**error_data, 'id': error_id}
             ).map()
             for error_id, error_data in errors_data.items()
         ]

--- a/tiferet/repos/feature.py
+++ b/tiferet/repos/feature.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List
 # ** app
 from ..interfaces import FeatureService
 from ..mappers import (
-    TransferObject,
     FeatureAggregate,
     FeatureYamlObject,
 )
@@ -110,10 +109,8 @@ class FeatureYamlRepository(FeatureService):
             return None
 
         # Map the feature data to a FeatureAggregate and return it.
-        return TransferObject.from_data(
-            FeatureYamlObject,
-            id=f'{group_id}.{feature_key}',
-            **feature_data,
+        return FeatureYamlObject.model_validate(
+            {**feature_data, 'id': f'{group_id}.{feature_key}'}
         ).map()
 
     # * method: list
@@ -142,20 +139,16 @@ class FeatureYamlRepository(FeatureService):
         if group_id:
             group_features = groups_data.get(group_id, {})
             for feature_key, feature_data in group_features.items():
-                features.append(TransferObject.from_data(
-                    FeatureYamlObject,
-                    id=f'{group_id}.{feature_key}',
-                    **feature_data,
+                features.append(FeatureYamlObject.model_validate(
+                    {**feature_data, 'id': f'{group_id}.{feature_key}'}
                 ))
 
         # Otherwise, flatten all groups.
         else:
             for group, group_features in groups_data.items():
                 for feature_key, feature_data in group_features.items():
-                    features.append(TransferObject.from_data(
-                        FeatureYamlObject,
-                        id=f'{group}.{feature_key}',
-                        **feature_data,
+                    features.append(FeatureYamlObject.model_validate(
+                        {**feature_data, 'id': f'{group}.{feature_key}'}
                     ))
 
         # Map all FeatureYamlObject instances to FeatureAggregates and return them.

--- a/tiferet/repos/logging.py
+++ b/tiferet/repos/logging.py
@@ -18,7 +18,6 @@ from ..mappers import (
     HandlerYamlObject,
     LoggerAggregate,
     LoggerYamlObject,
-    TransferObject
 )
 from ..utils import Yaml
 
@@ -90,10 +89,7 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create formatter data object from the model.
-        formatter_data = TransferObject.from_model(
-            FormatterYamlObject,
-            formatter
-        )
+        formatter_data = FormatterYamlObject.from_model(formatter)
 
         # Load the full configuration file.
         full_data = Yaml(
@@ -121,10 +117,7 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create handler data object from the model.
-        handler_data = TransferObject.from_model(
-            HandlerYamlObject,
-            handler
-        )
+        handler_data = HandlerYamlObject.from_model(handler)
 
         # Load the full configuration file.
         full_data = Yaml(
@@ -152,10 +145,7 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create logger data object from the model.
-        logger_data = TransferObject.from_model(
-            LoggerYamlObject,
-            logger
-        )
+        logger_data = LoggerYamlObject.from_model(logger)
 
         # Load the full configuration file.
         full_data = Yaml(

--- a/tiferet/repos/tests/test_app.py
+++ b/tiferet/repos/tests/test_app.py
@@ -9,10 +9,7 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import (
-    TransferObject,
-    AppInterfaceYamlObject,
-)
+from ...mappers import AppInterfaceYamlObject
 from ..app import AppYamlRepository
 
 
@@ -183,8 +180,7 @@ def test_int_app_config_repo_save(
     new_app_id = 'new.app'
 
     # Create new app interface config data and map to an aggregate.
-    app = TransferObject.from_data(
-        AppInterfaceYamlObject,
+    app = AppInterfaceYamlObject.model_validate(dict(
         id=new_app_id,
         name='New App',
         description='A new test app interface.',
@@ -192,7 +188,7 @@ def test_int_app_config_repo_save(
         class_name='NewApp',
         attributes={},
         constants={},
-    ).map()
+    )).map()
 
     # Save the new app interface.
     app_config_repo.save(app)

--- a/tiferet/repos/tests/test_cli.py
+++ b/tiferet/repos/tests/test_cli.py
@@ -10,7 +10,6 @@ import pytest, yaml
 
 # ** app
 from ...mappers import (
-    TransferObject,
     CliArgumentAggregate,
     CliCommandYamlObject,
 )
@@ -227,8 +226,7 @@ def test_int_cli_config_repo_save(
     new_cmd_id = 'calc.multiply'
 
     # Create new CLI command config data and map to an aggregate.
-    cmd = TransferObject.from_data(
-        CliCommandYamlObject,
+    cmd = CliCommandYamlObject.model_validate(dict(
         id=new_cmd_id,
         name='Multiply Number Command',
         description='Multiplies two numbers.',
@@ -246,7 +244,7 @@ def test_int_cli_config_repo_save(
                 'type': 'str',
             },
         ],
-    ).map()
+    )).map()
 
     # Save the new CLI command.
     cli_config_repo.save(cmd)
@@ -317,12 +315,12 @@ def test_int_cli_config_repo_save_parent_arguments(
 
     # Create new parent arguments.
     new_parent_args = [
-        CliArgumentAggregate.new(
+        CliArgumentAggregate(
             name_or_flags=['--debug', '-d'],
             description='Enable debug mode.',
             action='store_true',
         ),
-        CliArgumentAggregate.new(
+        CliArgumentAggregate(
             name_or_flags=['--output', '-o'],
             description='Output file path.',
             type='str',

--- a/tiferet/repos/tests/test_di.py
+++ b/tiferet/repos/tests/test_di.py
@@ -9,10 +9,7 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import (
-    TransferObject,
-    ServiceConfigurationYamlObject,
-)
+from ...mappers import ServiceConfigurationYamlObject
 from ..di import DIYamlRepository
 
 
@@ -199,13 +196,12 @@ def test_int_di_config_repo_save_configuration(
     new_service_id = 'new_service'
 
     # Create new service configuration data and map to an aggregate.
-    config = TransferObject.from_data(
-        ServiceConfigurationYamlObject,
+    config = ServiceConfigurationYamlObject.model_validate(dict(
         id=new_service_id,
         name='New Service',
         module_path='tiferet.services.new',
         class_name='NewServiceImpl',
-    ).map()
+    )).map()
 
     # Save the new service configuration.
     di_config_repo.save_configuration(config)

--- a/tiferet/repos/tests/test_error.py
+++ b/tiferet/repos/tests/test_error.py
@@ -9,10 +9,7 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import (
-    TransferObject,
-    ErrorYamlObject,
-)
+from ...mappers import ErrorYamlObject
 from ..error import ErrorYamlRepository
 
 
@@ -199,8 +196,7 @@ def test_int_error_config_repo_save(
     new_error_id = 'NEW_ERROR_CODE'
 
     # Create new error config data and map to an aggregate.
-    error = TransferObject.from_data(
-        ErrorYamlObject,
+    error = ErrorYamlObject.model_validate(dict(
         id=new_error_id,
         name='New Error',
         message=[
@@ -213,7 +209,7 @@ def test_int_error_config_repo_save(
                 'text': 'Ocurrió un nuevo error',
             },
         ],
-    ).map()
+    )).map()
 
     # Save the new error.
     error_config_repo.save(error)

--- a/tiferet/repos/tests/test_feature.py
+++ b/tiferet/repos/tests/test_feature.py
@@ -9,7 +9,7 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import TransferObject, FeatureYamlObject
+from ...mappers import FeatureYamlObject
 from ..feature import FeatureYamlRepository
 
 
@@ -236,14 +236,13 @@ def test_int_feature_config_repo_save(
     new_feature_id = 'new_group.new_feature'
 
     # Create new feature config data and map to a model.
-    feature = TransferObject.from_data(
-        FeatureYamlObject,
+    feature = FeatureYamlObject.model_validate(dict(
         id=new_feature_id,
         name='New Feature',
         description='A new test feature.',
         commands=[],
         log_params={},
-    ).map()
+    )).map()
 
     # Save the new feature.
     feature_config_repo.save(feature)

--- a/tiferet/repos/tests/test_logging.py
+++ b/tiferet/repos/tests/test_logging.py
@@ -6,7 +6,7 @@
 import pytest, yaml
 
 # ** app
-from ...mappers import TransferObject, FormatterYamlObject, HandlerYamlObject, LoggerYamlObject
+from ...mappers import FormatterYamlObject, HandlerYamlObject, LoggerYamlObject
 from ..logging import LoggingYamlRepository
 
 # *** constants
@@ -148,14 +148,13 @@ def test_int_logging_config_repo_save_formatter(
     NEW_FORMATTER_ID = 'new_test_formatter'
 
     # Create new formatter.
-    formatter = TransferObject.from_data(
-        FormatterYamlObject,
+    formatter = FormatterYamlObject.model_validate(dict(
         id=NEW_FORMATTER_ID,
         name='New Test Formatter',
         description='A new test formatter',
         format='%(levelname)s - %(message)s',
         datefmt='%H:%M:%S'
-    ).map()
+    )).map()
 
     # Save the formatter.
     logging_config_repo.save_formatter(formatter)
@@ -187,8 +186,7 @@ def test_int_logging_config_repo_save_handler(
     NEW_HANDLER_ID = 'new_test_handler'
 
     # Create new handler.
-    handler = TransferObject.from_data(
-        HandlerYamlObject,
+    handler = HandlerYamlObject.model_validate(dict(
         id=NEW_HANDLER_ID,
         name='New Test Handler',
         description='A new test handler',
@@ -197,7 +195,7 @@ def test_int_logging_config_repo_save_handler(
         level='ERROR',
         formatter=TEST_FORMATTER_ID,
         filename='test.log'
-    ).map()
+    )).map()
 
     # Save the handler.
     logging_config_repo.save_handler(handler)
@@ -230,8 +228,7 @@ def test_int_logging_config_repo_save_logger(
     NEW_LOGGER_ID = 'new_test_logger'
 
     # Create new logger.
-    logger = TransferObject.from_data(
-        LoggerYamlObject,
+    logger = LoggerYamlObject.model_validate(dict(
         id=NEW_LOGGER_ID,
         name='New Test Logger',
         description='A new test logger',
@@ -239,7 +236,7 @@ def test_int_logging_config_repo_save_logger(
         handlers=[TEST_HANDLER_ID],
         propagate=True,
         is_root=False
-    ).map()
+    )).map()
 
     # Save the logger.
     logging_config_repo.save_logger(logger)


### PR DESCRIPTION
## Summary

Update all six YAML-backed repository modules and their integration tests to use the Pydantic v2 mapper APIs introduced in Phase 3.

### Changes

**Read-path** (all 6 repos):
- `TransferObject.from_data(SomeYamlObject, id=id, **data)` → `SomeYamlObject.model_validate({**data, 'id': id})`

**Write-path** (logging repo):
- `TransferObject.from_model(Type, model)` → `Type.from_model(model)`

**CLI-specific**:
- `CliArgumentAggregate.new(**arg)` → `CliArgumentAggregate(**arg)`
- `arg.to_primitive()` → `arg.model_dump()`

**Imports**: Removed `TransferObject` from all 12 files (6 repos + 6 tests).

### Verification

- All 43 repo integration tests pass with 0 failures.
- No references to `TransferObject.from_data` or `TransferObject.from_model` remain in `repos/`.

Closes #760

---
[Warp Conversation](https://app.warp.dev/conversation/85d103ed-3476-4c26-82f1-ad43d7f7eb0f)

Co-Authored-By: Oz <oz-agent@warp.dev>