### PR TITLE
Events – Update All Domain Events for Pydantic v2 APIs (#761)

### DIFF
--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -89,9 +89,7 @@ class AddAppInterface(DomainEvent):
         }
 
         # Create the AppInterface model; flags defaults to ['default'].
-        interface = AppInterfaceAggregate.new(
-            app_interface_data=app_interface_data
-        )
+        interface = AppInterfaceAggregate(**app_interface_data)
 
         # Persist the new interface via the app service.
         self.app_service.save(interface)
@@ -160,9 +158,7 @@ class GetAppInterface(DomainEvent):
 
         # Ensure the interface is mutable before applying service/constant merges.
         if not isinstance(interface, AppInterfaceAggregate):
-            interface = AppInterfaceAggregate.new(
-                app_interface_data=interface.to_primitive(),
-            )
+            interface = AppInterfaceAggregate(**interface.model_dump())
 
         # Merge default services into the interface for any service_id not already present.
         if default_services:

--- a/tiferet/events/cli.py
+++ b/tiferet/events/cli.py
@@ -144,7 +144,7 @@ class AddCliCommand(DomainEvent):
         )
 
         # Create CLI command aggregate.
-        command = CliCommandAggregate.new(
+        command = CliCommandAggregate(
             id=id,
             name=name,
             key=key,

--- a/tiferet/events/di.py
+++ b/tiferet/events/di.py
@@ -78,14 +78,12 @@ class AddServiceConfiguration(DomainEvent):
         )
 
         # Create service configuration aggregate from dependency dicts.
-        configuration = ServiceConfigurationAggregate.new(
-            service_configuration_data=dict(
-                id=id,
-                module_path=module_path,
-                class_name=class_name,
-                parameters=parameters,
-                dependencies=flagged_dependencies,
-            ),
+        configuration = ServiceConfigurationAggregate(
+            id=id,
+            module_path=module_path,
+            class_name=class_name,
+            parameters=parameters,
+            dependencies=flagged_dependencies,
         )
 
         # Save the new configuration and return it.

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -73,7 +73,7 @@ class AddError(DomainEvent):
 
         # Create the Error aggregate.
         error_messages = [{'lang': lang, 'text': message}] + additional_messages
-        new_error = ErrorAggregate.new(
+        new_error = ErrorAggregate(
             id=id,
             name=name,
             message=error_messages
@@ -132,7 +132,7 @@ class GetError(DomainEvent):
         if include_defaults:
             error_data = a.DEFAULT_ERRORS.get(id)
             if error_data:
-                return ErrorAggregate.new(**error_data)
+                return ErrorAggregate(**error_data)
 
         # If still not found and defaults not included, raise structured error.
         self.raise_error(
@@ -180,7 +180,7 @@ class ListErrors(DomainEvent):
             return self.error_service.list()
 
         # If defaults are included, merge repository and default errors.
-        errors = {id: ErrorAggregate.new(**data) for id, data in a.const.DEFAULT_ERRORS.items()}
+        errors = {id: ErrorAggregate(**data) for id, data in a.const.DEFAULT_ERRORS.items()}
         repo_errors = self.error_service.list()
         errors.update({error.id: error for error in repo_errors})
 

--- a/tiferet/events/feature.py
+++ b/tiferet/events/feature.py
@@ -71,7 +71,7 @@ class AddFeature(DomainEvent):
         '''
 
         # Create feature using the aggregate factory.
-        feature = FeatureAggregate.new(
+        feature = FeatureAggregate(
             name=name,
             group_id=group_id,
             feature_key=feature_key,

--- a/tiferet/events/logging.py
+++ b/tiferet/events/logging.py
@@ -102,7 +102,7 @@ class AddFormatter(DomainEvent):
         '''
 
         # Create the formatter aggregate.
-        formatter = FormatterAggregate.new(
+        formatter = FormatterAggregate(
             id=id,
             name=name,
             format=format,
@@ -224,7 +224,7 @@ class AddHandler(DomainEvent):
         '''
 
         # Create the handler aggregate.
-        handler = HandlerAggregate.new(
+        handler = HandlerAggregate(
             id=id,
             name=name,
             module_path=module_path,
@@ -341,7 +341,7 @@ class AddLogger(DomainEvent):
         '''
 
         # Create the logger aggregate.
-        logger = LoggerAggregate.new(
+        logger = LoggerAggregate(
             id=id,
             name=name,
             level=level,

--- a/tiferet/events/tests/test_app.py
+++ b/tiferet/events/tests/test_app.py
@@ -21,10 +21,9 @@ from ..settings import TiferetError, DomainEvent, a
 from ...domain import (
     AppInterface,
     AppServiceDependency,
-    DomainObject,
 )
 from ...interfaces import AppService
-from ...mappers import Aggregate, AppInterfaceAggregate
+from ...mappers import AppInterfaceAggregate
 from .settings import DomainEventTestBase, ServiceEventTestBase
 
 # *** fixtures
@@ -40,8 +39,7 @@ def app_interface():
     '''
 
     # Create a test AppInterface instance.
-    return Aggregate.new(
-        AppInterfaceAggregate,
+    return AppInterfaceAggregate(
         id='test',
         name='Test App',
         module_path='tiferet.contexts.app',
@@ -49,8 +47,7 @@ def app_interface():
         description='The test app.',
         flags=['test'],
         services=[
-            DomainObject.new(
-                AppServiceDependency,
+            AppServiceDependency(
                 service_id='test_service',
                 module_path='test_module_path',
                 class_name='test_class_name',
@@ -220,15 +217,13 @@ class TestGetAppInterface(ServiceEventTestBase):
 
         # Create default services with one duplicate and one missing service_id.
         default_services = [
-            DomainObject.new(
-                AppServiceDependency,
+            AppServiceDependency(
                 service_id='test_service',
                 module_path='ignored.module',
                 class_name='IgnoredClass',
                 parameters={'ignored': 'value'},
             ),
-            DomainObject.new(
-                AppServiceDependency,
+            AppServiceDependency(
                 service_id='new_service',
                 module_path='new.module',
                 class_name='NewClass',
@@ -283,15 +278,13 @@ class TestGetAppInterface(ServiceEventTestBase):
         '''
 
         # Configure the service mock to return a plain AppInterface domain object.
-        domain_interface = DomainObject.new(
-            AppInterface,
+        domain_interface = AppInterface(
             id='test.interface',
             name='Test Interface',
             module_path='tiferet.contexts.app',
             class_name='AppContext',
             services=[
-                DomainObject.new(
-                    AppServiceDependency,
+                AppServiceDependency(
                     service_id='existing_service',
                     module_path='existing.module',
                     class_name='ExistingClass',
@@ -307,8 +300,7 @@ class TestGetAppInterface(ServiceEventTestBase):
             mock_dependencies,
             interface_id='test.interface',
             default_services=[
-                DomainObject.new(
-                    AppServiceDependency,
+                AppServiceDependency(
                     service_id='new_service',
                     module_path='new.module',
                     class_name='NewClass',
@@ -367,8 +359,7 @@ class TestListAppInterfaces(DomainEventTestBase):
         '''
 
         # Configure the service to return multiple interfaces.
-        another_interface = Aggregate.new(
-            AppInterfaceAggregate,
+        another_interface = AppInterfaceAggregate(
             id='other',
             name='Other App',
             module_path='tiferet.contexts.app',

--- a/tiferet/events/tests/test_cli.py
+++ b/tiferet/events/tests/test_cli.py
@@ -14,7 +14,7 @@ from ..cli import (
     GetParentArguments,
 )
 from ..settings import DomainEvent, a
-from ...domain import CliCommand, CliArgument, DomainObject
+from ...domain import CliCommand, CliArgument
 from ...interfaces import CliService
 from ...mappers import CliCommandAggregate
 from .settings import DomainEventTestBase, ServiceEventTestBase
@@ -32,7 +32,7 @@ def cli_command():
     '''
 
     # Create a test CliCommand instance.
-    return CliCommandAggregate.new(
+    return CliCommandAggregate(
         id='test.command',
         name='Test Command',
         key='command',
@@ -294,7 +294,7 @@ class TestListCliCommands(DomainEventTestBase):
         '''
 
         # Create another command for the list.
-        another = CliCommandAggregate.new(
+        another = CliCommandAggregate(
             id='test.another',
             name='Another Command',
             key='another',
@@ -337,15 +337,13 @@ class TestGetParentArguments(DomainEventTestBase):
 
         # Create sample parent arguments.
         parent_args = [
-            DomainObject.new(
-                CliArgument,
+            CliArgument(
                 name_or_flags=['--verbose', '-v'],
                 description='Enable verbose output',
                 type='str',
                 required=False,
             ),
-            DomainObject.new(
-                CliArgument,
+            CliArgument(
                 name_or_flags=['--debug'],
                 description='Enable debug mode',
                 type='str',

--- a/tiferet/events/tests/test_di.py
+++ b/tiferet/events/tests/test_di.py
@@ -25,7 +25,6 @@ from ...mappers.di import (
     ServiceConfigurationAggregate,
     FlaggedDependencyAggregate,
 )
-from ...mappers.settings import Aggregate
 from ...interfaces.di import DIService
 from .settings import DomainEventTestBase, ServiceEventTestBase
 
@@ -42,8 +41,7 @@ def flagged_dependency_for_di() -> FlaggedDependency:
     '''
 
     # Create a flagged dependency aggregate.
-    return Aggregate.new(
-        FlaggedDependencyAggregate,
+    return FlaggedDependencyAggregate(
         module_path='tiferet.repos.example',
         class_name='ExampleRepository',
         flag='test_alpha',
@@ -66,14 +64,12 @@ def service_configuration_aggregate(flagged_dependency_for_di) -> ServiceConfigu
     '''
 
     # Create a service configuration aggregate with a default type and one dependency.
-    return ServiceConfigurationAggregate.new(
-        service_configuration_data=dict(
-            id='svc_test',
-            module_path='tiferet.repos.example',
-            class_name='ExampleRepository',
-            parameters={'param_1': 'value_1'},
-            dependencies=[flagged_dependency_for_di],
-        ),
+    return ServiceConfigurationAggregate(
+        id='svc_test',
+        module_path='tiferet.repos.example',
+        class_name='ExampleRepository',
+        parameters={'param_1': 'value_1'},
+        dependencies=[flagged_dependency_for_di],
     )
 
 # *** tests
@@ -579,12 +575,10 @@ class TestRemoveServiceDependency(ServiceEventTestBase):
         '''
 
         # Create a configuration with only a dependency and no default type.
-        config = ServiceConfigurationAggregate.new(
-            service_configuration_data=dict(
-                id='svc_only_deps',
-                dependencies=[flagged_dependency_for_di],
-                parameters={},
-            ),
+        config = ServiceConfigurationAggregate(
+            id='svc_only_deps',
+            dependencies=[flagged_dependency_for_di],
+            parameters={},
         )
         mock_dependencies['di_service'].get_configuration.return_value = config
 

--- a/tiferet/events/tests/test_error.py
+++ b/tiferet/events/tests/test_error.py
@@ -38,7 +38,7 @@ def error() -> ErrorAggregate:
     '''
 
     # Create a sample error aggregate.
-    return ErrorAggregate.new(
+    return ErrorAggregate(
         id='TEST_ERROR',
         name='Test Error',
         message=[{
@@ -59,7 +59,7 @@ def default_errors() -> List[Error]:
 
     # Return a list of default Error aggregates.
     return [
-        ErrorAggregate.new(**data) for data in a.DEFAULT_ERRORS.values()
+        ErrorAggregate(**data) for data in a.DEFAULT_ERRORS.values()
     ]
 
 # *** tests
@@ -220,7 +220,7 @@ class TestGetError(ServiceEventTestBase):
         )
 
         # Assert the result matches the expected default error.
-        expected = ErrorAggregate.new(**a.DEFAULT_ERRORS.get(error_id))
+        expected = ErrorAggregate(**a.DEFAULT_ERRORS.get(error_id))
         assert result == expected
         mock_dependencies['error_service'].get.assert_called_once_with(error_id)
 
@@ -266,7 +266,7 @@ class TestListErrors(DomainEventTestBase):
         '''
 
         # Configure the mock to return a list with an additional error.
-        existing_error = ErrorAggregate.new(
+        existing_error = ErrorAggregate(
             id='EXISTING_ERROR',
             name='Existing Error',
             message=[{
@@ -292,7 +292,7 @@ class TestListErrors(DomainEventTestBase):
         '''
 
         # Create a repo error that overrides the default ERROR_NOT_FOUND.
-        overriding_error = ErrorAggregate.new(
+        overriding_error = ErrorAggregate(
             id=a.const.ERROR_NOT_FOUND_ID,
             name='Overriding Not Found Error',
             message=[{

--- a/tiferet/events/tests/test_feature.py
+++ b/tiferet/events/tests/test_feature.py
@@ -40,7 +40,7 @@ def sample_feature() -> Feature:
     '''
 
     # Create a sample feature aggregate.
-    return FeatureAggregate.new(
+    return FeatureAggregate(
         id='group.sample_feature',
         name='Sample Feature',
         group_id='group',

--- a/tiferet/events/tests/test_logging.py
+++ b/tiferet/events/tests/test_logging.py
@@ -36,7 +36,7 @@ def sample_formatter() -> Formatter:
     '''
 
     # Create a sample formatter aggregate.
-    return FormatterAggregate.new(
+    return FormatterAggregate(
         id='simple',
         name='Simple Formatter',
         format='%(levelname)s - %(message)s',
@@ -55,7 +55,7 @@ def sample_handler() -> Handler:
     '''
 
     # Create a sample handler aggregate.
-    return HandlerAggregate.new(
+    return HandlerAggregate(
         id='console',
         name='Console Handler',
         module_path='logging',
@@ -78,7 +78,7 @@ def sample_logger() -> Logger:
     '''
 
     # Create a sample logger aggregate.
-    return LoggerAggregate.new(
+    return LoggerAggregate(
         id='app',
         name='Application Logger',
         level='INFO',


### PR DESCRIPTION
## Summary

Updates all six domain event modules and their tests to use Pydantic v2 constructor APIs:

- `Aggregate.new(Type, ...)` / `Type.new(...)` → `Type(...)`
- `DomainObject.new(Type, ...)` → `Type(...)`
- `to_primitive()` → `model_dump()`

## Files Changed

**Event modules:** `events/app.py`, `cli.py`, `di.py`, `error.py`, `feature.py`, `logging.py`
**Test files:** `events/tests/test_app.py`, `test_cli.py`, `test_di.py`, `test_error.py`, `test_feature.py`, `test_logging.py`

## Verification

- `pytest tiferet/events/tests/` — 268 passed, 0 failures
- No remaining references to `Aggregate.new()`, `*.new()`, `DomainObject.new()`, or `to_primitive()` in `events/`

Closes #761

[Warp conversation](https://app.warp.dev/conversation/f0b28b66-2779-449b-b373-f8fa5ec7f714)

Co-Authored-By: Oz <oz-agent@warp.dev>