### PR TITLE
Contexts – Update Error, Logging, and All Context Tests for Pydantic v2

### DIFF
--- a/tiferet/contexts/error.py
+++ b/tiferet/contexts/error.py
@@ -55,7 +55,7 @@ class ErrorContext(object):
         except TiferetError:
             
             # Retrieve and raise the "error not found" error to use its details.
-            error: Error = Error.new(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
+            error: Error = Error(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
             raise TiferetAPIError(
                 **error.format_response(),
                 id=error_code

--- a/tiferet/contexts/logging.py
+++ b/tiferet/contexts/logging.py
@@ -8,7 +8,6 @@ from typing import Dict, Any, List, Callable
 # ** app
 from ..assets.logging import *
 from ..domain import (
-    DomainObject,
     Formatter,
     Handler,
     Logger,
@@ -126,18 +125,15 @@ class LoggingContext(object):
 
         # Set the default configurations if not provided.
         if not formatters:
-            formatters = [DomainObject.new(
-                Formatter,
+            formatters = [Formatter(
                 **data
             ) for data in DEFAULT_FORMATTERS]
         if not handlers:
-            handlers = [DomainObject.new(
-                Handler,
+            handlers = [Handler(
                 **data
             ) for data in DEFAULT_HANDLERS]
         if not loggers:
-            loggers = [DomainObject.new(
-                Logger,
+            loggers = [Logger(
                 **data
             ) for data in DEFAULT_LOGGERS]
 

--- a/tiferet/contexts/tests/test_app.py
+++ b/tiferet/contexts/tests/test_app.py
@@ -33,16 +33,14 @@ def app_interface():
     '''
 
     # Create a test AppInterfaceAggregate instance.
-    return AppInterfaceAggregate.new(
-        app_interface_data=dict(
-            id='test',
-            name='Test App',
-            module_path='tiferet.contexts.app',
-            class_name='AppInterfaceContext',
-            description='The test app.',
-            flags=['test'],
-            services=[],
-        ),
+    return AppInterfaceAggregate(
+        id='test',
+        name='Test App',
+        module_path='tiferet.contexts.app',
+        class_name='AppInterfaceContext',
+        description='The test app.',
+        flags=['test'],
+        services=[],
     )
 
 # ** fixture: feature_context

--- a/tiferet/contexts/tests/test_di.py
+++ b/tiferet/contexts/tests/test_di.py
@@ -10,13 +10,11 @@ from ..di import DIContext
 from ..cache import CacheContext
 from ...assets.exceptions import TiferetError
 from ...assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
+from ...di import ServiceProvider, DependenciesServiceProvider
 from ...domain import (
-    ServiceProvider,
-    DependenciesServiceProvider,
     ServiceConfiguration,
     FlaggedDependency,
 )
-from ...domain.settings import DomainObject
 from ...events.di import ListAllSettings
 
 
@@ -55,14 +53,12 @@ def di_service_content() -> Tuple[List[ServiceConfiguration], Dict[str, str]]:
 
     # Create a list of service configurations.
     configurations = [
-        DomainObject.new(
-            ServiceConfiguration,
+        ServiceConfiguration(
             id='test_service',
             module_path='tiferet.contexts.tests.test_di',
             class_name='TestService',
             dependencies=[
-                DomainObject.new(
-                    FlaggedDependency,
+                FlaggedDependency(
                     module_path='tiferet.contexts.tests.test_di',
                     class_name='TestService',
                     flag='test',

--- a/tiferet/contexts/tests/test_error.py
+++ b/tiferet/contexts/tests/test_error.py
@@ -55,7 +55,7 @@ def test_error_context_get_error_by_code(get_error_evt_mock: DomainEvent, error_
     '''
 
     # Mock the get_error_handler to return a sample Error.
-    get_error_evt_mock.execute.return_value = Error.new(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
+    get_error_evt_mock.execute.return_value = Error(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
     
     error = error_context.get_error_by_code(ERROR_NOT_FOUND_ID)
     
@@ -101,7 +101,7 @@ def test_error_context_handle_error(error_context):
     tiferet_error = TiferetError('ERROR_NOT_FOUND', id='NON_EXISTENT_ERROR')
 
     # Mock the get_error_handler to return the appropriate Error object.
-    error_context.get_error_handler = mock.Mock(return_value=Error.new(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID)))
+    error_context.get_error_handler = mock.Mock(return_value=Error(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID)))
 
     # Handle the error using the error context.
     response = error_context.handle_error(tiferet_error, lang='en_US')

--- a/tiferet/contexts/tests/test_feature.py
+++ b/tiferet/contexts/tests/test_feature.py
@@ -16,7 +16,6 @@ from ..feature import (
 from ...assets import TiferetError
 from ...events import DomainEvent
 from ...domain import (
-    DomainObject,
     Feature,
     FeatureEvent,
 )
@@ -84,8 +83,7 @@ def test_command():
 @pytest.fixture
 def feature():
 
-    return DomainObject.new(
-        Feature,
+    return Feature(
         id='test_group.test_feature',
         group_id='test_group',
         feature_key='test_feature',
@@ -164,8 +162,7 @@ def test_feature_context_load_feature_step_with_combined_flags(feature_context, 
 
     feature_flags = ['feature_flag_1', 'feature_flag_2']
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Test Command',
         service_id='test_command',
         flags=['command_flag_1', 'command_flag_2'],
@@ -189,8 +186,7 @@ def test_feature_context_load_feature_step_only_feature_flags(feature_context, s
 
     feature_flags = ['feature_flag']
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Test Command',
         service_id='test_command',
         flags=[],
@@ -205,8 +201,7 @@ def test_feature_context_load_feature_step_only_feature_flags(feature_context, s
 def test_feature_context_load_feature_step_only_command_flags(feature_context, services_context, test_command):
     """Test loading a feature step with only step flags."""
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Test Command',
         service_id='test_command',
         flags=['command_flag'],
@@ -221,8 +216,7 @@ def test_feature_context_load_feature_step_only_command_flags(feature_context, s
 def test_feature_context_load_feature_step_with_flags(feature_context, services_context, test_command):
     """Test loading a feature step that includes flags for dependency resolution."""
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Test Command',
         service_id='test_command',
         flags=['flag1', 'flag2'],
@@ -238,8 +232,7 @@ def test_feature_context_load_feature_step_with_flags(feature_context, services_
 def test_feature_context_load_feature_step_without_flags(feature_context, services_context, test_command):
     """Test loading a feature step when no flags are configured."""
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Test Command',
         service_id='test_command',
     )
@@ -260,8 +253,7 @@ def test_feature_context_load_feature_step_failed(feature_context, services_cont
         'Feature command not found in services: non_existent_command',
     )
 
-    feature_event: FeatureEvent = DomainObject.new(
-        FeatureEvent,
+    feature_event: FeatureEvent = FeatureEvent(
         name='Missing Command',
         service_id='non_existent_command',
         flags=['flagX'],
@@ -333,8 +325,7 @@ def test_feature_context_handle_command_with_pass_on_error(feature_context, test
 def test_feature_context_execute_feature(feature_context, get_feature_evt, feature):
 
     # Add a standard feature step with no data key or pass on error.
-    feature.steps.append(DomainObject.new(
-        FeatureEvent,
+    feature.steps.append(FeatureEvent(
         name='Test Command',
         service_id='test_command',
     ))
@@ -359,8 +350,7 @@ def test_feature_context_execute_feature_with_request_parameter(feature_context,
     """Test executing a feature with a request parameter in the FeatureContext."""
 
     # Add a feature step with a data key and request parameter.
-    feature.steps.append(DomainObject.new(
-        FeatureEvent,
+    feature.steps.append(FeatureEvent(
         name='Test Command',
         service_id='test_command',
         parameters=dict(
@@ -390,8 +380,7 @@ def test_feature_context_execute_feature_with_pass_on_error(feature_context, get
     """Test executing a feature with pass_on_error in the FeatureContext."""
 
     # Add a feature step with pass_on_error enabled.
-    feature.steps.append(DomainObject.new(
-        FeatureEvent,
+    feature.steps.append(FeatureEvent(
         name='Test Command',
         service_id='test_command',
         pass_on_error=True,

--- a/tiferet/contexts/tests/test_logging.py
+++ b/tiferet/contexts/tests/test_logging.py
@@ -11,7 +11,6 @@ from ..logging import *
 from ...assets import TiferetError
 from ...assets.logging import DEFAULT_FORMATTERS, DEFAULT_HANDLERS, DEFAULT_LOGGERS
 from ...domain.logging import Formatter, Handler, Logger
-from ...domain.settings import DomainObject
 
 
 # *** fixtures
@@ -23,8 +22,7 @@ def formatter():
     '''
     Fixture to create a Formatter instance.
     '''
-    return DomainObject.new(
-        Formatter,
+    return Formatter(
         id='simple',
         name='Simple Formatter',
         description='A simple logging formatter.',
@@ -39,8 +37,7 @@ def handler(formatter):
     '''
     Fixture to create a Handler instance.
     '''
-    return DomainObject.new(
-        Handler,
+    return Handler(
         id='console',
         name='Console Handler',
         description='A console logging handler.',
@@ -58,8 +55,7 @@ def logger_root(handler):
     '''
     Fixture to create a root Logger instance.
     '''
-    return DomainObject.new(
-        Logger,
+    return Logger(
         id='root',
         name='',
         description='Root logger.',
@@ -195,8 +191,7 @@ def test_logging_context_format_config_non_root_logger(logging_context, formatte
     '''
 
     # Create a non-root logger.
-    non_root_logger = DomainObject.new(
-        Logger,
+    non_root_logger = Logger(
         id='app',
         name='app',
         description='Application logger.',
@@ -283,8 +278,7 @@ def test_logging_context_build_logger_error(logging_context, logging_list_all_ev
     '''
 
     # Mock list_all to return invalid configurations that will fail.
-    invalid_formatter = DomainObject.new(
-        Formatter,
+    invalid_formatter = Formatter(
         id='invalid',
         name='Invalid Formatter',
         description='An invalid formatter.',

--- a/tiferet/contexts/tests/test_request.py
+++ b/tiferet/contexts/tests/test_request.py
@@ -4,7 +4,8 @@
 import pytest
 
 # ** app
-from ...domain import DomainObject, StringType
+from pydantic import Field
+from ...domain import DomainObject
 from ..request import *
 
 # *** fixtures
@@ -97,13 +98,13 @@ def test_request_context_handle_response_domain_object(request_context):
     # Create a DomainObject to simulate a response.
     class Data(DomainObject):
 
-        key = StringType(
+        key: str = Field(
             default='default_value',
-            required=True
+            description='The data key.'
         )
 
     # Set the request context result to a DomainObject.
-    request_context.result = DomainObject.new(Data, key='value')
+    request_context.result = Data(key='value')
 
     # Handle the response with a DomainObject.
     response = request_context.handle_response()
@@ -143,15 +144,15 @@ def test_request_context_handle_response_domain_object_list(request_context):
     # Create a DomainObject to simulate a response.
     class Item(DomainObject):
 
-        name = StringType(
+        name: str = Field(
             default='default_name',
-            required=True
+            description='The item name.'
         )
 
     # Set the request context result to a list of DomainObjects.
     request_context.result = [
-        DomainObject.new(Item, name='item1'),
-        DomainObject.new(Item, name='item2')
+        Item(name='item1'),
+        Item(name='item2')
     ]
 
     # Handle the response with a list of DomainObjects.


### PR DESCRIPTION
## Summary

Updates , , and all six context test files to use Pydantic v2 constructor APIs, replacing legacy `.new()` factory calls with direct constructors.

### Production changes
- **`contexts/error.py`**: `Error.new(...)` → `Error(...)`
- **`contexts/logging.py`**: Removed `DomainObject` import; replaced `DomainObject.new(Formatter/Handler/Logger, ...)` with direct constructors

### Test changes
- **`test_app.py`**: `AppInterfaceAggregate.new(app_interface_data=...)` → `AppInterfaceAggregate(...)`
- **`test_di.py`**: `DomainObject.new(ServiceConfiguration/FlaggedDependency, ...)` → direct constructors; fixed `ServiceProvider`/`DependenciesServiceProvider` import path (`...domain` → `...di`)
- **`test_error.py`**: `Error.new(...)` → `Error(...)`
- **`test_feature.py`**: `DomainObject.new(Feature/FeatureEvent, ...)` → direct constructors; removed unused `DomainObject` import
- **`test_logging.py`**: `DomainObject.new(Formatter/Handler/Logger, ...)` → direct constructors; removed `DomainObject` import
- **`test_request.py`**: Migrated inline `DomainObject` subclass fields from `StringType` to `pydantic.Field`; replaced `DomainObject.new(...)` with direct constructors

### Verification
- All 64 context tests pass with 0 failures
- No remaining `.new(` references in `contexts/` or `contexts/tests/`

Closes #762

---
[Warp conversation](https://app.warp.dev/conversation/5f57764e-b5b6-497b-85c8-69221b112261)

Co-Authored-By: Oz <oz-agent@warp.dev>