### PR TITLE
Builders – Update AppBuilder and CLI Tests for Pydantic v2

### DIFF
--- a/tiferet/builders/main.py
+++ b/tiferet/builders/main.py
@@ -10,7 +10,6 @@ from ..contexts.app import AppInterfaceContext
 from ..di import ServiceProvider, DependenciesServiceProvider
 from .. import assets as a
 from ..domain import (
-    DomainObject,
     AppInterface,
     AppServiceDependency,
 )
@@ -126,13 +125,11 @@ class AppBuilder(object):
 
         # Build domain dependency models from the default service configuration.
         return [
-            DomainObject.new(
-                AppServiceDependency,
+            AppServiceDependency.model_construct(
                 service_id=service_id,
                 module_path=module_path,
                 class_name=class_name,
                 parameters=parameters or {},
-                validate=False,
             )
             for service_id, module_path, class_name, parameters in a.bildr.DEFAULT_SERVICES
         ]

--- a/tiferet/builders/tests/test_cli.py
+++ b/tiferet/builders/tests/test_cli.py
@@ -11,7 +11,6 @@ from unittest import mock
 from ...assets import TiferetAPIError
 from ...contexts.app import AppInterfaceContext
 from ...domain import CliCommand, CliArgument
-from ...domain.settings import DomainObject
 from ...events.cli import ListCliCommands, GetParentArguments
 from ..main import AppBuilder
 from ..cli import CliBuilder
@@ -27,14 +26,13 @@ def cli_command_list():
 
     # Return a list of test CLI commands.
     return [
-        CliCommand.new(
+        CliCommand(
             group_key='test-group',
             key='test-feature',
             name='Test Feature Command',
             description='A test feature command.',
             arguments=[
-                DomainObject.new(
-                    CliArgument,
+                CliArgument(
                     name_or_flags=['--arg1', '-a'],
                     description='Test argument 1',
                     required=True,

--- a/tiferet/builders/tests/test_main.py
+++ b/tiferet/builders/tests/test_main.py
@@ -49,17 +49,15 @@ def app_interface_aggregate(app_builder: AppBuilder) -> AppInterfaceAggregate:
     '''
 
     # Create and return a representative app interface aggregate.
-    return AppInterfaceAggregate.new(
-        app_interface_data={
-            'id': 'test_calc',
-            'name': 'Test Calculator',
-            'module_path': 'tiferet.contexts.app',
-            'class_name': 'AppInterfaceContext',
-            'description': 'Test calculator interface',
-            'flags': ['test'],
-            'services': app_builder.load_default_services(),
-            'constants': a.bildr.DEFAULT_CONSTANTS,
-        }
+    return AppInterfaceAggregate(
+        id='test_calc',
+        name='Test Calculator',
+        module_path='tiferet.contexts.app',
+        class_name='AppInterfaceContext',
+        description='Test calculator interface',
+        flags=['test'],
+        services=app_builder.load_default_services(),
+        constants=a.bildr.DEFAULT_CONSTANTS,
     )
 
 # *** tests


### PR DESCRIPTION
## Summary

Resolves #763.

Updates `builders/main.py` and builder test files to use Pydantic v2 APIs:

- **`builders/main.py`**: Remove `DomainObject` import; replace `DomainObject.new(AppServiceDependency, ..., validate=False)` with `AppServiceDependency.model_construct(...)` in `load_default_services()`.
- **`builders/tests/test_main.py`**: Replace `AppInterfaceAggregate.new(app_interface_data={...})` with direct `AppInterfaceAggregate(...)` constructor.
- **`builders/tests/test_cli.py`**: Remove `DomainObject` import; replace `CliCommand.new(...)` and `DomainObject.new(CliArgument, ...)` with direct constructors.

All 17 builder tests pass.

---

[Warp conversation](https://app.warp.dev/conversation/176bfc2c-d1cb-4ad7-97de-fbfe570b1a87)

Co-Authored-By: Oz <oz-agent@warp.dev>