### PR TITLE
Docs/Core – Update domain.md, mappers.md, repos.md for Pydantic v2

### DIFF
--- a/docs/core/domain.md
+++ b/docs/core/domain.md
@@ -45,44 +45,35 @@ This duality ensures a single source of truth for domain structure and behavior,
 
 ## The DomainObject Base Class
 
-`DomainObject` extends `schematics.Model` and provides a static factory method for consistent instantiation:
+`DomainObject` extends `pydantic.BaseModel` with a shared `ConfigDict`:
 
 ```python
 # tiferet/domain/settings.py
 
-class DomainObject(Model):
+from pydantic import BaseModel, ConfigDict
+
+class DomainObject(BaseModel):
     '''
-    A domain model object.
+    The base domain model object for Tiferet, backed by Pydantic v2.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        model_type: type,
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'DomainObject':
-        '''
-        Initializes a new domain object.
-        '''
-
-        # Create a new domain object.
-        domain_object = model_type(dict(**kwargs), strict=strict)
-
-        # Validate if specified.
-        if validate:
-            domain_object.validate()
-
-        # Return the new domain object.
-        return domain_object
+    # * attribute: model_config
+    model_config = ConfigDict(
+        extra='forbid',
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        coerce_numbers_to_str=True,
+    )
 ```
 
 Key characteristics:
-- **`DomainObject.new(Type, **kwargs)`** is the standard factory for all domain objects.
-- Validation is enabled by default; pass `validate=False` to skip.
-- Strict mode is enabled by default; pass `strict=False` to allow extra fields.
-- Domain-specific models may override `new` with custom factory logic (e.g., `Error.new` derives `error_code` from `id`).
+- **`extra='forbid'`** rejects unknown fields by default; subclasses may override (e.g., `TransferObject` uses `extra='ignore'`).
+- **`validate_assignment=True`** triggers field validation on every `setattr`, ensuring aggregates stay consistent after mutation.
+- **`populate_by_name=True`** allows construction by canonical field name even when aliases are defined.
+- Instantiate domain objects directly via the Pydantic constructor: `Error(id='invalid_input', name='Invalid Input')`.
+- For input from untrusted/external sources, use `model_validate(data_dict)` which applies all validators.
+- Domain-specific derivation logic uses `@model_validator(mode='before')` instead of custom factory methods (e.g., `Error._derive_error_code` computes `error_code` from `id`).
 
 ## Structured Code Design
 
@@ -90,9 +81,9 @@ Domain objects follow a strict artifact comment structure for consistency and AI
 
 - `# *** models` – top-level section (retained for backward compatibility; these are domain objects).
 - `# ** model: <name>` – individual domain object (snake_case).
-- `# * attribute: <name>` – instance attributes (Schematics types).
+- `# * attribute: <name>` – instance attributes (Pydantic `Field(...)` annotations).
 - `# * method: <name>` – domain methods.
-- `# * method: new` – optional custom factory.
+- `# * method: _derive_* (validator)` – optional `@model_validator` for derivation logic.
 
 **Spacing rules:**
 - One empty line between `# *** models` and first `# ** model`.
@@ -103,19 +94,19 @@ Domain objects follow a strict artifact comment structure for consistency and AI
 
 ### 1. Define the Domain Object
 - Extend `DomainObject` from `tiferet.domain.settings`.
-- Use Schematics types with metadata.
-- Prefer `DomainObject.new()` for instantiation; add `# * method: new` for custom logic.
+- Declare fields with Pydantic `Field(...)` annotations.
+- Instantiate directly via the constructor or `model_validate()`.
+- Use `@model_validator(mode='before')` for derivation logic that was previously in custom `new()` factories.
 
 **Example** – `CalculatorResult`:
 ```python
 # *** imports
 
+# ** infra
+from pydantic import Field
+
 # ** app
-from tiferet import (
-    DomainObject, 
-    FloatType, 
-    StringType
-)
+from tiferet import DomainObject
 
 # *** models
 
@@ -126,10 +117,10 @@ class CalculatorResult(DomainObject):
     '''
 
     # * attribute: value
-    value = FloatType(required=True)
+    value: float = Field(..., description='The computed result value.')
 
     # * attribute: operation
-    operation = StringType(required=True)
+    operation: str = Field(..., description='The operation that produced this result.')
 
     # * method: format_result
     def format_result(self, precision: int = 2) -> str:
@@ -147,11 +138,11 @@ Domain objects are extended in the mappers layer as Aggregates (with mutation me
 
 ### Best Practices
 - Use artifact comments consistently.
-- Define validation/metadata on attributes.
+- Declare fields with `Field(...)` including `description` metadata.
 - Keep domain objects focused on **structure and read-only behavior** (formatting, lookups).
 - Place **mutation logic** (e.g., `rename`, `add_command`, `set_message`) in Aggregate classes in the mappers layer.
-- Use `DomainObject.new` unless a custom factory is needed.
-- Override `new` as a `@staticmethod` when domain-specific derivation is required (e.g., `Error.new` computes `error_code`).
+- Instantiate directly via the constructor or `model_validate()` — there is no `DomainObject.new()` factory.
+- Use `@model_validator(mode='before')` for domain-specific derivation logic (e.g., `Error._derive_error_code` computes `error_code` from `id`).
 
 ## Testing Domain Objects
 
@@ -163,26 +154,32 @@ Tests validate instantiation, behavior, and edge cases using `pytest`.
 - `# *** tests`
 - `# ** test: <name>`
 
-**Example** – Error domain object tests cover `new`, `format_message`, `format_response`, and multilingual support.
+**Example** – Error domain object tests cover constructor instantiation, `format_message`, `format_response`, and multilingual support.
 
 ## Package Layout
 
 Domain objects are defined in `tiferet/domain/`:
 
-- `settings.py` – `DomainObject` base class and Schematics type wrappers.
-- `app.py` – `AppInterface`, `AppAttribute`.
+- `settings.py` – `DomainObject` base class (extends `pydantic.BaseModel` with `ConfigDict`).
+- `app.py` – `AppInterface`, `AppServiceDependency`.
 - `cli.py` – `CliCommand`, `CliArgument`.
-- `container.py` – `ContainerAttribute`, `FlaggedDependency`.
+- `di.py` – `ServiceConfiguration`, `FlaggedDependency`.
 - `error.py` – `Error`, `ErrorMessage`.
-- `feature.py` – `Feature`, `FeatureCommand`.
+- `feature.py` – `Feature`, `FeatureStep`, `FeatureEvent`.
 - `logging.py` – `Formatter`, `Handler`, `Logger`.
-- `__init__.py` – Public exports for all domain objects and types.
+- `__init__.py` – Public exports for all domain objects.
 
 Tests live in `tiferet/domain/tests/`.
 
-## Migration from ModelObject
+## Migration from Schematics to Pydantic v2
 
-In v2.0, `ModelObject` was renamed to `DomainObject` and the `tiferet/entities/` package was renamed to `tiferet/domain/`. All import paths and references throughout the framework (domain, events, mappers, repos, contexts, and top-level exports) have been updated accordingly. The API is identical — only the names have changed.
+In v2.0, the domain layer was migrated from `schematics.Model` to `pydantic.BaseModel`:
+
+- `DomainObject` now extends `pydantic.BaseModel` with a shared `ConfigDict` instead of `schematics.Model`.
+- Schematics type descriptors (`StringType`, `IntegerType`, `FloatType`, etc.) are replaced with standard Python type annotations and `pydantic.Field(...)`.
+- The `DomainObject.new(Type, **kwargs)` static factory is removed; use the Pydantic constructor directly or `model_validate()` for external data.
+- Custom `new()` factory methods with derivation logic are replaced by `@model_validator(mode='before')` class methods.
+- `tiferet/entities/` was renamed to `tiferet/domain/`, and `ModelObject` was renamed to `DomainObject`.
 
 ## Conclusion
 

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -8,14 +8,15 @@
 The mappers layer (`tiferet.mappers`) provides the bridge between persistent configuration and runtime domain objects. It introduces two base classes:
 
 1. **Aggregate**  
-   - Extends `schematics.Model`.
-   - Provides a static factory (`Aggregate.new`) and mutation-safe attribute updates (`set_attribute`) with validation via `RaiseError`.
+   - Extends `DomainObject` (which extends `pydantic.BaseModel`).
+   - Inherits the strict `extra='forbid'` and `validate_assignment=True` config from `DomainObject`.
+   - Provides mutation-safe attribute updates via `set_attribute` with validation using `model_fields` and `RaiseError`.
    - Concrete aggregates combine a domain object with `Aggregate` to add mutation logic (e.g., `ErrorAggregate(Error, Aggregate)`).
 
 2. **TransferObject**  
-   - Extends `schematics.Model`.
-   - Manages role-based serialization, mapping, and transformation between configuration data and runtime models.
-   - Provides `map`, `from_model`, `from_data`, `allow`, and `deny` methods.
+   - Extends `DomainObject` with a lenient `ConfigDict` (`extra='ignore'`, `validate_assignment=False`).
+   - Manages role-based serialization via a `_ROLES` ClassVar mapping role names to `model_dump` kwargs.
+   - Provides `to_primitive(role)`, `map(target)`, and `from_model` classmethod for mapping and transformation.
    - Concrete transfer objects combine a domain object with `TransferObject` to add serialization roles (e.g., `ErrorYamlObject(Error, TransferObject)`).
 
 Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`) with a clearer separation of mutation (Aggregate) and serialization (TransferObject) concerns.
@@ -38,69 +39,70 @@ Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`
 
 ## The Aggregate Base Class
 
-`Aggregate` extends `schematics.Model` and provides:
+`Aggregate` extends `DomainObject` and provides mutation-safe attribute updates:
 
 ```python
 # tiferet/mappers/settings.py
 
-class Aggregate(Model):
+class Aggregate(DomainObject):
     '''
-    A data representation of an aggregate object.
+    A mutable, validated representation of a domain aggregate.
     '''
-
-    # * method: new
-    @staticmethod
-    def new(
-        aggregate_type: type,
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'Aggregate':
-        '''Initializes a new aggregate object.'''
-        aggregate_object = aggregate_type(dict(**kwargs), strict=strict)
-        if validate:
-            aggregate_object.validate()
-        return aggregate_object
 
     # * method: set_attribute
     def set_attribute(self, attribute: str, value: Any) -> None:
-        '''Update an attribute with validation.'''
-        if not hasattr(self, attribute):
+        '''Update an attribute, raising an error if it is unknown.'''
+
+        # Reject unknown attribute names by raising a structured error.
+        if attribute not in type(self).model_fields:
             RaiseError.execute(
                 error_code=a.const.INVALID_MODEL_ATTRIBUTE_ID,
                 attribute=attribute,
             )
+
+        # Apply the update; validate_assignment=True triggers field validation.
         setattr(self, attribute, value)
-        self.validate()
 ```
 
 Key characteristics:
-- **`Aggregate.new(Type, **kwargs)`** is the standard factory for all aggregates.
-- **`set_attribute`** validates the attribute exists before mutation and re-validates after update.
+- Aggregates are instantiated directly via the Pydantic constructor: `ErrorAggregate(id='...', name='...')`.
+- **`set_attribute`** checks `model_fields` to verify the attribute exists before mutation; `validate_assignment=True` (inherited from `DomainObject`) triggers field validation on every `setattr`.
 - Invalid attribute mutations raise `TiferetError` via `RaiseError.execute` with `INVALID_MODEL_ATTRIBUTE_ID`.
 
 ## The TransferObject Base Class
 
-`TransferObject` extends `schematics.Model` and provides:
+`TransferObject` extends `DomainObject` with a lenient config and provides:
 
-- **`map(type, role, validate, **kwargs)`** — Serializes via `to_primitive(role)`, merges kwargs, attempts `type.new(...)` then falls back to `Aggregate.new(...)`.
-- **`from_model(transfer_obj, aggregate, validate, **kwargs)`** — Creates a transfer object from an aggregate's primitive data.
-- **`from_data(data, **kwargs)`** — Creates a transfer object from a raw dictionary.
-- **`allow(*args)`** — Creates a whitelist transform (or wholelist if no args).
-- **`deny(*args)`** — Creates a blacklist transform.
+- **`to_primitive(role, **overrides)`** — Serializes via `model_dump`, applying role-specific kwargs from `_ROLES` and caller overrides.
+- **`map(target, **overrides)`** — Serializes via the `to_model` role, merges overrides, and constructs the target aggregate.
+- **`from_model(model, **overrides)`** — Classmethod that creates a transfer object from a domain model or aggregate via `model_dump` + `model_validate`.
 
 ### Role-Based Serialization
 
-Transfer objects use Schematics `Options.roles` to control which fields are serialized for different contexts:
+Transfer objects use a `_ROLES` ClassVar to control which fields are serialized for different contexts. Each role maps to a dict of `model_dump` kwargs:
 
 ```python
 class ErrorYamlObject(Error, TransferObject):
-    class Options:
-        serialize_when_none = False
-        roles = {
-            'to_data': TransferObject.allow('id', 'name', 'message'),
-            'to_model': TransferObject.allow('id', 'name', 'message'),
-        }
+    '''
+    A YAML data representation of an error object.
+    '''
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'message'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+    }
+```
+
+The `to_primitive` method delegates to Pydantic `model_dump`, defaulting to `exclude_none=True` and merging role-specific and caller-supplied kwargs:
+
+```python
+def to_primitive(self, role: str = None, **overrides) -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {'exclude_none': True}
+    if role and role in type(self)._ROLES:
+        kwargs.update(type(self)._ROLES[role])
+    kwargs.update(overrides)
+    return self.model_dump(**kwargs)
 ```
 
 ## Structured Code Design
@@ -109,8 +111,8 @@ Mapper classes follow the standard Tiferet artifact comment structure:
 
 - `# *** mappers` — top-level section for mapper modules.
 - `# ** mapper: <name>` — individual mapper (snake_case).
-- `# * attribute: <name>` — instance attributes (Schematics types).
-- `# * method: <name>` — instance or static methods.
+- `# * attribute: <name>` — instance attributes (Pydantic `Field(...)` annotations or `ClassVar`).
+- `# * method: <name>` — instance or class methods.
 
 Use `# *** classes` in `settings.py` for the base classes themselves.
 
@@ -124,6 +126,7 @@ Use `# *** classes` in `settings.py` for the base classes themselves.
 ### 1. Define an Aggregate
 - Combine domain object + `Aggregate`.
 - Add mutation methods under `# * method: <name>`.
+- Instantiate directly via the Pydantic constructor.
 
 **Example** – `FeatureAggregate`:
 ```python
@@ -138,13 +141,16 @@ class FeatureAggregate(Feature, Aggregate):
     # * method: rename
     def rename(self, name: str) -> None:
         '''Rename the feature.'''
-        self.set_attribute('name', name)
+        # validate_assignment=True handles re-validation.
+        self.name = name
 ```
 
 ### 2. Define a TransferObject
 - Combine domain object + `TransferObject`.
-- Define `Options.roles` for serialization.
-- Use `serialized_name` and `deserialize_from` for attribute aliasing.
+- Define `_ROLES` ClassVar for role-based serialization with `model_dump` kwargs.
+- Use `serialization_alias` and `AliasChoices` / `validation_alias` for attribute aliasing.
+- Override `map()` to specify the target aggregate and handle nested mapping.
+- Override `from_model()` as a `@classmethod` to handle nested conversions.
 
 **Example** – `FeatureYamlObject`:
 ```python
@@ -154,24 +160,69 @@ class FeatureYamlObject(Feature, TransferObject):
     YAML transfer object for the Feature domain object.
     '''
 
-    class Options:
-        serialize_when_none = False
-        roles = {
-            'to_data': TransferObject.allow('id', 'name', 'description'),
-            'to_model': TransferObject.allow('id', 'name', 'description'),
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'steps'}},
+        'to_data.yaml': {
+            'by_alias': True,
+            'exclude': {'feature_key', 'group_id', 'id'},
+        },
+    }
+
+    # * attribute: steps
+    steps: List[FeatureEventYamlObject] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
+        description='The step workflow for the feature.',
+    )
+
+    # * method: map
+    def map(self, **overrides) -> FeatureAggregate:
+        '''Maps the feature data to a feature aggregate.'''
+        return super().map(
+            FeatureAggregate,
+            steps=[step.map() for step in (self.steps or [])],
+            **overrides,
+        )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, feature: Feature, **overrides) -> 'FeatureYamlObject':
+        '''Creates a FeatureYamlObject from a Feature model.'''
+        return super().from_model(
+            feature,
+            steps=[
+                FeatureEventYamlObject.from_model(step)
+                for step in feature.steps
+            ],
+            **overrides,
+        )
 ```
 
-### 3. Use in Repositories
+### 3. Attribute Aliasing
+
+TransferObjects support `serialization_alias` for output aliasing and `validation_alias` (with `AliasChoices`) for accepting multiple input field names:
+
+```python
+# * attribute: parameters
+parameters: Dict[str, str] = Field(
+    default_factory=dict,
+    serialization_alias='params',
+    validation_alias=AliasChoices('params', 'parameters'),
+    description='The parameters for the feature event.',
+)
+```
+
+### 4. Use in Repositories
 Repositories use transfer objects to load from configuration and map to aggregates/domain objects.
 
 ### Best Practices
 - Use artifact comments consistently (`# *** mappers`, `# ** mapper:`, `# *`).
 - Keep aggregates focused on mutation; keep transfer objects focused on serialization.
-- Use `Aggregate.new` for factory instantiation.
-- Use `set_attribute` for validated mutations.
-- Define `Options.roles` on all transfer objects.
-- Use `allow`/`deny` for role definitions.
+- Instantiate aggregates directly via the Pydantic constructor — there is no `Aggregate.new()` factory.
+- Use `set_attribute` for validated mutations with unknown-field checking.
+- Define `_ROLES` ClassVar on all transfer objects for role-based serialization.
+- Use `model_dump` kwargs (`exclude`, `by_alias`, `include`) in `_ROLES` definitions.
 
 ## Testing Mappers
 
@@ -183,7 +234,7 @@ Tests validate factory creation, mutation, mapping, serialization, and error han
 - `# *** tests`
 - `# ** test: <name>`
 
-**Example** – Aggregate tests cover `new` (with/without validation, strict/non-strict), `set_attribute` (success and invalid attribute error).
+**Example** – Aggregate tests cover constructor instantiation, `set_attribute` (success and invalid attribute error).
 
 #### `MapperAssertions` (mixin)
 Provides shared assertion helpers used by both base classes:
@@ -203,11 +254,11 @@ Base class for testing Aggregate components. Subclasses define class attributes 
 - `field_normalizers` — Dict mapping field names to normalizer callables for complex comparisons.
 
 **Inherited tests:**
-- `test_new` — Verifies `Aggregate.new()` instantiation and field values.
+- `test_new` — Verifies direct constructor instantiation and field values.
 - `test_set_attribute` — Parametrized test for valid and invalid attribute mutations. Parametrization is driven by `conftest.pytest_generate_tests`.
 
 **Override hook:**
-- `make_aggregate(data=None)` — Override when the aggregate has a custom `new()` signature (e.g., `AppInterfaceAggregate.new(app_interface_data=...)` instead of `Aggregate.new(cls, **kwargs)`).
+- `make_aggregate(data=None)` — Override when the aggregate has a custom constructor signature. The default implementation uses the standard Pydantic constructor: `self.aggregate_cls(**data)`.
 
 #### `TransferObjectTestBase`
 Base class for testing TransferObject components.
@@ -224,8 +275,8 @@ Base class for testing TransferObject components.
 - `map_kwargs` — Extra kwargs to pass to `.map()`.
 
 **Inherited tests:**
-- `test_map` — Verifies `from_data()` → `map()` produces a valid aggregate.
-- `test_from_model` — Verifies aggregate → TransferObject conversion.
+- `test_map` — Verifies `model_validate()` → `map()` produces a valid aggregate.
+- `test_from_model` — Verifies aggregate → TransferObject conversion via `from_model()` classmethod.
 - `test_round_trip` — Verifies aggregate → TransferObject → aggregate preserves data.
 
 **Override hook:**
@@ -289,9 +340,9 @@ class TestSomeAggregate(AggregateTestBase):
 
     # * method: make_aggregate
     def make_aggregate(self, data=None):
-        '''Override for custom new() signature.'''
-        return SomeAggregate.new(
-            some_data=(data if data is not None else self.sample_data).copy()
+        '''Override for custom constructor signature.'''
+        return SomeAggregate(
+            **(data if data is not None else self.sample_data)
         )
 
     # *** domain-specific mutation tests
@@ -316,9 +367,9 @@ class TestSomeYamlObject(TransferObjectTestBase):
 
     # * method: make_aggregate
     def make_aggregate(self, data=None):
-        '''Override for custom new() signature.'''
-        return SomeAggregate.new(
-            some_data=(data if data is not None else self.aggregate_sample_data).copy()
+        '''Override for custom constructor signature.'''
+        return SomeAggregate(
+            **(data if data is not None else self.aggregate_sample_data)
         )
 
     # *** child mapper: ChildYamlObject
@@ -374,23 +425,27 @@ The following use the legacy standalone style and are candidates for migration:
 Mappers are defined in `tiferet/mappers/`:
 
 - `settings.py` — `Aggregate` and `TransferObject` base classes + constants.
+- `app.py` — `AppInterfaceAggregate`, `AppInterfaceYamlObject`.
+- `cli.py` — `CliArgumentAggregate`, `CliCommandAggregate`, `CliCommandYamlObject`.
+- `di.py` — `ServiceConfigurationAggregate`, `ServiceConfigurationYamlObject`.
+- `error.py` — `ErrorAggregate`, `ErrorYamlObject`, `ErrorMessageYamlObject`.
+- `feature.py` — `FeatureAggregate`, `FeatureYamlObject`, `FeatureEventAggregate`, `FeatureEventYamlObject`.
+- `logging.py` — `FormatterAggregate`, `HandlerAggregate`, `LoggerAggregate`, and their YamlObject counterparts.
 - `__init__.py` — Public exports.
 
 Tests live in `tiferet/mappers/tests/`.
 
-Concrete mappers (e.g., `error.py`, `feature.py`) will be added in future stories as they are migrated from `tiferet.data`.
+## Migration from Schematics to Pydantic v2
 
-## Migration from DataObject
+The mappers layer was migrated from `schematics.Model` to Pydantic v2:
 
-The `Aggregate` and `TransferObject` classes together replace the legacy `DataObject` (`tiferet.data.settings`):
-
-- `DataObject.map` → `TransferObject.map` (now targets `Aggregate` instead of `ModelObject`)
-- `DataObject.from_model` → `TransferObject.from_model` (parameter names updated to `transfer_obj`/`aggregate`)
-- `DataObject.from_data` → `TransferObject.from_data`
-- `DataObject.allow` / `DataObject.deny` → `TransferObject.allow` / `TransferObject.deny`
-- Mutation logic (previously inline in domain objects) → `Aggregate.set_attribute`
-
-The `tiferet.data` package remains fully functional during the migration period. Concrete mappers will be migrated incrementally in subsequent stories.
+- `Aggregate.new(Type, **kwargs)` → Direct Pydantic constructor: `Type(**kwargs)`.
+- `set_attribute` now checks `model_fields` instead of `hasattr`; `validate_assignment=True` handles re-validation.
+- `TransferObject.from_data(Type, **kwargs)` → `Type.model_validate(data_dict)`.
+- `TransferObject.allow()` / `deny()` / `class Options` / `serialize_when_none` → `_ROLES` ClassVar with `model_dump` kwargs (`include`, `exclude`, `by_alias`, `exclude_none`).
+- `to_primitive(role)` now delegates to `model_dump` with role-resolved kwargs.
+- `from_model` is now a `@classmethod` on `TransferObject` using `model_dump(by_alias=False)` + `model_validate`.
+- Attribute aliasing: `serialized_name` → `serialization_alias`; `deserialize_from` → `validation_alias` with `AliasChoices`.
 
 ## Conclusion
 

--- a/docs/core/repos.md
+++ b/docs/core/repos.md
@@ -51,7 +51,6 @@ from typing import List
 # ** app
 from ..interfaces import ErrorService
 from ..mappers import (
-    TransferObject,
     ErrorAggregate,
     ErrorYamlObject,
 )
@@ -144,7 +143,6 @@ from typing import List
 # ** app
 from ..interfaces import ErrorService           # Service interface
 from ..mappers import (                          # Transfer objects and aggregates
-    TransferObject,
     ErrorAggregate,
     ErrorYamlObject,
 )
@@ -153,7 +151,7 @@ from ..utils import Yaml                         # Data utility
 
 The `# ** app` section imports three categories:
 1. The **Service interface** being implemented.
-2. The **transfer objects and aggregates** used for mapping.
+2. The **transfer objects and aggregates** used for mapping (concrete classes only; no base-class imports needed).
 3. The **data utility** used for file I/O.
 
 No `# ** infra` section is needed — repositories do not import third-party libraries directly; all external interaction flows through Tiferet utilities.
@@ -176,32 +174,32 @@ error_data = Yaml(self.yaml_file, encoding=self.encoding).load(
 )
 ```
 
-Mapping from raw YAML data to domain aggregates uses `TransferObject.from_data` with the YAML dictionary key injected as the `id`:
+Mapping from raw YAML data to domain aggregates uses `model_validate` on the concrete TransferObject class with the YAML dictionary key injected as the `id`:
 
 ```python
-return TransferObject.from_data(
-    ErrorYamlObject,
-    id=id,
-    **error_data,
+return ErrorYamlObject.model_validate(
+    {**error_data, 'id': id}
 ).map()
 ```
 
 ### Writing: `save`
 
 Save methods follow a three-step sequence:
-1. **Serialize** the aggregate via `YamlObject.from_model()`.
+1. **Serialize** the aggregate via the TransferObject's `from_model()` classmethod.
 2. **Load the full file** to preserve sibling sections.
-3. **Update** the target section with `setdefault` and persist.
+3. **Update** the target section with `setdefault` and persist via `to_primitive(role)`.
 
 ```python
-# Serialize.
+# Convert the error model to configuration data.
 error_data = ErrorYamlObject.from_model(error)
 
-# Load full file.
+# Load the full configuration file.
 full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
 
-# Update and persist.
+# Update or insert the error entry.
 full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
+
+# Persist the updated configuration file.
 Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
 ```
 
@@ -254,7 +252,6 @@ from typing import List
 # ** app
 from ..interfaces.calculator import CalculatorService
 from ..mappers.calculator import (
-    TransferObject,
     CalculatorResultAggregate,
     CalculatorResultYamlObject,
 )
@@ -336,7 +333,8 @@ Create tests in `tiferet/repos/tests/test_<domain>.py` using `tmp_path` fixtures
 ### Best Practices
 - Use artifact comments consistently (`# *** repos`, `# ** repo:`, `# *`).
 - Follow the three-attribute foundation for all YAML-backed repos.
-- Use `TransferObject.from_data` for reads and `YamlObject.from_model` for writes.
+- Use `YamlObject.model_validate({**data, 'id': id}).map()` for reads.
+- Use `YamlObject.from_model(aggregate)` classmethod for writes, then `to_primitive(self.default_role)` to serialize.
 - Make delete operations idempotent.
 - Use `setdefault` for safe section updates on save.
 - Use `start_node` lambdas for all read operations.
@@ -389,17 +387,16 @@ Repositories are defined in `tiferet/repos/`:
 
 Tests live in `tiferet/repos/tests/`.
 
-## Migration from Proxies
+## Migration from Proxies and Schematics
 
 Repositories are the v2.0 successor to Proxies (`tiferet/proxies/`). Key changes:
 
 - **Package rename**: `tiferet/proxies/yaml/<domain>.py` → `tiferet/repos/<domain>.py`. The nested middleware-specific directory structure is flattened because the utility suffix in the class name (`YamlRepository`) already identifies the backing technology.
 - **Base class**: Proxies extended `YamlConfigurationProxy` (a middleware base class). Repositories extend the Service interface directly and compose the `Yaml` utility internally.
 - **Artifact comments**: `# *** proxies` / `# ** proxy:` → `# *** repos` / `# ** repo:`.
-- **Data mapping**: Proxies used `DataObject` (`from_data`, `map`). Repositories use `TransferObject` (`from_data`, `map`) and `Aggregate` for the same operations with clearer separation of concerns.
+- **Data mapping**: Proxies used `DataObject.from_data()` and `DataObject.map()`. Repositories use `model_validate()` for reads and `from_model()` classmethod + `to_primitive(role)` for writes.
 - **Contract alignment**: Proxies implemented `Repository` contracts. Repositories implement `Service` interfaces — the unified v2.0 contract type.
-
-The `tiferet/proxies/` package remains available for backward compatibility. New repositories should be created in `tiferet/repos/`.
+- **Pydantic v2 migration**: `TransferObject.from_data(Type, **kwargs)` → `Type.model_validate(data_dict)`; `Aggregate.new(Type, **kwargs)` → direct Pydantic constructor.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary

Updates the three core reference documents to reflect the Pydantic v2 migration, replacing all schematics-era APIs with their Pydantic v2 equivalents.

### `docs/core/domain.md`
- `DomainObject` base class: `schematics.Model` → `pydantic.BaseModel` + `ConfigDict`
- Removed `DomainObject.new()` factory; documents direct constructor and `model_validate()`
- Code examples use `Field(...)` annotations instead of `FloatType`/`StringType`
- Documents `@model_validator(mode='before')` for derivation logic
- Updated package layout (corrected model names, removed Schematics type wrappers)

### `docs/core/mappers.md`
- `Aggregate`: removed `Aggregate.new()`, documents direct constructor; `set_attribute` uses `model_fields`
- `TransferObject`: replaced `from_data`/`allow`/`deny`/`class Options`/`serialize_when_none` with `_ROLES` ClassVar, `to_primitive(role)`, `map(target)`, `from_model` classmethod
- Code examples use `AliasChoices`, `serialization_alias`, `model_dump` kwargs
- Test harness docs updated (`model_validate` instead of `from_data`, direct constructor)
- Package layout expanded with all current concrete mappers

### `docs/core/repos.md`
- Read-path: `TransferObject.from_data()` → `YamlObject.model_validate()`
- Write-path: documents `YamlObject.from_model()` classmethod pattern
- Removed stale `TransferObject` base-class import from examples
- Migration section updated for Pydantic v2

Closes #764

---
[Warp conversation](https://app.warp.dev/conversation/f89c3bf3-e692-4048-a883-c65d96d61ad7)

Co-Authored-By: Oz <oz-agent@warp.dev>