### PR TITLE
Docs/Guides – Update All Domain, Mapper, Event, Repo, and Builder Guides for Pydantic v2

### DIFF
--- a/docs/guides/builders.md
+++ b/docs/guides/builders.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/builders/`  
-**Version:** 2.0.0a9
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -83,7 +83,7 @@ def load_app_service(self, module_path=..., class_name=..., **parameters) -> 'Ap
 ```python
 def load_default_services(self) -> List[AppServiceDependency]:
     return [
-        DomainObject.new(AppServiceDependency, **data, validate=False)
+        AppServiceDependency.model_validate(data)
         for data in a.const.DEFAULT_SERVICES
     ]
 ```

--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 11, 2026  
-**Version:** 2.0.0a5
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -25,11 +25,11 @@ Represents a single injectable service dependency binding for an application int
 
 | Attribute      | Type                   | Required | Default | Description                                                                      |
 |----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
-| `module_path`  | `StringType`           | Yes      | —       | The module path for the app dependency.                                           |
-| `class_name`   | `StringType`           | Yes      | —       | The class name for the app dependency.                                            |
-| `service_id`   | `StringType`           | No *(todo: required)* | — | The canonical service id for the application dependency.             |
-| `attribute_id` | `StringType`           | No *(obsolete)* | — | The attribute id for the application dependency. Superseded by `service_id`. |
-| `parameters`   | `DictType(StringType)` | No       | `{}`    | The parameters for the application dependency.                                    |
+| `module_path`  | `str`                  | Yes      | —       | The module path for the app dependency.                                           |
+| `class_name`   | `str`                  | Yes      | —       | The class name for the app dependency.                                            |
+| `service_id`   | `str`                  | No *(todo: required)* | — | The canonical service id for the application dependency.             |
+| `attribute_id` | `str`                  | No *(obsolete)* | — | The attribute id for the application dependency. Superseded by `service_id`. |
+| `parameters`   | `Dict[str, str]`       | No       | `{}`    | The parameters for the application dependency.                                    |
 
 No methods. Pure data structure.
 
@@ -43,15 +43,15 @@ Represents the complete configuration of an application entry point.
 
 | Attribute      | Type                                | Required | Default       | Description                                           |
 |----------------|-------------------------------------|----------|---------------|-------------------------------------------------------|
-| `id`           | `StringType`                        | Yes      | —             | The unique identifier for the application interface.   |
-| `name`         | `StringType`                        | Yes      | —             | The name of the application interface.                 |
-| `description`  | `StringType`                        | No       | —             | The description of the application interface.          |
-| `module_path`  | `StringType`                        | Yes      | —             | The module path for the application instance context.  |
-| `class_name`   | `StringType`                        | Yes      | —             | The class name for the application instance context.   |
-| `logger_id`    | `StringType`                        | No       | `'default'`   | The logger ID for the application instance.            |
-| `flags`        | `ListType(StringType)`              | No       | `['default']` | The flags for the application interface.               |
-| `services`     | `ListType(ModelType(AppServiceDependency))` | Yes | `[]`        | The application instance service dependencies.         |
-| `constants`    | `DictType(StringType)`              | No       | `{}`          | The application dependency constants.                  |
+| `id`           | `str`                               | Yes      | —             | The unique identifier for the application interface.   |
+| `name`         | `str`                               | Yes      | —             | The name of the application interface.                 |
+| `description`  | `str \| None`                       | No       | `None`        | The description of the application interface.          |
+| `module_path`  | `str`                               | Yes      | —             | The module path for the application instance context.  |
+| `class_name`   | `str`                               | Yes      | —             | The class name for the application instance context.   |
+| `logger_id`    | `str`                               | No       | `'default'`   | The logger ID for the application instance.            |
+| `flags`        | `List[str]`                         | No       | `['default']` | The flags for the application interface.               |
+| `services`     | `List[AppServiceDependency]`        | Yes      | `[]`          | The application instance service dependencies.         |
+| `constants`    | `Dict[str, str]`                    | No       | `{}`          | The application dependency constants.                  |
 
 #### Methods
 
@@ -133,21 +133,19 @@ Concrete implementations (e.g., `AppYamlRepository`) satisfy this interface.
 
 ## Instantiation
 
-Both domain objects are instantiated via the standard `DomainObject.new()` factory:
+Both domain objects are instantiated directly via the Pydantic constructor:
 
 ```python
-from tiferet.domain import DomainObject, AppServiceDependency, AppInterface
+from tiferet.domain import AppServiceDependency, AppInterface
 
-dep = DomainObject.new(
-    AppServiceDependency,
+dep = AppServiceDependency(
     service_id='cli_repo',
     module_path='tiferet.proxies.yaml.cli',
     class_name='CliYamlProxy',
     parameters={'cli_config_file': 'app/configs/cli.yml'},
 )
 
-interface = DomainObject.new(
-    AppInterface,
+interface = AppInterface(
     id='calc_cli',
     name='Calculator CLI',
     module_path='tiferet.contexts.cli',

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -28,14 +28,14 @@ Represents a single command-line argument or flag.
 
 | Attribute       | Type                   | Required | Default | Description                                                                      |
 |-----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
-| `name_or_flags` | `ListType(StringType)` | Yes      | —       | The name or flags of the argument (e.g., `["-f", "--flag"]`).                     |
-| `description`   | `StringType`           | No       | —       | A brief description of the argument.                                              |
-| `type`          | `StringType`           | No       | `'str'` | The type: `"str"`, `"int"`, or `"float"`.                                         |
-| `required`      | `BooleanType`          | No       | —       | Whether the argument is required.                                                 |
-| `default`       | `StringType`           | No       | —       | The default value if not provided.                                                |
-| `choices`       | `ListType(StringType)` | No       | —       | Valid choices for the argument.                                                   |
-| `nargs`         | `StringType`           | No       | —       | Number of arguments: `"?"`, `"*"`, `"+"`, or an integer.                          |
-| `action`        | `StringType`           | No       | —       | The action: `store`, `store_true`, `store_false`, `append`, `count`, `help`, etc. |
+| `name_or_flags` | `List[str]`            | Yes      | —       | The name or flags of the argument (e.g., `["-f", "--flag"]`).                     |
+| `description`   | `str \| None`          | No       | `None`  | A brief description of the argument.                                              |
+| `type`          | `str \| None`          | No       | `'str'` | The type: `"str"`, `"int"`, or `"float"`.                                         |
+| `required`      | `bool \| None`         | No       | `None`  | Whether the argument is required.                                                 |
+| `default`       | `str \| None`          | No       | `None`  | The default value if not provided.                                                |
+| `choices`       | `List[str] \| None`    | No       | `None`  | Valid choices for the argument.                                                   |
+| `nargs`         | `str \| None`          | No       | `None`  | Number of arguments: `"?"`, `"*"`, `"+"`, or an integer.                          |
+| `action`        | `str \| None`          | No       | `None`  | The action: `store`, `store_true`, `store_false`, `append`, `count`, `help`, etc. |
 
 #### Methods
 
@@ -44,7 +44,7 @@ Represents a single command-line argument or flag.
 Maps the stored `type` string to a Python type object. Falls back to `str` if the type is `None` or unrecognized.
 
 ```python
-arg = DomainObject.new(CliArgument, name_or_flags=['--count'], type='int')
+arg = CliArgument(name_or_flags=['--count'], type='int')
 assert arg.get_type() is int
 ```
 
@@ -54,24 +54,24 @@ Represents a CLI command with a composite identifier.
 
 | Attribute    | Type                              | Required | Default | Description                                                  |
 |--------------|-----------------------------------|----------|---------|--------------------------------------------------------------|
-| `id`         | `StringType`                      | Yes      | —       | The unique identifier, formatted as `"group_key.key"`.        |
-| `name`       | `StringType`                      | Yes      | —       | The name of the command.                                      |
-| `description`| `StringType`                      | No       | —       | A brief description of the command.                           |
-| `key`        | `StringType`                      | Yes      | —       | The unique key for the command.                               |
-| `group_key`  | `StringType`                      | Yes      | —       | The group key the command belongs to.                         |
-| `arguments`  | `ListType(ModelType(CliArgument))`| No       | `[]`    | A list of arguments for the command.                          |
+| `id`         | `str`                             | Yes      | —       | The unique identifier, formatted as `"group_key.key"`.        |
+| `name`       | `str`                             | Yes      | —       | The name of the command.                                      |
+| `description`| `str \| None`                     | No       | `None`  | A brief description of the command.                           |
+| `key`        | `str`                             | Yes      | —       | The unique key for the command.                               |
+| `group_key`  | `str`                             | Yes      | —       | The group key the command belongs to.                         |
+| `arguments`  | `List[CliArgument]`               | No       | `[]`    | A list of arguments for the command.                          |
 
 #### Methods
 
-**`new(group_key, key, name, description=None, arguments=[]) -> CliCommand`** (static)
+**ID Derivation via `@model_validator`**
 
-Custom factory that derives the `id` by normalizing hyphens to underscores in both `group_key` and `key`, then joining with a dot:
+The `id` is automatically derived by a `@model_validator(mode='before')` that normalizes hyphens to underscores in both `group_key` and `key`, then joins them with a dot:
 
 ```python
-cmd = CliCommand.new(group_key='calc', key='add', name='Add Number')
+cmd = CliCommand(group_key='calc', key='add', name='Add Number')
 assert cmd.id == 'calc.add'
 
-cmd = CliCommand.new(group_key='my-group', key='my-cmd', name='My Command')
+cmd = CliCommand(group_key='my-group', key='my-cmd', name='My Command')
 assert cmd.id == 'my_group.my_cmd'
 ```
 
@@ -169,19 +169,18 @@ Concrete implementations (e.g., `CliYamlRepository`) satisfy this interface.
 ## Instantiation
 
 ```python
-from tiferet.domain import DomainObject, CliArgument, CliCommand
+from tiferet.domain import CliArgument, CliCommand
 
-# Create an argument directly
-arg = DomainObject.new(
-    CliArgument,
+# Create an argument directly via Pydantic constructor
+arg = CliArgument(
     name_or_flags=['--count', '-c'],
     description='Number of iterations.',
     type='int',
     required=True,
 )
 
-# Create a command via the custom factory
-cmd = CliCommand.new(
+# Create a command — id is derived automatically via @model_validator
+cmd = CliCommand(
     group_key='calc',
     key='add',
     name='Add Number',

--- a/docs/guides/domain/di.md
+++ b/docs/guides/domain/di.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -29,10 +29,10 @@ Represents one flag-qualified implementation override for a service.
 
 | Attribute      | Type                   | Required | Default | Description                                   |
 |----------------|------------------------|----------|---------|-----------------------------------------------|
-| `module_path`  | `StringType`           | Yes      | —       | The module path.                               |
-| `class_name`   | `StringType`           | Yes      | —       | The class name.                                |
-| `flag`         | `StringType`           | Yes      | —       | The flag for the container dependency.          |
-| `parameters`   | `DictType(StringType)` | No       | `{}`    | The container dependency parameters.            |
+| `module_path`  | `str`                  | Yes      | —       | The module path.                               |
+| `class_name`   | `str`                  | Yes      | —       | The class name.                                |
+| `flag`         | `str`                  | Yes      | —       | The flag for the container dependency.          |
+| `parameters`   | `Dict[str, str]`       | No       | `{}`    | The container dependency parameters.            |
 
 No methods. Pure data structure.
 
@@ -42,12 +42,12 @@ Represents a single injectable service entry in the DI registry.
 
 | Attribute       | Type                                  | Required | Default | Description                                       |
 |-----------------|---------------------------------------|----------|---------|---------------------------------------------------|
-| `id`            | `StringType`                          | Yes      | —       | The unique identifier for the service configuration. |
-| `name`          | `StringType`                          | No       | —       | The name of the service configuration.             |
-| `module_path`   | `StringType`                          | No       | —       | The default module path for the dependency class.  |
-| `class_name`    | `StringType`                          | No       | —       | The default class name for the dependency class.   |
-| `parameters`    | `DictType(StringType)`                | No       | `{}`    | The default configuration parameters.              |
-| `dependencies`  | `ListType(ModelType(FlaggedDependency))` | No    | `[]`    | The flag-specific implementation overrides.        |
+| `id`            | `str`                                 | Yes      | —       | The unique identifier for the service configuration. |
+| `name`          | `str \| None`                         | No       | `None`  | The name of the service configuration.             |
+| `module_path`   | `str \| None`                         | No       | `None`  | The default module path for the dependency class.  |
+| `class_name`    | `str \| None`                         | No       | `None`  | The default class name for the dependency class.   |
+| `parameters`    | `Dict[str, str]`                      | No       | `{}`    | The default configuration parameters.              |
+| `dependencies`  | `List[FlaggedDependency]`             | No       | `[]`    | The flag-specific implementation overrides.        |
 
 #### Methods
 
@@ -143,21 +143,19 @@ Concrete implementations (e.g., `ContainerYamlRepository`) satisfy this interfac
 
 ## Instantiation
 
-Both domain objects are instantiated via the standard `DomainObject.new()` factory:
+Both domain objects are instantiated directly via the Pydantic constructor:
 
 ```python
-from tiferet.domain import DomainObject, FlaggedDependency, ServiceConfiguration
+from tiferet.domain import FlaggedDependency, ServiceConfiguration
 
-dep = DomainObject.new(
-    FlaggedDependency,
+dep = FlaggedDependency(
     flag='sqlite',
     module_path='tiferet.repos.error_sqlite',
     class_name='ErrorSqliteRepository',
     parameters={'db_path': 'app/data/errors.db'},
 )
 
-config = DomainObject.new(
-    ServiceConfiguration,
+config = ServiceConfiguration(
     id='error_service',
     module_path='tiferet.repos.error',
     class_name='ErrorYamlRepository',

--- a/docs/guides/domain/error.md
+++ b/docs/guides/domain/error.md
@@ -6,8 +6,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -25,8 +25,8 @@ Represents a single localized error message.
 
 | Attribute | Type         | Required | Default | Description                         |
 |-----------|--------------|----------|---------|-------------------------------------|
-| `lang`    | `StringType` | Yes      | —       | The language of the error message.   |
-| `text`    | `StringType` | Yes      | —       | The error message text (may contain format placeholders). |
+| `lang`    | `str`        | Yes      | —       | The language of the error message.   |
+| `text`    | `str`        | Yes      | —       | The error message text (may contain format placeholders). |
 
 #### Methods
 
@@ -35,7 +35,7 @@ Represents a single localized error message.
 Returns the raw `text` when no kwargs are provided. When kwargs are given, performs Python string formatting:
 
 ```python
-msg = DomainObject.new(ErrorMessage, lang='en_US', text='Value {value} is invalid')
+msg = ErrorMessage(lang='en_US', text='Value {value} is invalid')
 msg.format()                    # 'Value {value} is invalid'
 msg.format(value='abc')         # 'Value abc is invalid'
 ```
@@ -46,20 +46,20 @@ Represents a named error definition with multilingual message support.
 
 | Attribute    | Type                              | Required | Default | Description                                   |
 |--------------|-----------------------------------|----------|---------|-----------------------------------------------|
-| `id`         | `StringType`                      | Yes      | —       | The unique identifier of the error.            |
-| `name`       | `StringType`                      | Yes      | —       | The name of the error.                         |
-| `description`| `StringType`                      | No       | —       | The description of the error.                  |
-| `error_code` | `StringType`                      | No       | —       | The unique code of the error (derived from id).|
-| `message`    | `ListType(ModelType(ErrorMessage))`| Yes     | —       | The error message translations.                |
+| `id`         | `str`                             | Yes      | —       | The unique identifier of the error.            |
+| `name`       | `str`                             | Yes      | —       | The name of the error.                         |
+| `description`| `str \| None`                     | No       | `None`  | The description of the error.                  |
+| `error_code` | `str \| None`                     | No       | —       | The unique code of the error (derived from id via `@model_validator`).|
+| `message`    | `List[ErrorMessage]`              | Yes      | —       | The error message translations.                |
 
 #### Methods
 
-**`new(name, id, message=[], **kwargs) -> Error`** (static)
+**ID Derivation via `@model_validator`**
 
-Custom factory that derives `error_code` by uppercasing `id` and replacing spaces with underscores:
+The `error_code` is automatically derived by a `@model_validator(mode='before')` that uppercases `id` and replaces spaces with underscores:
 
 ```python
-error = Error.new(id='invalid_input', name='Invalid Input', message=[...])
+error = Error(id='invalid_input', name='Invalid Input', message=[...])
 assert error.error_code == 'INVALID_INPUT'
 ```
 
@@ -154,17 +154,17 @@ Concrete implementations (e.g., `ErrorYamlRepository`) satisfy this interface.
 ## Instantiation
 
 ```python
-from tiferet.domain import DomainObject, ErrorMessage, Error
+from tiferet.domain import ErrorMessage, Error
 
-msg_en = DomainObject.new(ErrorMessage, lang='en_US', text='Value {value} is invalid')
-msg_es = DomainObject.new(ErrorMessage, lang='es_ES', text='El valor {value} no es válido')
+msg_en = ErrorMessage(lang='en_US', text='Value {value} is invalid')
+msg_es = ErrorMessage(lang='es_ES', text='El valor {value} no es válido')
 
-error = Error.new(
+error = Error(
     id='invalid_input',
     name='Invalid Input',
     message=[msg_en, msg_es],
 )
-# error.error_code == 'INVALID_INPUT'
+# error.error_code == 'INVALID_INPUT' (derived via @model_validator)
 # error.format_message('es_ES', value='abc') == 'El valor abc no es válido'
 ```
 

--- a/docs/guides/domain/feature.md
+++ b/docs/guides/domain/feature.md
@@ -3,8 +3,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 11, 2026  
-**Version:** 2.0.0a5
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -24,10 +24,10 @@ Base class for steps in a feature workflow. Provides a `type` discriminator for 
 
 | Attribute | Type         | Required | Default   | Description                        |
 |-----------|--------------|----------|-----------|------------------------------------|
-| `type`    | `StringType` | No       | `'event'` | The type of the feature step.      |
-| `name`    | `StringType` | Yes      | —         | The name of the feature step.      |
+| `type`    | `Literal['event']` | No | `'event'` | The type of the feature step.      |
+| `name`    | `str`        | Yes      | —         | The name of the feature step.      |
 
-Currently the only supported `type` value is `'event'`, constrained via `choices=['event']`.
+Currently the only supported `type` value is `'event'`, constrained via `Literal['event']`.
 
 ### FeatureEvent
 
@@ -35,13 +35,13 @@ Concrete step type that extends `FeatureStep`. Represents the execution of a dom
 
 | Attribute        | Type                    | Required | Default | Description                                                        |
 |------------------|-------------------------|----------|---------|--------------------------------------------------------------------|
-| `service_id`     | `StringType`            | No *(todo: required)* | — | The service configuration ID for the feature event.          |
-| `attribute_id`   | `StringType`            | No *(obsolete)*       | — | The container attribute ID for the domain event. Replaced by `service_id`. |
-| `flags`          | `ListType(StringType)`  | No       | `[]`    | Feature flags that activate this event.                            |
-| `parameters`     | `DictType(StringType)`  | No       | `{}`    | Custom parameters for the event.                                   |
-| `return_to_data` | `BooleanType`           | No       | `False` | Whether to return the result to the feature data context (obsolete). |
-| `data_key`       | `StringType`            | No       | —       | Data key to store the result in if `return_to_data` is True.       |
-| `pass_on_error`  | `BooleanType`           | No       | `False` | Whether to continue the workflow if the event fails.               |
+| `service_id`     | `str \| None`           | No *(todo: required)* | `None` | The service configuration ID for the feature event.          |
+| `attribute_id`   | `str \| None`           | No *(obsolete)*       | `None` | The container attribute ID for the domain event. Replaced by `service_id`. |
+| `flags`          | `List[str]`             | No       | `[]`    | Feature flags that activate this event.                            |
+| `parameters`     | `Dict[str, str]`        | No       | `{}`    | Custom parameters for the event.                                   |
+| `return_to_data` | `bool`                  | No       | `False` | Whether to return the result to the feature data context (obsolete). |
+| `data_key`       | `str \| None`           | No       | `None`  | Data key to store the result in if `return_to_data` is True.       |
+| `pass_on_error`  | `bool`                  | No       | `False` | Whether to continue the workflow if the event fails.               |
 
 Inherits `type` (defaults to `'event'`) and `name` from `FeatureStep`.
 
@@ -58,14 +58,14 @@ Immutable value object representing a complete feature workflow definition.
 
 | Attribute      | Type                            | Required | Default | Description                                          |
 |----------------|---------------------------------|----------|---------|------------------------------------------------------|
-| `id`           | `StringType`                    | Yes      | —       | The unique identifier (`group_id.feature_key`).      |
-| `name`         | `StringType`                    | Yes      | —       | The name of the feature.                             |
-| `flags`        | `ListType(StringType)`          | No       | `[]`    | Feature flags that activate this entire feature.     |
-| `description`  | `StringType`                    | No       | —       | The description of the feature.                      |
-| `group_id`     | `StringType`                    | Yes      | —       | The context group identifier for the feature.        |
-| `feature_key`  | `StringType`                    | Yes      | —       | The key of the feature.                              |
-| `steps`        | `ListType(ModelType(FeatureEvent))` | No   | `[]`    | The ordered step workflow for the feature.            |
-| `log_params`   | `DictType(StringType)`          | No       | `{}`    | Parameters to log for the feature.                   |
+| `id`           | `str`                           | Yes      | —       | The unique identifier (`group_id.feature_key`).      |
+| `name`         | `str`                           | Yes      | —       | The name of the feature.                             |
+| `flags`        | `List[str]`                     | No       | `[]`    | Feature flags that activate this entire feature.     |
+| `description`  | `str \| None`                   | No       | `None`  | The description of the feature.                      |
+| `group_id`     | `str`                           | Yes      | —       | The context group identifier for the feature.        |
+| `feature_key`  | `str`                           | Yes      | —       | The key of the feature.                              |
+| `steps`        | `List[FeatureEvent]`            | No       | `[]`    | The ordered step workflow for the feature.            |
+| `log_params`   | `Dict[str, str]`                | No       | `{}`    | Parameters to log for the feature.                   |
 
 #### Methods
 
@@ -74,7 +74,7 @@ Immutable value object representing a complete feature workflow definition.
 Returns the step at the given index, or `None` if the index is out of range or invalid (e.g., non-integer):
 
 ```python
-feature = DomainObject.new(Feature, id='calc.add', name='Add', group_id='calc', feature_key='add', steps=[...])
+feature = Feature(id='calc.add', name='Add', group_id='calc', feature_key='add', steps=[...])
 step = feature.get_step(0)    # First step
 step = feature.get_step(99)   # None (out of range)
 step = feature.get_step('x')  # None (invalid type)
@@ -151,17 +151,15 @@ Concrete implementations (e.g., `FeatureYamlRepository`) satisfy this interface.
 ## Instantiation
 
 ```python
-from tiferet.domain import DomainObject, Feature, FeatureEvent
+from tiferet.domain import Feature, FeatureEvent
 
-step = DomainObject.new(
-    FeatureEvent,
+step = FeatureEvent(
     name='Add a and b',
     service_id='add_number_event',
     parameters={'b': '0.5'},
 )
 
-feature = DomainObject.new(
-    Feature,
+feature = Feature(
     id='calc.add',
     name='Add Number',
     group_id='calc',

--- a/docs/guides/domain/logging.md
+++ b/docs/guides/domain/logging.md
@@ -3,8 +3,8 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Date:** March 06, 2026  
-**Version:** 2.0.0a2
+**Date:** May 04, 2026  
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -34,13 +34,13 @@ Logger → [handler_id, ...] → Handler → formatter_id → Formatter
 
 Immutable value object representing a logging formatter configuration.
 
-| Attribute     | Type         | Required | Default | Description                          |
-|---------------|--------------|----------|---------|--------------------------------------|
-| `id`          | `StringType` | Yes      | —       | The unique identifier of the formatter. |
-| `name`        | `StringType` | Yes      | —       | The name of the formatter.           |
-| `description` | `StringType` | No       | —       | The description of the formatter.    |
-| `format`      | `StringType` | Yes      | —       | The format string for log messages.  |
-| `datefmt`     | `StringType` | No       | —       | The date format for log timestamps.  |
+| Attribute     | Type            | Required | Default | Description                          |
+|---------------|-----------------|----------|---------|--------------------------------------|
+| `id`          | `str`           | Yes      | —       | The unique identifier of the formatter. |
+| `name`        | `str`           | Yes      | —       | The name of the formatter.           |
+| `description` | `str \| None`   | No       | `None`  | The description of the formatter.    |
+| `format`      | `str`           | Yes      | —       | The format string for log messages.  |
+| `datefmt`     | `str \| None`   | No       | `None`  | The date format for log timestamps.  |
 
 #### Methods
 
@@ -49,7 +49,7 @@ Immutable value object representing a logging formatter configuration.
 Returns a `dictConfig`-compatible formatter entry:
 
 ```python
-formatter = DomainObject.new(Formatter, id='simple', name='Simple',
+formatter = Formatter(id='simple', name='Simple',
     format='%(asctime)s - %(message)s', datefmt='%Y-%m-%d')
 formatter.format_config()
 # {'format': '%(asctime)s - %(message)s', 'datefmt': '%Y-%m-%d'}
@@ -61,17 +61,17 @@ When `datefmt` is not set, the key is still present with a `None` value.
 
 Immutable value object representing a logging handler configuration.
 
-| Attribute     | Type         | Required | Default | Description                                              |
-|---------------|--------------|----------|---------|----------------------------------------------------------|
-| `id`          | `StringType` | Yes      | —       | The unique identifier of the handler.                    |
-| `name`        | `StringType` | Yes      | —       | The name of the handler.                                 |
-| `description` | `StringType` | No       | —       | The description of the handler.                          |
-| `module_path` | `StringType` | Yes      | —       | The module path for the handler class.                   |
-| `class_name`  | `StringType` | Yes      | —       | The class name of the handler.                           |
-| `level`       | `StringType` | Yes      | —       | The logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
-| `formatter`   | `StringType` | Yes      | —       | The ID of the formatter to use.                          |
-| `stream`      | `StringType` | No       | —       | The stream for StreamHandler (e.g., `ext://sys.stdout`). |
-| `filename`    | `StringType` | No       | —       | The file path for FileHandler (e.g., `app.log`).         |
+| Attribute     | Type            | Required | Default | Description                                              |
+|---------------|-----------------|----------|---------|----------------------------------------------------------|
+| `id`          | `str`           | Yes      | —       | The unique identifier of the handler.                    |
+| `name`        | `str`           | Yes      | —       | The name of the handler.                                 |
+| `description` | `str \| None`   | No       | `None`  | The description of the handler.                          |
+| `module_path` | `str`           | Yes      | —       | The module path for the handler class.                   |
+| `class_name`  | `str`           | Yes      | —       | The class name of the handler.                           |
+| `level`       | `str`           | Yes      | —       | The logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
+| `formatter`   | `str`           | Yes      | —       | The ID of the formatter to use.                          |
+| `stream`      | `str \| None`   | No       | `None`  | The stream for StreamHandler (e.g., `ext://sys.stdout`). |
+| `filename`    | `str \| None`   | No       | `None`  | The file path for FileHandler (e.g., `app.log`).         |
 
 #### Methods
 
@@ -80,7 +80,7 @@ Immutable value object representing a logging handler configuration.
 Returns a `dictConfig`-compatible handler entry. The `class` key is composed from `module_path` and `class_name`. Optional attributes (`stream`, `filename`) are only included when set:
 
 ```python
-handler = DomainObject.new(Handler, id='console', name='Console',
+handler = Handler(id='console', name='Console',
     module_path='logging', class_name='StreamHandler',
     level='INFO', formatter='simple', stream='ext://sys.stdout')
 handler.format_config()
@@ -91,15 +91,15 @@ handler.format_config()
 
 Immutable value object representing a logger configuration.
 
-| Attribute     | Type                   | Required | Default | Description                                              |
-|---------------|------------------------|----------|---------|----------------------------------------------------------|
-| `id`          | `StringType`           | Yes      | —       | The unique identifier of the logger.                     |
-| `name`        | `StringType`           | Yes      | —       | The name of the logger.                                  |
-| `description` | `StringType`           | No       | —       | The description of the logger.                           |
-| `level`       | `StringType`           | Yes      | —       | The logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
-| `handlers`    | `ListType(StringType)` | No       | `[]`    | List of handler IDs for the logger.                      |
-| `propagate`   | `BooleanType`          | No       | `False` | Whether to propagate messages to parent loggers.         |
-| `is_root`     | `BooleanType`          | No       | `False` | Whether this is the root logger.                         |
+| Attribute     | Type             | Required | Default | Description                                              |
+|---------------|------------------|----------|---------|----------------------------------------------------------|
+| `id`          | `str`            | Yes      | —       | The unique identifier of the logger.                     |
+| `name`        | `str`            | Yes      | —       | The name of the logger.                                  |
+| `description` | `str \| None`    | No       | `None`  | The description of the logger.                           |
+| `level`       | `str`            | Yes      | —       | The logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
+| `handlers`    | `List[str]`      | No       | `[]`    | List of handler IDs for the logger.                      |
+| `propagate`   | `bool`           | No       | `False` | Whether to propagate messages to parent loggers.         |
+| `is_root`     | `bool`           | No       | `False` | Whether this is the root logger.                         |
 
 #### Methods
 
@@ -108,7 +108,7 @@ Immutable value object representing a logger configuration.
 Returns a `dictConfig`-compatible logger entry:
 
 ```python
-logger = DomainObject.new(Logger, id='app', name='App Logger',
+logger = Logger(id='app', name='App Logger',
     level='DEBUG', handlers=['console'], propagate=True)
 logger.format_config()
 # {'level': 'DEBUG', 'handlers': ['console'], 'propagate': True}
@@ -194,18 +194,16 @@ Concrete implementations (e.g., `LoggingYamlRepository`) satisfy this interface.
 ## Instantiation
 
 ```python
-from tiferet.domain import DomainObject, Formatter, Handler, Logger
+from tiferet.domain import Formatter, Handler, Logger
 
-fmt = DomainObject.new(
-    Formatter,
+fmt = Formatter(
     id='simple',
     name='Simple Formatter',
     format='%(asctime)s - %(message)s',
     datefmt='%Y-%m-%d',
 )
 
-hdlr = DomainObject.new(
-    Handler,
+hdlr = Handler(
     id='console',
     name='Console Handler',
     module_path='logging',
@@ -215,8 +213,7 @@ hdlr = DomainObject.new(
     stream='ext://sys.stdout',
 )
 
-lgr = DomainObject.new(
-    Logger,
+lgr = Logger(
     id='app',
     name='App Logger',
     level='DEBUG',

--- a/docs/guides/events/app.md
+++ b/docs/guides/events/app.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/events/app.py`  
-**Version:** 2.0.0a6
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -52,7 +52,7 @@ Creates a new `AppInterface` and persists it via `AppService.save()`.
 
 **Behavior:**
 1. Collects all parameters into a data dict.
-2. Delegates to `AppInterfaceAggregate.new(app_interface_data=...)` for creation and validation.
+2. Creates an `AppInterfaceAggregate` via the Pydantic constructor for creation and validation.
 3. Saves via `app_service.save(interface)`.
 
 ```python

--- a/docs/guides/events/cli.md
+++ b/docs/guides/events/cli.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/events/cli.py`  
-**Version:** 2.0.0a6
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -51,7 +51,7 @@ Creates a new `CliCommand` and persists it via `CliService.save()`. Verifies the
 
 **Behavior:**
 1. Verifies the ID is not already in use via `cli_service.exists(id)`.
-2. Creates the command via `CliCommandAggregate.new(...)`.
+2. Creates the command via the `CliCommandAggregate` Pydantic constructor.
 3. Saves via `cli_service.save(command)`.
 
 ```python

--- a/docs/guides/events/logging.md
+++ b/docs/guides/events/logging.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/events/logging.py`  
-**Version:** 2.0.0a6
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -193,6 +193,6 @@ DomainEvent.handle(
 
 - **Artifact comments:** `# *** commands` → `# *** events`; `# ** command:` → `# ** event:`.
 - **Docstrings:** "Command to" → "Event to" throughout.
-- **Aggregate factory:** `Aggregate.new(FormatterAggregate, ...)` → `FormatterAggregate.new(...)` (same for Handler and Logger aggregates). The `Aggregate` base import is no longer needed.
+- **Aggregate instantiation:** Aggregates are instantiated directly via the Pydantic constructor (e.g., `FormatterAggregate(...)`, `HandlerAggregate(...)`, `LoggerAggregate(...)`). No static factory methods are used.
 - **No parameter renames** — logging events do not use `attribute_id`.
 - **Tests:** Converted from 13 function-based tests to 7 harness classes using `DomainEventTestBase` (27 pass, 1 skip).

--- a/docs/guides/mappers.md
+++ b/docs/guides/mappers.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/mappers/`  
-**Version:** 2.0.0a3
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -34,55 +34,48 @@ If a domain object is only ever used as a **nested sub-object** inside a parent 
 | `FlaggedDependency` | Yes (`FlaggedDependencyAggregate`) | Parameter merge-and-prune logic |
 | `Formatter`, `Handler`, `Logger` | Yes (thin aggregates) | Provide `new` factory for consistent instantiation |
 
-**Rule of thumb:** if you need `DomainObject.new(SubType, ...)` to create it and nothing else, you don't need an aggregate for it.
+**Rule of thumb:** if you only need `SubType(...)` to create it and nothing else, you don't need an aggregate for it.
 
-## The `new` Factory Pattern
+## Instantiation Pattern
 
-Every aggregate provides a static `new` method. There are two common signatures:
+Aggregates are instantiated directly via the Pydantic constructor. There are two common patterns:
 
-### Pass-through factory
-Delegates directly to `Aggregate.new` with no additional logic. Used when the domain object's fields are sufficient as-is.
-
-```python
-@staticmethod
-def new(validate=True, strict=True, **kwargs) -> 'ErrorAggregate':
-    return Aggregate.new(ErrorAggregate, validate=validate, strict=strict, **kwargs)
-```
-
-### Derivation factory
-Computes or derives fields before delegating. Used when the aggregate needs to normalize inputs, compute IDs, or provide defaults.
+### Direct construction
+Used when the domain object's fields are sufficient as-is:
 
 ```python
-@staticmethod
-def new(name=None, group_id=None, feature_key=None, id=None, ...) -> 'FeatureAggregate':
-    # Derive group_id and feature_key from id if provided.
-    if id and '.' in id and (not group_id or not feature_key):
-        group_id, feature_key = id.split('.', 1)
-    # ...
-    return Aggregate.new(FeatureAggregate, id=id, name=name, ...)
+aggregate = ErrorAggregate(id='invalid_input', name='Invalid Input', message=[...])
 ```
 
-### Dict-wrapper factory
-Accepts a single data dict and unpacks it. Used when the caller already has a dict (e.g., from YAML loading).
+### Derivation via `@model_validator`
+Used when the aggregate needs to normalize inputs, compute IDs, or provide defaults. A `@model_validator(mode='before')` on the domain object handles derivation automatically:
 
 ```python
-@staticmethod
-def new(app_interface_data: Dict[str, Any], validate=True, strict=True, **kwargs):
-    return Aggregate.new(AppInterfaceAggregate, **app_interface_data, **kwargs)
+# FeatureAggregate inherits the @model_validator from Feature,
+# which derives group_id and feature_key from id if provided.
+aggregate = FeatureAggregate(id='calc.add', name='Add Number')
+# aggregate.group_id == 'calc'
+# aggregate.feature_key == 'add'
 ```
 
-Choose the pattern that fits the domain. Derivation factories are useful when an ID is composed from multiple parts; dict-wrapper factories are useful when the aggregate is populated from configuration data.
+### Dict-wrapper construction
+Used when the caller already has a dict (e.g., from YAML loading):
+
+```python
+aggregate = AppInterfaceAggregate(**app_interface_data)
+```
+
+Choose the pattern that fits the domain. Derivation via `@model_validator` is useful when an ID is composed from multiple parts; dict-wrapper construction is useful when the aggregate is populated from configuration data.
 
 ## Nested Sub-Objects Without Aggregates
 
-When a domain object has no aggregate, the parent aggregate creates instances via `DomainObject.new()` and mutates them directly. The parent transfer object handles all structural transformation.
+When a domain object has no aggregate, the parent aggregate creates instances directly via the Pydantic constructor and mutates them. The parent transfer object handles all structural transformation.
 
 ### Creation in the parent aggregate
 
 ```python
 # AppInterfaceAggregate.add_service
-dependency = DomainObject.new(
-    AppServiceDependency,
+dependency = AppServiceDependency(
     module_path=module_path,
     class_name=class_name,
     attribute_id=attribute_id,
@@ -110,7 +103,7 @@ This pattern appears in every domain that nests sub-objects: services in app int
 
 ## Transfer Object Role Strategy
 
-Transfer objects use Schematics role-based serialization to control which fields appear in different contexts. Tiferet defines three standard roles:
+Transfer objects use a `_ROLES` ClassVar to control which fields appear in different serialization contexts. Each role maps to a dict of `model_dump` kwargs. Tiferet defines three standard roles:
 
 | Role | Purpose |
 |---|---|
@@ -118,43 +111,42 @@ Transfer objects use Schematics role-based serialization to control which fields
 | `to_data.yaml` | Fields included when serializing to YAML configuration |
 | `to_data.json` | Fields included when serializing to JSON |
 
-### Deny vs Allow
+### Exclude vs Include
 
-- **`deny`** (blacklist) is the default strategy. Start with all fields and exclude the ones that don't belong in the role.
-- **`allow`** (whitelist) is used when the domain object is simple enough that listing included fields is clearer, or when you want a full pass-through (`allow()` with no arguments).
+- **`exclude`** (blacklist) is the default strategy. Start with all fields and exclude the ones that don't belong in the role.
+- **`include`** (whitelist) is used when the domain object is simple enough that listing included fields is clearer.
 
-### Common deny patterns
+### Common exclude patterns
 
-**Deny the ID on data roles.** The ID is typically derived from the YAML dictionary key, not stored as a field in the YAML value:
+**Exclude the ID on data roles.** The ID is typically derived from the YAML dictionary key, not stored as a field in the YAML value:
 
 ```python
-roles = {
-    'to_data.yaml': TransferObject.deny('id'),
-    'to_data.json': TransferObject.deny('id'),
+_ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+    'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+    'to_data.json': {'exclude': {'id'}},
 }
 ```
 
-**Deny nested collections on `to_model`.** Nested sub-objects need custom mapping (e.g., dict→list conversion), so they are excluded from the primitive and composed manually in `map()`:
+**Exclude nested collections on `to_model`.** Nested sub-objects need custom mapping (e.g., dict→list conversion), so they are excluded from the dump and composed manually in `map()`:
 
 ```python
-roles = {
-    'to_model': TransferObject.deny('services', 'constants', 'module_path', 'class_name'),
+_ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+    'to_model': {'exclude': {'services', 'constants', 'module_path', 'class_name'}},
 }
 ```
 
-The fields denied from `to_model` are then passed explicitly in `map()` with the correct transformation applied.
+The fields excluded from `to_model` are then passed explicitly in `map()` with the correct transformation applied.
 
-### The map/deny handshake
+### The map/exclude handshake
 
-The `map()` method and `to_model` role work together. Whatever `to_model` denies, `map()` must supply:
+The `map()` method and `to_model` role work together. Whatever `to_model` excludes, `map()` must supply:
 
 ```python
-def map(self, **kwargs) -> ErrorAggregate:
+def map(self, **overrides) -> ErrorAggregate:
     return super().map(
         ErrorAggregate,
-        message=[msg.map() for msg in self.message],   # denied from to_model
-        **self.to_primitive('to_model'),                # everything else
-        **kwargs
+        message=[msg.map() for msg in self.message],   # excluded from to_model
+        **overrides
     )
 ```
 
@@ -162,20 +154,20 @@ This pattern ensures the transfer object's role controls what gets auto-serializ
 
 ## Attribute Aliasing
 
-Transfer objects support `serialized_name` and `deserialize_from` for mapping between YAML/JSON field names and domain attribute names. Domain objects must **not** use aliasing — only transfer objects.
+Transfer objects support `serialization_alias` and `validation_alias=AliasChoices(...)` for mapping between YAML/JSON field names and domain attribute names. Domain objects must **not** use aliasing — only transfer objects.
 
 Common aliases:
 
-| Domain field | YAML alias | `deserialize_from` |
+| Domain field | YAML alias (`serialization_alias`) | `validation_alias` (AliasChoices) |
 |---|---|---|
-| `parameters` | `params` | `['params', 'parameters']` |
-| `module_path` | `module` | `['module_path', 'module']` |
-| `class_name` | `class` | `['class_name', 'class']` |
-| `services` | `attrs` | `['attrs', 'services', 'dependencies', 'attributes']` |
-| `dependencies` | `deps` | `['deps', 'dependencies', 'flags']` |
-| `steps` | `commands` | `['handlers', 'functions', 'commands', 'steps']` |
+| `parameters` | `params` | `AliasChoices('params', 'parameters')` |
+| `module_path` | `module` | `AliasChoices('module_path', 'module')` |
+| `class_name` | `class` | `AliasChoices('class_name', 'class')` |
+| `services` | `attrs` | `AliasChoices('attrs', 'services', 'dependencies', 'attributes')` |
+| `dependencies` | `deps` | `AliasChoices('deps', 'dependencies', 'flags')` |
+| `steps` | `commands` | `AliasChoices('handlers', 'functions', 'commands', 'steps')` |
 
-Broad `deserialize_from` lists provide backward compatibility with older configuration formats. The `serialized_name` controls the canonical output key.
+Broad `AliasChoices` lists provide backward compatibility with older configuration formats. The `serialization_alias` controls the canonical output key.
 
 ## Gated `set_attribute` Pattern
 
@@ -240,17 +232,16 @@ When the transfer object performs structural transformations (dict↔list), both
 
 Some transfer objects don't extend a domain object — they compose multiple domain objects into a single configuration structure. `LoggingSettingsYamlObject` is the canonical example: it holds dicts of `FormatterYamlObject`, `HandlerYamlObject`, and `LoggerYamlObject`, representing the entire `logging.yml` file.
 
-These composite transfer objects override `from_data` to handle sub-object hydration:
+These composite transfer objects use `model_validate` with custom hydration logic:
 
 ```python
-@staticmethod
-def from_data(**data) -> 'LoggingSettingsYamlObject':
-    return TransferObject.from_data(
-        LoggingSettingsYamlObject,
-        formatters={id: TransferObject.from_data(FormatterYamlObject, **d, id=id)
+@classmethod
+def hydrate(cls, **data) -> 'LoggingSettingsYamlObject':
+    return cls.model_validate(dict(
+        formatters={id: FormatterYamlObject.model_validate({**d, 'id': id})
                     for id, d in data.get('formatters', {}).items()},
         # ...
-    )
+    ))
 ```
 
 Use this pattern when a YAML file contains multiple related configuration sections that are loaded together.
@@ -263,11 +254,11 @@ When the standard role-based serialization isn't sufficient, transfer objects ca
 def to_primitive(self, role='to_data.yaml', **kwargs) -> Dict[str, Any]:
     return dict(
         **super().to_primitive(role=role, **kwargs),
-        args=[arg.to_primitive() for arg in self.arguments]
+        args=[arg.model_dump(exclude_none=True) for arg in self.arguments]
     )
 ```
 
-Use sparingly — prefer role-based deny/allow when possible.
+Use sparingly — prefer role-based `_ROLES` exclude/include when possible.
 
 ## Related Documentation
 

--- a/docs/guides/repos.md
+++ b/docs/guides/repos.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Module:** `tiferet/repos/`  
-**Version:** 2.0.0a4
+**Version:** 2.0.0b1
 
 ## Overview
 
@@ -79,7 +79,7 @@ For complex loading that needs to construct multiple transfer objects in a singl
 ```python
 def data_factory(data):
     attrs = [
-        TransferObject.from_data(ServiceConfigurationYamlObject, id=id, **attr_data)
+        ServiceConfigurationYamlObject.model_validate({**attr_data, 'id': id})
         for id, attr_data in data.get('services', {}).items()
     ] if data.get('services') else []
     consts = data.get('const', {}) if data.get('const') else {}
@@ -97,10 +97,8 @@ Use `data_factory` when the YAML file contains **multiple sibling sections** tha
 YAML configuration files store entries as dictionaries keyed by identifier. The ID is not stored inside the value — it is derived from the key and injected during mapping:
 
 ```python
-return TransferObject.from_data(
-    ErrorYamlObject,
-    id=id,          # Key becomes the domain object's ID.
-    **error_data    # Value contains the remaining fields.
+return ErrorYamlObject.model_validate(
+    {**error_data, 'id': id}   # Key becomes the domain object's ID.
 ).map()
 ```
 
@@ -112,13 +110,13 @@ This pattern is universal across all repositories.
 
 Every save method follows the same three-step sequence:
 
-1. **Serialize** the domain object via `TransferObject.from_model()` and `to_primitive(default_role)`.
+1. **Serialize** the domain object via `TransferObject.from_model()` and `to_primitive(default_role)` (which delegates to `model_dump`).
 2. **Load the full file** to preserve sibling sections.
 3. **Update** the target section with `setdefault` and write back.
 
 ```python
 # Serialize.
-error_data = TransferObject.from_model(ErrorYamlObject, error)
+error_data = ErrorYamlObject.from_model(error)
 
 # Load full file.
 full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
@@ -207,7 +205,7 @@ The logging repository uses `LoggingSettingsYamlObject` — a transfer object th
 
 ```python
 data = Yaml(self.yaml_file, encoding=self.encoding).load(
-    data_factory=lambda d: LoggingSettingsYamlObject.from_data(**d),
+    data_factory=lambda d: LoggingSettingsYamlObject.hydrate(**d),
     start_node=lambda d: d.get('logging', {})
 )
 return (


### PR DESCRIPTION
## Summary

Updates all 12 guide-level documents under `docs/guides/` to replace schematics-era APIs with Pydantic v2 conventions, as specified in #765.

## Changes

**Domain guides (6):**
- `docs/guides/domain/app.md` — attribute tables, instantiation examples
- `docs/guides/domain/cli.md` — attribute tables, `CliCommand.new()` → `@model_validator`
- `docs/guides/domain/error.md` — attribute tables, `Error.new()` → `@model_validator`
- `docs/guides/domain/feature.md` — attribute tables, instantiation examples
- `docs/guides/domain/logging.md` — attribute tables, instantiation examples
- `docs/guides/domain/di.md` — attribute tables, instantiation examples

**Cross-cutting guides (3):**
- `docs/guides/mappers.md` — `Aggregate.new()` → constructor, `allow()`/`deny()` → `_ROLES` ClassVar, `serialized_name`/`deserialize_from` → `serialization_alias`/`AliasChoices`, `TransferObject.from_data()` → `model_validate()`
- `docs/guides/repos.md` — `TransferObject.from_data()`/`from_model()` call-site patterns
- `docs/guides/builders.md` — `DomainObject.new()` → `model_validate()`

**Event guides (3):**
- `docs/guides/events/app.md` — aggregate factory references
- `docs/guides/events/cli.md` — aggregate factory references
- `docs/guides/events/logging.md` — aggregate factory references

## Key Replacements
- `StringType`/`IntegerType`/`FloatType`/`BooleanType`/`ListType`/`DictType`/`ModelType` → native Python type annotations
- `DomainObject.new(Type, ...)` → `Type(...)`
- `Aggregate.new(Type, ...)` → `Type(...)`
- `*.new()` custom factories → `@model_validator(mode='before')`
- `TransferObject.from_data(Type, ...)` → `Type.model_validate({...})`
- `allow()`/`deny()` → `_ROLES` ClassVar with `model_dump` kwargs
- `serialized_name`/`deserialize_from` → `serialization_alias`/`AliasChoices`
- Version metadata → `2.0.0b1`

## Verification
```bash
grep -r "schematics\|StringType\|DomainObject\.new\|Aggregate\.new\|from_data\|allow()\|deny()" docs/guides/
```
Returns no matches.

Closes #765

---
[Warp conversation](https://app.warp.dev/conversation/696aeb6f-335c-409d-95c4-a6ad08bb5156)

Co-Authored-By: Oz <oz-agent@warp.dev>