### PR TITLE
DI – DynamicServiceProvider Implementation (#789)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.6",
     "pyyaml>=6.0.1",
-    "dependencies>=7.7.0"
+    "dependencies>=7.7.0",
+    "dependency-injector>=4.49.0"
 ]
 
 [project.urls]

--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -3,3 +3,4 @@
 # ** app
 from .settings import ServiceProvider
 from .dependencies import DependenciesServiceProvider
+from .dynamic import DynamicServiceProvider

--- a/tiferet/di/dynamic.py
+++ b/tiferet/di/dynamic.py
@@ -1,0 +1,175 @@
+"""Dynamic DI Service Provider"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict
+import inspect
+
+# ** infra
+from dependency_injector import containers, providers
+
+# ** app
+from ..events import RaiseError
+from .settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: dynamic_service_provider
+class DynamicServiceProvider(ServiceProvider):
+    '''
+    A service provider for managing app context dependencies via the
+    dependency_injector DynamicContainer.
+    '''
+
+    # * attribute: container
+    container: containers.DynamicContainer
+
+    # * init
+    def __init__(self, services: Dict[str, type] = None):
+        '''
+        Initialize the dynamic service provider.
+
+        :param services: Initial service ID-to-type mapping.
+        :type services: Dict[str, type]
+        '''
+
+        # Create the underlying DynamicContainer.
+        self.container = containers.DynamicContainer()
+
+        # Register initial services if provided.
+        if services:
+            self.add_services(services)
+
+    # * method: add_service
+    def add_service(self, service_id: str, service_type: type):
+        '''
+        Add a service dependency to the service provider.
+
+        :param service_id: The ID of the service to add.
+        :type service_id: str
+        :param service_type: The type of the service to add.
+        :type service_type: type
+        '''
+
+        # Build a Factory provider with constructor kwargs wired to sibling providers.
+        factory = self._build_factory(service_type)
+
+        # Register the provider on the container.
+        self.container.set_provider(service_id, factory)
+
+    # * method: add_services
+    def add_services(self, services: Dict[str, type]):
+        '''
+        Add multiple service dependencies to the service provider.
+
+        :param services: A dictionary of service IDs and their corresponding types.
+        :type services: Dict[str, type]
+        '''
+
+        # Register each service individually.
+        for service_id, service_type in services.items():
+            self.add_service(service_id, service_type)
+
+    # * method: add_constants
+    def add_constants(self, constants: Dict[str, Any]):
+        '''
+        Add constant dependencies to the service provider.
+
+        :param constants: A dictionary of constant names and their corresponding values.
+        :type constants: Dict[str, Any]
+        '''
+
+        # Register each constant as an Object provider for scalar pass-through.
+        for name, value in constants.items():
+            self.container.set_provider(name, providers.Object(value))
+
+    # * method: get_service
+    def get_service(self, service_id: str) -> Any:
+        '''
+        Get a service dependency by its ID.
+
+        :param service_id: The service ID.
+        :type service_id: str
+        :return: The resolved service dependency instance.
+        :rtype: Any
+        '''
+
+        # Attempt to retrieve and invoke the provider from the container.
+        try:
+            provider = self.container.providers.get(service_id)
+
+            # If no provider was found, raise an error.
+            if provider is None:
+                RaiseError.execute(
+                    'INVALID_DEPENDENCY_ERROR',
+                    f'Dependency {service_id} could not be resolved: not registered.',
+                    dependency_name=service_id,
+                    exception=f'No provider registered for {service_id}.',
+                )
+
+            # Invoke the provider to resolve the dependency.
+            return provider()
+
+        # Re-raise TiferetErrors without wrapping.
+        except Exception as e:
+            from ..assets.exceptions import TiferetError
+            if isinstance(e, TiferetError):
+                raise
+
+            # Wrap unexpected resolution errors in a structured error.
+            RaiseError.execute(
+                'INVALID_DEPENDENCY_ERROR',
+                f'Dependency {service_id} could not be resolved: {str(e)}',
+                dependency_name=service_id,
+                exception=str(e),
+            )
+
+    # * method: remove_service
+    def remove_service(self, service_id: str):
+        '''
+        Remove a service dependency from the service provider.
+
+        :param service_id: The service ID to remove.
+        :type service_id: str
+        '''
+
+        # Remove the provider if it exists; no-op for nonexistent IDs.
+        if service_id in self.container.providers:
+            delattr(self.container, service_id)
+
+    # * method: _build_factory
+    def _build_factory(self, service_type: type) -> providers.Factory:
+        '''
+        Build a Factory provider with constructor kwargs wired to sibling providers.
+
+        :param service_type: The service class to build a factory for.
+        :type service_type: type
+        :return: A Factory provider with cascading dependency resolution.
+        :rtype: providers.Factory
+        '''
+
+        # Inspect the constructor signature to identify injectable parameters.
+        try:
+            sig = inspect.signature(service_type.__init__)
+        except (ValueError, TypeError):
+            return providers.Factory(service_type)
+
+        # Build kwargs mapping from constructor parameter names to sibling providers.
+        kwargs = {}
+        for param_name, param in sig.parameters.items():
+
+            # Skip self and variadic parameters.
+            if param_name == 'self':
+                continue
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+
+            # Wire the parameter to a sibling provider if one exists.
+            sibling = self.container.providers.get(param_name)
+            if sibling is not None:
+                kwargs[param_name] = sibling
+
+        # Return the Factory provider with wired kwargs.
+        return providers.Factory(service_type, **kwargs)

--- a/tiferet/di/tests/test_dynamic.py
+++ b/tiferet/di/tests/test_dynamic.py
@@ -1,0 +1,327 @@
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ...assets.exceptions import TiferetError
+from ..dynamic import DynamicServiceProvider
+from ..settings import ServiceProvider
+
+
+# *** classes
+
+# ** class: simple_service
+class SimpleService:
+    '''A dependency-free service used for testing.'''
+
+    pass
+
+
+# ** class: dependent_service
+class DependentService:
+    '''A service with a constructor dependency on SimpleService.'''
+
+    # * attribute: simple_service
+    simple_service: SimpleService
+
+    # * init
+    def __init__(self, simple_service: SimpleService):
+        '''
+        Initialize the dependent service.
+
+        :param simple_service: The injected simple service.
+        :type simple_service: SimpleService
+        '''
+
+        # Assign the injected dependency.
+        self.simple_service = simple_service
+
+
+# ** class: configurable_service
+class ConfigurableService:
+    '''A service with a scalar constructor parameter, used to test constant injection.'''
+
+    # * attribute: config_value
+    config_value: str
+
+    # * init
+    def __init__(self, config_value: str):
+        '''
+        Initialize the configurable service.
+
+        :param config_value: A scalar configuration value injected at construction.
+        :type config_value: str
+        '''
+
+        # Assign the injected constant.
+        self.config_value = config_value
+
+
+# *** fixtures
+
+# ** fixture: empty_provider
+@pytest.fixture
+def empty_provider() -> DynamicServiceProvider:
+    '''
+    Fixture to create an empty DynamicServiceProvider.
+
+    :return: An empty provider instance.
+    :rtype: DynamicServiceProvider
+    '''
+
+    # Return a provider with no initial services.
+    return DynamicServiceProvider()
+
+
+# ** fixture: populated_provider
+@pytest.fixture
+def populated_provider() -> DynamicServiceProvider:
+    '''
+    Fixture to create a DynamicServiceProvider pre-populated with a SimpleService.
+
+    :return: A provider with SimpleService registered.
+    :rtype: DynamicServiceProvider
+    '''
+
+    # Return a provider with SimpleService registered under 'simple_service'.
+    return DynamicServiceProvider(services={'simple_service': SimpleService})
+
+
+# *** tests
+
+# ** test: init_empty
+def test_init_empty(empty_provider: DynamicServiceProvider):
+    '''
+    Test that an empty provider initializes with no providers in the container.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Assert that the container has no registered providers.
+    assert len(empty_provider.container.providers) == 0
+
+
+# ** test: init_with_services
+def test_init_with_services(populated_provider: DynamicServiceProvider):
+    '''
+    Test that a provider initialized with services registers them correctly.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DynamicServiceProvider
+    '''
+
+    # Assert that the service is present in the container providers.
+    assert 'simple_service' in populated_provider.container.providers
+
+
+# ** test: is_service_provider
+def test_is_service_provider(empty_provider: DynamicServiceProvider):
+    '''
+    Test that DynamicServiceProvider is an instance of ServiceProvider.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Assert that the provider satisfies the ServiceProvider contract.
+    assert isinstance(empty_provider, ServiceProvider)
+
+
+# ** test: add_service
+def test_add_service(empty_provider: DynamicServiceProvider):
+    '''
+    Test that add_service registers a service and makes it resolvable.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Add a single service.
+    empty_provider.add_service('simple_service', SimpleService)
+
+    # Assert it was added to the container.
+    assert 'simple_service' in empty_provider.container.providers
+
+    # Assert the resolved instance is of the expected type.
+    service = empty_provider.get_service('simple_service')
+    assert isinstance(service, SimpleService)
+
+
+# ** test: add_service_new_instance_per_call
+def test_add_service_new_instance_per_call(populated_provider: DynamicServiceProvider):
+    '''
+    Test that Factory providers resolve as new instances per call.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DynamicServiceProvider
+    '''
+
+    # Resolve two instances of the same service.
+    instance_a = populated_provider.get_service('simple_service')
+    instance_b = populated_provider.get_service('simple_service')
+
+    # Assert that both are SimpleService instances but are distinct objects.
+    assert isinstance(instance_a, SimpleService)
+    assert isinstance(instance_b, SimpleService)
+    assert instance_a is not instance_b
+
+
+# ** test: add_services
+def test_add_services(empty_provider: DynamicServiceProvider):
+    '''
+    Test that add_services registers multiple services at once.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Add multiple services.
+    empty_provider.add_services({
+        'simple_service': SimpleService,
+        'dependent_service': DependentService,
+    })
+
+    # Assert both were added.
+    assert 'simple_service' in empty_provider.container.providers
+    assert 'dependent_service' in empty_provider.container.providers
+
+    # Assert both resolve correctly.
+    assert isinstance(empty_provider.get_service('simple_service'), SimpleService)
+    assert isinstance(empty_provider.get_service('dependent_service'), DependentService)
+
+
+# ** test: add_constants
+def test_add_constants(empty_provider: DynamicServiceProvider):
+    '''
+    Test that add_constants registers scalar values returned as-is on resolution.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Register a scalar constant.
+    empty_provider.add_constants({'config_value': 'test_config'})
+
+    # Assert the constant was stored in the container.
+    assert 'config_value' in empty_provider.container.providers
+
+    # Assert the constant resolves to the original value.
+    assert empty_provider.get_service('config_value') == 'test_config'
+
+
+# ** test: add_constants_injected_into_service
+def test_add_constants_injected_into_service(empty_provider: DynamicServiceProvider):
+    '''
+    Test that constants registered via add_constants are injected into
+    services that depend on them via constructor parameters.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Register a constant first, then a service that depends on it.
+    empty_provider.add_constants({'config_value': 'test_config'})
+    empty_provider.add_service('configurable_service', ConfigurableService)
+
+    # Resolve the service and assert the constant was injected correctly.
+    service = empty_provider.get_service('configurable_service')
+    assert isinstance(service, ConfigurableService)
+    assert service.config_value == 'test_config'
+
+
+# ** test: get_service_success
+def test_get_service_success(populated_provider: DynamicServiceProvider):
+    '''
+    Test that get_service resolves a registered service to the correct type.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DynamicServiceProvider
+    '''
+
+    # Resolve the service.
+    service = populated_provider.get_service('simple_service')
+
+    # Assert it is an instance of SimpleService.
+    assert isinstance(service, SimpleService)
+
+
+# ** test: get_service_not_found
+def test_get_service_not_found(empty_provider: DynamicServiceProvider):
+    '''
+    Test that get_service raises TiferetError for an unregistered service ID.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Attempt to resolve a service that was never registered.
+    with pytest.raises(TiferetError) as exc_info:
+        empty_provider.get_service('nonexistent_service')
+
+    # Assert the correct error code was raised.
+    assert exc_info.value.error_code == 'INVALID_DEPENDENCY_ERROR'
+
+    # Assert the dependency name is in the error kwargs.
+    assert exc_info.value.kwargs.get('dependency_name') == 'nonexistent_service'
+
+
+# ** test: remove_service
+def test_remove_service(populated_provider: DynamicServiceProvider):
+    '''
+    Test that remove_service deregisters a service from the provider.
+
+    :param populated_provider: The pre-populated provider fixture.
+    :type populated_provider: DynamicServiceProvider
+    '''
+
+    # Remove the registered service.
+    populated_provider.remove_service('simple_service')
+
+    # Assert it was removed from the container.
+    assert 'simple_service' not in populated_provider.container.providers
+
+    # Assert it is no longer resolvable.
+    with pytest.raises(TiferetError):
+        populated_provider.get_service('simple_service')
+
+
+# ** test: remove_service_nonexistent
+def test_remove_service_nonexistent(empty_provider: DynamicServiceProvider):
+    '''
+    Test that remove_service is a no-op for an unregistered service ID.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Removing an ID that was never registered should not raise.
+    empty_provider.remove_service('nonexistent_service')
+
+    # Assert the container is still empty.
+    assert len(empty_provider.container.providers) == 0
+
+
+# ** test: cascading_dependency_injection
+def test_cascading_dependency_injection(empty_provider: DynamicServiceProvider):
+    '''
+    Test that cascading DI works: a service with a constructor dependency
+    on another registered service resolves both correctly.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Register SimpleService first, then DependentService which depends on it.
+    empty_provider.add_service('simple_service', SimpleService)
+    empty_provider.add_service('dependent_service', DependentService)
+
+    # Resolve the dependent service.
+    service = empty_provider.get_service('dependent_service')
+
+    # Assert the dependent service is the correct type.
+    assert isinstance(service, DependentService)
+
+    # Assert the injected dependency is the correct type.
+    assert isinstance(service.simple_service, SimpleService)


### PR DESCRIPTION
## Summary

Implements `DynamicServiceProvider(ServiceProvider)` in `tiferet/di/dynamic.py`, backed by `dependency_injector.containers.DynamicContainer`.

### Changes
- **`tiferet/di/dynamic.py`** — New provider class using `providers.Factory` for service types (new instance per resolution) and `providers.Object` for constants (scalar pass-through). Cascading constructor injection via introspection of constructor signatures. Structured error handling via `RaiseError.execute()` with `INVALID_DEPENDENCY_ERROR`.
- **`tiferet/di/tests/test_dynamic.py`** — 13 tests covering all acceptance criteria.
- **`tiferet/di/__init__.py`** — Added `DynamicServiceProvider` to exports.
- **`pyproject.toml`** — Added `dependency-injector>=4.49.0` dependency.

### Acceptance Criteria
- [x] Satisfies `ServiceProvider` ABC
- [x] Services resolve as new instances per call (Factory)
- [x] Constants returned as-is (Object)
- [x] Cascading DI works
- [x] `get_service` raises `TiferetError` with `INVALID_DEPENDENCY_ERROR` for unregistered IDs
- [x] `remove_service` is idempotent

Closes #789

---
[Conversation](https://app.warp.dev/conversation/69db6808-9ea9-433f-a045-f82142460e24)

Co-Authored-By: Oz <oz-agent@warp.dev>