### PR TITLE
DI – Update Exports and Backward-Compatible Alias (#791)

### DIFF
--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -2,5 +2,8 @@
 
 # ** app
 from .settings import ServiceProvider
-from .dependencies import DependenciesServiceProvider
 from .dynamic import DynamicServiceProvider
+
+# Backward-compatible alias: downstream consumers importing
+# DependenciesServiceProvider will receive DynamicServiceProvider.
+DependenciesServiceProvider = DynamicServiceProvider


### PR DESCRIPTION
## Summary

Updates `tiferet/di/__init__.py` to export `DynamicServiceProvider` as the primary provider and alias `DependenciesServiceProvider` to it for backward compatibility.

### Changes
- **`tiferet/di/__init__.py`** — Replaced `from .dependencies import DependenciesServiceProvider` with `DependenciesServiceProvider = DynamicServiceProvider` alias.

### Acceptance Criteria
- [x] `from tiferet.di import DynamicServiceProvider` works
- [x] `from tiferet.di import DependenciesServiceProvider` still works (alias)
- [x] `from tiferet.di import ServiceProvider` unchanged
- [x] Both names resolve to the same class

Closes #791

---
[Conversation](https://app.warp.dev/conversation/69db6808-9ea9-433f-a045-f82142460e24)

Co-Authored-By: Oz <oz-agent@warp.dev>