### PR TITLE
Builders – Migrate AppBuilder to DynamicServiceProvider (#792)

### DIFF
--- a/tiferet/builders/main.py
+++ b/tiferet/builders/main.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, List
 
 # ** app
 from ..contexts.app import AppInterfaceContext
-from ..di import ServiceProvider, DependenciesServiceProvider
+from ..di import ServiceProvider, DynamicServiceProvider
 from .. import assets as a
 from ..domain import (
     AppInterface,
@@ -57,7 +57,7 @@ class AppBuilder(object):
     # * method: create_service_provider (static)
     @staticmethod
     def create_service_provider(
-        provider_type: type = DependenciesServiceProvider,
+        provider_type: type = DynamicServiceProvider,
         type_map: Dict[str, type] = None,
         **constants
     ) -> ServiceProvider:

--- a/tiferet/builders/tests/test_main.py
+++ b/tiferet/builders/tests/test_main.py
@@ -9,7 +9,7 @@ from unittest import mock
 # ** app
 from ... import assets as a
 from ...assets import TiferetError
-from ...di import DependenciesServiceProvider
+from ...di import DynamicServiceProvider
 from ...contexts.app import AppInterfaceContext
 from ...mappers import AppInterfaceAggregate
 from ...repos.app import AppYamlRepository
@@ -84,7 +84,7 @@ def test_app_builder_initialization():
     # Assert initialized state.
     assert isinstance(builder.cache, dict)
     assert len(builder.cache) == 0
-    assert isinstance(builder.service_provider, DependenciesServiceProvider)
+    assert isinstance(builder.service_provider, DynamicServiceProvider)
 
 
 # ** test: app_builder_load_app_service_defaults

--- a/tiferet/di/dynamic.py
+++ b/tiferet/di/dynamic.py
@@ -64,13 +64,20 @@ class DynamicServiceProvider(ServiceProvider):
         '''
         Add multiple service dependencies to the service provider.
 
-        :param services: A dictionary of service IDs and their corresponding types.
+        Class types are registered as Factory providers (new instance per
+        resolution). Non-type values (scalars, callables, etc.) are registered
+        as Object providers (pass-through).
+
+        :param services: A dictionary of service IDs and their corresponding types or values.
         :type services: Dict[str, type]
         '''
 
-        # Register each service individually.
-        for service_id, service_type in services.items():
-            self.add_service(service_id, service_type)
+        # Route each entry to the appropriate provider type.
+        for service_id, value in services.items():
+            if isinstance(value, type):
+                self.add_service(service_id, value)
+            else:
+                self.container.set_provider(service_id, providers.Object(value))
 
     # * method: add_constants
     def add_constants(self, constants: Dict[str, Any]):

--- a/tiferet/di/tests/test_dynamic.py
+++ b/tiferet/di/tests/test_dynamic.py
@@ -303,6 +303,31 @@ def test_remove_service_nonexistent(empty_provider: DynamicServiceProvider):
     assert len(empty_provider.container.providers) == 0
 
 
+# ** test: add_services_mixed_types_and_scalars
+def test_add_services_mixed_types_and_scalars(empty_provider: DynamicServiceProvider):
+    '''
+    Test that add_services routes class types to Factory providers and
+    non-type values to Object providers when given a mixed dict.
+
+    :param empty_provider: The empty provider fixture.
+    :type empty_provider: DynamicServiceProvider
+    '''
+
+    # Register a mix of types and scalars in a single call.
+    empty_provider.add_services({
+        'config_value': 'test_config',
+        'configurable_service': ConfigurableService,
+    })
+
+    # Assert the scalar resolves as-is.
+    assert empty_provider.get_service('config_value') == 'test_config'
+
+    # Assert the service resolves with the scalar injected.
+    service = empty_provider.get_service('configurable_service')
+    assert isinstance(service, ConfigurableService)
+    assert service.config_value == 'test_config'
+
+
 # ** test: cascading_dependency_injection
 def test_cascading_dependency_injection(empty_provider: DynamicServiceProvider):
     '''

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -96,13 +96,13 @@ class AppInterface(DomainObject):
 
     # * attribute: service_provider_path
     service_provider_path: str = Field(
-        default='tiferet.di.dependencies',
+        default='tiferet.di.dynamic',
         description='The module path for the service provider to use for this dependency.',
     )
 
     # * attribute: service_provider_class_name
     service_provider_class_name: str = Field(
-        default='DependenciesServiceProvider',
+        default='DynamicServiceProvider',
         description='The class name for the service provider to use for this dependency.',
     )
 
@@ -153,12 +153,8 @@ class AppInterface(DomainObject):
         :rtype: Dict[str, type]
         '''
 
-        # Retrieve the app context dependency, interface id, and logger id.
+        # Register scalars and constants first.
         dependencies: Dict[str, type] = dict(
-            app_context=getattr(
-                import_module(self.module_path),
-                self.class_name,
-            ),
             interface_id=self.id,
             logger_id=getattr(self, 'logger_id', None),
         )
@@ -171,6 +167,12 @@ class AppInterface(DomainObject):
             dependencies[dep.service_id] = dep.get_service_type()
             for param, value in dep.parameters.items():
                 dependencies[param] = value
+
+        # Register app_context last so all its dependencies are available.
+        dependencies['app_context'] = getattr(
+            import_module(self.module_path),
+            self.class_name,
+        )
 
         # Return the assembled dependencies mapping.
         return dependencies

--- a/tiferet/domain/tests/test_app.py
+++ b/tiferet/domain/tests/test_app.py
@@ -13,7 +13,7 @@ from ..app import (
 )
 from ...di import (
     ServiceProvider,
-    DependenciesServiceProvider,
+    DynamicServiceProvider,
 )
 
 # *** fixtures
@@ -203,8 +203,8 @@ def test_app_interface_service_provider_defaults() -> None:
     )
 
     # Assert default provider module path and class name values.
-    assert interface.service_provider_path == 'tiferet.di.dependencies'
-    assert interface.service_provider_class_name == 'DependenciesServiceProvider'
+    assert interface.service_provider_path == 'tiferet.di.dynamic'
+    assert interface.service_provider_class_name == 'DynamicServiceProvider'
 
 
 # ** test: app_interface_create_service_provider
@@ -229,6 +229,6 @@ def test_app_interface_create_service_provider(resolvable_app_dependency: AppSer
 
     # Assert the provider is correctly created and populated.
     assert isinstance(provider, ServiceProvider)
-    assert isinstance(provider, DependenciesServiceProvider)
-    assert 'app_context' in provider.services
-    assert 'resolvable_service' in provider.services
+    assert isinstance(provider, DynamicServiceProvider)
+    assert 'app_context' in provider.container.providers
+    assert 'resolvable_service' in provider.container.providers


### PR DESCRIPTION
## Summary

Migrates `AppBuilder` and supporting components to use `DynamicServiceProvider` as the default provider.

### Changes
- **`tiferet/builders/main.py`** — Import and default `provider_type` changed from `DependenciesServiceProvider` to `DynamicServiceProvider`
- **`tiferet/di/dynamic.py`** — `add_services` now routes class types to Factory providers and non-type values (scalars, callables) to Object providers
- **`tiferet/domain/app.py`** — Reordered `get_service_type_mapping()` so `app_context` is registered last (after its dependencies). Updated default `service_provider_path`/`service_provider_class_name` to `tiferet.di.dynamic`/`DynamicServiceProvider`
- **Tests** — Updated builder, DI, and domain tests accordingly. Added `test_add_services_mixed_types_and_scalars` for the new routing logic

### Acceptance Criteria
- [x] `AppBuilder` uses `DynamicServiceProvider` by default
- [x] All existing `test_main.py` tests pass without behavioral changes
- [x] `create_service_provider()` still accepts a custom `provider_type` parameter

### Additional scope (companion changes)
- Subsumes #794 (Domain – Update AppInterface Default Provider References) since the default field values were updated here

Closes #792
Closes #794

---
[Conversation](https://app.warp.dev/conversation/69db6808-9ea9-433f-a045-f82142460e24)

Co-Authored-By: Oz <oz-agent@warp.dev>