### PR TITLE
Contexts – Migrate DIContext to DynamicServiceProvider (#793)

### DIFF
--- a/tiferet/contexts/di.py
+++ b/tiferet/contexts/di.py
@@ -6,7 +6,7 @@ from typing import Callable, Any, List, Dict
 # ** app
 from .cache import CacheContext
 from ..assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
-from ..di import ServiceProvider, DependenciesServiceProvider
+from ..di import ServiceProvider, DynamicServiceProvider
 from ..domain import ServiceConfiguration
 from ..events import DomainEvent, RaiseError, ParseParameter
 
@@ -48,11 +48,11 @@ class DIContext(object):
         # Assign the attributes.
         self.list_all_configs_handler = di_list_all_configs_evt.execute
         self.cache = cache if cache else CacheContext()
-        self.create_service_provider = create_service_provider if create_service_provider else self._default_service_provider
+        self.create_service_provider = create_service_provider if create_service_provider else self.default_service_provider
 
-    # * method: _default_service_provider (static)
+    # * method: default_service_provider (static)
     @staticmethod
-    def _default_service_provider(type_map: Dict[str, type] = None, **constants) -> ServiceProvider:
+    def default_service_provider(type_map: Dict[str, type] = None, **constants) -> ServiceProvider:
         '''
         Create the default service provider for DI context resolution.
 
@@ -64,11 +64,14 @@ class DIContext(object):
         :rtype: ServiceProvider
         '''
 
-        # Create a provider seeded with service dependency types.
-        provider = DependenciesServiceProvider(services=type_map or {})
-
-        # Add constants to the provider for constructor injection.
+        # Create an empty provider and register constants first
+        # so Factory providers can wire constructor parameters.
+        provider = DynamicServiceProvider()
         provider.add_constants(constants)
+
+        # Add service types after constants are available.
+        if type_map:
+            provider.add_services(type_map)
 
         # Return the configured provider.
         return provider

--- a/tiferet/contexts/tests/test_di.py
+++ b/tiferet/contexts/tests/test_di.py
@@ -10,7 +10,7 @@ from ..di import DIContext
 from ..cache import CacheContext
 from ...assets.exceptions import TiferetError
 from ...assets.constants import DEPENDENCY_TYPE_NOT_FOUND_ID
-from ...di import ServiceProvider, DependenciesServiceProvider
+from ...di import ServiceProvider, DynamicServiceProvider
 from ...domain import (
     ServiceConfiguration,
     FlaggedDependency,
@@ -163,7 +163,7 @@ def test_di_context_default_service_provider_factory():
     '''
 
     # Build a provider with a type map and injected constants.
-    provider = DIContext._default_service_provider(
+    provider = DIContext.default_service_provider(
         type_map={'test_service': TestService},
         test_config='factory_value',
     )
@@ -181,7 +181,7 @@ def test_di_context_custom_service_provider_factory(di_list_all_configs_evt_mock
     '''
 
     # Create a custom factory mock and provider return value.
-    provider = DependenciesServiceProvider()
+    provider = DynamicServiceProvider()
     create_factory = mock.Mock(return_value=provider)
 
     # Create context with custom provider factory and build provider.


### PR DESCRIPTION
## Summary

Migrates `DIContext` feature-level DI to use `DynamicServiceProvider`.

### Changes
- **`tiferet/contexts/di.py`** — Import changed to `DynamicServiceProvider`. `default_service_provider()` (renamed from `_default_service_provider`) now registers constants before services so Factory providers can wire constructor parameters.
- **`tiferet/contexts/tests/test_di.py`** — Updated imports and method references.

### Acceptance Criteria
- [x] `DIContext.default_service_provider()` creates a `DynamicServiceProvider`
- [x] All existing `test_di.py` tests pass without behavioral changes
- [x] Feature-level dependency resolution continues to work end-to-end

Closes #793

---
[Conversation](https://app.warp.dev/conversation/69db6808-9ea9-433f-a045-f82142460e24)

Co-Authored-By: Oz <oz-agent@warp.dev>