### PR TITLE
Assets – New Error Constants and DEFAULT_ERRORS (#806)

### DIFF
--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -130,6 +130,9 @@ INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
 # ** constant: configuration_already_exists_id
 CONFIGURATION_ALREADY_EXISTS_ID = 'CONFIGURATION_ALREADY_EXISTS'
 
+# ** constant: invalid_dependency_error_id
+INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
+
 # ** constant: invalid_model_attribute_id
 INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
 
@@ -633,8 +636,8 @@ DEFAULT_ERRORS = {
     },
     
     # * error: INVALID_DEPENDENCY_ERROR
-    'INVALID_DEPENDENCY_ERROR': {
-        'id': 'INVALID_DEPENDENCY_ERROR',
+    INVALID_DEPENDENCY_ERROR_ID: {
+        'id': INVALID_DEPENDENCY_ERROR_ID,
         'name': 'Invalid Dependency Error',
         'message': [
             {'lang': 'en_US', 'text': 'Dependency {dependency} could not be resolved: {reason}.'}


### PR DESCRIPTION
## Summary

Closes #806.

Adds the `INVALID_DEPENDENCY_ERROR_ID` constant and updates the corresponding `DEFAULT_ERRORS` entry to use it instead of a string literal. All other constants listed in the TRD were already present.

## Changes

- Added `INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'` constant to `tiferet/assets/constants.py`.
- Updated the `INVALID_DEPENDENCY_ERROR` `DEFAULT_ERRORS` entry to reference the constant for both key and `id` value.

## Verification

- All 702 existing tests pass.
- Constant is accessible via `a.const.INVALID_DEPENDENCY_ERROR_ID`.

---

[Conversation](https://app.warp.dev/conversation/c8ce1442-4b6e-47f8-838e-4f3c73d52d10)

Co-Authored-By: Oz <oz-agent@warp.dev>