### PR TITLE
Domain – Feature derive_keys Validator (#807)

### DIFF
--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -81,10 +81,10 @@ class Feature(DomainObject):
     # * attribute: log_params
     log_params: Dict[str, str] = Field(default_factory=dict, description='The parameters to log for the feature.')
 
-    # * method: _derive_keys (validator)
+    # * method: derive_keys (validator)
     @model_validator(mode='before')
     @classmethod
-    def _derive_keys(cls, data: Any) -> Any:
+    def derive_keys(cls, data: Any) -> Any:
         '''
         Derive ``id``, ``group_id``, ``feature_key``, and ``description`` from
         whichever inputs are provided so callers may supply any consistent subset.

--- a/tiferet/domain/tests/test_feature.py
+++ b/tiferet/domain/tests/test_feature.py
@@ -81,6 +81,58 @@ def test_feature_event_flags_creation_and_round_trip() -> None:
     # Assert flags are preserved through round-trip.
     assert reloaded.flags == ['flag1', 'flag2']
 
+# ** test: feature_derive_keys_from_dotted_id
+def test_feature_derive_keys_from_dotted_id() -> None:
+    '''
+    Test that Feature auto-derives group_id and feature_key from a dotted id.
+    '''
+
+    # Create a Feature with only id and name.
+    feature = Feature(id='calc.add', name='Add')
+
+    # Assert group_id and feature_key are derived.
+    assert feature.group_id == 'calc'
+    assert feature.feature_key == 'add'
+    assert feature.description == 'Add'
+
+# ** test: feature_derive_keys_from_group_and_name
+def test_feature_derive_keys_from_group_and_name() -> None:
+    '''
+    Test that Feature auto-derives feature_key and id from group_id and name.
+    '''
+
+    # Create a Feature with group_id and name only.
+    feature = Feature(group_id='calc', name='Add Number')
+
+    # Assert feature_key is snake-cased from name, and id is composed.
+    assert feature.feature_key == 'add_number'
+    assert feature.id == 'calc.add_number'
+    assert feature.description == 'Add Number'
+
+# ** test: feature_derive_keys_description_defaults_to_name
+def test_feature_derive_keys_description_defaults_to_name() -> None:
+    '''
+    Test that description defaults to name when not provided.
+    '''
+
+    # Create a Feature without description.
+    feature = Feature(id='calc.add', name='Add')
+
+    # Assert description equals name.
+    assert feature.description == 'Add'
+
+# ** test: feature_derive_keys_explicit_description_preserved
+def test_feature_derive_keys_explicit_description_preserved() -> None:
+    '''
+    Test that an explicit description is not overwritten by the validator.
+    '''
+
+    # Create a Feature with an explicit description.
+    feature = Feature(id='calc.add', name='Add', description='Custom description')
+
+    # Assert the explicit description is preserved.
+    assert feature.description == 'Custom description'
+
 # ** test: feature_get_step_valid_and_invalid_indices
 def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
     '''


### PR DESCRIPTION
## Summary

Closes #807.

Renames the `_derive_keys` model validator to `derive_keys` (public) and adds unit tests covering the Feature derivation logic.

## Changes

- **`tiferet/domain/feature.py`**: Renamed `_derive_keys` → `derive_keys` on the `Feature` model validator.
- **`tiferet/domain/tests/test_feature.py`**: Added 4 new tests:
  - `test_feature_derive_keys_from_dotted_id` — derives `group_id`/`feature_key` from dotted `id`
  - `test_feature_derive_keys_from_group_and_name` — derives `feature_key` (snake-case) and `id` from `group_id` + `name`
  - `test_feature_derive_keys_description_defaults_to_name` — defaults `description` to `name`
  - `test_feature_derive_keys_explicit_description_preserved` — explicit `description` is preserved

## Verification

- All 706 tests pass (702 existing + 4 new).

---

[Conversation](https://app.warp.dev/conversation/c8ce1442-4b6e-47f8-838e-4f3c73d52d10)

Co-Authored-By: Oz <oz-agent@warp.dev>