### PR TITLE
Utils – SQLite API Refinements (#808)

### DIFF
--- a/docs/guides/utils/sqlite.md
+++ b/docs/guides/utils/sqlite.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Date:** March 02, 2026  
-**Version:** 2.0.0a1
+**Version:** 2.0.0b3
 
 ## Overview
 
@@ -25,7 +25,7 @@ The context manager is especially helpful here:
 | Quick query or small script / test            | `with Sqlite(...) as db:`                    | Zero setup, immediate access                                                |
 | Need to mock or swap database backends later  | Inject `SqliteService`                       | Follows dependency injection; easy to test & replace                        |
 | Persistent domain objects (users, settings…)  | Use domain repository + injected service     | Keeps business logic clean and path-agnostic                                |
-| One-time database backup                      | `source.backup(target)`                      | Built-in, safe, with proper error wrapping                                  |
+| One-time database backup                      | `source.backup(target_path)`                 | Built-in, safe, with proper error wrapping and optional progress callback    |
 | Enforce read-only access                      | `mode='ro'`                                  | SQLite itself prevents writes at connection level                           |
 
 ## Quick examples to get you started
@@ -37,8 +37,7 @@ from tiferet.utils import Sqlite
 with Sqlite() as db:                        # defaults to :memory:
     db.execute("CREATE TABLE pets (name TEXT, age INTEGER)")
     db.execute("INSERT INTO pets VALUES (?, ?)", ("Luna", 3))
-    db.execute("SELECT * FROM pets WHERE age > 2")
-    print(db.fetch_all())                   # → [('Luna', 3)]
+    print(db.fetch_all("SELECT * FROM pets WHERE age > 2"))  # → [('Luna', 3)]
 
 # === Persistent file database – create if missing ===
 with Sqlite(path="data/myapp.db", mode="rwc") as db:
@@ -52,8 +51,7 @@ with Sqlite(path="data/myapp.db", mode="rwc") as db:
 
 # === Read-only connection (safe for shared / production read paths) ===
 with Sqlite("data/myapp.db", mode="ro") as db:
-    db.execute("SELECT value FROM config WHERE key = 'theme'")
-    theme = db.fetch_one()[0]               # → 'dark'
+    theme = db.fetch_one("SELECT value FROM config WHERE key = 'theme'")[0]  # → 'dark'
 ```
 
 ## Constructor parameters (the ones you’ll use most)
@@ -69,11 +67,11 @@ with Sqlite("data/myapp.db", mode="ro") as db:
 
 - `execute(sql, parameters=())` → run one statement, get a cursor back  
 - `executemany(sql, sequence)` → bulk insert / update  
-- `executescript(sql_script)` → run several statements at once ( DDL + data usually)  
-- `fetch_one()` → get next row (or `None`)  
-- `fetch_all()` → get list of all remaining rows  
+- `executescript(sql_script)` → run several statements at once (DDL + data usually)  
+- `fetch_one(query, parameters=())` → execute query and get next row (or `None`)  
+- `fetch_all(query, parameters=())` → execute query and get list of all rows  
 - `commit()` / `rollback()` → manual transaction control (rarely needed with context manager)  
-- `backup(target_client)` → efficient page-by-page copy to another database
+- `backup(target_path, pages=-1, progress=None)` → efficient backup to a file path with optional progress callback
 
 The context manager handles commit / rollback / close for you automatically.
 
@@ -99,8 +97,7 @@ class RecordVisit(DomainEvent):
                 )
             """)
             db.execute("INSERT INTO visits (page) VALUES (?)", (page,))
-            db.execute("SELECT COUNT(*) FROM visits")
-            return db.fetch_one()[0]
+            return db.fetch_one("SELECT COUNT(*) FROM visits")[0]
 ```
 
 ## Automatic rollback example (safety net)
@@ -130,8 +127,7 @@ def test_record_visit_creates_table_and_row(tmp_path):
     assert count == 1
 
     with Sqlite(db_path, mode="ro") as db:
-        db.execute("SELECT page FROM visits")
-        assert db.fetch_one()[0] == "/home"
+        assert db.fetch_one("SELECT page FROM visits")[0] == "/home"
 ```
 
 ## Quick reminders – how SqliteClient is different

--- a/tiferet/interfaces/tests/test_sqlite.py
+++ b/tiferet/interfaces/tests/test_sqlite.py
@@ -1,0 +1,171 @@
+"""Tiferet Interfaces SQLite Contract Tests"""
+
+# *** imports
+
+# ** core
+import inspect
+from typing import Any, Callable, Iterable, Optional
+
+# ** infra
+import pytest
+
+# ** app
+from ..sqlite import SqliteService
+
+# *** tests
+
+# ** test: sqlite_service_has_execute
+def test_sqlite_service_has_execute():
+    '''
+    Test that SqliteService defines the execute method with expected signature.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'execute')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.execute)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'sql', 'parameters']
+
+# ** test: sqlite_service_has_executemany
+def test_sqlite_service_has_executemany():
+    '''
+    Test that SqliteService defines the executemany method with expected signature.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'executemany')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.executemany)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'sql', 'seq_of_parameters']
+
+# ** test: sqlite_service_has_executescript
+def test_sqlite_service_has_executescript():
+    '''
+    Test that SqliteService defines the executescript method with expected signature.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'executescript')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.executescript)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'sql_script']
+
+# ** test: sqlite_service_has_fetch_one
+def test_sqlite_service_has_fetch_one():
+    '''
+    Test that SqliteService defines the fetch_one method with query and parameters.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'fetch_one')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.fetch_one)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names include query and parameters.
+    assert params == ['self', 'query', 'parameters']
+
+    # Verify parameters has a default value.
+    assert sig.parameters['parameters'].default == ()
+
+# ** test: sqlite_service_has_fetch_all
+def test_sqlite_service_has_fetch_all():
+    '''
+    Test that SqliteService defines the fetch_all method with query and parameters.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'fetch_all')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.fetch_all)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names include query and parameters.
+    assert params == ['self', 'query', 'parameters']
+
+    # Verify parameters has a default value.
+    assert sig.parameters['parameters'].default == ()
+
+# ** test: sqlite_service_has_commit
+def test_sqlite_service_has_commit():
+    '''
+    Test that SqliteService defines the commit method.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'commit')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.commit)
+    params = list(sig.parameters.keys())
+
+    # Verify only self parameter.
+    assert params == ['self']
+
+# ** test: sqlite_service_has_rollback
+def test_sqlite_service_has_rollback():
+    '''
+    Test that SqliteService defines the rollback method.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'rollback')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.rollback)
+    params = list(sig.parameters.keys())
+
+    # Verify only self parameter.
+    assert params == ['self']
+
+# ** test: sqlite_service_has_backup
+def test_sqlite_service_has_backup():
+    '''
+    Test that SqliteService defines the backup method with target_path, pages, and progress.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(SqliteService, 'backup')
+
+    # Inspect the signature.
+    sig = inspect.signature(SqliteService.backup)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names include target_path, pages, and progress.
+    assert params == ['self', 'target_path', 'pages', 'progress']
+
+    # Verify default values.
+    assert sig.parameters['pages'].default == -1
+    assert sig.parameters['progress'].default is None
+
+# ** test: sqlite_service_methods_are_abstract
+def test_sqlite_service_methods_are_abstract():
+    '''
+    Test that all SqliteService methods are marked as abstract.
+    '''
+
+    # Define the expected abstract methods.
+    expected_methods = [
+        'execute', 'executemany', 'executescript',
+        'fetch_one', 'fetch_all',
+        'commit', 'rollback', 'backup',
+    ]
+
+    # Verify each method is in the abstract methods set.
+    for method_name in expected_methods:
+        assert method_name in SqliteService.__abstractmethods__, \
+            f'{method_name} should be abstract'

--- a/tiferet/utils/sqlite.py
+++ b/tiferet/utils/sqlite.py
@@ -4,7 +4,7 @@
 
 # ** core
 from pathlib import Path
-from typing import Any, Iterable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional
 
 import sqlite3
 
@@ -213,39 +213,41 @@ class SqliteClient(FileLoader, SqliteService):
         return self.cursor.executescript(sql_script)
 
     # * method: fetch_one
-    def fetch_one(self) -> Optional[tuple]:
+    def fetch_one(self, query: str, parameters: Iterable[Any] = ()) -> Optional[tuple]:
         '''
-        Fetch the next row from the last executed query.
+        Execute a query and fetch a single row.
 
-        :return: The next row as a tuple, or None if no more rows.
+        :param query: The SQL query to execute.
+        :type query: str
+        :param parameters: Parameters for the SQL query.
+        :type parameters: Iterable[Any]
+        :return: The first row as a tuple, or None if no rows.
         :rtype: tuple | None
         '''
 
-        # Guard against uninitialized connection.
-        if self.cursor is None:
-            RaiseError.execute(
-                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
-            )
+        # Execute the query.
+        self.execute(query, parameters)
 
         # Fetch and return the next row.
         return self.cursor.fetchone()
 
     # * method: fetch_all
-    def fetch_all(self) -> List[tuple]:
+    def fetch_all(self, query: str, parameters: Iterable[Any] = ()) -> List[tuple]:
         '''
-        Fetch all remaining rows from the last executed query.
+        Execute a query and fetch all rows.
 
-        :return: All remaining rows as a list of tuples.
+        :param query: The SQL query to execute.
+        :type query: str
+        :param parameters: Parameters for the SQL query.
+        :type parameters: Iterable[Any]
+        :return: All rows as a list of tuples.
         :rtype: list[tuple]
         '''
 
-        # Guard against uninitialized connection.
-        if self.cursor is None:
-            RaiseError.execute(
-                error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
-            )
+        # Execute the query.
+        self.execute(query, parameters)
 
-        # Fetch and return all remaining rows.
+        # Fetch and return all rows.
         return self.cursor.fetchall()
 
     # * method: commit
@@ -279,26 +281,43 @@ class SqliteClient(FileLoader, SqliteService):
         self.conn.rollback()
 
     # * method: backup
-    def backup(self, target: 'SqliteClient', pages: int = -1) -> None:
+    def backup(self,
+            target_path: str,
+            pages: int = -1,
+            progress: Optional[Callable[[int, int, int], None]] = None,
+        ) -> None:
         '''
-        Backup database to another SqliteClient connection.
+        Backup database to a target file path.
 
-        :param target: The target SqliteClient to backup to.
-        :type target: SqliteClient
+        :param target_path: The file path for the backup database.
+        :type target_path: str
         :param pages: Number of pages to copy at a time (-1 for all).
         :type pages: int
+        :param progress: Optional progress callback(status, remaining, total).
+        :type progress: Optional[Callable[[int, int, int], None]]
         '''
 
-        # Guard against uninitialized source or target connection.
-        if self.conn is None or target.conn is None:
+        # Guard against uninitialized source connection.
+        if self.conn is None:
             RaiseError.execute(
                 error_code=a.const.SQLITE_CONN_NOT_INITIALIZED_ID,
             )
 
+        # Open a target connection for the backup.
+        target = SqliteClient(path=target_path, mode='rwc')
+
         try:
 
+            # Open the target connection.
+            target.open_file()
+
+            # Build backup kwargs.
+            backup_kwargs = dict(pages=pages)
+            if progress is not None:
+                backup_kwargs['progress'] = progress
+
             # Perform the backup to the target connection.
-            self.conn.backup(target.conn, pages=pages)
+            self.conn.backup(target.conn, **backup_kwargs)
 
         except sqlite3.Error as e:
 
@@ -306,8 +325,13 @@ class SqliteClient(FileLoader, SqliteService):
             RaiseError.execute(
                 error_code=a.const.SQLITE_BACKUP_FAILED_ID,
                 original_error=str(e),
-                target_path=str(target.path),
+                target_path=str(target_path),
             )
+
+        finally:
+
+            # Always close the target connection.
+            target.close_file()
 
     # * method: __enter__
     def __enter__(self) -> 'SqliteClient':

--- a/tiferet/utils/tests/test_sqlite.py
+++ b/tiferet/utils/tests/test_sqlite.py
@@ -169,8 +169,7 @@ def test_sqlite_client_execute_success(memory_client: SqliteClient, sample_table
         assert isinstance(cursor, sqlite3.Cursor)
 
         # Verify the row was inserted.
-        db.execute('SELECT COUNT(*) FROM items')
-        count = db.fetch_one()[0]
+        count = db.fetch_one('SELECT COUNT(*) FROM items')[0]
         assert count == 1
 
 # ** test: sqlite_client_executemany_success
@@ -196,8 +195,7 @@ def test_sqlite_client_executemany_success(memory_client: SqliteClient, sample_t
         db.executemany(sample_insert_sql, rows)
 
         # Verify all rows were inserted.
-        db.execute('SELECT COUNT(*) FROM items')
-        count = db.fetch_one()[0]
+        count = db.fetch_one('SELECT COUNT(*) FROM items')[0]
         assert count == 3
 
 # ** test: sqlite_client_executescript_success
@@ -222,8 +220,7 @@ def test_sqlite_client_executescript_success(memory_client: SqliteClient):
         db.executescript(script)
 
         # Verify the rows were created.
-        db.execute('SELECT COUNT(*) FROM colors')
-        count = db.fetch_one()[0]
+        count = db.fetch_one('SELECT COUNT(*) FROM colors')[0]
         assert count == 2
 
 # ** test: sqlite_client_fetch_one
@@ -246,8 +243,7 @@ def test_sqlite_client_fetch_one(memory_client: SqliteClient, sample_table_sql: 
         db.execute(sample_insert_sql, ('widget', 9.99))
 
         # Fetch one row.
-        db.execute('SELECT name, value FROM items WHERE name = ?', ('widget',))
-        row = db.fetch_one()
+        row = db.fetch_one('SELECT name, value FROM items WHERE name = ?', ('widget',))
 
         # Verify the row is a tuple with expected values.
         assert row == ('widget', 9.99)
@@ -255,8 +251,7 @@ def test_sqlite_client_fetch_one(memory_client: SqliteClient, sample_table_sql: 
     # Verify fetch_one returns None when no more rows.
     with SqliteClient(path=':memory:') as db:
         db.execute('CREATE TABLE empty (id INTEGER)')
-        db.execute('SELECT * FROM empty')
-        assert db.fetch_one() is None
+        assert db.fetch_one('SELECT * FROM empty') is None
 
 # ** test: sqlite_client_fetch_all
 def test_sqlite_client_fetch_all(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
@@ -278,8 +273,7 @@ def test_sqlite_client_fetch_all(memory_client: SqliteClient, sample_table_sql: 
         db.executemany(sample_insert_sql, [('a', 1.0), ('b', 2.0)])
 
         # Fetch all rows.
-        db.execute('SELECT name, value FROM items ORDER BY name')
-        rows = db.fetch_all()
+        rows = db.fetch_all('SELECT name, value FROM items ORDER BY name')
 
         # Verify all rows returned.
         assert rows == [('a', 1.0), ('b', 2.0)]
@@ -301,8 +295,7 @@ def test_sqlite_client_context_manager_commit_on_success(tmp_path: Path):
 
     # Reopen and verify the data persisted.
     with SqliteClient(path=db_path, mode='ro') as db:
-        db.execute('SELECT val FROM test')
-        row = db.fetch_one()
+        row = db.fetch_one('SELECT val FROM test')
         assert row == ('committed',)
 
 # ** test: sqlite_client_context_manager_rollback_on_exception
@@ -327,15 +320,16 @@ def test_sqlite_client_context_manager_rollback_on_exception(tmp_path: Path):
 
     # Verify the insert was rolled back.
     with SqliteClient(path=db_path, mode='ro') as db:
-        db.execute('SELECT COUNT(*) FROM test')
-        count = db.fetch_one()[0]
+        count = db.fetch_one('SELECT COUNT(*) FROM test')[0]
         assert count == 0
 
 # ** test: sqlite_client_backup_success
-def test_sqlite_client_backup_success(memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+def test_sqlite_client_backup_success(tmp_path: Path, memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
     '''
-    Test successful database backup between two connections.
+    Test successful database backup to a file path.
 
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
     :param memory_client: The in-memory SqliteClient fixture.
     :type memory_client: SqliteClient
     :param sample_table_sql: SQL to create a sample table.
@@ -350,41 +344,88 @@ def test_sqlite_client_backup_success(memory_client: SqliteClient, sample_table_
     memory_client.execute(sample_insert_sql, ('backup_item', 42.0))
     memory_client.commit()
 
-    # Create and open target database.
-    target = SqliteClient(path=':memory:')
-    target.open_file()
+    # Define the backup target path.
+    backup_path = tmp_path / 'backup.db'
 
     try:
 
-        # Perform backup.
-        memory_client.backup(target)
+        # Perform backup to file path.
+        memory_client.backup(str(backup_path))
 
-        # Verify the target has the data.
-        target.execute('SELECT name, value FROM items')
-        row = target.fetch_one()
-        assert row == ('backup_item', 42.0)
+        # Verify the target file was created and has the data.
+        with SqliteClient(path=backup_path, mode='ro') as db:
+            row = db.fetch_one('SELECT name, value FROM items')
+            assert row == ('backup_item', 42.0)
 
     finally:
 
-        # Clean up both connections.
-        target.close_file()
+        # Clean up source connection.
+        memory_client.close_file()
+
+# ** test: sqlite_client_backup_with_progress
+def test_sqlite_client_backup_with_progress(tmp_path: Path, memory_client: SqliteClient, sample_table_sql: str, sample_insert_sql: str):
+    '''
+    Test backup with a progress callback.
+
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
+    :param memory_client: The in-memory SqliteClient fixture.
+    :type memory_client: SqliteClient
+    :param sample_table_sql: SQL to create a sample table.
+    :type sample_table_sql: str
+    :param sample_insert_sql: SQL to insert a row.
+    :type sample_insert_sql: str
+    '''
+
+    # Set up source database.
+    memory_client.open_file()
+    memory_client.execute(sample_table_sql)
+    memory_client.execute(sample_insert_sql, ('progress_item', 7.0))
+    memory_client.commit()
+
+    # Track progress calls.
+    progress_calls = []
+    def on_progress(status, remaining, total):
+        progress_calls.append((status, remaining, total))
+
+    # Define the backup target path.
+    backup_path = tmp_path / 'progress_backup.db'
+
+    try:
+
+        # Perform backup with progress callback.
+        memory_client.backup(str(backup_path), progress=on_progress)
+
+        # Verify the progress callback was invoked.
+        assert len(progress_calls) > 0
+
+        # Verify the backup succeeded.
+        with SqliteClient(path=backup_path, mode='ro') as db:
+            row = db.fetch_one('SELECT name, value FROM items')
+            assert row == ('progress_item', 7.0)
+
+    finally:
+
+        # Clean up source connection.
         memory_client.close_file()
 
 # ** test: sqlite_client_backup_not_initialized
-def test_sqlite_client_backup_not_initialized(memory_client: SqliteClient):
+def test_sqlite_client_backup_not_initialized(memory_client: SqliteClient, tmp_path: Path):
     '''
-    Test that backup raises SQLITE_CONN_NOT_INITIALIZED when connections are not open.
+    Test that backup raises SQLITE_CONN_NOT_INITIALIZED when source is not open.
 
     :param memory_client: The in-memory SqliteClient fixture.
     :type memory_client: SqliteClient
+    :param tmp_path: The temporary directory path provided by pytest.
+    :type tmp_path: pathlib.Path
     '''
 
-    # Create a target that is not opened.
-    target = SqliteClient(path=':memory:')
+    # Define a target path.
+    backup_path = tmp_path / 'backup_fail.db'
 
-    # Attempt backup with both closed; expect error.
+    # Attempt backup with source closed; expect error.
     with pytest.raises(TiferetError) as exc_info:
-        memory_client.backup(target)
+        memory_client.backup(str(backup_path))
 
     # Verify the error code.
     assert exc_info.value.error_code == a.const.SQLITE_CONN_NOT_INITIALIZED_ID


### PR DESCRIPTION
## Summary

Refines the `SqliteClient` API to align `fetch_one`, `fetch_all`, and `backup` with the `SqliteService` interface contract. Adds interface contract signature tests.

Closes #808

## Changes

### `tiferet/utils/sqlite.py`
- **`fetch_one(query, parameters)`** — now executes the query before fetching (previously took no arguments)
- **`fetch_all(query, parameters)`** — same execute-then-fetch pattern
- **`backup(target_path, pages, progress)`** — accepts a file path string and optional progress callback instead of a `SqliteClient` instance; manages the target connection lifecycle internally

### `tiferet/interfaces/tests/test_sqlite.py` (new)
- Contract signature tests verifying all `SqliteService` method signatures, default values, and abstractness

### `tiferet/utils/tests/test_sqlite.py`
- All existing tests updated to the new `fetch_one`/`fetch_all`/`backup` signatures
- New `test_sqlite_client_backup_with_progress` test for the progress callback

## Test Results
- 716 passed, 11 skipped, 1 warning (pre-existing)

---
[Conversation](https://app.warp.dev/conversation/3e8b4913-bf47-4eb5-9d7f-a1f8d4d430eb)

Co-Authored-By: Oz <oz-agent@warp.dev>