### PR TITLE
DI – Public build_factory and Domain Tests (#809)

### DIFF
--- a/docs/core/di.md
+++ b/docs/core/di.md
@@ -88,7 +88,7 @@ class ServiceProvider(ABC):
 - `Factory` — Wraps a class type. Each `get_service()` call creates a new instance with constructor kwargs wired to sibling providers.
 - `Object` — Wraps a scalar value or callable. Each `get_service()` call returns the same value.
 
-**Automatic constructor wiring.** `_build_factory()` inspects the service class constructor via `inspect.signature()` and wires each parameter to a sibling provider if one exists. This enables cascading dependency resolution without explicit wiring configuration.
+**Automatic constructor wiring.** `build_factory()` inspects the service class constructor via `inspect.signature()` and wires each parameter to a sibling provider if one exists. This enables cascading dependency resolution without explicit wiring configuration.
 
 **No empty scope guard needed.** Unlike the `dependencies` library, `DynamicContainer` works correctly with zero providers. No special `None` guard is required.
 
@@ -109,7 +109,7 @@ class DynamicServiceProvider(ServiceProvider):
 
     # * method: add_service
     def add_service(self, service_id: str, service_type: type):
-        factory = self._build_factory(service_type)
+        factory = self.build_factory(service_type)
         self.container.set_provider(service_id, factory)
 
     # * method: add_services
@@ -127,8 +127,8 @@ class DynamicServiceProvider(ServiceProvider):
             RaiseError.execute('INVALID_DEPENDENCY_ERROR', ...)
         return provider()
 
-    # * method: _build_factory
-    def _build_factory(self, service_type: type) -> providers.Factory:
+    # * method: build_factory
+    def build_factory(self, service_type: type) -> providers.Factory:
         sig = inspect.signature(service_type.__init__)
         kwargs = {}
         for param_name, param in sig.parameters.items():

--- a/tiferet/di/dynamic.py
+++ b/tiferet/di/dynamic.py
@@ -54,7 +54,7 @@ class DynamicServiceProvider(ServiceProvider):
         '''
 
         # Build a Factory provider with constructor kwargs wired to sibling providers.
-        factory = self._build_factory(service_type)
+        factory = self.build_factory(service_type)
 
         # Register the provider on the container.
         self.container.set_provider(service_id, factory)
@@ -146,8 +146,8 @@ class DynamicServiceProvider(ServiceProvider):
         if service_id in self.container.providers:
             delattr(self.container, service_id)
 
-    # * method: _build_factory
-    def _build_factory(self, service_type: type) -> providers.Factory:
+    # * method: build_factory
+    def build_factory(self, service_type: type) -> providers.Factory:
         '''
         Build a Factory provider with constructor kwargs wired to sibling providers.
 


### PR DESCRIPTION
## Summary

Closes #809

### Changes
- Renamed `DynamicServiceProvider._build_factory` → `build_factory` in `tiferet/di/dynamic.py` (public method).
- Updated the internal call site in `add_service`.
- Updated `docs/core/di.md` references accordingly.
- `ServiceConfiguration.get_service_type` tests were already present in `tiferet/domain/tests/test_di.py` covering all required scenarios (default, flagged, no-match, priority, multi-flag).

### Tests
All 21 tests in `tiferet/domain/tests/test_di.py` and `tiferet/di/tests/test_dynamic.py` pass.

---

Conversation: https://app.warp.dev/conversation/ac77be6f-148c-48cf-a2f4-45891b6779c6

Co-Authored-By: Oz <oz-agent@warp.dev>