### PR TITLE
Mappers – App and Feature Aggregate Fixes (#810)

### DIFF
--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -160,15 +160,17 @@ class AppInterfaceAggregate(AppInterface, Aggregate):
                     if value is not None
                 }
 
+            # Return early after in-place update.
+            return
+
         # If the service dependency does not exist, create a new one and reassign.
-        else:
-            new_dep = AppServiceDependency(
-                service_id=service_id,
-                module_path=module_path,
-                class_name=class_name,
-                parameters=parameters or {},
-            )
-            self.services = list(self.services) + [new_dep]
+        new_dep = AppServiceDependency(
+            service_id=service_id,
+            module_path=module_path,
+            class_name=class_name,
+            parameters=parameters or {},
+        )
+        self.services = list(self.services) + [new_dep]
 
     # * method: set_constants
     def set_constants(self, constants: Dict[str, Any] | None = None) -> None:


### PR DESCRIPTION
## Summary

Closes #810

### Changes
- `AppInterfaceAggregate.set_service` (`tiferet/mappers/app.py`): replaced the `if/else` structure with an early `return` after the in-place update, eliminating the `else` clause for cleaner guard-clause style.
- All other TRD items (`remove_service` None return, `FeatureEventAggregate.set_attribute` `pass_on_error` handling, docstring/comment cleanups across `app.py`, `error.py`, `feature.py`) were already implemented on this branch.

### Tests
All 161 mapper tests pass.

---

Conversation: https://app.warp.dev/conversation/ac77be6f-148c-48cf-a2f4-45891b6779c6

Co-Authored-By: Oz <oz-agent@warp.dev>