### PR TITLE
Docs: fix guide formatting and update config path references

### DIFF
--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Domain – App: AppInterface and AppServiceDependency
 
 **Project:** Tiferet Framework  
@@ -163,4 +159,3 @@ interface = AppInterface(
 - [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Domain – CLI: CliArgument and CliCommand
 
 **Project:** Tiferet Framework  
@@ -106,7 +102,7 @@ The `build_cli` blueprint (`tiferet/blueprints/cli.py`) is the primary consumer 
 
 ## Configuration Mapping
 
-CLI commands are defined in `app/configs/cli.yml`. Each entry under `cli.cmds.<group>.<key>` maps to a `CliCommand`:
+CLI commands are defined in the `cli` section of the configuration file (typically `config.yml`, though per-file configs such as `cli.yml` are also supported). Each entry under `cli.cmds.<group>.<key>` maps to a `CliCommand`:
 
 ```yaml
 cli:
@@ -197,4 +193,3 @@ cmd = CliCommand(
 - [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (interface configuration)
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/domain/di.md
+++ b/docs/guides/domain/di.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Domain – DI: ServiceConfiguration and FlaggedDependency
 
 **Project:** Tiferet Framework  
@@ -172,4 +168,3 @@ config = ServiceConfiguration(
 - [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (AppInterface, flags)
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/domain/error.md
+++ b/docs/guides/domain/error.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Domain – Error: ErrorMessage and Error
 
 **Project:** Tiferet Framework  
@@ -95,11 +91,11 @@ Tiferet provides built-in error definitions in `assets/constants.py::DEFAULT_ERR
 - `FEATURE_NOT_FOUND` — unknown feature ID
 - `INVALID_MODEL_ATTRIBUTE` — invalid attribute on a domain object
 
-Application-specific errors are defined in `app/configs/error.yml` and loaded via `ErrorService`.
+Application-specific errors are defined in the `errors` section of the configuration file (typically `config.yml`, though per-file configs such as `error.yml` are also supported) and loaded via `ErrorService`.
 
 ## Configuration Mapping
 
-Errors are defined in `app/configs/error.yml`. Each top-level key maps to an `Error`:
+Errors are defined in the `errors` section of the configuration file (typically `config.yml`). Each top-level key maps to an `Error`:
 
 ```yaml
 errors:
@@ -176,4 +172,3 @@ error = Error(
 - [docs/guides/domain/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/di.md) — DI domain guide
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/domain/feature.md
+++ b/docs/guides/domain/feature.md
@@ -1,4 +1,3 @@
-```markdown
 # Domain – Feature: FeatureStep, FeatureEvent, and Feature
 
 **Project:** Tiferet Framework  
@@ -98,7 +97,7 @@ The Feature domain objects participate in runtime workflow execution through the
 
 ## Configuration Mapping
 
-Features are defined in `app/configs/feature.yml`. Each group contains keyed features:
+Features are defined in the `features` section of the configuration file (typically `config.yml`, though per-file configs such as `feature.yml` are also supported). Each group contains keyed features:
 
 ```yaml
 features:
@@ -185,4 +184,3 @@ feature = Feature(
 - [docs/guides/domain/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/di.md) — DI domain guide
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/domain/logging.md
+++ b/docs/guides/domain/logging.md
@@ -1,4 +1,3 @@
-```markdown
 # Domain – Logging: Formatter, Handler, and Logger
 
 **Project:** Tiferet Framework  
@@ -131,7 +130,7 @@ The Logging domain objects participate in runtime configuration through the foll
 
 ## Configuration Mapping
 
-Logging is configured in `app/configs/logging.yml`:
+Logging is configured in the `logging` section of the configuration file (typically `config.yml`, though per-file configs such as `logging.yml` are also supported):
 
 ```yaml
 formatters:
@@ -235,4 +234,3 @@ lgr = Logger(
 - [docs/guides/domain/feature.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/feature.md) — Feature domain guide
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/utils/csv.md
+++ b/docs/guides/utils/csv.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Utilities – CsvLoader (alias: Csv) & CsvDictLoader (alias: CsvDict)
 
 **Project:** Tiferet Framework  
@@ -281,4 +277,3 @@ def test_import_csv_records_file_not_found(tmp_path):
 - [docs/guides/utils/json.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/json.md) — JsonLoader guide (sibling utility)
 - [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/utils/file.md
+++ b/docs/guides/utils/file.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Utilities – FileLoader (alias: File)
 
 **Project:** Tiferet Framework  

--- a/docs/guides/utils/json.md
+++ b/docs/guides/utils/json.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Utilities – JsonLoader (alias: Json)
 
 **Project:** Tiferet Framework  
@@ -229,4 +225,3 @@ def test_load_json_config_file_not_found(tmp_path):
 - [docs/guides/utils/yaml.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/utils/yaml.md) — YamlLoader guide (sibling utility)
 - [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
-```

--- a/docs/guides/utils/yaml.md
+++ b/docs/guides/utils/yaml.md
@@ -1,7 +1,3 @@
-**This conversation is part of the Tiferet Framework project.**  
-**Repository:** https://github.com/greatstrength/tiferet – Tiferet Framework  
-
-```markdown
 # Utilities – YamlLoader (alias: Yaml)
 
 **Project:** Tiferet Framework  


### PR DESCRIPTION
## Summary

Fixes two documentation audit items identified during the docs reorganization effort:

### #4 — Formatting fixes (high priority)
- Removed stray preamble lines and wrapping markdown code fences from all 10 guide files in docs/guides/domain/ and docs/guides/utils/
- These fences caused the entire guide content to render as a raw code block

### #8 — Config path references (low priority)
- Updated cli.md, error.md, feature.md, and logging.md to reference the consolidated config.yml pattern
- Added note that per-file configs (e.g., cli.yml, error.yml) are still supported

### Files changed (10)
- docs/guides/utils/file.md
- docs/guides/utils/yaml.md
- docs/guides/utils/json.md
- docs/guides/utils/csv.md
- docs/guides/domain/app.md
- docs/guides/domain/di.md
- docs/guides/domain/cli.md
- docs/guides/domain/error.md
- docs/guides/domain/feature.md
- docs/guides/domain/logging.md

---
[Warp conversation](https://app.warp.dev/conversation/be923552-bc91-481a-bea3-766817c4b061)

Co-Authored-By: Oz <oz-agent@warp.dev>