### PR TITLE
Docs – Contribution Stream Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to the Tiferet framework! This docum
 ## Getting Started
 
 1. **Fork** the repository and clone your fork locally.
-2. Create a new branch from the appropriate base branch (e.g., `v1.x-proto` or `v2.0-proto`).
+2. Create a new branch from the appropriate base branch (see Contribution Streams below).
 3. Set up a virtual environment and install the package in development mode:
    ```bash
    python3.10 -m venv venv
@@ -13,13 +13,27 @@ Thank you for your interest in contributing to the Tiferet framework! This docum
    pip install -e .
    ```
 
-## Contribution Workflow
+## Contribution Streams
 
-### 1. Open or Claim an Issue
+Tiferet uses three distinct contribution streams, each with its own branching, versioning, and review process:
 
-All contributions should be tied to a GitHub issue. If one doesn't exist for the work you'd like to do, open an issue first to discuss the change with maintainers before starting.
+- **[RFP — Request for Prototype](docs/collab/rfp.md)**: Exploratory and architectural work developed on prototype branches with alpha/beta versioning. Used for significant refactors and new architectural ideas.
+- **[Main — Feature Release](docs/collab/main.md)**: The primary path for feature releases. Work is organized into milestones, implemented on feature branches from `main`, and merged via pull requests.
+- **[Doc — Documentation Updates](docs/collab/doc.md)**: Standalone documentation changes merged directly into `main` via pull requests. No milestones or releases involved.
 
-### 2. Write a Technical Requirements Document (TRD)
+Each stream guide covers branch naming, workflow steps, and versioning conventions in detail.
+
+For a reference of git and `gh` CLI commands used across all streams, see **[docs/collab/commands.md](docs/collab/commands.md)**.
+
+## Common Workflow Steps
+
+Regardless of stream, all contributions share the following practices.
+
+### Open or Claim an Issue
+
+All contributions should be tied to a GitHub issue (except internal RFPs and standalone doc changes). If one doesn't exist for the work you'd like to do, open an issue first to discuss the change with maintainers before starting.
+
+### Write a Technical Requirements Document (TRD)
 
 For non-trivial changes (new features, refactors, architectural updates), a **Technical Requirements Document** is required before implementation begins. TRDs ensure clarity, alignment, and traceability across the project.
 
@@ -30,8 +44,9 @@ Key points:
 - Follow the standard structure (Overview, Scope, Components Affected, Detailed Requirements, Acceptance Criteria).
 - Include code signatures and behavior descriptions where applicable.
 - Reference the relevant [code style guides](docs/core/) for the components you're modifying.
+- Set the **Version** field according to the applicable stream (milestone version for Main, "Request for Prototype" for RFP, latest released version for Doc).
 
-### 3. Implement
+### Implement
 
 - Follow the [Structured Code Style](docs/core/code_style.md) — artifact comments, spacing rules, RST docstrings, and snippet conventions are enforced across the codebase.
 - Consult the component-specific guides in `docs/core/` for the layers you're working in:
@@ -44,20 +59,21 @@ Key points:
   - [utils.md](docs/core/utils.md) — Utilities
 - Write tests using `pytest`.
 
-### 4. Commit Hygiene
+### Commit Hygiene
 
 - Separate functional code changes from documentation, configuration, and packaging into distinct, atomic commits.
 - Title commits by scope (e.g., `Events – AddFeature event`, `Docs/Packaging – update guides`).
 - Include `Co-Authored-By: <name> <email>` in commit messages when collaborating with AI agents or other contributors.
 
-### 5. Open a Pull Request
+### Open a Pull Request
 
-- Target the appropriate base branch.
+- Target the appropriate base branch for the stream (`main` for Main/Doc, prototype branch for RFP).
 - Reference the GitHub issue in the PR description.
 - Ensure all tests pass and the code follows project conventions.
 - Keep PRs focused — one logical change per PR.
+- After submitting, provide the PR URL to the user.
 
-### 6. Collaboration Report
+### Collaboration Report
 
 Upon completion of a story or issue, a **Collaboration Report** is published as a comment on the originating GitHub issue. This report documents the implementation, deviations from the TRD, git state, and a log of key decisions made during development.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Thank you for your interest in contributing to the Tiferet framework! This docum
    pip install -e .
    ```
 
-## Contribution Streams
+## Contribution Workflow Streams
 
-Tiferet uses three distinct contribution streams, each with its own branching, versioning, and review process:
+Tiferet uses three distinct contribution workflow streams, each with its own branching, versioning, and review process:
 
 - **[RFP — Request for Prototype](docs/collab/rfp.md)**: Exploratory and architectural work developed on prototype branches with alpha/beta versioning. Used for significant refactors and new architectural ideas.
 - **[Main — Feature Release](docs/collab/main.md)**: The primary path for feature releases. Work is organized into milestones, implemented on feature branches from `main`, and merged via pull requests.
@@ -62,7 +62,7 @@ Key points:
 ### Commit Hygiene
 
 - Separate functional code changes from documentation, configuration, and packaging into distinct, atomic commits.
-- Title commits by scope (e.g., `Events – AddFeature event`, `Docs/Packaging – update guides`).
+- Title commits by scope (e.g., `Events – AddFeature Event`, `Docs/Packaging – Update Guides`).
 - Include `Co-Authored-By: <name> <email>` in commit messages when collaborating with AI agents or other contributors.
 
 ### Open a Pull Request

--- a/docs/collab/collab_report.md
+++ b/docs/collab/collab_report.md
@@ -20,7 +20,7 @@ Use **pure Markdown** and follow this exact structure and heading levels:
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
 **Date:** [Current date — e.g., February 23, 2026]  
-**Version:** [Milestone version — e.g., 1.9.0]
+**Version:** [Milestone version — e.g., 1.9.0. For RFP work, use "Request for Prototype".]
 
 ## 1. Story / TRD Summary
 - **Issue:** `[exact title]` (greatstrength/tiferet#[issue-number])
@@ -53,6 +53,11 @@ Numbered list of intentional differences (only include meaningful ones):
   1. `short commit message` (abcdef1) – [optional Co-Authored-By note]
   2. …
 - **Current state:** pushed / merged / up-to-date with main / tagged, etc.
+
+**RFP-specific fields** (include when the report covers RFP stream work):
+- **Prototype worktree branch:** full branch name (e.g., `v2.0.0b6-dicontext-varargs`)
+- **Alpha tags:** list any alpha tags created on the worktree branch (e.g., `v2.0.0a11`, `v2.0.0a12`)
+- **Beta tag:** the final beta tag applied to the main prototype branch (e.g., `v2.0.0b6`)
 
 ## 5. Collaboration Log (AI ↔ Human)
 Chronological numbered list of key decision points:

--- a/docs/collab/commands.md
+++ b/docs/collab/commands.md
@@ -3,7 +3,7 @@
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet
 
-This document lists key commands used across all contribution streams. Each entry notes whether the operation is available via **GitHub MCP tools** (model-agnostic, preferred when available) or requires the **`gh` CLI** directly.
+This document lists key commands used across all contribution workflow streams. Each entry notes whether the operation is available via **Warp/Oz GitHub MCP tools** (preferred when available) or requires the **`gh` CLI** directly.
 
 ## Branch Operations
 
@@ -28,7 +28,7 @@ git pull origin main
 
 ## Issue and PR Management
 
-**Tool availability:** Available via **GitHub MCP tools** where supported; fall back to `gh` CLI.
+**Tool availability:** Available via **Warp/Oz GitHub MCP tools**; fall back to `gh` CLI.
 
 ```bash
 # Create an issue
@@ -136,7 +136,7 @@ git tag --list 'v2.0.0*' --sort=-version:refname
 
 ## Issue Linking and Labels
 
-**Tool availability:** Available via **GitHub MCP tools** where supported; fall back to `gh` CLI.
+**Tool availability:** Available via **Warp/Oz GitHub MCP tools**; fall back to `gh` CLI.
 
 ```bash
 # Add a label to an issue

--- a/docs/collab/commands.md
+++ b/docs/collab/commands.md
@@ -1,0 +1,151 @@
+# Useful Commands Reference
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+This document lists key commands used across all contribution streams. Each entry notes whether the operation is available via **GitHub MCP tools** (model-agnostic, preferred when available) or requires the **`gh` CLI** directly.
+
+## Branch Operations
+
+**Tool availability:** Git shell commands.
+
+```bash
+# Create a feature branch from main
+git checkout -b <branch-name> main
+
+# Create a prototype worktree branch from the prototype branch
+git checkout -b v2.0.0b6-my-context v2.0-proto
+
+# Delete a local branch
+git branch -d <branch-name>
+
+# Delete a remote branch
+git push origin --delete <branch-name>
+
+# Pull latest from a branch
+git pull origin main
+```
+
+## Issue and PR Management
+
+**Tool availability:** Available via **GitHub MCP tools** where supported; fall back to `gh` CLI.
+
+```bash
+# Create an issue
+gh issue create --repo greatstrength/tiferet --title "<title>" --body "<body>"
+
+# Create a pull request
+gh pr create --repo greatstrength/tiferet --base main --head <branch> --title "<title>" --body "<body>"
+
+# Link a branch to an issue (development branch)
+# Use the GitHub UI or MCP tool — no direct gh CLI equivalent.
+
+# View PR status
+gh pr view <pr-number> --repo greatstrength/tiferet
+
+# List open PRs
+gh pr list --repo greatstrength/tiferet
+```
+
+## Milestone Management
+
+**Tool availability:** **`gh` CLI only** — no MCP equivalent.
+
+```bash
+# Create a milestone
+gh api repos/greatstrength/tiferet/milestones \
+  -f title="v2.1.0" \
+  -f description="Description here" \
+  -f state="open"
+
+# List open milestones
+gh api 'repos/greatstrength/tiferet/milestones?state=open' \
+  --jq '.[] | {number, title, state}'
+
+# Close a milestone (replace <number> with milestone number)
+gh api repos/greatstrength/tiferet/milestones/<number> \
+  -X PATCH -f state="closed"
+```
+
+## Project Status Updates
+
+**Tool availability:** **`gh` CLI only** — no MCP equivalent.
+
+```bash
+# List project fields (to find the Status field ID and option IDs)
+gh project field-list 2 --owner greatstrength --format json
+
+# Update an item's status (requires the project item ID and status option ID)
+gh project item-edit \
+  --project-id <project-id> \
+  --id <item-id> \
+  --field-id <status-field-id> \
+  --single-select-option-id <option-id>
+```
+
+**Status option IDs** for project #2 (Tiferet Framework):
+
+- Backlog: `f75ad846`
+- Ready: `08afe404`
+- In Progress: `47fc9ee4`
+- In Review: `4cc61d42`
+- Done: `98236657`
+
+## Release Publishing
+
+**Tool availability:** **`gh` CLI only**.
+
+```bash
+# Create a release with tag
+gh release create v2.1.0 \
+  --repo greatstrength/tiferet \
+  --title "Tiferet v2.1.0 – Release Title" \
+  --notes-file release-notes.md
+
+# Create a pre-release (for alpha/beta tags)
+gh release create v2.0.0b6 \
+  --repo greatstrength/tiferet \
+  --title "Tiferet v2.0.0b6" \
+  --prerelease \
+  --notes "Condensed release notes here."
+
+# List recent releases
+gh release list --repo greatstrength/tiferet --limit 5
+```
+
+## Tagging
+
+**Tool availability:** Git shell commands.
+
+```bash
+# Create an annotated tag (beta release on prototype branch)
+git tag -a v2.0.0b6 -m "v2.0.0b6 – Condensed release notes here."
+
+# Create an annotated tag (alpha release on worktree branch)
+git tag -a v2.0.0a11 -m "v2.0.0a11 – Detailed mini-release description."
+
+# Push tags to remote
+git push origin --tags
+
+# Push a single tag
+git push origin v2.0.0b6
+
+# List tags matching a pattern
+git tag --list 'v2.0.0*' --sort=-version:refname
+```
+
+## Issue Linking and Labels
+
+**Tool availability:** Available via **GitHub MCP tools** where supported; fall back to `gh` CLI.
+
+```bash
+# Add a label to an issue
+gh issue edit <issue-number> --repo greatstrength/tiferet --add-label "<label>"
+
+# Assign an issue to a milestone (replace <milestone-number>)
+gh api repos/greatstrength/tiferet/issues/<issue-number> \
+  -X PATCH -f milestone=<milestone-number>
+
+# Close an issue
+gh issue close <issue-number> --repo greatstrength/tiferet
+```

--- a/docs/collab/doc.md
+++ b/docs/collab/doc.md
@@ -1,0 +1,32 @@
+# Doc — Documentation Updates Stream
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose
+
+The Doc stream is for standalone documentation changes — guides, style docs, collaboration docs, README updates, tutorials, and similar content — that are not tied to a milestone or release. It is the simplest of the three contribution streams.
+
+## Branch Conventions
+
+Documentation branches are created from `main`:
+
+- Format: `docs-<lowercase-hyphenated-context>`
+- Examples: `docs-contribution-streams`, `docs-toml-guide`, `docs-tutorial-cli`
+
+## Version Field
+
+When documentation references a version (e.g., in a TRD header or guide metadata), use the **latest released version** of the project to match surrounding files, unless the user specifies a different version.
+
+## Workflow
+
+1. **Create branch** from `main`: `docs-<context>`.
+2. **Author** and commit the documentation changes.
+3. **Submit PR** targeting `main` with the title format: `Docs – <Capitalized Semantic Title>` (e.g., `Docs – Contribution Stream Guidelines`). Return the PR URL to the user.
+4. **PR review** follows the same process as the Main stream: if comments are received, address them and re-push.
+5. The user **squash-merges** the PR.
+6. **Local cleanup:** pull latest from `main` and delete the local docs branch.
+
+## No Milestone or Release
+
+Doc stream changes do not require a milestone, release tag, or GitHub Release. They are merged directly into `main` via pull request.

--- a/docs/collab/main.md
+++ b/docs/collab/main.md
@@ -1,0 +1,105 @@
+# Main — Feature Release Stream
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose
+
+The Main stream is the primary contribution path for feature releases. Work is organized into milestones, each containing a set of issues that are implemented on feature branches cut from `main`, reviewed via pull requests, and merged back into `main`. Upon milestone completion, a release tag and GitHub Release are published.
+
+## Milestones
+
+### Naming
+
+Milestone titles use the version number only — no semantic subtitle:
+
+- Format: `v<version>`
+- Examples: `v2.0.0b3`, `v1.9.0`, `v2.1.0`
+
+### Description
+
+The milestone description captures all semantic context:
+
+- A brief summary of the release's goals.
+- A list of linked issues, each prefixed with its component group, issue number, and a short description of intent.
+- Optionally, a "What's Included" summary and a "Release" section with tag/PyPI links (added upon completion).
+
+### Scope
+
+- Minor releases typically contain **3–7 issues** per milestone.
+- Major releases may use **domain-scoped milestones** (e.g., one milestone per architectural area).
+
+### Project Assignment
+
+Each issue and TRD in a milestone is assigned to the **Tiferet Framework** project (#2) on GitHub.
+
+## Issue Conventions
+
+### Title Format
+
+Issue titles follow the pattern:
+
+```
+<Component Group> – <Brief Capitalized Title>
+```
+
+- The **Component Group** identifies the primary framework layer being modified: Assets, Blueprints, Contexts, DI, Domain, Events, Interfaces, Mappers, Repos, Utils, Docs, Tests, etc.
+- The **title portion** (excluding the component group) should be **5–8 words**, using standard capitalization (not all caps).
+- Use an en-dash (`–`) to separate the component group from the title.
+
+**Examples:**
+- `Domain – Feature Model Condition Evaluation Enhancements`
+- `Events – Add Declarative Parameter Validation Decorator`
+- `Utils – SQLite Client Connection Lifecycle`
+- `Docs – Contribution Stream Guidelines`
+
+## Project Status States
+
+Issues in the Tiferet Framework project (#2) use the following status values:
+
+- **Backlog** — Issue created but not yet scheduled.
+- **Ready** — Issue is planned and ready to be picked up.
+- **In Progress** — Active implementation underway.
+- **In Review** — PR submitted; awaiting review.
+- **Done** — Merged and verified.
+
+## Per-Issue Workflow
+
+For each issue in the milestone:
+
+1. **Create feature branch** from `main`: `<issue-number>-<lowercase-hyphenated-title>`.
+2. **Link** the branch to the GitHub issue and set the project status to **In Progress**.
+3. **Implement** and test the changes.
+4. **Submit PR** targeting `main`. Set the project status to **In Review**. Return the PR URL to the user.
+5. **If PR comments are received:** set the status back to **In Progress**, address the feedback, re-push, then set the status back to **In Review**.
+6. The user **squash-merges** the PR.
+7. The agent **posts a Collaboration Report** as a comment on the issue.
+8. **Local cleanup:** pull latest from `main` and delete the local feature branch.
+9. **Repeat** for remaining issues in the milestone.
+
+## Closing the Milestone
+
+Once all issues in the milestone are complete and merged, mark the milestone as **closed**.
+
+## Release Tagging and Publishing
+
+A release tag and GitHub Release are created on `main` upon milestone completion.
+
+### Tag
+
+- Format: `v<version>` (e.g., `v2.0.0b3`, `v1.9.0`)
+- Created on `main` after all milestone work is merged.
+
+### GitHub Release
+
+- **Title** may include a semantic subtitle separated by a dash:  
+  `Tiferet v<version> – <Brief Title>` (e.g., `Tiferet v2.0.0b3 – Blueprints Pattern`).
+- **Body** follows the established changelog format:
+  - **Header block:** version, tag, released date, branch, repository link.
+  - **Highlights:** 2–3 sentence summary of the release.
+  - **What's Changed:** Grouped by component/domain area, each group listing issue links, class/function names, and behavioral changes.
+  - **Breaking Changes** (if any).
+  - **Upgrade Notes** (if any) — before/after code snippets.
+  - **Installation** — pip install and source checkout commands.
+
+See the [v2.0.0b3 release](https://github.com/greatstrength/tiferet/releases/tag/v2.0.0b3) as the canonical formatting example.

--- a/docs/collab/rfp.md
+++ b/docs/collab/rfp.md
@@ -1,0 +1,98 @@
+# RFP — Request for Prototype
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose
+
+The RFP (Request for Prototype) stream is used for exploratory, experimental, or architectural work that is developed on a prototype branch before being promoted to a stable release. RFPs allow new ideas and significant refactors to be iterated on in isolation, with incremental alpha releases tracking progress and a beta release marking completion.
+
+An RFP may originate from a submitted GitHub issue (**external RFP**) or be initiated internally by a maintainer or AI agent without a prior issue (**internal RFP**).
+
+## TRD Version Field
+
+When a TRD is written for an RFP, the **Version** field must be set to:
+
+```
+Version: Request for Prototype
+```
+
+Do not use the target release version. The actual version is determined during the tagging process.
+
+## Branch Conventions
+
+### Main Prototype Branch
+
+Each major version line maintains a long-lived prototype branch:
+
+- Format: `v<major>.<minor>-proto`
+- Examples: `v0.1-proto`, `v1.0-proto`, `v2.0-proto`
+
+This branch serves as the integration target for all prototype worktree branches within that version line.
+
+### Prototype Worktree Branch
+
+For each RFP, a short-lived worktree branch is created from the main prototype branch:
+
+- Format: `v<major>.<minor>.<patch>b<next_beta>-<context>`
+- Examples: `v2.0.0b6-dicontext-varargs`, `v1.0.0b2-mappers-refactor`
+- The `<context>` portion is lowercase and hyphen-separated.
+
+The worktree branch is created from and targets the main prototype branch.
+
+## Versioning and Tagging Rules
+
+### Beta Tags
+
+A beta tag is applied to the **main prototype branch** after the worktree branch is rebased into it. The tag marks the completion of the RFP.
+
+- Format: `v<major>.<minor>.<patch>b<N>` (e.g., `v2.0.0b6`)
+- The tag description contains condensed release notes summarizing the work.
+
+### Alpha Tags
+
+When a prototype worktree branch requires more than one commit, each commit is tagged with an incremental alpha release on the worktree branch itself.
+
+- Format: `v<major>.<minor>.<patch>a<N>` (e.g., `v2.0.0a11`, `v2.0.0a12`)
+- Each alpha tag includes a detailed description of the specific work in that commit (a "mini-release doc").
+
+### Alpha Increment Rules
+
+The alpha counter is **global** to the `<major>.<minor>.<patch>` version and does **not** reset between betas.
+
+**Example:** If `v1.0.0b1` consumed alphas `a1`–`a4`, then a new worktree branch for `v1.0.0b2` starts its first alpha at `a5` (not `a1`).
+
+The alpha and beta counters **reset to 1** only when the major or minor version changes (e.g., moving from `v1.0.x` to `v1.1.x` or `v2.0.x`).
+
+### Discovering the Next Version
+
+To determine the next alpha or beta increment, query existing tags:
+
+```bash
+# Find the latest alpha for v2.0.0
+git tag --list 'v2.0.0a*' --sort=-version:refname | head -1
+
+# Find the latest beta for v2.0.0
+git tag --list 'v2.0.0b*' --sort=-version:refname | head -1
+```
+
+## External RFP Workflow (Issue-Driven)
+
+When an RFP originates from a GitHub issue:
+
+1. **Create worktree branch** from the main prototype branch and link it to the originating GitHub issue.
+2. **Implement** the changes. If multiple commits are needed, tag each with an incremental alpha release.
+3. **Submit PR** against the main prototype branch. Return the PR URL to the user.
+4. After PR approval, **rebase-merge** the worktree branch into the main prototype branch.
+5. **Delete** the worktree branch (both local and remote).
+6. **Tag** the beta release on the main prototype branch with condensed release notes.
+
+## Internal RFP Workflow (No Submitted Issue)
+
+When an RFP is initiated internally (no prior GitHub issue):
+
+1. **Create worktree branch** from the main prototype branch.
+2. **Implement** the changes, tagging alpha releases per commit if multi-commit.
+3. **Rebase** the worktree branch directly into the main prototype branch (no PR).
+4. **Delete** the worktree branch (both local and remote).
+5. **Tag** the beta release on the main prototype branch with condensed release notes.

--- a/docs/collab/tech_requirements.md
+++ b/docs/collab/tech_requirements.md
@@ -100,33 +100,40 @@ Additional component-specific style guides will be added as the framework evolve
 
 ## Branch Naming and Workflow Conventions
 
-All work in the Tiferet project follows a standard GitHub branching workflow. TRD authors and AI agents must follow these conventions.
+Branch naming and workflow differ by **contribution stream**. TRD authors and AI agents must follow the conventions for the applicable stream. See [docs/collab/](.) for the full stream guides.
 
-### Branch Naming
+### Stream-Specific Branch Naming
+
+**Main stream** (feature releases):
 - Feature branches are named after their GitHub issue: `<issue-number>-<lowercase-hyphenated-title>`.
-- Spaces and special characters are replaced with a single hyphen (`-`). All letters are lowercase.
+- Created from and targeting `main`.
 - Examples:
   - Issue #574 "Utils – JsonLoader Utility" → `574-utils-jsonloader-utility`
   - Issue #568 "Interfaces – File, Configuration, and SQLite Service Contracts" → `568-interfaces-file-configuration-and-sqlite-service-contracts`
+- See [main.md](main.md) for the full workflow.
 
-### Branch Workflow
-- **Feature branches** are created from and target the current **release branch** (e.g., `v2.0a1-release`).
-- PRs are opened against the release branch, not `main`.
-- Upon completion of all release work, the **release branch is rebased into `main`**.
-- After merge, the feature branch is deleted (both remote and local).
+**RFP stream** (prototype work):
+- Prototype worktree branches: `v<major>.<minor>.<patch>b<next_beta>-<context>` (e.g., `v2.0.0b6-dicontext-varargs`).
+- Created from and targeting the main prototype branch (e.g., `v2.0-proto`).
+- TRD **Version** field is set to `Request for Prototype`.
+- See [rfp.md](rfp.md) for branch conventions, versioning/tagging rules, and workflows.
+
+**Doc stream** (documentation updates):
+- Documentation branches: `docs-<lowercase-hyphenated-context>` (e.g., `docs-contribution-streams`).
+- Created from and targeting `main`.
+- See [doc.md](doc.md) for the full workflow.
 
 ### AI Agent Checkout Conventions
 When an AI agent begins work on a TRD:
-1. Confirm the current branch matches the expected feature branch (check `git_head` in environment context).
-2. If the feature branch does not exist yet, create it from the release branch: `git checkout -b <feature-branch> <release-branch>`.
-3. After PR merge, check out the release branch, pull changes, confirm the merge landed, and delete the local feature branch.
-4. Do **not** check out or push directly to `main`.
+1. Confirm the current branch matches the expected branch for the applicable stream (check `git_head` in environment context).
+2. If the branch does not exist yet, create it from the appropriate base branch (`main` for Main/Doc streams, `v<major>.<minor>-proto` for RFP stream).
+3. After PR merge, check out the base branch, pull changes, confirm the merge landed, and delete the local feature/docs branch.
 
 ### Acceptance Criteria (branch-related)
 When a TRD includes branch/PR work, Acceptance Criteria should reference:
-- Feature branch name follows the naming convention.
-- PR targets the correct release branch.
-- Feature branch deleted after merge.
+- Branch name follows the naming convention for its stream.
+- PR targets the correct base branch (`main` or the prototype branch).
+- Branch deleted after merge.
 
 ## Process Conventions (for TRD authors and executors)
 


### PR DESCRIPTION
Introduces three formal contribution streams (RFP, Main, Doc) with dedicated guides, updates existing collaboration docs, and adds a commands reference.

## Changes

### New files
- `docs/collab/rfp.md` — RFP stream guide (prototype branches, alpha/beta tagging, external/internal workflows)
- `docs/collab/main.md` — Main stream guide (milestones, issue conventions, project status states, release publishing)
- `docs/collab/doc.md` — Doc stream guide (branch from main, PR workflow, no milestone/release)
- `docs/collab/commands.md` — Useful commands reference (MCP vs `gh` CLI availability)

### Updated files
- `CONTRIBUTING.md` — Restructured with Contribution Streams section linking all three guides
- `docs/collab/tech_requirements.md` — Branch conventions rewritten for three streams
- `docs/collab/collab_report.md` — Added RFP-specific version and tag fields

Co-Authored-By: Oz <oz-agent@warp.dev>