### PR TITLE
Events – Event Middleware / Pipeline Hooks (#836)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ A working calculator application is provided in `examples/basic_calculator/`.
 - **DomainObject** (`domain/settings.py`): Base domain model class extending `pydantic.BaseModel`. Instantiate via direct Pydantic constructors (e.g., `Feature(id='calc.add', ...)`). Use `model_construct()` to skip validation. Domain objects are read-only; mutation goes through Aggregates.
 - **DomainEvent** (`events/settings.py`): Base class for domain operations. Receives dependencies via constructor injection. Entry point is `execute(**kwargs)`. Use `@DomainEvent.parameters_required([...])` for declarative input validation. Use `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` for invocation in tests.
 - **Service** (`interfaces/settings.py`): Abstract base class (`ABC`) for all service contracts. All vertical concerns (data access, config, utilities) are unified under Service.
+- **MiddlewareService** (`interfaces/middleware.py`): Abstract callable that wraps domain event execution. Implement `__call__(self, event, kwargs, next_fn)` for sync middleware or `async def __call__` for async. Resolved from the DI container by `service_id` and composed into an ordered chain by `FeatureContext`.
 - **Aggregate** (`mappers/settings.py`): Mutable extension of domain objects. Instantiate via direct constructors. Provides `set_attribute()` for validated mutation with `validate_assignment=True`.
 - **TransferObject** (`mappers/settings.py`): Serialization layer with role-based field control via `_ROLES` ClassVar. Methods: `to_primitive(role)`, `map(target)`, `@classmethod from_model()`. Uses lenient config (`extra='ignore'`).
 
@@ -194,7 +195,7 @@ result = DomainEvent.handle(
 - Extend `Service` (ABC) from `tiferet/interfaces/settings.py`.
 - All methods marked `@abstractmethod`.
 - Artifact comments use `# *** interfaces` / `# ** interface: <name>`.
-- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
+- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`, `MiddlewareService`.
 
 ## Mappers
 
@@ -248,7 +249,7 @@ Applications are configured in a consolidated root `config.yml` file:
 
 - `interfaces` — Interface definitions (name, module_path, class_name, service dependencies)
 - `services` — Feature-level DI service configurations (module_path, class_name, parameters, flagged dependencies)
-- `features` — Feature workflows (commands with service_id, parameters, data mapping, and optional `condition` expressions for conditional step execution)
+- `features` — Feature workflows (commands with service_id, parameters, data mapping, optional `condition` expressions for conditional step execution, and optional `middleware` lists at feature or step level)
 - `errors` — Error definitions with multilingual messages
 - `cli` — CLI command definitions with arguments
 - `logging` — Logging formatters, handlers, loggers
@@ -276,6 +277,8 @@ Current utilities:
 - `Csv` / `CsvLoader` — List-based CSV with helpers.
 - `CsvDict` / `CsvDictLoader` — Dict-based CSV.
 - `Sqlite` / `SqliteClient` — SQLite client implementing `SqliteService` and `FileService`.
+- `LoggingMiddleware` — DEBUG/ERROR logging middleware via stdlib `logging`; takes `logger_id: str`.
+- `TimingMiddleware` — Wall-clock timing middleware via `time.perf_counter`; takes `logger_id: str`.
 
 ### SQLite API (v2.0.0b3)
 

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -308,6 +308,75 @@ def test_add_error_success(mock_error_service):
 - Use `DomainEvent.handle` for consistent instantiation and execution.
 - Override `mock_dependencies` when tests need a pre-configured aggregate.
 
+## Middleware Support
+
+`DomainEvent.handle()` and `DomainEvent.handle_async()` accept an optional `middleware` list that wraps event execution with cross-cutting concerns.
+
+### Protocol
+
+Each middleware is a callable (or `MiddlewareService` instance) that receives three arguments:
+
+- **`event`** — the instantiated `DomainEvent` instance.
+- **`kwargs`** — the merged execution keyword arguments dict.
+- **`next_fn`** — a zero-argument callable that invokes the next middleware or the event. In async contexts `next_fn` is a coroutine function.
+
+The first entry in the list is the outermost wrapper.
+
+### Sync example
+
+```python
+class TimingMiddleware(MiddlewareService):
+    def __call__(self, event, kwargs, next_fn):
+        start = time.perf_counter()
+        result = next_fn()
+        print(f"{event.__class__.__name__} took {time.perf_counter() - start:.4f}s")
+        return result
+
+result = DomainEvent.handle(
+    AddNumber,
+    dependencies={'...'},
+    middleware=[TimingMiddleware()],
+    a=1, b=2,
+)
+```
+
+### Async example
+
+Async middleware must implement `async def __call__` and `await next_fn()`:
+
+```python
+class AuditMiddleware(MiddlewareService):
+    async def __call__(self, event, kwargs, next_fn):
+        print(f"Before: {event.__class__.__name__}")
+        result = await next_fn()
+        print(f"After: {event.__class__.__name__}")
+        return result
+
+result = await DomainEvent.handle_async(
+    AsyncAddNumber,
+    middleware=[AuditMiddleware()],
+    a=1, b=2,
+)
+```
+
+### Configuration-driven middleware
+
+Middleware service IDs declared in `config.yml` are resolved from the DI container by `FeatureContext` and applied automatically during `execute_feature` / `execute_feature_async`. Feature-level middleware wraps every step; step-level middleware applies to that step only.
+
+```yaml
+features:
+  calc:
+    middleware:
+      - timing_middleware     # outermost — applies to every step
+    add:
+      commands:
+        - attribute_id: add_number_event
+          middleware:
+            - audit_middleware  # innermost — step-specific
+```
+
+See `docs/guides/middleware.md` for full usage guidance.
+
 ## Package Layout
 
 Domain events are defined in `tiferet/events/`:

--- a/docs/core/interfaces.md
+++ b/docs/core/interfaces.md
@@ -191,6 +191,36 @@ New service interfaces should be created in `tiferet.interfaces` from the start.
 - Inject Services into commands and events — never hard-code concrete classes.
 - Maintain one empty line between sections, comments, and code blocks.
 
+## MiddlewareService
+
+`MiddlewareService` (`tiferet/interfaces/middleware.py`) is the abstract contract for domain event middleware. Middleware instances are resolved from the DI container by `service_id` and composed into an ordered chain that wraps event execution.
+
+```python
+# *** interfaces
+
+# ** interface: middleware_service
+class MiddlewareService(Service):
+    '''
+    Abstract service interface for domain event middleware.
+    '''
+
+    # * method: __call__
+    @abstractmethod
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the middleware, calling next_fn() to continue the chain.
+
+        In async execution contexts next_fn is a coroutine function
+        and must be awaited.
+        '''
+        raise NotImplementedError()
+```
+
+For async middleware, implement `async def __call__` and `await next_fn()`. The concrete class is exported from `tiferet.interfaces` as `MiddlewareService`.
+
 ## Conclusion
 
 Services are the unified vertical interfaces in Tiferet, serving as the primary interface for middleware, data access, configuration management, and utilities. Commands and domain events depend exclusively on these Service interfaces, achieving high decoupling, testability, and extensibility. Concrete implementations satisfy the Service interfaces while hiding infrastructure details.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,0 +1,237 @@
+# Middleware Guide
+
+**Project:** Tiferet Framework
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Overview
+
+Middleware provides a standardized attachment point for cross-cutting concerns — audit logging, execution timing, distributed tracing, metrics, and retry logic — without modifying domain event code. Middleware instances are resolved from the DI container, composed into an ordered chain, and called around every event execution.
+
+## Built-in Middleware
+
+Tiferet ships two ready-to-use implementations in `tiferet.utils.middleware`, exported directly from the top-level package:
+
+| Class | Alias | Purpose |
+|---|---|---|
+| `LoggingMiddleware` | — | DEBUG/ERROR logging via stdlib `logging` |
+| `TimingMiddleware` | — | Wall-clock timing logged at DEBUG via stdlib `logging` |
+
+Both take a single `logger_id: str` parameter (defaults to `'root'`) and rely on `LoggingContext` having configured the logging subsystem at startup, which happens automatically in any standard Tiferet application.
+
+```python
+from tiferet import LoggingMiddleware, TimingMiddleware
+
+result = DomainEvent.handle(
+    AddNumber,
+    middleware=[
+        TimingMiddleware(logger_id='my_app'),   # outermost
+        LoggingMiddleware(logger_id='my_app'),  # innermost
+    ],
+    a=1, b=2,
+)
+```
+
+## The MiddlewareService Interface
+
+For custom middleware, extend `tiferet.interfaces.MiddlewareService`:
+
+```python
+from tiferet.interfaces import MiddlewareService
+
+class TraceMiddleware(MiddlewareService):
+    def __call__(self, event, kwargs, next_fn):
+        # inject trace context, call next, clean up
+        result = next_fn()
+        return result
+```
+
+The three arguments:
+
+| Argument  | Type                     | Description                                                                       |
+|-----------|--------------------------|-----------------------------------------------------------------------------------|
+| `event`   | `DomainEvent` instance   | The instantiated domain event — inspect type, attributes, or service dependencies |
+| `kwargs`  | `Dict[str, Any]`         | The merged execution keyword arguments passed to `execute`                        |
+| `next_fn` | `Callable[[], Any]`      | Calls the next middleware or the event itself; always call it to continue         |
+
+## Sync vs Async
+
+### Sync middleware
+
+Implement `def __call__` for use in synchronous execution paths (`execute_feature`, `DomainEvent.handle`):
+
+```python
+class AuditMiddleware(MiddlewareService):
+    def __init__(self, audit_log_service):
+        self.log = audit_log_service
+
+    def __call__(self, event, kwargs, next_fn):
+        self.log.record(event.__class__.__name__, kwargs)
+        result = next_fn()
+        return result
+```
+
+### Async middleware
+
+Implement `async def __call__` and `await next_fn()` for use in async execution paths (`execute_feature_async`, `DomainEvent.handle_async`):
+
+```python
+class AsyncAuditMiddleware(MiddlewareService):
+    async def __call__(self, event, kwargs, next_fn):
+        print(f"Before: {event.__class__.__name__}")
+        result = await next_fn()
+        print(f"After: {event.__class__.__name__}")
+        return result
+```
+
+> **Note:** Async middleware works in both sync and async contexts. Sync middleware used in an async context will receive an async `next_fn` — calling `next_fn()` returns a coroutine that the framework awaits for transparent pass-through middleware. For pre/post inspection in async contexts always use `async def __call__`.
+
+## Ordering
+
+Middleware is composed **outermost-first**: the first entry in the list runs first on entry and last on exit. Feature-level middleware wraps step-level middleware:
+
+```
+Feature-level outer  →  Step-level inner  →  Event execution
+```
+
+For a feature with `middleware: [timing]` and a step with `middleware: [audit]`:
+
+```
+timing.pre → audit.pre → event.execute() → audit.post → timing.post
+```
+
+## Registering Middleware in config.yml
+
+Declare middleware as `service_id` values — the same convention used for feature steps. The DI container resolves them at runtime.
+
+### Feature-level middleware (applies to every step)
+
+```yaml
+features:
+  calc:
+    middleware:
+      - timing_middleware    # service_id registered in services section
+    add:
+      name: Add Number
+      commands:
+        - attribute_id: add_number_event
+          name: Add a and b
+```
+
+### Step-level middleware (applies to one step only)
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Number
+      commands:
+        - attribute_id: add_number_event
+          name: Add a and b
+          middleware:
+            - audit_middleware
+```
+
+### Both levels combined
+
+```yaml
+features:
+  calc:
+    middleware:
+      - timing_middleware    # outermost — wraps all steps
+    add:
+      commands:
+        - attribute_id: add_number_event
+          middleware:
+            - audit_middleware  # innermost — step-specific
+```
+
+### Registering the service
+
+Register the middleware implementation in the `services` section just like any other dependency. Use the built-in utilities directly by pointing at `tiferet.utils.middleware`:
+
+```yaml
+services:
+  timing_middleware:
+    module_path: tiferet.utils.middleware
+    class_name: TimingMiddleware
+    parameters:
+      logger_id: my_app_logger
+  logging_middleware:
+    module_path: tiferet.utils.middleware
+    class_name: LoggingMiddleware
+    parameters:
+      logger_id: my_app_logger
+  audit_middleware:
+    module_path: myapp.middleware
+    class_name: AuditMiddleware
+```
+
+## Using Middleware Directly via handle()
+
+For ad-hoc use or testing, pass middleware directly to `DomainEvent.handle` or `DomainEvent.handle_async`:
+
+```python
+from tiferet.events import DomainEvent
+
+result = DomainEvent.handle(
+    AddNumber,
+    dependencies={'number_service': svc},
+    middleware=[TimingMiddleware(), AuditMiddleware()],
+    a=1,
+    b=2,
+)
+```
+
+```python
+result = await DomainEvent.handle_async(
+    AsyncAddNumber,
+    dependencies={'number_service': svc},
+    middleware=[AsyncAuditMiddleware()],
+    a=1,
+    b=2,
+)
+```
+
+## Error Handling in Middleware
+
+Middleware can intercept, transform, or suppress exceptions raised by the event or downstream middleware:
+
+```python
+class RetryMiddleware(MiddlewareService):
+    def __init__(self, max_attempts: int = 3):
+        self.max_attempts = max_attempts
+
+    def __call__(self, event, kwargs, next_fn):
+        last_exc = None
+        for attempt in range(self.max_attempts):
+            try:
+                return next_fn()
+            except Exception as e:
+                last_exc = e
+        raise last_exc
+```
+
+If middleware raises, the exception propagates normally through `handle_command` — `pass_on_error` on the step still applies.
+
+## Testing Middleware
+
+Test middleware in isolation by providing a `next_fn` mock:
+
+```python
+def test_timing_middleware_calls_next():
+    mw = TimingMiddleware()
+    called = {}
+
+    class FakeEvent:
+        pass
+
+    def next_fn():
+        called['ran'] = True
+        return 'result'
+
+    result = mw(FakeEvent(), {}, next_fn)
+    assert result == 'result'
+    assert called.get('ran') is True
+```
+
+For integration-style tests, use `DomainEvent.handle` with a real event and inline middleware.

--- a/tests/contexts/test_feature.py
+++ b/tests/contexts/test_feature.py
@@ -696,6 +696,119 @@ async def test_feature_context_execute_feature_async_basic(async_feature_context
     # Assert the result.
     assert request.handle_response() == {"status": "async_success", "data": {"key": "value"}}
 
+# ** test: feature_context_handle_command_with_middleware
+def test_feature_context_handle_command_with_middleware(feature_context, test_command):
+    """Test that middleware is applied when provided to handle_command."""
+
+    # Track execution order.
+    order = []
+
+    # Define a simple middleware.
+    class TrackMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            order.append('pre')
+            result = next_fn()
+            order.append('post')
+            return result
+
+    # Create a mock request.
+    request = RequestContext(data={'key': 'value'})
+
+    # Handle the command with middleware.
+    feature_context.handle_command(
+        test_command,
+        request,
+        middleware=[TrackMiddleware()],
+    )
+
+    # Assert middleware ran in correct order and result is correct.
+    assert order == ['pre', 'post']
+    assert request.handle_response() == {'status': 'success', 'data': {'key': 'value'}}
+
+# ** test: feature_context_execute_feature_with_feature_middleware
+def test_feature_context_execute_feature_with_feature_middleware(
+        feature_context, get_feature_evt, feature):
+    """Test execute_feature resolves and applies feature-level middleware."""
+
+    # Track call count.
+    call_counts = {'pre': 0, 'post': 0}
+
+    # Define tracking middleware.
+    class CountMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            call_counts['pre'] += 1
+            result = next_fn()
+            call_counts['post'] += 1
+            return result
+
+    # Wire up the DI context to return the middleware for the middleware service_id.
+    mw_instance = CountMiddleware()
+    original_get_dep = feature_context.services.get_dependency.side_effect
+
+    def resolve(service_id, *flags):
+        if service_id == 'count_middleware':
+            return mw_instance
+        from unittest import mock
+        return mock.Mock()
+
+    feature_context.services.get_dependency.side_effect = resolve
+    feature_context.services.get_dependency.return_value = None
+
+    # Add feature-level middleware and a step.
+    feature.middleware = ['count_middleware']
+    feature.steps.append(FeatureEvent(
+        name='Test Command',
+        service_id='test_command',
+    ))
+
+    # Manually register the test command resolution.
+    def resolve_full(service_id, *flags):
+        if service_id == 'count_middleware':
+            return mw_instance
+        from tiferet.contexts.feature import DomainEvent
+        from typing import Any
+        class TestEvent(DomainEvent):
+            def execute(self, key=None, **kwargs) -> Any:
+                return {'status': 'success', 'data': {'key': key}}
+        return TestEvent()
+
+    feature_context.services.get_dependency.side_effect = resolve_full
+
+    get_feature_evt.execute.return_value = feature
+    request = RequestContext(data={'key': 'value'})
+    feature_context.cache.clear()
+
+    feature_context.execute_feature(feature.id, request)
+
+    # Assert middleware was called once per step.
+    assert call_counts['pre'] == 1
+    assert call_counts['post'] == 1
+
+# ** test: feature_context_load_feature_middleware_empty
+def test_feature_context_load_feature_middleware_empty(feature_context):
+    """Test that load_feature_middleware returns empty list for empty input."""
+
+    # Assert empty list returned for no middleware.
+    assert feature_context.load_feature_middleware([]) == []
+    assert feature_context.load_feature_middleware(None) == []
+
+# ** test: feature_context_load_feature_middleware_resolves_services
+def test_feature_context_load_feature_middleware_resolves_services(
+        feature_context, services_context):
+    """Test that load_feature_middleware resolves service IDs from the DI context."""
+
+    # Configure the DI context to return a sentinel value.
+    sentinel = object()
+    services_context.get_dependency.return_value = sentinel
+
+    # Resolve middleware.
+    result = feature_context.load_feature_middleware(['mw_a', 'mw_b'])
+
+    # Verify both service IDs were resolved.
+    assert len(result) == 2
+    assert result[0] is sentinel
+    assert result[1] is sentinel
+
 # ** test: feature_context_execute_feature_async_mixed_chain
 @pytest.mark.asyncio
 async def test_feature_context_execute_feature_async_mixed_chain(get_feature_evt, feature):

--- a/tests/domain/test_feature.py
+++ b/tests/domain/test_feature.py
@@ -171,6 +171,79 @@ def test_feature_event_condition_preserves_value() -> None:
     # Assert condition is preserved through round-trip.
     assert reloaded.condition == '$r.x > 0'
 
+# ** test: feature_event_middleware_defaults_to_empty
+def test_feature_event_middleware_defaults_to_empty() -> None:
+    '''
+    Test that FeatureEvent middleware defaults to an empty list.
+    '''
+
+    # Create a FeatureEvent without middleware.
+    event = FeatureEvent(
+        name='Test Event',
+        service_id='test_event_service',
+    )
+
+    # Assert middleware defaults to empty list.
+    assert event.middleware == []
+
+# ** test: feature_event_middleware_preserves_value
+def test_feature_event_middleware_preserves_value() -> None:
+    '''
+    Test that FeatureEvent middleware is preserved through construction and round-trip.
+    '''
+
+    # Create a FeatureEvent with middleware.
+    event = FeatureEvent(
+        name='Middleware Event',
+        service_id='middleware_event_service',
+        middleware=['timing_middleware', 'audit_middleware'],
+    )
+
+    # Assert middleware is set correctly.
+    assert event.middleware == ['timing_middleware', 'audit_middleware']
+
+    # Serialize via model_dump() and reload.
+    primitive = event.model_dump()
+    reloaded = FeatureEvent(**primitive)
+
+    # Assert middleware is preserved through round-trip.
+    assert reloaded.middleware == ['timing_middleware', 'audit_middleware']
+
+# ** test: feature_middleware_defaults_to_empty
+def test_feature_middleware_defaults_to_empty() -> None:
+    '''
+    Test that Feature middleware defaults to an empty list.
+    '''
+
+    # Create a Feature without middleware.
+    feature = Feature(id='calc.add', name='Add')
+
+    # Assert middleware defaults to empty list.
+    assert feature.middleware == []
+
+# ** test: feature_middleware_preserves_value
+def test_feature_middleware_preserves_value() -> None:
+    '''
+    Test that Feature middleware is preserved through construction and round-trip.
+    '''
+
+    # Create a Feature with middleware.
+    feature = Feature(
+        id='calc.add',
+        name='Add',
+        middleware=['timing_middleware'],
+    )
+
+    # Assert middleware is set correctly.
+    assert feature.middleware == ['timing_middleware']
+
+    # Serialize via model_dump() and reload.
+    primitive = feature.model_dump()
+    reloaded = Feature(**primitive)
+
+    # Assert middleware is preserved through round-trip.
+    assert reloaded.middleware == ['timing_middleware']
+
 # ** test: feature_get_step_valid_and_invalid_indices
 def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
     '''

--- a/tests/events/test_settings.py
+++ b/tests/events/test_settings.py
@@ -467,3 +467,244 @@ def test_async_domain_event_inherits_domain_event():
     # Verify instance check.
     event = AsyncDomainEvent()
     assert isinstance(event, DomainEvent), 'AsyncDomainEvent instance should be a DomainEvent'
+
+# ** test: test_handle_with_single_middleware
+def test_handle_with_single_middleware():
+    '''
+    Test that a single middleware wraps event execution correctly.
+    '''
+
+    # Track execution order.
+    order = []
+
+    # Define a simple event.
+    class AddEvent(DomainEvent):
+        def execute(self, a=0, b=0, **kwargs):
+            order.append('execute')
+            return a + b
+
+    # Define middleware that records pre/post execution.
+    class TrackMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            order.append('pre')
+            result = next_fn()
+            order.append('post')
+            return result
+
+    # Handle with middleware.
+    mw = TrackMiddleware()
+    result = DomainEvent.handle(AddEvent, middleware=[mw], a=2, b=3)
+
+    # Verify result and execution order.
+    assert result == 5, 'Should return the sum'
+    assert order == ['pre', 'execute', 'post'], 'Should run pre, execute, post in order'
+
+# ** test: test_handle_with_multiple_middleware_ordering
+def test_handle_with_multiple_middleware_ordering():
+    '''
+    Test that multiple middleware execute in outermost-first order.
+    '''
+
+    # Track execution order.
+    order = []
+
+    # Define a simple event.
+    class EchoEvent(DomainEvent):
+        def execute(self, **kwargs):
+            order.append('execute')
+            return 'result'
+
+    # Define two middleware layers.
+    class OuterMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            order.append('outer-pre')
+            result = next_fn()
+            order.append('outer-post')
+            return result
+
+    class InnerMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            order.append('inner-pre')
+            result = next_fn()
+            order.append('inner-post')
+            return result
+
+    # Handle with two middleware (outer first).
+    result = DomainEvent.handle(
+        EchoEvent,
+        middleware=[OuterMiddleware(), InnerMiddleware()],
+    )
+
+    # Verify result and ordering: outer wraps inner.
+    assert result == 'result'
+    assert order == ['outer-pre', 'inner-pre', 'execute', 'inner-post', 'outer-post'], \
+        'Should execute in outermost-first order'
+
+# ** test: test_handle_without_middleware_unchanged
+def test_handle_without_middleware_unchanged(mocker: mock.Mock):
+    '''
+    Test that handle() with no middleware behaves identically to before.
+    '''
+
+    # Create mock command.
+    mock_instance = mocker()
+    mock_instance.execute.return_value = 'plain'
+    mock_cls = mocker(return_value=mock_instance)
+
+    # Handle with no middleware.
+    result = DomainEvent.handle(mock_cls, dependencies={'dep': 'val'}, x=1)
+
+    # Verify unchanged behavior.
+    assert result == 'plain'
+    mock_cls.assert_called_once_with(dep='val')
+    mock_instance.execute.assert_called_once_with(x=1)
+
+# ** test: test_handle_middleware_receives_event_and_kwargs
+def test_handle_middleware_receives_event_and_kwargs():
+    '''
+    Test that middleware receives the event instance and kwargs dict.
+    '''
+
+    # Capture middleware arguments.
+    captured = {}
+
+    # Define a simple event.
+    class SimpleEvent(DomainEvent):
+        def execute(self, val=None, **kwargs):
+            return val
+
+    # Define middleware that captures its arguments.
+    class CaptureMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            captured['event'] = event
+            captured['kwargs'] = dict(kwargs)
+            return next_fn()
+
+    # Handle with capture middleware.
+    instance = SimpleEvent()
+    DomainEvent.handle(SimpleEvent, middleware=[CaptureMiddleware()], val='hello')
+
+    # Verify middleware received correct arguments.
+    assert isinstance(captured['event'], SimpleEvent), 'Should receive the event instance'
+    assert captured['kwargs'].get('val') == 'hello', 'Should receive the execution kwargs'
+
+# ** test: test_handle_middleware_pass_on_error
+def test_handle_middleware_pass_on_error():
+    '''
+    Test that middleware can intercept and suppress errors.
+    '''
+
+    # Define a failing event.
+    class FailEvent(DomainEvent):
+        def execute(self, **kwargs):
+            raise ValueError('boom')
+
+    # Define error-suppressing middleware.
+    class SuppressMiddleware:
+        def __call__(self, event, kwargs, next_fn):
+            try:
+                return next_fn()
+            except ValueError:
+                return 'suppressed'
+
+    # Handle with suppressing middleware.
+    result = DomainEvent.handle(FailEvent, middleware=[SuppressMiddleware()])
+
+    # Verify error was suppressed and a fallback returned.
+    assert result == 'suppressed', 'Middleware should suppress the error'
+
+# ** test: test_handle_async_with_middleware
+@pytest.mark.asyncio
+async def test_handle_async_with_middleware():
+    '''
+    Test that async handle_async correctly applies async middleware.
+    '''
+
+    # Track execution order.
+    order = []
+
+    # Define a simple async event.
+    class AsyncAdd(AsyncDomainEvent):
+        async def execute(self, a=0, b=0, **kwargs):
+            order.append('execute')
+            return a + b
+
+    # Define async middleware.
+    class AsyncTrackMiddleware:
+        async def __call__(self, event, kwargs, next_fn):
+            order.append('pre')
+            result = await next_fn()
+            order.append('post')
+            return result
+
+    # Handle via handle_async.
+    result = await DomainEvent.handle_async(
+        AsyncAdd,
+        middleware=[AsyncTrackMiddleware()],
+        a=4,
+        b=6,
+    )
+
+    # Verify result and execution order.
+    assert result == 10, 'Should return the sum'
+    assert order == ['pre', 'execute', 'post'], 'Should run pre, execute, post in order'
+
+# ** test: test_handle_async_multiple_middleware_ordering
+@pytest.mark.asyncio
+async def test_handle_async_multiple_middleware_ordering():
+    '''
+    Test async middleware executes in outermost-first order.
+    '''
+
+    # Track execution order.
+    order = []
+
+    # Define a simple async event.
+    class EchoAsync(AsyncDomainEvent):
+        async def execute(self, **kwargs):
+            order.append('execute')
+            return 'async-result'
+
+    # Define two async middleware layers.
+    class OuterAsync:
+        async def __call__(self, event, kwargs, next_fn):
+            order.append('outer-pre')
+            result = await next_fn()
+            order.append('outer-post')
+            return result
+
+    class InnerAsync:
+        async def __call__(self, event, kwargs, next_fn):
+            order.append('inner-pre')
+            result = await next_fn()
+            order.append('inner-post')
+            return result
+
+    # Handle with two middleware (outer first).
+    result = await DomainEvent.handle_async(
+        EchoAsync,
+        middleware=[OuterAsync(), InnerAsync()],
+    )
+
+    # Verify result and ordering.
+    assert result == 'async-result'
+    assert order == ['outer-pre', 'inner-pre', 'execute', 'inner-post', 'outer-post'], \
+        'Should execute in outermost-first order'
+
+# ** test: test_handle_async_without_middleware_unchanged
+@pytest.mark.asyncio
+async def test_handle_async_without_middleware_unchanged():
+    '''
+    Test that handle_async() with no middleware behaves identically to before.
+    '''
+
+    # Define a simple async event.
+    class SimpleAsync(AsyncDomainEvent):
+        async def execute(self, val=None, **kwargs):
+            return val
+
+    # Handle without middleware.
+    result = await DomainEvent.handle_async(SimpleAsync, val='unchanged')
+
+    # Verify unchanged behavior.
+    assert result == 'unchanged', 'Should return the value without modification'

--- a/tests/mappers/test_feature.py
+++ b/tests/mappers/test_feature.py
@@ -464,3 +464,68 @@ class TestFeatureYamlObject(TransferObjectTestBase):
         assert yaml_obj.name == model.name
         assert yaml_obj.service_id == model.service_id
         assert yaml_obj.parameters == model.parameters
+
+    # ** test: feature_event_yaml_middleware_round_trip
+    def test_feature_event_yaml_middleware_round_trip(self):
+        '''
+        Test that middleware is preserved through FeatureEventYamlObject map/from_model round-trip.
+        '''
+
+        # Create a YAML object with middleware and map to aggregate.
+        yaml_obj = FeatureEventYamlObject.model_validate(dict(
+            name='Middleware Event',
+            service_id='mw_handler',
+            middleware=['timing_middleware', 'audit_middleware'],
+        ))
+        event = yaml_obj.map()
+
+        # Verify the middleware list is preserved on the aggregate.
+        assert event.middleware == ['timing_middleware', 'audit_middleware']
+
+        # Round-trip: aggregate -> YamlObject -> re-map.
+        yaml_obj2 = FeatureEventYamlObject.from_model(event)
+        event2 = yaml_obj2.map()
+        assert event2.middleware == ['timing_middleware', 'audit_middleware']
+
+    # ** test: feature_yaml_middleware_round_trip
+    def test_feature_yaml_middleware_round_trip(self):
+        '''
+        Test that feature-level middleware is preserved through FeatureYamlObject round-trip.
+        '''
+
+        # Create a YAML object with feature-level middleware.
+        yaml_obj = FeatureYamlObject.model_validate(dict(
+            id='calc.add',
+            name='Add Number',
+            group_id='calc',
+            feature_key='add',
+            middleware=['timing_middleware'],
+            steps=[],
+        ))
+        aggregate = yaml_obj.map()
+
+        # Verify feature-level middleware on the aggregate.
+        assert aggregate.middleware == ['timing_middleware']
+
+        # Round-trip: aggregate -> YamlObject -> re-map.
+        yaml_obj2 = FeatureYamlObject.from_model(aggregate)
+        aggregate2 = yaml_obj2.map()
+        assert aggregate2.middleware == ['timing_middleware']
+
+    # ** test: feature_aggregate_add_step_with_middleware
+    def test_feature_aggregate_add_step_with_middleware(self):
+        '''
+        Test that add_step accepts and stores a middleware list.
+        '''
+
+        # Create a FeatureAggregate and add a step with middleware.
+        agg = FeatureAggregate(name='Add Number', group_id='calc')
+        step = agg.add_step(
+            name='Step One',
+            service_id='step_one_event',
+            middleware=['timing_middleware'],
+        )
+
+        # Verify the middleware is attached to the step.
+        assert step.middleware == ['timing_middleware']
+        assert agg.steps[0].middleware == ['timing_middleware']

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     'AsyncDomainEvent',
     'ParseParameter',
     'Service',
+    'MiddlewareService',
     'Aggregate',
     'TransferObject',
     'FileLoader',
@@ -28,6 +29,8 @@ __all__ = [
     'Sqlite',
     'TomlLoader',
     'Toml',
+    'LoggingMiddleware',
+    'TimingMiddleware',
 ]
 
 # ** app
@@ -43,7 +46,7 @@ try:
         AsyncDomainEvent,
         ParseParameter,
     )
-    from .interfaces import Service
+    from .interfaces import Service, MiddlewareService
     from .mappers import (
         Aggregate,
         TransferObject,
@@ -63,6 +66,8 @@ try:
         CsvDictLoader as CsvDict,
         SqliteClient,
         SqliteClient as Sqlite,
+        LoggingMiddleware,
+        TimingMiddleware,
     )
 except Exception as e:
     import os, sys

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -115,43 +115,84 @@ class FeatureContext(object):
         # Return the loaded feature.
         return feature
     
+    # * method: load_feature_middleware
+    def load_feature_middleware(self, middleware_ids: list) -> list:
+        '''
+        Resolve a list of middleware service IDs to callable middleware instances.
+
+        :param middleware_ids: Ordered list of service IDs to resolve.
+        :type middleware_ids: list
+        :return: Resolved middleware instances in the same order.
+        :rtype: list
+        '''
+
+        # Return early when no middleware is configured.
+        if not middleware_ids:
+            return []
+
+        # Resolve each service ID from the DI context.
+        return [self.services.get_dependency(mid_id) for mid_id in middleware_ids]
+
     # * method: handle_command
     def handle_command(self,
         command: DomainEvent,
         request: RequestContext,
         data_key: str = None,
         pass_on_error: bool = False,
+        middleware: list = None,
         **kwargs
     ):
         '''
         Handle the execution of a command with the provided request and command-handling options.
-        
+
+        When ``middleware`` is provided the command execution is wrapped in an
+        ordered chain.  Each middleware callable receives
+        ``(event, kwargs, next_fn)`` and must call ``next_fn()`` to continue.
+
         :param command: The command to execute.
         :type command: DomainEvent
         :param request: The request context object.
         :type request: RequestContext
-        :param debug: Debug flag.
-        :type debug: bool
         :param data_key: Optional key to store the result in the request data.
         :type data_key: str
         :param pass_on_error: If True, pass on the error instead of raising it.
         :type pass_on_error: bool
+        :param middleware: Optional ordered list of resolved middleware callables.
+        :type middleware: list | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         '''
 
-        # Execute the command with the request data and parameters, and optional contexts.
+        # Merge request data with step parameters.
+        merged_kwargs = {**request.data, **kwargs}
+
+        # Build the base execution callable.
+        def base():
+            return command.execute(**merged_kwargs)
+
+        # Compose middleware chain when middleware is configured.
+        if middleware:
+            chain = base
+            for mw in reversed(middleware):
+                _next = chain
+                _mw = mw
+                def _make_wrapper(_mw, _next):
+                    def wrapper():
+                        return _mw(command, merged_kwargs, _next)
+                    return wrapper
+                chain = _make_wrapper(_mw, _next)
+        else:
+            chain = base
+
+        # Execute the command (or chain), handling errors per pass_on_error.
         try:
-            result = command.execute(
-                **request.data,
-                **kwargs
-            )
+            result = chain()
 
         # If an error occurs during command execution, handle it based on the pass_on_error flag.
         except Exception as e:
             if not pass_on_error:
                 raise e
-            
+
             # Set the result to None if passing on the error.
             result = None
 
@@ -289,13 +330,23 @@ class FeatureContext(object):
         :type kwargs: dict
         '''
 
+        # Resolve feature-level middleware once for all steps.
+        feature = self.load_feature(feature_id)
+        feature_middleware = self.load_feature_middleware(feature.middleware)
+
         # Resolve and execute each step synchronously.
         for cmd, step, params in self.resolve_feature_steps(feature_id, request):
+
+            # Compose feature-level (outer) + step-level (inner) middleware.
+            step_middleware = self.load_feature_middleware(step.middleware)
+            combined_middleware = feature_middleware + step_middleware or None
+
             self.handle_command(
                 cmd,
                 request,
                 data_key=step.data_key,
                 pass_on_error=step.pass_on_error,
+                middleware=combined_middleware,
                 **params,
                 services=self.services,
                 cache=self.cache,
@@ -308,6 +359,7 @@ class FeatureContext(object):
         request: RequestContext,
         data_key: str = None,
         pass_on_error: bool = False,
+        middleware: list = None,
         **kwargs
     ):
         '''
@@ -316,6 +368,8 @@ class FeatureContext(object):
 
         Detects whether the command's ``execute`` is a coroutine function
         and awaits it when necessary, otherwise calls it synchronously.
+        When ``middleware`` is provided the execution is wrapped in an ordered
+        async chain; async middleware must ``await next_fn()``.
 
         :param command: The command to execute (sync or async).
         :type command: DomainEvent
@@ -325,22 +379,43 @@ class FeatureContext(object):
         :type data_key: str
         :param pass_on_error: If True, pass on the error instead of raising it.
         :type pass_on_error: bool
+        :param middleware: Optional ordered list of resolved middleware callables.
+        :type middleware: list | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         '''
 
-        # Execute the command, awaiting if async or calling directly if sync.
-        try:
+        # Merge request data with step parameters.
+        merged_kwargs = {**request.data, **kwargs}
+
+        # Build the base async execution callable.
+        async def base():
             if asyncio.iscoroutinefunction(command.execute):
-                result = await command.execute(
-                    **request.data,
-                    **kwargs
-                )
-            else:
-                result = command.execute(
-                    **request.data,
-                    **kwargs
-                )
+                return await command.execute(**merged_kwargs)
+            return command.execute(**merged_kwargs)
+
+        # Compose async middleware chain when middleware is configured.
+        if middleware:
+            chain = base
+            for mw in reversed(middleware):
+                _next = chain
+                _mw = mw
+                def _make_async_wrapper(_mw, _next):
+                    async def wrapper():
+                        # Call the middleware; await the result if it is a coroutine
+                        # (handles both async def functions and async def __call__ instances).
+                        result = _mw(command, merged_kwargs, _next)
+                        if asyncio.iscoroutine(result):
+                            return await result
+                        return result
+                    return wrapper
+                chain = _make_async_wrapper(_mw, _next)
+        else:
+            chain = base
+
+        # Execute the chain, handling errors per pass_on_error.
+        try:
+            result = await chain()
 
         # If an error occurs during command execution, handle it based on the pass_on_error flag.
         except Exception as e:
@@ -367,13 +442,23 @@ class FeatureContext(object):
         :type kwargs: dict
         '''
 
+        # Resolve feature-level middleware once for all steps.
+        feature = self.load_feature(feature_id)
+        feature_middleware = self.load_feature_middleware(feature.middleware)
+
         # Resolve and execute each step, awaiting async commands as needed.
         for cmd, step, params in self.resolve_feature_steps(feature_id, request):
+
+            # Compose feature-level (outer) + step-level (inner) middleware.
+            step_middleware = self.load_feature_middleware(step.middleware)
+            combined_middleware = feature_middleware + step_middleware or None
+
             await self.handle_command_async(
                 cmd,
                 request,
                 data_key=step.data_key,
                 pass_on_error=step.pass_on_error,
+                middleware=combined_middleware,
                 **params,
                 services=self.services,
                 cache=self.cache,

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -55,6 +55,12 @@ class FeatureEvent(FeatureStep):
         description='Optional boolean expression evaluated against request data. Step executes only when the expression resolves to True. When None, the step always executes.',
     )
 
+    # * attribute: middleware
+    middleware: List[str] = Field(
+        default_factory=list,
+        description='Ordered list of middleware service IDs applied to this step. Outermost wrapper first.',
+    )
+
 
 # ** model: feature
 class Feature(DomainObject):
@@ -82,6 +88,12 @@ class Feature(DomainObject):
 
     # * attribute: steps
     steps: List[FeatureEvent] = Field(default_factory=list, description='The step workflow for the feature.')
+
+    # * attribute: middleware
+    middleware: List[str] = Field(
+        default_factory=list,
+        description='Ordered list of middleware service IDs applied to every step in this feature. Outermost wrapper first.',
+    )
 
     # * attribute: log_params
     log_params: Dict[str, str] = Field(default_factory=dict, description='The parameters to log for the feature.')

--- a/tiferet/events/settings.py
+++ b/tiferet/events/settings.py
@@ -147,14 +147,22 @@ class DomainEvent(object):
     def handle(
             event_cls: type,
             dependencies: Dict[str, Any] = {},
+            middleware: list = None,
             **kwargs) -> Any:
         '''
         Handle a domain event instance via the instantiate-execute pattern.
+
+        When ``middleware`` is provided, the event execution is wrapped in an
+        ordered middleware chain.  Each middleware callable receives
+        ``(event, kwargs, next_fn)`` and must call ``next_fn()`` to continue.
+        The first entry in the list is the outermost wrapper.
 
         :param event_cls: The domain event class to handle.
         :type event_cls: type
         :param dependencies: The event dependencies.
         :type dependencies: Dict[str, Any]
+        :param middleware: Optional ordered list of middleware callables.
+        :type middleware: list | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The result of the event.
@@ -164,23 +172,51 @@ class DomainEvent(object):
         # Instantiate the event with its dependencies.
         event_handler = event_cls(**dependencies)
 
-        # Execute the event handler.
-        result = event_handler.execute(**kwargs)
-        return result
+        # Build the base execution callable.
+        def base():
+            return event_handler.execute(**kwargs)
+
+        # Return immediately when no middleware is configured.
+        if not middleware:
+            return base()
+
+        # Compose the middleware chain (outermost = first in list).
+        chain = base
+        for mw in reversed(middleware):
+            _next = chain
+            _mw = mw
+            def _make_wrapper(_mw, _next):
+                def wrapper():
+                    return _mw(event_handler, kwargs, _next)
+                return wrapper
+            chain = _make_wrapper(_mw, _next)
+
+        # Execute the composed chain.
+        return chain()
 
     # * method: handle_async (static)
     @staticmethod
     async def handle_async(
             event_cls: type,
             dependencies: Dict[str, Any] = {},
+            middleware: list = None,
             **kwargs) -> Any:
         '''
         Handle an async domain event instance via the instantiate-await pattern.
+
+        When ``middleware`` is provided, the event execution is wrapped in an
+        ordered async middleware chain.  Each middleware callable receives
+        ``(event, kwargs, next_fn)`` where ``next_fn`` is a coroutine function.
+        Async middleware must ``await next_fn()``; sync middleware may call
+        ``next_fn()`` but will receive a coroutine it cannot inspect directly.
+        The first entry in the list is the outermost wrapper.
 
         :param event_cls: The domain event class to handle.
         :type event_cls: type
         :param dependencies: The event dependencies.
         :type dependencies: Dict[str, Any]
+        :param middleware: Optional ordered list of middleware callables.
+        :type middleware: list | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The result of the event.
@@ -190,9 +226,32 @@ class DomainEvent(object):
         # Instantiate the event with its dependencies.
         event_handler = event_cls(**dependencies)
 
-        # Await the async event handler.
-        result = await event_handler.execute(**kwargs)
-        return result
+        # Build the base async execution callable.
+        async def base():
+            return await event_handler.execute(**kwargs)
+
+        # Return immediately when no middleware is configured.
+        if not middleware:
+            return await base()
+
+        # Compose the async middleware chain (outermost = first in list).
+        chain = base
+        for mw in reversed(middleware):
+            _next = chain
+            _mw = mw
+            def _make_async_wrapper(_mw, _next):
+                async def wrapper():
+                    # Call the middleware; await the result if it is a coroutine
+                    # (handles both async def functions and async def __call__ instances).
+                    result = _mw(event_handler, kwargs, _next)
+                    if asyncio.iscoroutine(result):
+                        return await result
+                    return result
+                return wrapper
+            chain = _make_async_wrapper(_mw, _next)
+
+        # Execute the composed async chain.
+        return await chain()
 
 
 # ** class: async_domain_event

--- a/tiferet/interfaces/__init__.py
+++ b/tiferet/interfaces/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     'ErrorService',
     'FeatureService',
     'LoggingService',
+    'MiddlewareService',
 ]
 
 # ** app
@@ -26,3 +27,4 @@ from .di import DIService
 from .error import ErrorService
 from .feature import FeatureService
 from .logging import LoggingService
+from .middleware import MiddlewareService

--- a/tiferet/interfaces/middleware.py
+++ b/tiferet/interfaces/middleware.py
@@ -1,0 +1,85 @@
+"""Tiferet Middleware Interface"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import Any, Callable, Dict
+
+# ** app
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: middleware_service
+class MiddlewareService(Service):
+    '''
+    Abstract service interface for domain event middleware.
+
+    Middleware wraps domain event execution with cross-cutting concerns such
+    as audit logging, execution timing, distributed tracing, and retry logic.
+    Middleware instances are resolved from the DI container by ``service_id``
+    and composed into an ordered chain before the event executes.
+
+    **Protocol**
+
+    Each middleware receives:
+
+    - ``event`` — the instantiated ``DomainEvent`` (or ``AsyncDomainEvent``) instance.
+    - ``kwargs`` — the merged execution kwargs dict passed to ``execute``.
+    - ``next_fn`` — a zero-argument callable that invokes the next middleware in
+      the chain, or the event itself when no further middleware remains.
+      In synchronous execution paths ``next_fn`` is a plain callable.
+      In asynchronous execution paths ``next_fn`` is a coroutine function —
+      middleware intended for async contexts must be implemented as
+      ``async def __call__`` and must ``await next_fn()``.
+
+    **Ordering**
+
+    Middleware is composed outermost-first: the first entry in the list is the
+    outermost wrapper (first to run on entry, last to run on exit).  Feature-level
+    middleware wraps step-level middleware.
+
+    **Sync example**::
+
+        class TimingMiddleware(MiddlewareService):
+            def __call__(self, event, kwargs, next_fn):
+                start = time.perf_counter()
+                result = next_fn()
+                elapsed = time.perf_counter() - start
+                print(f"{event.__class__.__name__} took {elapsed:.4f}s")
+                return result
+
+    **Async example**::
+
+        class AsyncAuditMiddleware(MiddlewareService):
+            async def __call__(self, event, kwargs, next_fn):
+                print(f"Before: {event.__class__.__name__}")
+                result = await next_fn()
+                print(f"After: {event.__class__.__name__}")
+                return result
+    '''
+
+    # * method: __call__
+    @abstractmethod
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the middleware, calling ``next_fn()`` to continue the chain.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that invokes the remainder of
+            the chain.  In async execution contexts this is a coroutine function
+            and must be awaited.
+        :type next_fn: Callable[[], Any]
+        :return: The result of the event execution.
+        :rtype: Any
+        '''
+
+        # Not implemented.
+        raise NotImplementedError()

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -123,6 +123,12 @@ class FeatureEventYamlObject(FeatureEvent, TransferObject):
         description='The parameters for the feature event.',
     )
 
+    # * attribute: middleware
+    middleware: List[str] = Field(
+        default_factory=list,
+        description='Ordered list of middleware service IDs for this step.',
+    )
+
     # * method: map
     def map(self, **overrides) -> FeatureEventAggregate:
         '''
@@ -170,6 +176,7 @@ class FeatureAggregate(Feature, Aggregate):
         data_key: str | None = None,
         pass_on_error: bool = False,
         condition: str | None = None,
+        middleware: List[str] | None = None,
         position: int | None = None,
     ) -> FeatureEvent:
         '''
@@ -187,6 +194,8 @@ class FeatureAggregate(Feature, Aggregate):
         :type pass_on_error: bool
         :param condition: Optional boolean expression for conditional execution.
         :type condition: str | None
+        :param middleware: Optional ordered list of middleware service IDs.
+        :type middleware: list[str] | None
         :param position: Insertion position (None to append).
         :type position: int | None
         :return: Created FeatureEvent instance.
@@ -201,6 +210,7 @@ class FeatureAggregate(Feature, Aggregate):
             data_key=data_key,
             pass_on_error=pass_on_error,
             condition=condition,
+            middleware=middleware or [],
         )
 
         # Copy steps to a local list, insert or append, then reassign.
@@ -333,6 +343,12 @@ class FeatureYamlObject(Feature, TransferObject):
             'exclude': {'feature_key', 'group_id', 'id'},
         },
     }
+
+    # * attribute: middleware
+    middleware: List[str] = Field(
+        default_factory=list,
+        description='Ordered list of feature-level middleware service IDs.',
+    )
 
     # * attribute: steps
     steps: List[FeatureEventYamlObject] = Field(

--- a/tiferet/utils/__init__.py
+++ b/tiferet/utils/__init__.py
@@ -17,6 +17,8 @@ __all__ = [
     'CsvDict',
     'SqliteClient',
     'Sqlite',
+    'LoggingMiddleware',
+    'TimingMiddleware',
 ]
 
 # ** app
@@ -26,3 +28,4 @@ from .yaml import YamlLoader, YamlLoader as Yaml
 from .toml import TomlLoader, TomlLoader as Toml
 from .csv import CsvLoader, CsvLoader as Csv, CsvDictLoader, CsvDictLoader as CsvDict
 from .sqlite import SqliteClient, SqliteClient as Sqlite
+from .middleware import LoggingMiddleware, TimingMiddleware

--- a/tiferet/utils/middleware.py
+++ b/tiferet/utils/middleware.py
@@ -1,0 +1,190 @@
+"""Tiferet Middleware Utilities"""
+
+# *** imports
+
+# ** core
+import logging
+import time
+from typing import Any, Callable, Dict
+
+# ** app
+from ..interfaces.middleware import MiddlewareService
+
+# *** utils
+
+# ** util: logging_middleware
+class LoggingMiddleware(MiddlewareService):
+    '''
+    Middleware utility that logs domain event execution using Python's standard
+    ``logging`` module.
+
+    Emits a ``DEBUG`` record before execution and after successful execution.
+    Emits an ``ERROR`` record (with ``exc_info``) when execution raises an
+    exception, then re-raises so normal error handling is unaffected.
+
+    The logger is resolved by name via ``logging.getLogger(logger_id)`` —
+    ``LoggingContext.build_logger()`` must have been called during application
+    startup (as it is by default) before any feature step executes.
+
+    **Config example**::
+
+        services:
+          logging_middleware:
+            module_path: tiferet.utils.middleware
+            class_name: LoggingMiddleware
+            parameters:
+              logger_id: my_app_logger
+
+    **Direct use**::
+
+        DomainEvent.handle(
+            AddNumber,
+            middleware=[LoggingMiddleware(logger_id='my_app_logger')],
+            a=1, b=2,
+        )
+    '''
+
+    # * attribute: logger
+    logger: logging.Logger
+
+    # * init
+    def __init__(self, logger_id: str = 'root'):
+        '''
+        Initialize the logging middleware.
+
+        :param logger_id: Name of the logger to use (must match a logger
+            defined in ``logging.yml`` or a stdlib root/named logger).
+        :type logger_id: str
+        '''
+
+        # Resolve the named logger; relies on LoggingContext having configured
+        # the logging subsystem during application startup.
+        self.logger = logging.getLogger(logger_id)
+
+    # * method: __call__
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the logging middleware.
+
+        Logs a DEBUG message before and after execution; logs an ERROR on
+        exception and re-raises.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that continues the chain.
+        :type next_fn: Callable[[], Any]
+        :return: The result of the event execution.
+        :rtype: Any
+        '''
+
+        # Capture the event class name for log messages.
+        name = event.__class__.__name__
+
+        # Log the pre-execution entry.
+        self.logger.debug('Executing %s', name)
+
+        # Execute the chain, logging errors and re-raising for normal handling.
+        try:
+            result = next_fn()
+
+        except Exception as exc:
+            self.logger.error('Failed %s: %s', name, exc, exc_info=True)
+            raise
+
+        # Log the post-execution exit.
+        self.logger.debug('Completed %s', name)
+
+        # Return the result.
+        return result
+
+
+# ** util: timing_middleware
+class TimingMiddleware(MiddlewareService):
+    '''
+    Middleware utility that measures and logs wall-clock execution time for
+    each domain event using ``time.perf_counter``.
+
+    Emits a single ``DEBUG`` record after execution (or after an exception)
+    reporting elapsed time in milliseconds.  Exceptions are always re-raised
+    so normal error handling is unaffected.
+
+    **Config example**::
+
+        services:
+          timing_middleware:
+            module_path: tiferet.utils.middleware
+            class_name: TimingMiddleware
+            parameters:
+              logger_id: my_app_logger
+
+    **Direct use**::
+
+        DomainEvent.handle(
+            AddNumber,
+            middleware=[TimingMiddleware(logger_id='my_app_logger')],
+            a=1, b=2,
+        )
+    '''
+
+    # * attribute: logger
+    logger: logging.Logger
+
+    # * init
+    def __init__(self, logger_id: str = 'root'):
+        '''
+        Initialize the timing middleware.
+
+        :param logger_id: Name of the logger to use (must match a logger
+            defined in ``logging.yml`` or a stdlib root/named logger).
+        :type logger_id: str
+        '''
+
+        # Resolve the named logger; relies on LoggingContext having configured
+        # the logging subsystem during application startup.
+        self.logger = logging.getLogger(logger_id)
+
+    # * method: __call__
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the timing middleware.
+
+        Records wall-clock elapsed time and logs it at DEBUG level after
+        execution.  Re-raises any exception after logging the elapsed time.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that continues the chain.
+        :type next_fn: Callable[[], Any]
+        :return: The result of the event execution.
+        :rtype: Any
+        '''
+
+        # Capture the event class name and start the timer.
+        name = event.__class__.__name__
+        start = time.perf_counter()
+
+        # Execute the chain, ensuring elapsed time is always logged.
+        try:
+            result = next_fn()
+
+        except Exception as exc:
+            elapsed = (time.perf_counter() - start) * 1000
+            self.logger.debug('%s raised after %.2fms', name, elapsed)
+            raise
+
+        # Log the elapsed execution time.
+        elapsed = (time.perf_counter() - start) * 1000
+        self.logger.debug('%s completed in %.2fms', name, elapsed)
+
+        # Return the result.
+        return result


### PR DESCRIPTION
Closes #836

## Summary

Implements ordered middleware chain support for domain event execution. Middleware instances are resolved from the DI container, composed outermost-first, and called around every event invocation — enabling audit logging, timing, tracing, and retry logic without touching event code.

## Changes

### Functional
- **`tiferet/interfaces/middleware.py`** — new `MiddlewareService(Service)` abstract interface with `__call__(event, kwargs, next_fn)`
- **`tiferet/domain/feature.py`** — add `middleware: List[str]` to `Feature` and `FeatureEvent`
- **`tiferet/mappers/feature.py`** — serialize `middleware` on YAML objects; add `middleware` param to `FeatureAggregate.add_step()`
- **`tiferet/events/settings.py`** — `handle()` and `handle_async()` accept optional `middleware` list with chain composition
- **`tiferet/contexts/feature.py`** — `load_feature_middleware()` resolves service IDs; `execute_feature` / `execute_feature_async` compose feature-level (outer) + step-level (inner) middleware per step
- 112 tests passing; fully backward-compatible

### Utils & Docs
- **`tiferet/utils/middleware.py`** — built-in `LoggingMiddleware` and `TimingMiddleware` (stdlib only; both take `logger_id: str`)
- Exported from `tiferet.utils` and `tiferet` top-level alongside `MiddlewareService`
- `docs/guides/middleware.md` — new full usage guide
- `docs/core/events.md`, `docs/core/interfaces.md`, `AGENTS.md` updated

## Config example

```yaml
services:
  timing_middleware:
    module_path: tiferet.utils.middleware
    class_name: TimingMiddleware
    parameters:
      logger_id: my_app_logger

features:
  calc:
    middleware:
      - timing_middleware       # feature-level: wraps all steps
    add:
      commands:
        - attribute_id: add_number_event
          middleware:
            - logging_middleware  # step-level: innermost
```

---

Conversation: https://app.warp.dev/conversation/aee6df14-62d9-4cab-9537-517efb33f845

Co-Authored-By: Oz <oz-agent@warp.dev>