### PR TITLE
v2.0.0b11 – CliContext Reincorporation (Phase 3 integration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The v2.0 codebase is a clean, single-layer architecture. All legacy packages hav
 tiferet/
 ├── assets/               # Constants, exceptions (TiferetError), shared config
 ├── blueprints/           # build_app, build_cli and top-level runtime orchestration
-├── contexts/             # Runtime orchestration: BaseContext registry + AppInterfaceContext hub (Feature, Error, Logging)
+├── contexts/             # Runtime orchestration: BaseContext registry + AppInterfaceContext hub (Feature, Error, Logging) + CliContext
 ├── di/                   # DI: ServiceContainer engine + ServiceResolver provider
 ├── domain/               # DomainObject base class and domain modules
 ├── events/               # DomainEvent base class and domain event modules
@@ -58,12 +58,12 @@ A working calculator application is provided in `examples/basic_calculator/`.
 Blueprints (`tiferet/blueprints/`) are module-level functions that orchestrate application bootstrapping and execution. They replace the previous class-based `AppBuilder`/`CliBuilder` pattern from v2.0.0b2.
 
 - `build_app(interface_id, ...)` is defined in `tiferet/blueprints/main.py` and exported as `App` from `tiferet/__init__.py`. It resolves the interface definition, composes the DI `ServiceResolver`, and returns a fully wired `AppInterfaceContext`.
-- `build_cli(interface_id, ...)` is defined in `tiferet/blueprints/cli.py` and exported as `CLI` from `tiferet/__init__.py`. It extends the app blueprint with argparse-based CLI parsing.
+- `build_cli(interface_id, ...)` is defined in `tiferet/blueprints/cli.py` and exported as `CLI` from `tiferet/__init__.py`. It is a thin entrypoint that resolves and realizes a CLI interface (which must point at `CliContext`) and delegates `argv` parsing and feature dispatch to `CliContext.run_cli`.
 
 **Pure helpers in `main.py` (`# *** functions`):** side-effect-free transforms grouped above the blueprints.
 - `resolve_ctor_kwargs(service_type, registry)` — Matches a service type's injectable constructor parameters (via the shared `injectable_parameter_names`) to registry entries, returning resolved kwargs or `None` to defer instantiation.
 - `build_wiring_constants(app_interface)` — Builds the wiring-registry seed constants (interface scalars + declared constants).
-- `resolve_collaborators(registry)` — Resolves the hub's event collaborators by name from the registry.
+- `resolve_collaborators(context_cls, registry)` — Resolves a context class's event collaborators by name from the registry, inspecting the context class's own injectable constructor parameters (so a `CliContext` also receives `list_commands_evt`/`get_parent_args_evt`) while skipping the explicitly-supplied `get_dependency`/`cache` and any bootstrap `default_*` kwargs.
 
 **Key blueprint functions in `main.py` (`# *** blueprints`):**
 - `wire_services(services, constants)` — Declaratively instantiates the interface's service dependencies into a name-to-value registry (no app-level DI container), deferring services whose constructor args are not yet resolvable.
@@ -74,15 +74,10 @@ Blueprints (`tiferet/blueprints/`) are module-level functions that orchestrate a
 - `realize_interface(app_interface, interface_id, **context_kwargs)` — Builds (via `load_app_instance`) and validates the concrete `AppInterfaceContext`; forwards `**context_kwargs` (e.g. bootstrap defaults) to the context constructor.
 - `build_app(interface_id, ...)` — Resolves and realizes the interface in a single call.
 
-**CLI blueprint functions in `cli.py`:**
-- `get_commands(service_provider)` — Resolves and groups `CliCommand` objects by `group_key`.
-- `get_parent_arguments(service_provider)` — Resolves parent-level CLI arguments.
-- `build_parser(cli_commands, parent_arguments)` — Composes the root `argparse.ArgumentParser`.
-- `parse_argv(parser, argv)` — Parses CLI arguments; exits 2 on failure.
-- `derive_feature_request(parsed)` — Derives `feature_id` and `headers` from parsed arguments.
-- `build_app(interface_id, argv, ...)` — Full CLI build: resolve interface, build parser, parse argv, dispatch feature. Exits 1 on `TiferetAPIError`.
+**CLI blueprint function in `cli.py`:**
+- `build_app(interface_id, argv, ...)` — Thin CLI entrypoint: resolves the interface, realizes the context (a `CliContext`), and delegates to `cli_context.run_cli(argv)`. Exported as `build_cli` / `CLI`.
 
-CLI interfaces resolve to the default `AppInterfaceContext`; `CliContext` has been retired.
+CLI parsing is owned by `CliContext` (`tiferet/contexts/cli.py`): the side-effect-free module-level helpers `group_commands_by_key`, `build_parser`, and `derive_feature_request`, plus the `get_commands` / `parse_cli_request` / `run_cli` methods. Per-argument argparse translation lives on `CliArgument.to_argparse_kwargs()`. Consumer CLI interfaces opt in by pointing their config at `tiferet.contexts.cli` / `CliContext`.
 
 ### Dependency Injection
 
@@ -340,6 +335,7 @@ The top-level `tiferet/__init__.py` exports:
 - `tiferet/blueprints/cli.py` — `build_cli` (CLI orchestration entry point, exported as `CLI`)
 - `tiferet/contexts/base.py` — `BaseContext` and `ContextMeta` (domain→context registry, `for_domain`, `from_domain`)
 - `tiferet/contexts/app.py` — `AppInterfaceContext` (minimal declarative hub bound to the loaded `AppInterface`)
+- `tiferet/contexts/cli.py` — `CliContext` (CLI high-level context: argparse parsing helpers + `get_commands`/`parse_cli_request`/`run_cli`)
 - `tiferet/contexts/feature.py` — `FeatureContext` (sync feature execution engine) and `AsyncFeatureContext` (async subclass selected when `Feature.is_async` is set)
 - `tiferet/assets/constants.py` — Error codes and `DEFAULT_SERVICES` configuration
 - `tiferet/assets/exceptions.py` — `TiferetError` and `TiferetAPIError`
@@ -347,6 +343,16 @@ The top-level `tiferet/__init__.py` exports:
 - `examples/basic_calculator/` — Working calculator application example
 
 ## Migration Notes
+
+### v2.0.0b11: CliContext Reincorporation
+
+The v2.0.0b11 cycle reincorporates `CliContext` as a high-level context and slims both CLI blueprints to thin entrypoints. Key changes:
+
+- **`CliContext`** (`tiferet/contexts/cli.py`) — Extends `AppInterfaceContext` with command-line concerns: `get_commands`, `parse_cli_request`, and `run_cli`, orchestrating the side-effect-free module-level helpers `group_commands_by_key`, `build_parser`, and `derive_feature_request`. It intentionally omits `domain_type`, so the `ContextMeta` registry still maps `AppInterface` to `AppInterfaceContext`; the CLI context is selected via the interface's `module_path`/`class_name`.
+- **Generalized collaborator wiring** — `resolve_collaborators(context_cls, registry)` now inspects the realized context class's injectable constructor parameters (skipping `get_dependency`/`cache` and `default_*`), so a `CliContext` receives `list_commands_evt`/`get_parent_args_evt` while the generic `AppInterfaceContext` still resolves only its original three. `load_app_instance` imports the context class before resolving collaborators.
+- **Slim CLI blueprints** — `tiferet/blueprints/cli.py` (`build_cli`/`CLI`) reduces to resolve → realize → `cli_context.run_cli(argv)`; the old `get_commands`/`get_parent_arguments`/`build_argument_kwargs`/`build_parser`/`parse_argv`/`derive_feature_request` helpers were removed (the shared logic lives in `tiferet/contexts/cli.py`). `tiferet/blueprints/tiferet_cli.py` drops `_build_tiferet_command_map` and the mapper import, seeds bootstrap commands via `default_commands`, and decodes JSON args after `parse_cli_request` before `run`.
+- **Built-in CLI interface** — `DEFAULT_TIFERET_CLI_INTERFACE` (`tiferet/assets/app.py`) now points at `tiferet.contexts.cli` / `CliContext`. Consumer CLI interfaces must likewise opt in.
+- **`CliArgument.to_argparse_kwargs()`** — Per-argument argparse translation moved onto the `CliArgument` domain model (co-located with `get_type()`), replacing the module-level `build_argument_kwargs`.
 
 ### v2.0.0b10: DI Redesign, Per-Module Base Events, and Async Feature Split
 

--- a/docs/core/blueprints.md
+++ b/docs/core/blueprints.md
@@ -27,7 +27,7 @@ This design keeps application code simple while maintaining full extensibility a
 Tiferet currently defines two blueprints:
 
 - **App blueprint**: `build_app` — used for general script and custom interfaces. Exposed globally as `App`.
-- **CLI blueprint**: `build_cli` — extends the app blueprint with argparse-based CLI build-time translation of `sys.argv` into a feature invocation. Exposed globally as `CLI`.
+- **CLI blueprint**: `build_cli` — a thin entrypoint that resolves and realizes a CLI interface (which must point at `CliContext`) and delegates `sys.argv` translation and feature dispatch to `CliContext.run_cli`. Exposed globally as `CLI`.
 
 Future specialized blueprints may include:
 
@@ -36,14 +36,13 @@ Future specialized blueprints may include:
 
 ### CLI Blueprint Build Procedure
 
-The CLI blueprint (`build_cli`) keeps all build-time CLI parsing in the blueprint and delegates runtime execution to the `AppInterfaceContext`. Its flow follows these steps:
+The CLI blueprint (`build_cli`) is a thin entrypoint; argparse parsing and request derivation live in the reincorporated `CliContext` (`tiferet/contexts/cli.py`). Its flow follows these steps:
 
 1. **Resolve the interface** via `resolve_interface(interface_id)`.
-2. **Build the argparse parser** by composing `get_commands()` (resolves `list_commands_evt` and groups returned commands by `group_key`), `get_parent_arguments()` (resolves `get_parent_args_evt`), and `build_parser(cli_commands, parent_arguments)`.
-3. **Parse arguments** with `parse_argv(parser, argv)`; on failure, print to stderr and `sys.exit(2)`.
-4. **Dispatch the feature** by deriving `feature_id` and `headers` via `derive_feature_request(parsed)`, then calling `interface_context.run(feature_id=feature_id, headers=headers, data=parsed)`. On `TiferetAPIError`, print to stderr and `sys.exit(1)`; otherwise print and return the response.
+2. **Realize the context** via `realize_interface(...)`. The interface must point at `tiferet.contexts.cli` / `CliContext`, so the realized context is a `CliContext`.
+3. **Delegate to the context** by calling `cli_context.run_cli(argv)`, which builds the parser from the interface's CLI commands and parent arguments, parses `argv` (argparse exits `2` on failure), derives `feature_id`/`headers`, dispatches through the inherited `run`, prints the response, and converts a `TiferetAPIError` into `sys.exit(1)`.
 
-Because the default `AppInterfaceContext` is sufficient for CLI interfaces, CLI interface definitions in YAML no longer require `module_path`/`class_name` overrides.
+Consumer CLI interfaces opt in by declaring `module_path: tiferet.contexts.cli` / `class_name: CliContext` in their interface config.
 
 ## Structured Code Design of Blueprints
 

--- a/docs/core/contexts.md
+++ b/docs/core/contexts.md
@@ -11,7 +11,7 @@ All contexts extend `BaseContext` (`tiferet/contexts/base.py`), which provides a
 
 Tiferet recognizes two broad categories:
 
-- **High-Level Contexts**: Handle user interactions (e.g., `FlaskApiContext` for web APIs). They typically extend `AppInterfaceContext`, the minimal hub built declaratively from the loaded `AppInterface`. CLI interfaces use `AppInterfaceContext` directly, with argparse wiring handled by the `build_cli` blueprint.
+- **High-Level Contexts**: Handle user interactions (e.g., `CliContext` for command-line interfaces, `FlaskApiContext` for web APIs). They extend `AppInterfaceContext`, the minimal hub built declaratively from the loaded `AppInterface`. CLI interfaces point at `CliContext`, which owns argparse parsing; the `build_cli` blueprint is a thin entrypoint that delegates to `CliContext.run_cli`.
 - **Low-Level Contexts**: Support specific functions (e.g., `FeatureContext`, `AsyncFeatureContext`, `ErrorContext`, `CacheContext`, `RequestContext`, `LoggingContext`).
 
 In the calculator application, `AppInterfaceContext` handles feature execution, while low-level contexts manage dependency injection, error handling, and logging.

--- a/docs/core/di.md
+++ b/docs/core/di.md
@@ -182,7 +182,7 @@ The `build_app` blueprint (`tiferet/blueprints/main.py`) wires the interface dec
 
 1. `wire_services(services, constants)` seeds a name-to-value registry with interface scalars and constants (via the pure `build_wiring_constants`), then iteratively instantiates each `AppServiceDependency` whose constructor arguments are all resolvable (via the pure `resolve_ctor_kwargs`), wiring events to the repositories they depend on.
 2. `load_app_instance` composes the `ServiceResolver` by handling the `CreateServiceResolver` bootstrap event, which locates the interface's `di_service` dependency, constructs the DI repository, injects `ParseParameter.execute`, and routes bootstrap DI defaults (`default_configurations`, `default_constants`) into it.
-3. The hub's event collaborators (`get_feature_evt`, `get_error_evt`, `logging_list_all_evt`) are resolved by name from the registry (via the pure `resolve_collaborators`), and the context is constructed via `from_domain`, injecting `resolver.get_dependency`.
+3. The context class's event collaborators are resolved by name from the registry (via the pure `resolve_collaborators`, which inspects the imported context class's own injectable constructor parameters — so a `CliContext` also receives `list_commands_evt`/`get_parent_args_evt` — while skipping the explicitly-supplied `get_dependency`/`cache` and any bootstrap `default_*` kwargs), and the context is constructed via `from_domain`, injecting `resolver.get_dependency`.
 
 ```python
 # tiferet/blueprints/main.py (excerpt)

--- a/docs/guides/blueprints.md
+++ b/docs/guides/blueprints.md
@@ -103,7 +103,7 @@ def build_app(interface_id, ...) -> AppInterfaceContext:
 
 ## The build_cli Blueprint
 
-The CLI blueprint extends the app blueprint with argparse-based CLI parsing. All argparse wiring lives in the blueprint; runtime execution is delegated to `AppInterfaceContext.run`.
+The CLI blueprint is a thin entrypoint. Argparse parsing and request derivation are owned by the reincorporated `CliContext` (`tiferet/contexts/cli.py`); the blueprint only resolves, realizes, and delegates.
 
 ### Usage
 
@@ -119,11 +119,10 @@ if __name__ == '__main__':
 `build_cli(interface_id, argv=None, ...)` follows these steps:
 
 1. Resolve the interface via `resolve_interface(interface_id, ...)`.
-2. Build the argparse parser by composing `get_commands()`, `get_parent_arguments()`, and `build_parser(cli_commands, parent_arguments)`.
-3. Parse arguments with `parse_argv(parser, argv)`; on failure, print to stderr and `sys.exit(2)`.
-4. Derive `feature_id` and `headers` via `derive_feature_request(parsed)` and dispatch to `interface_context.run(...)`. On `TiferetAPIError`, print to stderr and `sys.exit(1)`; otherwise print and return the response.
+2. Realize the interface context via `realize_interface(...)`. Because the interface points at `CliContext`, the realized context exposes `run_cli`.
+3. Delegate to `cli_context.run_cli(argv)`, which builds the parser, parses `argv` (exiting `2` on failure), derives the feature request, dispatches through the inherited `run`, prints the response, and converts a `TiferetAPIError` into `sys.exit(1)`.
 
-Because the CLI blueprint uses the default `AppInterfaceContext`, CLI interface definitions in YAML no longer require `module_path`/`class_name` overrides.
+Consumer CLI interfaces opt in by declaring `module_path: tiferet.contexts.cli` / `class_name: CliContext` in their interface config.
 
 ## When to Create a New Blueprint
 

--- a/docs/guides/contexts.md
+++ b/docs/guides/contexts.md
@@ -23,6 +23,7 @@ Every context in `tiferet/contexts/` has a single, well-defined responsibility:
 | Context | Responsibility |
 | --- | --- |
 | `AppInterfaceContext` | Parse the incoming request, execute the feature, format the response, and handle errors at the interface boundary. |
+| `CliContext` | Extend `AppInterfaceContext` with CLI concerns: build an argparse parser from configured commands/arguments, parse `argv` into a request (`parse_cli_request`), and dispatch via the inherited `run` (`run_cli`). |
 | `FeatureContext` | Resolve each configured step via the injected `get_dependency` handler, parse parameters, and execute the steps sequentially against a `RequestContext` (operating on a pre-loaded `Feature`). |
 | `AsyncFeatureContext` | Subclass of `FeatureContext` that awaits coroutine-based steps via `execute_feature_async`; selected by `AppInterfaceContext` when a feature's `is_async` flag is set. |
 | `ErrorContext` | Format exceptions into structured, localized API responses using `ErrorService`. |
@@ -90,11 +91,11 @@ class FlaskApiContext(AppInterfaceContext):
 
 Override only the methods you need. Always call `super()` for shared behavior (e.g., adding `interface_id` to headers).
 
-### CLI Interfaces Without Custom Contexts
+### CLI Interfaces and CliContext
 
-In v2.0+, CLI interfaces are handled by the `build_cli` blueprint rather than a `CliContext`. All argparse wiring lives in the blueprint; the CLI interface runs against the default `AppInterfaceContext`. As a result, CLI interface definitions no longer require `module_path`/`class_name` overrides.
+CLI interfaces are handled by `CliContext` (`tiferet/contexts/cli.py`), a high-level context that extends `AppInterfaceContext` with command-line concerns. It retrieves CLI commands (`list_commands_evt`) and parent arguments (`get_parent_args_evt`), builds an argparse parser, parses `argv` into a `RequestContext` (`parse_cli_request`), and dispatches through the inherited `run` pipeline (`run_cli`). Stateless parsing helpers — `group_commands_by_key`, `build_parser`, and `derive_feature_request` — live as side-effect-free module-level functions, and per-argument argparse translation lives on `CliArgument.to_argparse_kwargs()`.
 
-If a CLI interface needs custom request parsing beyond argparse, the preferred pattern is to extend the `build_cli` blueprint — not to reintroduce a dedicated CLI context.
+A consumer CLI interface opts in by pointing its config at `module_path: tiferet.contexts.cli` / `class_name: CliContext`. The `build_cli` blueprint is a thin entrypoint that realizes the interface and calls `cli_context.run_cli(argv)`. `CliContext` is selected explicitly through the interface config; it intentionally omits `domain_type`, so the `ContextMeta` registry keeps mapping `AppInterface` to `AppInterfaceContext`.
 
 ## Low-Level Context Lifecycles
 

--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -91,6 +91,8 @@ interfaces:
   basic_calc_cli:
     name: Calculator CLI
     description: Perform basic calculator operations via CLI
+    module_path: tiferet.contexts.cli
+    class_name: CliContext
     attrs:
       cli_repo:
         module_path: tiferet.repos.cli
@@ -99,7 +101,7 @@ interfaces:
           cli_config: config.yml
 ```
 
-CLI interfaces no longer require `module_path`/`class_name` overrides — they use the default `AppInterfaceContext` with argparse wiring handled by the `build_cli` blueprint.
+CLI interfaces declare `module_path: tiferet.contexts.cli` / `class_name: CliContext` to opt into the CLI context; the `build_cli` blueprint realizes that context and delegates argv parsing to `CliContext.run_cli`.
 
 ## Domain Events
 

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -44,6 +44,18 @@ arg = CliArgument(name_or_flags=['--count'], type='int')
 assert arg.get_type() is int
 ```
 
+**`to_argparse_kwargs() -> Dict[str, Any]`**
+
+Builds the keyword arguments for `argparse.add_argument()` from the argument's fields. Trivial fields come from a pydantic `model_dump(exclude_none=True, ...)` and `description` is mapped to `help`. Value-consuming actions (the default, `store`, `append`) receive a resolved `type` callable (via `get_type()`) and retain `nargs`/`choices`, while flag and const actions (e.g. `store_true`) omit those keywords so parser construction stays valid. `name_or_flags` is excluded because it is passed positionally to `add_argument`.
+
+```python
+arg = CliArgument(name_or_flags=['a'], description='First operand.', type='int')
+arg.to_argparse_kwargs()  # {'help': 'First operand.', 'type': int}
+
+flag = CliArgument(name_or_flags=['--verbose'], description='Verbose.', action='store_true')
+flag.to_argparse_kwargs()  # {'action': 'store_true', 'help': 'Verbose.'}
+```
+
 ### CliCommand
 
 Represents a CLI command with a composite identifier.
@@ -92,13 +104,12 @@ This 1:1 mapping ensures CLI commands are thin entry points that delegate all bu
 
 ## Runtime Role
 
-The `build_cli` blueprint (`tiferet/blueprints/cli.py`) is the primary consumer of the CLI domain at runtime:
+`CliContext` (`tiferet/contexts/cli.py`) is the primary consumer of the CLI domain at runtime; the `build_cli` blueprint is a thin entrypoint that realizes the context and calls `run_cli`:
 
-1. **`get_commands(service_provider)`** resolves all `CliCommand` entries from the configuration via `CliService`.
-2. **`build_parser()`** iterates each `CliCommand`, registering subparsers and arguments with `argparse` using `CliArgument` attributes (`name_or_flags`, `type`, `required`, `default`, `choices`, `nargs`, `action`).
-3. **`parse_argv()`** parses the user's CLI input and returns the matched command group and key.
-4. **`derive_feature_request()`** maps the parsed arguments to a feature ID (`group_key.key`) and dispatches to `AppInterfaceContext.run()`.
-5. **`FeatureContext`** executes the corresponding feature with the parsed data.
+1. **`get_commands()`** resolves all `CliCommand` entries via the injected `list_commands_evt` (backed by `CliService`) and groups them by `group_key` (`group_commands_by_key`).
+2. **`build_parser(commands, parent_arguments)`** iterates each `CliCommand`, registering subparsers and adding each argument via `CliArgument.to_argparse_kwargs()`.
+3. **`parse_cli_request(argv)`** parses the user's CLI input, derives the feature ID (`derive_feature_request`), and builds a `RequestContext`.
+4. **`run_cli(argv)`** dispatches the request through the inherited `AppInterfaceContext.run`, which executes the corresponding feature via `FeatureContext`.
 
 ## Configuration Mapping
 
@@ -159,7 +170,7 @@ Concrete implementations (e.g., `CliConfigRepository`) satisfy this interface.
 ## Relationships to Other Domains
 
 - **Feature:** `CliCommand.id` maps 1:1 to feature IDs in `feature.yml`. CLI commands are thin entry points that delegate to the feature layer.
-- **App:** The CLI interface in the configuration specifies `CliService` as a service dependency. The `build_cli` blueprint handles argparse wiring and dispatches to `AppInterfaceContext`.
+- **App:** The CLI interface in the configuration points at `CliContext` and specifies `CliService` as a service dependency. `CliContext` handles argparse wiring; the `build_cli` blueprint realizes the context and delegates to `CliContext.run_cli`.
 - **Error:** CLI error responses are formatted via `ErrorContext`, providing user-friendly messages for validation failures and domain errors.
 
 ## Instantiation

--- a/docs/tutorial/basic_calculator/06-cli-interface.md
+++ b/docs/tutorial/basic_calculator/06-cli-interface.md
@@ -117,19 +117,15 @@ interfaces:
 **calc_cli.py**
 
 ```python
-from tiferet import App
-
-app = App().load_app_service(app_config="config.yml")
-
-# Load the CLI interface we defined in config.yml
-cli = app.load_interface("calc_cli")
+from tiferet import CLI
 
 if __name__ == "__main__":
-    cli.run()
+    # Realize the calc_cli interface (CliContext) and dispatch sys.argv.
+    CLI("calc_cli", app_config="config.yml")
 ```
 
 That's it — super short!  
-`app.load_interface("calc_cli")` pulls in `CliContext` from root `config.yml`, which also contains the CLI command definitions.
+`CLI("calc_cli", ...)` realizes the `CliContext` declared by `calc_cli` in root `config.yml` (which also holds the CLI command definitions) and delegates `sys.argv` parsing and feature dispatch to `CliContext.run_cli`.
 
 ### 6.4 Run and play with it
 

--- a/tests/blueprints/test_cli.py
+++ b/tests/blueprints/test_cli.py
@@ -3,281 +3,81 @@
 # *** imports
 
 # ** infra
-import argparse
 import pytest
 from unittest import mock
 
 # ** app
-from tiferet.assets import TiferetAPIError
-from tiferet.contexts.app import AppInterfaceContext
-from tiferet.domain import CliCommand, CliArgument
-from tiferet.events.cli import ListCliCommands, GetParentArguments
-from tiferet.blueprints.cli import (
-    build_app,
-    get_commands,
-    get_parent_arguments,
-    build_parser,
-    parse_argv,
-    derive_feature_request,
-)
-
-# *** fixtures
-
-# ** fixture: cli_command_list
-@pytest.fixture
-def cli_command_list():
-    '''
-    Fixture to create a list of mock CLI commands.
-    '''
-
-    # Return a list of test CLI commands.
-    return [
-        CliCommand(
-            group_key='test-group',
-            key='test-feature',
-            name='Test Feature Command',
-            description='A test feature command.',
-            arguments=[
-                CliArgument(name_or_flags=['--arg1', '-a'],
-                    description='Test argument 1',
-                    required=True,
-                    type='str',
-                    default='default_value',
-                )
-            ]
-        )
-    ]
-
-# ** fixture: list_commands_evt
-@pytest.fixture
-def list_commands_evt(cli_command_list):
-    '''
-    Fixture to create a mock ListCliCommands event.
-    '''
-
-    # Build and return a mock ListCliCommands event.
-    evt = mock.Mock(spec=ListCliCommands)
-    evt.execute.return_value = cli_command_list
-    return evt
-
-# ** fixture: get_parent_args_evt
-@pytest.fixture
-def get_parent_args_evt():
-    '''
-    Fixture to create a mock GetParentArguments event.
-    '''
-
-    # Build and return a mock GetParentArguments event.
-    evt = mock.Mock(spec=GetParentArguments)
-    evt.execute.return_value = []
-    return evt
-
-# ** fixture: mock_service_provider
-@pytest.fixture
-def mock_service_provider(list_commands_evt, get_parent_args_evt):
-    '''
-    Fixture to create a wiring registry populated with the CLI events.
-    '''
-
-    # Return a registry mapping service IDs to the mocked events.
-    return {
-        'list_commands_evt': list_commands_evt,
-        'get_parent_args_evt': get_parent_args_evt,
-    }
+import tiferet.blueprints.cli as cli_blueprint
+from tiferet.blueprints.cli import build_app
 
 # *** tests
 
-# ** test: get_commands_groups_by_key
-def test_get_commands_groups_by_key(mock_service_provider, list_commands_evt):
+# ** test: build_app_delegates_to_run_cli
+def test_build_app_delegates_to_run_cli():
     '''
-    Test that get_commands groups CLI commands by group_key.
-
-    :param mock_service_provider: The mock service provider fixture.
-    :type mock_service_provider: mock.Mock
-    :param list_commands_evt: The mock ListCliCommands event.
-    :type list_commands_evt: ListCliCommands
+    Test that build_app resolves, realizes, and delegates argv to CliContext.run_cli.
     '''
 
-    # Invoke get_commands with the mock provider.
-    command_map = get_commands(mock_service_provider)
+    # Arrange a mock CLI context whose run_cli returns a sentinel response.
+    mock_cli_context = mock.Mock()
+    mock_cli_context.run_cli.return_value = 'cli-response'
 
-    # Assert the list_commands_evt was invoked once.
-    list_commands_evt.execute.assert_called_once()
-
-    # Assert the returned map is grouped by group_key.
-    assert 'test-group' in command_map
-    assert len(command_map['test-group']) == 1
-    assert command_map['test-group'][0].key == 'test-feature'
-
-# ** test: get_parent_arguments_delegates
-def test_get_parent_arguments_delegates(mock_service_provider, get_parent_args_evt):
-    '''
-    Test that get_parent_arguments delegates to the resolved event.
-
-    :param mock_service_provider: The mock service provider fixture.
-    :type mock_service_provider: mock.Mock
-    :param get_parent_args_evt: The mock GetParentArguments event.
-    :type get_parent_args_evt: GetParentArguments
-    '''
-
-    # Invoke get_parent_arguments with the mock provider.
-    parent_arguments = get_parent_arguments(mock_service_provider)
-
-    # Assert event delegation and expected result.
-    get_parent_args_evt.execute.assert_called_once()
-    assert parent_arguments == []
-
-# ** test: build_parser_produces_valid_parser
-def test_build_parser_produces_valid_parser(cli_command_list):
-    '''
-    Test that build_parser produces a parser that accepts a valid argv.
-
-    :param cli_command_list: The sample list of CLI commands.
-    :type cli_command_list: list
-    '''
-
-    # Build the parser from the grouped commands with no parent arguments.
-    command_map = {'test-group': cli_command_list}
-    parser = build_parser(command_map, [])
-
-    # Assert the parser is an argparse.ArgumentParser.
-    assert isinstance(parser, argparse.ArgumentParser)
-
-    # Parse a valid argv and verify the namespace.
-    parsed = vars(parser.parse_args(['test-group', 'test-feature', '--arg1', 'hello']))
-    assert parsed['group'] == 'test-group'
-    assert parsed['command'] == 'test-feature'
-    assert parsed['arg1'] == 'hello'
-
-# ** test: parse_argv_success
-def test_parse_argv_success(cli_command_list):
-    '''
-    Test that parse_argv returns a dict from valid arguments.
-
-    :param cli_command_list: The sample list of CLI commands.
-    :type cli_command_list: list
-    '''
-
-    # Build a parser and parse valid argv.
-    parser = build_parser({'test-group': cli_command_list}, [])
-    parsed = parse_argv(parser, ['test-group', 'test-feature', '--arg1', 'hello'])
-
-    # Assert the result is a dict with expected values.
-    assert isinstance(parsed, dict)
-    assert parsed['group'] == 'test-group'
-    assert parsed['arg1'] == 'hello'
-
-# ** test: parse_argv_exits_on_error
-def test_parse_argv_exits_on_error(cli_command_list):
-    '''
-    Test that parse_argv exits with code 2 on invalid arguments.
-
-    :param cli_command_list: The sample list of CLI commands.
-    :type cli_command_list: list
-    '''
-
-    # Build a parser and attempt to parse invalid argv.
-    parser = build_parser({'test-group': cli_command_list}, [])
-
-    # Assert SystemExit with code 2.
-    with pytest.raises(SystemExit) as exc_info:
-        parse_argv(parser, ['invalid-group'])
-    assert exc_info.value.code == 2
-
-# ** test: derive_feature_request_normalizes
-def test_derive_feature_request_normalizes():
-    '''
-    Test that derive_feature_request normalizes hyphens to underscores.
-    '''
-
-    # Derive feature request from parsed arguments.
-    parsed = {'group': 'test-group', 'command': 'test-feature'}
-    feature_id, headers = derive_feature_request(parsed)
-
-    # Assert normalization.
-    assert feature_id == 'test_group.test_feature'
-    assert headers == dict(
-        command_group='test-group',
-        command_key='test-feature',
-    )
-
-# ** test: build_app_success
-def test_build_app_success(mock_service_provider, capsys):
-    '''
-    Test the happy-path build_app flow dispatches to interface_context.run.
-
-    :param mock_service_provider: The mock service provider fixture.
-    :type mock_service_provider: mock.Mock
-    :param capsys: Pytest capsys fixture.
-    :type capsys: pytest.CaptureFixture
-    '''
-
-    # Create a mock interface context.
-    mock_context = mock.Mock(spec=AppInterfaceContext)
-    mock_context.run.return_value = 'test-response'
-
-    # Mock a minimal app interface with constants.
+    # Arrange a minimal resolved interface.
     mock_interface = mock.Mock()
-    mock_interface.constants = {}
 
-    # Patch internal dependencies to isolate build_app.
-    with mock.patch('tiferet.blueprints.cli.resolve_interface', return_value=(mock_interface, [])), \
-         mock.patch('tiferet.blueprints.cli.wire_services', return_value=mock_service_provider), \
-         mock.patch('tiferet.blueprints.cli.realize_interface', return_value=mock_context):
+    # Patch interface resolution and realization to isolate build_app.
+    with mock.patch.object(cli_blueprint, 'resolve_interface', return_value=(mock_interface, [])) as mock_resolve, \
+         mock.patch.object(cli_blueprint, 'realize_interface', return_value=mock_cli_context) as mock_realize:
 
-        # Invoke build_app.
-        response = build_app(
-            'test_cli',
-            argv=['test-group', 'test-feature', '--arg1', 'hello'],
-        )
+        # Invoke build_app with a sample argv.
+        argv = ['calc', 'add', '1', '2']
+        response = build_app('test_cli', argv=argv)
 
-    # Assert the interface context was invoked with the correct arguments.
-    mock_context.run.assert_called_once()
-    call_kwargs = mock_context.run.call_args.kwargs
-    assert call_kwargs['feature_id'] == 'test_group.test_feature'
-    assert call_kwargs['headers'] == dict(
-        command_group='test-group',
-        command_key='test-feature',
-    )
-    assert call_kwargs['data']['arg1'] == 'hello'
+    # Assert the interface was resolved and realized for the requested id.
+    mock_resolve.assert_called_once()
+    mock_realize.assert_called_once_with(mock_interface, 'test_cli')
 
-    # Assert the response was returned and printed.
-    assert response == 'test-response'
-    captured = capsys.readouterr()
-    assert 'test-response' in captured.out
+    # Assert argv was delegated to run_cli and its response returned.
+    mock_cli_context.run_cli.assert_called_once_with(argv)
+    assert response == 'cli-response'
 
-# ** test: build_app_feature_error
-def test_build_app_feature_error(mock_service_provider):
+# ** test: build_app_defaults_argv_none
+def test_build_app_defaults_argv_none():
     '''
-    Test that a TiferetAPIError from interface_context.run triggers sys.exit(1).
-
-    :param mock_service_provider: The mock service provider fixture.
-    :type mock_service_provider: mock.Mock
+    Test that build_app forwards a None argv to run_cli when none is provided.
     '''
 
-    # Create a mock interface context that raises a TiferetAPIError.
-    mock_context = mock.Mock(spec=AppInterfaceContext)
-    mock_context.run.side_effect = TiferetAPIError(
-        error_code='FEATURE_EXECUTION_FAILED',
-        name='Feature Execution Failed',
-        message='Feature execution failed',
-    )
-
-    # Mock a minimal app interface with constants.
+    # Arrange a mock CLI context and interface.
+    mock_cli_context = mock.Mock()
+    mock_cli_context.run_cli.return_value = None
     mock_interface = mock.Mock()
-    mock_interface.constants = {}
 
-    # Patch internal dependencies to isolate build_app.
-    with mock.patch('tiferet.blueprints.cli.resolve_interface', return_value=(mock_interface, [])), \
-         mock.patch('tiferet.blueprints.cli.wire_services', return_value=mock_service_provider), \
-         mock.patch('tiferet.blueprints.cli.realize_interface', return_value=mock_context):
+    # Patch resolution/realization and invoke without an explicit argv.
+    with mock.patch.object(cli_blueprint, 'resolve_interface', return_value=(mock_interface, [])), \
+         mock.patch.object(cli_blueprint, 'realize_interface', return_value=mock_cli_context):
+        build_app('test_cli')
 
-        # Invoke build_app and expect SystemExit with code 1.
-        with pytest.raises(SystemExit) as exc_info:
-            build_app(
-                'test_cli',
-                argv=['test-group', 'test-feature', '--arg1', 'hello'],
-            )
+    # Assert run_cli received None (defaulted to sys.argv[1:] inside the context).
+    mock_cli_context.run_cli.assert_called_once_with(None)
 
-        # Assert the exit code is 1.
-        assert exc_info.value.code == 1
+# ** test: blueprint_drops_parsing_helpers
+def test_blueprint_drops_parsing_helpers():
+    '''
+    Test that the slimmed blueprint no longer defines the parsing helpers (now
+    owned by tiferet.contexts.cli) and imports neither argparse nor mappers.
+    '''
+
+    # Assert the removed module-level helpers are gone from the blueprint.
+    for name in (
+        'get_commands',
+        'get_parent_arguments',
+        'build_argument_kwargs',
+        'build_parser',
+        'parse_argv',
+        'derive_feature_request',
+    ):
+        assert not hasattr(cli_blueprint, name)
+
+    # Assert the blueprint imports neither argparse nor mapper classes.
+    assert not hasattr(cli_blueprint, 'argparse')
+    assert not hasattr(cli_blueprint, 'CliCommandAggregate')

--- a/tests/blueprints/test_main.py
+++ b/tests/blueprints/test_main.py
@@ -10,6 +10,7 @@ from unittest import mock
 from tiferet import assets as a
 from tiferet.assets import TiferetError
 from tiferet.contexts.app import AppInterfaceContext
+from tiferet.contexts.cli import CliContext
 from tiferet.mappers import AppInterfaceAggregate
 from tiferet.repos.app import AppConfigRepository
 from tiferet import App
@@ -18,6 +19,7 @@ from tiferet.blueprints.main import (
     load_app_service,
     load_default_services,
     load_app_instance,
+    resolve_collaborators,
 )
 
 # *** fixtures
@@ -98,6 +100,99 @@ def test_load_app_instance_success(app_interface_aggregate):
 
     # Assert the result is an AppInterfaceContext.
     assert isinstance(result, AppInterfaceContext)
+
+
+# ** test: load_app_instance_injects_cli_collaborators
+def test_load_app_instance_injects_cli_collaborators():
+    '''
+    Test that realizing a CliContext interface injects the CLI event
+    collaborators that are not part of the generic hub's fixed set.
+    '''
+
+    # Build a CLI interface aggregate pointing at the reincorporated CliContext.
+    cli_interface = AppInterfaceAggregate(
+        id='test_cli',
+        name='Test CLI',
+        module_path='tiferet.contexts.cli',
+        class_name='CliContext',
+        description='Test CLI interface',
+        flags=['test'],
+        services=load_default_services(),
+        constants=a.bps.DEFAULT_CONSTANTS,
+    )
+
+    # Realize the interface context from the aggregate.
+    result = load_app_instance(cli_interface)
+
+    # Assert a CliContext is realized with the CLI collaborators injected.
+    assert isinstance(result, CliContext)
+    assert result.list_commands_evt is not None
+    assert result.get_parent_args_evt is not None
+
+
+# ** test: resolve_collaborators_generic_unchanged
+def test_resolve_collaborators_generic_unchanged():
+    '''
+    Test that the generic AppInterfaceContext resolves only its original three
+    collaborators, excluding reserved args, default_* kwargs, and unrelated ids.
+    '''
+
+    # Build a registry with the hub events plus reserved/default/unrelated ids.
+    registry = {
+        'get_feature_evt': 'gf',
+        'get_error_evt': 'ge',
+        'logging_list_all_evt': 'll',
+        'list_commands_evt': 'lc',
+        'get_parent_args_evt': 'gpa',
+        'get_dependency': 'gd',
+        'cache': 'c',
+        'default_features': 'df',
+        'default_commands': 'dc',
+        'unrelated': 'x',
+    }
+
+    # Resolve collaborators for the generic hub.
+    resolved = resolve_collaborators(AppInterfaceContext, registry)
+
+    # Assert only the original three collaborators are resolved.
+    assert set(resolved.keys()) == {
+        'get_feature_evt',
+        'get_error_evt',
+        'logging_list_all_evt',
+    }
+
+
+# ** test: resolve_collaborators_cli_adds_cli_events
+def test_resolve_collaborators_cli_adds_cli_events():
+    '''
+    Test that the CliContext additionally resolves its CLI event collaborators
+    while still excluding reserved args and default_* kwargs.
+    '''
+
+    # Build a registry with hub and CLI events plus reserved/default ids.
+    registry = {
+        'get_feature_evt': 'gf',
+        'get_error_evt': 'ge',
+        'logging_list_all_evt': 'll',
+        'list_commands_evt': 'lc',
+        'get_parent_args_evt': 'gpa',
+        'get_dependency': 'gd',
+        'cache': 'c',
+        'default_features': 'df',
+        'default_commands': 'dc',
+    }
+
+    # Resolve collaborators for the CLI context.
+    resolved = resolve_collaborators(CliContext, registry)
+
+    # Assert the hub events plus the two CLI events are resolved.
+    assert set(resolved.keys()) == {
+        'get_feature_evt',
+        'get_error_evt',
+        'logging_list_all_evt',
+        'list_commands_evt',
+        'get_parent_args_evt',
+    }
 
 
 # ** test: build_app_success

--- a/tests/blueprints/test_tiferet_cli.py
+++ b/tests/blueprints/test_tiferet_cli.py
@@ -1,0 +1,218 @@
+"""Tiferet Built-in CLI Blueprint Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from tiferet import assets as a
+from tiferet.assets import TiferetAPIError
+import tiferet.blueprints.tiferet_cli as tiferet_cli
+from tiferet.blueprints.tiferet_cli import (
+    build_tiferet_cli,
+    _decode_json_arguments,
+)
+
+# *** fixtures
+
+# ** fixture: mock_request
+@pytest.fixture
+def mock_request():
+    '''
+    Fixture for a parsed request context returned by CliContext.parse_cli_request.
+
+    :return: A mock request carrying feature_id, headers, and data.
+    :rtype: mock.Mock
+    '''
+
+    # Build a mock request with realistic parsed CLI data.
+    request = mock.Mock()
+    request.feature_id = 'feature.add'
+    request.headers = {'command_group': 'feature', 'command_key': 'add'}
+    request.data = {'name': 'Test Feature', 'group_id': 'group'}
+    return request
+
+# ** fixture: mock_cli_context
+@pytest.fixture
+def mock_cli_context(mock_request):
+    '''
+    Fixture for a realized CLI context that parses and dispatches a request.
+
+    :param mock_request: The parsed request fixture.
+    :type mock_request: mock.Mock
+    :return: A mock CLI context.
+    :rtype: mock.Mock
+    '''
+
+    # Build a mock context whose parse_cli_request returns the request and whose
+    # run returns a sentinel response.
+    context = mock.Mock()
+    context.parse_cli_request.return_value = mock_request
+    context.run.return_value = 'cli-response'
+    return context
+
+# ** fixture: mock_interface
+@pytest.fixture
+def mock_interface():
+    '''
+    Fixture for a resolved app interface with mutable constants.
+
+    :return: A mock app interface.
+    :rtype: mock.Mock
+    '''
+
+    # Build a mock interface that supports constant seeding.
+    interface = mock.Mock()
+    interface.constants = {}
+    return interface
+
+# *** tests
+
+# ** test: build_tiferet_cli_realizes_cli_context_with_bootstrap_defaults
+def test_build_tiferet_cli_realizes_cli_context_with_bootstrap_defaults(
+    mock_interface, mock_cli_context, mock_request, capsys
+):
+    '''
+    Test that build_tiferet_cli seeds bootstrap defaults, realizes the CLI
+    context, and dispatches the parsed request through it.
+
+    :param mock_interface: The resolved interface fixture.
+    :type mock_interface: mock.Mock
+    :param mock_cli_context: The realized CLI context fixture.
+    :type mock_cli_context: mock.Mock
+    :param mock_request: The parsed request fixture.
+    :type mock_request: mock.Mock
+    :param capsys: The pytest stdout/stderr capture fixture.
+    :type capsys: pytest.CaptureFixture
+    '''
+
+    # Patch interface resolution and realization to isolate the blueprint.
+    with mock.patch.object(tiferet_cli, 'resolve_interface', return_value=(mock_interface, [])), \
+         mock.patch.object(tiferet_cli, 'realize_interface', return_value=mock_cli_context) as mock_realize:
+
+        # Invoke the built-in CLI for a sample feature command.
+        response = build_tiferet_cli('config.yml', argv=['feature', 'add', 'Test Feature', 'group'])
+
+    # Assert the interface constants were re-seeded before realization.
+    mock_interface.set_constants.assert_called_once()
+
+    # Assert realization received the framework bootstrap defaults.
+    realize_kwargs = mock_realize.call_args.kwargs
+    assert realize_kwargs['default_features'] is a.cli_feat.DEFAULT_TIFERET_CLI_FEATURES
+    assert realize_kwargs['default_commands'] is a.cli_cmd.DEFAULT_TIFERET_CLI_COMMANDS
+    assert isinstance(realize_kwargs['default_configurations'], list)
+    assert realize_kwargs['default_configurations']
+    assert realize_kwargs['default_constants']['app_config'] == 'config.yml'
+    assert realize_kwargs['default_constants']['cli_config'] == 'config.yml'
+
+    # Assert the context parsed argv and dispatched the request.
+    mock_cli_context.parse_cli_request.assert_called_once_with(
+        ['feature', 'add', 'Test Feature', 'group'],
+    )
+    mock_cli_context.run.assert_called_once_with(
+        feature_id=mock_request.feature_id,
+        headers=mock_request.headers,
+        data=mock_request.data,
+    )
+
+    # Assert the response is returned and printed.
+    assert response == 'cli-response'
+    assert 'cli-response' in capsys.readouterr().out
+
+# ** test: build_tiferet_cli_decodes_json_arguments
+def test_build_tiferet_cli_decodes_json_arguments(mock_interface, mock_cli_context, mock_request):
+    '''
+    Test that JSON-valued CLI arguments are decoded before dispatch.
+
+    :param mock_interface: The resolved interface fixture.
+    :type mock_interface: mock.Mock
+    :param mock_cli_context: The realized CLI context fixture.
+    :type mock_cli_context: mock.Mock
+    :param mock_request: The parsed request fixture.
+    :type mock_request: mock.Mock
+    '''
+
+    # Arrange a request whose 'parameters' arg is a raw JSON string.
+    mock_request.data = {'id': 'svc', 'parameters': '{"a": 1, "b": 2}'}
+
+    # Patch resolution/realization and dispatch the CLI.
+    with mock.patch.object(tiferet_cli, 'resolve_interface', return_value=(mock_interface, [])), \
+         mock.patch.object(tiferet_cli, 'realize_interface', return_value=mock_cli_context):
+        build_tiferet_cli('config.yml', argv=['di', 'add', 'svc'])
+
+    # Assert the JSON string was decoded into structured data before run.
+    run_data = mock_cli_context.run.call_args.kwargs['data']
+    assert run_data['parameters'] == {'a': 1, 'b': 2}
+
+# ** test: build_tiferet_cli_api_error_exits_1
+def test_build_tiferet_cli_api_error_exits_1(mock_interface, mock_cli_context):
+    '''
+    Test that a TiferetAPIError raised during dispatch exits with code 1.
+
+    :param mock_interface: The resolved interface fixture.
+    :type mock_interface: mock.Mock
+    :param mock_cli_context: The realized CLI context fixture.
+    :type mock_cli_context: mock.Mock
+    '''
+
+    # Make the context's run raise a TiferetAPIError.
+    mock_cli_context.run.side_effect = TiferetAPIError(
+        error_code='X', name='X Error', message='boom',
+    )
+
+    # Patch resolution/realization and assert a clean exit with code 1.
+    with mock.patch.object(tiferet_cli, 'resolve_interface', return_value=(mock_interface, [])), \
+         mock.patch.object(tiferet_cli, 'realize_interface', return_value=mock_cli_context):
+        with pytest.raises(SystemExit) as exc_info:
+            build_tiferet_cli('config.yml', argv=['feature', 'add', 'X', 'g'])
+
+    # Assert the exit code is 1.
+    assert exc_info.value.code == 1
+
+# ** test: decode_json_arguments_valid
+def test_decode_json_arguments_valid():
+    '''
+    Test that valid JSON-valued arguments are decoded into structured data.
+    '''
+
+    # Decode a namespace containing JSON-valued complex arguments.
+    parsed = _decode_json_arguments({
+        'name': 'plain',
+        'parameters': '{"x": 1}',
+        'services': '[{"id": "svc"}]',
+    })
+
+    # Assert complex args are decoded and plain values are untouched.
+    assert parsed['parameters'] == {'x': 1}
+    assert parsed['services'] == [{'id': 'svc'}]
+    assert parsed['name'] == 'plain'
+
+# ** test: decode_json_arguments_malformed_exits_2
+def test_decode_json_arguments_malformed_exits_2():
+    '''
+    Test that malformed JSON in a complex argument exits with code 2.
+    '''
+
+    # Assert malformed JSON triggers a clean exit with code 2.
+    with pytest.raises(SystemExit) as exc_info:
+        _decode_json_arguments({'parameters': '{not valid json}'})
+    assert exc_info.value.code == 2
+
+# ** test: blueprint_drops_command_map_and_mapper_import
+def test_blueprint_drops_command_map_and_mapper_import():
+    '''
+    Test that the slimmed built-in blueprint no longer builds a command map or
+    imports mapper classes / the removed generic CLI parsing helpers.
+    '''
+
+    # Assert the bootstrap command-map builder is gone.
+    assert not hasattr(tiferet_cli, '_build_tiferet_command_map')
+
+    # Assert no mapper class leaked into the blueprint namespace.
+    assert not hasattr(tiferet_cli, 'CliCommandAggregate')
+
+    # Assert the generic CLI parsing helpers are no longer imported.
+    for name in ('build_parser', 'parse_argv', 'derive_feature_request'):
+        assert not hasattr(tiferet_cli, name)

--- a/tests/contexts/test_cli.py
+++ b/tests/contexts/test_cli.py
@@ -12,7 +12,6 @@ from tiferet.domain import CliArgument, CliCommand
 from tiferet.mappers import AppInterfaceAggregate
 from tiferet.contexts.cli import (
     CliContext,
-    build_argument_kwargs,
     build_parser,
     derive_feature_request,
     group_commands_by_key,
@@ -163,56 +162,6 @@ def test_get_commands_passes_default_commands_list(app_interface):
         default_commands_list=context.default_commands_list,
     )
     assert result == {}
-
-# ** test: build_argument_kwargs_value_action
-def test_build_argument_kwargs_value_action():
-    '''
-    Test that value-consuming arguments include type, nargs, and choices.
-    '''
-
-    # Build a value-consuming argument.
-    argument = CliArgument(
-        name_or_flags=['a'],
-        description='First operand.',
-        type='int',
-        nargs='?',
-        choices=['1', '2'],
-        default='1',
-    )
-
-    # Build the argparse keyword arguments.
-    kwargs = build_argument_kwargs(argument)
-
-    # Assert value keywords are present and flag-only keywords are absent.
-    assert kwargs['type'] is int
-    assert kwargs['nargs'] == '?'
-    assert kwargs['choices'] == ['1', '2']
-    assert kwargs['default'] == '1'
-    assert 'action' not in kwargs
-    assert 'required' not in kwargs
-
-# ** test: build_argument_kwargs_flag_action
-def test_build_argument_kwargs_flag_action():
-    '''
-    Test that flag actions omit value-only keywords.
-    '''
-
-    # Build a flag argument.
-    argument = CliArgument(
-        name_or_flags=['--verbose'],
-        description='Enable verbose output.',
-        action='store_true',
-    )
-
-    # Build the argparse keyword arguments.
-    kwargs = build_argument_kwargs(argument)
-
-    # Assert the action is present and value-only keywords are omitted.
-    assert kwargs['action'] == 'store_true'
-    assert 'type' not in kwargs
-    assert 'nargs' not in kwargs
-    assert 'choices' not in kwargs
-    assert 'default' not in kwargs
 
 # ** test: build_parser_parses_command_arguments
 def test_build_parser_parses_command_arguments():

--- a/tests/contexts/test_cli.py
+++ b/tests/contexts/test_cli.py
@@ -1,0 +1,410 @@
+"""Tiferet CLI Context Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from tiferet.assets import TiferetAPIError
+from tiferet.domain import CliArgument, CliCommand
+from tiferet.mappers import AppInterfaceAggregate
+from tiferet.contexts.cli import (
+    CliContext,
+    build_argument_kwargs,
+    build_parser,
+    derive_feature_request,
+    group_commands_by_key,
+)
+from tiferet.contexts.request import RequestContext
+
+# *** fixtures
+
+# ** fixture: app_interface
+@pytest.fixture
+def app_interface():
+    '''
+    Fixture to create an AppInterfaceAggregate bound as the CLI context domain.
+
+    :return: An AppInterfaceAggregate instance.
+    :rtype: AppInterfaceAggregate
+    '''
+
+    # Create a test interface pointing at the CLI context.
+    return AppInterfaceAggregate(
+        id='test_cli',
+        name='Test CLI',
+        module_path='tiferet.contexts.cli',
+        class_name='CliContext',
+        description='The test CLI interface.',
+        flags=['test'],
+        services=[],
+    )
+
+# ** fixture: cli_context
+@pytest.fixture
+def cli_context(app_interface):
+    '''
+    Fixture to create a CliContext bound to the test interface with mock events.
+
+    The CLI collaborators default to returning empty lists; individual tests
+    override ``list_commands_evt`` / ``get_parent_args_evt`` return values.
+
+    :return: A CliContext instance.
+    :rtype: CliContext
+    '''
+
+    # Build mock CLI collaborators with empty defaults.
+    list_commands_evt = mock.Mock()
+    list_commands_evt.execute.return_value = []
+    get_parent_args_evt = mock.Mock()
+    get_parent_args_evt.execute.return_value = []
+
+    # Construct the CLI context declaratively from the loaded interface.
+    return CliContext.from_domain(
+        app_interface,
+        get_feature_evt=mock.Mock(),
+        get_error_evt=mock.Mock(),
+        logging_list_all_evt=mock.Mock(),
+        get_dependency=mock.Mock(),
+        list_commands_evt=list_commands_evt,
+        get_parent_args_evt=get_parent_args_evt,
+    )
+
+# *** tests
+
+# ** test: group_commands_by_key
+def test_group_commands_by_key():
+    '''
+    Test that group_commands_by_key groups commands by group key in order.
+    '''
+
+    # Group a flat list of commands spanning two groups.
+    commands = group_commands_by_key([
+        CliCommand(name='Add', key='add', group_key='calc'),
+        CliCommand(name='Subtract', key='subtract', group_key='calc'),
+        CliCommand(name='Boot', key='boot', group_key='sys'),
+    ])
+
+    # Assert the commands are grouped by group key preserving order.
+    assert set(commands.keys()) == {'calc', 'sys'}
+    assert [c.key for c in commands['calc']] == ['add', 'subtract']
+    assert [c.key for c in commands['sys']] == ['boot']
+
+# ** test: derive_feature_request
+def test_derive_feature_request():
+    '''
+    Test that derive_feature_request builds the feature id and headers,
+    normalizing hyphens to underscores in the feature id only.
+    '''
+
+    # Derive from a parsed namespace with hyphenated group and command.
+    feature_id, headers = derive_feature_request(
+        {'group': 'my-calc', 'command': 'sub-tract', 'a': 1},
+    )
+
+    # Assert the feature id is normalized and headers keep raw values.
+    assert feature_id == 'my_calc.sub_tract'
+    assert headers == {'command_group': 'my-calc', 'command_key': 'sub-tract'}
+
+# ** test: get_commands_groups_by_group_key
+def test_get_commands_groups_by_group_key(cli_context):
+    '''
+    Test that get_commands groups commands by their group key in order.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    '''
+
+    # Arrange the list-commands event to return commands across two groups.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(name='Add', key='add', group_key='calc'),
+        CliCommand(name='Subtract', key='subtract', group_key='calc'),
+        CliCommand(name='Boot', key='boot', group_key='sys'),
+    ]
+
+    # Retrieve the grouped command map.
+    commands = cli_context.get_commands()
+
+    # Assert the commands are grouped by group key preserving order.
+    assert set(commands.keys()) == {'calc', 'sys'}
+    assert [c.key for c in commands['calc']] == ['add', 'subtract']
+    assert [c.key for c in commands['sys']] == ['boot']
+
+# ** test: get_commands_passes_default_commands_list
+def test_get_commands_passes_default_commands_list(app_interface):
+    '''
+    Test that get_commands forwards the context's default command list to the event.
+
+    :param app_interface: The bound app interface.
+    :type app_interface: AppInterfaceAggregate
+    '''
+
+    # Build a CLI context seeded with bootstrap default commands.
+    list_commands_evt = mock.Mock()
+    list_commands_evt.execute.return_value = []
+    context = CliContext.from_domain(
+        app_interface,
+        get_feature_evt=mock.Mock(),
+        get_error_evt=mock.Mock(),
+        logging_list_all_evt=mock.Mock(),
+        get_dependency=mock.Mock(),
+        list_commands_evt=list_commands_evt,
+        get_parent_args_evt=mock.Mock(),
+        default_commands=[{'name': 'Boot', 'key': 'boot', 'group_key': 'sys'}],
+    )
+
+    # Retrieve the commands.
+    result = context.get_commands()
+
+    # Assert the event was called with the context's default command list.
+    list_commands_evt.execute.assert_called_once_with(
+        default_commands_list=context.default_commands_list,
+    )
+    assert result == {}
+
+# ** test: build_argument_kwargs_value_action
+def test_build_argument_kwargs_value_action():
+    '''
+    Test that value-consuming arguments include type, nargs, and choices.
+    '''
+
+    # Build a value-consuming argument.
+    argument = CliArgument(
+        name_or_flags=['a'],
+        description='First operand.',
+        type='int',
+        nargs='?',
+        choices=['1', '2'],
+        default='1',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = build_argument_kwargs(argument)
+
+    # Assert value keywords are present and flag-only keywords are absent.
+    assert kwargs['type'] is int
+    assert kwargs['nargs'] == '?'
+    assert kwargs['choices'] == ['1', '2']
+    assert kwargs['default'] == '1'
+    assert 'action' not in kwargs
+    assert 'required' not in kwargs
+
+# ** test: build_argument_kwargs_flag_action
+def test_build_argument_kwargs_flag_action():
+    '''
+    Test that flag actions omit value-only keywords.
+    '''
+
+    # Build a flag argument.
+    argument = CliArgument(
+        name_or_flags=['--verbose'],
+        description='Enable verbose output.',
+        action='store_true',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = build_argument_kwargs(argument)
+
+    # Assert the action is present and value-only keywords are omitted.
+    assert kwargs['action'] == 'store_true'
+    assert 'type' not in kwargs
+    assert 'nargs' not in kwargs
+    assert 'choices' not in kwargs
+    assert 'default' not in kwargs
+
+# ** test: build_parser_parses_command_arguments
+def test_build_parser_parses_command_arguments():
+    '''
+    Test that build_parser produces a parser that parses command arguments.
+    '''
+
+    # Build a command map with a single typed command.
+    commands = {
+        'calc': [
+            CliCommand(
+                name='Add', key='add', group_key='calc',
+                arguments=[
+                    CliArgument(name_or_flags=['a'], type='int'),
+                    CliArgument(name_or_flags=['b'], type='int'),
+                ],
+            ),
+        ],
+    }
+
+    # Build the parser (no parent arguments) and parse a sample argv.
+    parser = build_parser(commands, [])
+    parsed = vars(parser.parse_args(['calc', 'add', '1', '2']))
+
+    # Assert the group, command, and typed values parse correctly.
+    assert parsed['group'] == 'calc'
+    assert parsed['command'] == 'add'
+    assert parsed['a'] == 1
+    assert parsed['b'] == 2
+
+# ** test: build_parser_merges_parent_args_and_skips_collisions
+def test_build_parser_merges_parent_args_and_skips_collisions():
+    '''
+    Test that parent arguments are merged but colliding flags are skipped.
+    '''
+
+    # Arrange parent arguments including one that collides with the command arg.
+    parent_arguments = [
+        CliArgument(name_or_flags=['--verbose'], action='store_true'),
+        CliArgument(name_or_flags=['a']),
+    ]
+
+    # Build a command map whose command declares a colliding 'a' argument.
+    commands = {
+        'calc': [
+            CliCommand(
+                name='Add', key='add', group_key='calc',
+                arguments=[CliArgument(name_or_flags=['a'], type='int')],
+            ),
+        ],
+    }
+
+    # Build the parser and parse argv including the non-colliding parent flag.
+    parser = build_parser(commands, parent_arguments)
+    parsed = vars(parser.parse_args(['calc', 'add', '5', '--verbose']))
+
+    # Assert the command arg parses and the parent flag is merged in.
+    assert parsed['a'] == 5
+    assert parsed['verbose'] is True
+
+# ** test: parse_cli_request_builds_request
+def test_parse_cli_request_builds_request(cli_context):
+    '''
+    Test that parse_cli_request derives feature id, headers, and data.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    '''
+
+    # Arrange a single typed command.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(
+            name='Add', key='add', group_key='calc',
+            arguments=[
+                CliArgument(name_or_flags=['a'], type='int'),
+                CliArgument(name_or_flags=['b'], type='int'),
+            ],
+        ),
+    ]
+
+    # Parse the CLI request.
+    request = cli_context.parse_cli_request(['calc', 'add', '1', '2'])
+
+    # Assert the request context carries the derived feature id, headers, and data.
+    assert isinstance(request, RequestContext)
+    assert request.feature_id == 'calc.add'
+    assert request.headers['command_group'] == 'calc'
+    assert request.headers['command_key'] == 'add'
+    assert request.headers['interface_id'] == cli_context.domain.id
+    assert request.data['a'] == 1
+    assert request.data['b'] == 2
+
+# ** test: parse_cli_request_normalizes_hyphens
+def test_parse_cli_request_normalizes_hyphens(cli_context):
+    '''
+    Test that hyphenated group/command keys normalize to an underscore feature id.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    '''
+
+    # Arrange a command with hyphenated group and key.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(name='Subtract', key='sub-tract', group_key='my-calc'),
+    ]
+
+    # Parse the CLI request.
+    request = cli_context.parse_cli_request(['my-calc', 'sub-tract'])
+
+    # Assert the feature id normalizes hyphens while headers keep raw values.
+    assert request.feature_id == 'my_calc.sub_tract'
+    assert request.headers['command_group'] == 'my-calc'
+    assert request.headers['command_key'] == 'sub-tract'
+
+# ** test: run_cli_success_prints_and_returns
+def test_run_cli_success_prints_and_returns(cli_context, capsys):
+    '''
+    Test that run_cli delegates to run, prints, and returns the response.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    :param capsys: The pytest stdout/stderr capture fixture.
+    :type capsys: pytest.CaptureFixture
+    '''
+
+    # Arrange a single typed command and stub the inherited run.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(
+            name='Add', key='add', group_key='calc',
+            arguments=[
+                CliArgument(name_or_flags=['a'], type='int'),
+                CliArgument(name_or_flags=['b'], type='int'),
+            ],
+        ),
+    ]
+    cli_context.run = mock.Mock(return_value='RESULT')
+
+    # Run the CLI for a valid command.
+    result = cli_context.run_cli(['calc', 'add', '1', '2'])
+
+    # Assert the response is returned and printed.
+    assert result == 'RESULT'
+    assert 'RESULT' in capsys.readouterr().out
+
+    # Assert the inherited run was delegated to with the parsed request data.
+    call = cli_context.run.call_args
+    assert call.kwargs['feature_id'] == 'calc.add'
+    assert call.kwargs['headers']['command_group'] == 'calc'
+    assert call.kwargs['headers']['command_key'] == 'add'
+    assert call.kwargs['data']['a'] == 1
+    assert call.kwargs['data']['b'] == 2
+
+# ** test: run_cli_parser_failure_exits_2
+def test_run_cli_parser_failure_exits_2(cli_context):
+    '''
+    Test that an invalid CLI invocation exits with code 2.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    '''
+
+    # Arrange a known command group.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(name='Add', key='add', group_key='calc'),
+    ]
+
+    # Run the CLI with an unknown group and assert an exit code of 2.
+    with pytest.raises(SystemExit) as exc_info:
+        cli_context.run_cli(['nonexistent-group'])
+    assert exc_info.value.code == 2
+
+# ** test: run_cli_api_error_exits_1
+def test_run_cli_api_error_exits_1(cli_context):
+    '''
+    Test that a TiferetAPIError during execution exits with code 1.
+
+    :param cli_context: The CliContext instance.
+    :type cli_context: CliContext
+    '''
+
+    # Arrange a valid command and make the inherited run raise an API error.
+    cli_context.list_commands_evt.execute.return_value = [
+        CliCommand(
+            name='Add', key='add', group_key='calc',
+            arguments=[CliArgument(name_or_flags=['a'], type='int')],
+        ),
+    ]
+    cli_context.run = mock.Mock(
+        side_effect=TiferetAPIError(error_code='X', name='X Error', message='boom'),
+    )
+
+    # Run the CLI for a valid command and assert an exit code of 1.
+    with pytest.raises(SystemExit) as exc_info:
+        cli_context.run_cli(['calc', 'add', '1'])
+    assert exc_info.value.code == 1

--- a/tests/domain/test_cli.py
+++ b/tests/domain/test_cli.py
@@ -112,6 +112,58 @@ def test_cli_argument_get_type_default_str() -> None:
     assert arg.type == 'str'
     assert arg.get_type() is str
 
+# ** test: cli_argument_to_argparse_kwargs_value_action
+def test_cli_argument_to_argparse_kwargs_value_action() -> None:
+    '''
+    Test that value-consuming arguments include resolved type, nargs, and choices.
+    '''
+
+    # Build a value-consuming argument.
+    argument = CliArgument(
+        name_or_flags=['a'],
+        description='First operand.',
+        type='int',
+        nargs='?',
+        choices=['1', '2'],
+        default='1',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert value keywords are present and flag-only keywords are absent.
+    assert kwargs['type'] is int
+    assert kwargs['nargs'] == '?'
+    assert kwargs['choices'] == ['1', '2']
+    assert kwargs['default'] == '1'
+    assert kwargs['help'] == 'First operand.'
+    assert 'action' not in kwargs
+    assert 'required' not in kwargs
+
+# ** test: cli_argument_to_argparse_kwargs_flag_action
+def test_cli_argument_to_argparse_kwargs_flag_action() -> None:
+    '''
+    Test that flag actions omit value-only keywords.
+    '''
+
+    # Build a flag argument.
+    argument = CliArgument(
+        name_or_flags=['--verbose'],
+        description='Enable verbose output.',
+        action='store_true',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert the action and help are present and value-only keywords are omitted.
+    assert kwargs['action'] == 'store_true'
+    assert kwargs['help'] == 'Enable verbose output.'
+    assert 'type' not in kwargs
+    assert 'nargs' not in kwargs
+    assert 'choices' not in kwargs
+    assert 'default' not in kwargs
+
 # ** test: cli_command_new
 def test_cli_command_new(cli_command: CliCommand) -> None:
     '''

--- a/tests_int/test_cli.py
+++ b/tests_int/test_cli.py
@@ -116,7 +116,9 @@ TEST_CALC_CONFIG = {
         },
         'test_calc_cli': {
             'name': 'Integration Test - Basic Calculator CLI',
-            'description': 'CLI interface for testing calculator features via CliBuilder.',
+            'description': 'CLI interface for testing calculator features via the CLI blueprint.',
+            'module_path': 'tiferet.contexts.cli',
+            'class_name': 'CliContext',
             'constants': {
                 'feature_config': None,
                 'error_config': None,

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -82,4 +82,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0b9'
+__version__ = '2.0.0b11'

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -20,6 +20,6 @@ DEFAULT_TIFERET_CLI_INTERFACE = {
     'id': 'tiferet_cli',
     'name': 'Tiferet CLI',
     'description': 'Built-in CLI for managing Tiferet application configurations',
-    'module_path': 'tiferet.contexts.app',
-    'class_name': 'AppInterfaceContext',
+    'module_path': 'tiferet.contexts.cli',
+    'class_name': 'CliContext',
 }

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -3,223 +3,16 @@
 # *** imports
 
 # ** core
-import sys
-import argparse
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional
 
 # ** app
-from ..assets import TiferetAPIError
-from ..domain import CliArgument, CliCommand
 from .. import assets as a
-from ..events import DomainEvent
-from ..events.app import GetAppInterface
 from .main import (
-    wire_services,
-    load_default_services,
     resolve_interface,
     realize_interface,
 )
 
 # *** blueprints
-
-# ** blueprint: get_commands
-def get_commands(registry: Dict[str, Any]) -> Dict[str, List[CliCommand]]:
-    '''
-    Retrieve the CLI commands grouped by their group_key.
-
-    :param registry: The wiring registry of instantiated services keyed by id.
-    :type registry: Dict[str, Any]
-    :return: A dictionary mapping group keys to lists of CLI commands.
-    :rtype: Dict[str, List[CliCommand]]
-    '''
-
-    # Resolve the list CLI commands event and execute it.
-    list_commands_evt = registry['list_commands_evt']
-    cli_commands = list_commands_evt.execute()
-
-    # Group the commands by group_key.
-    command_map: Dict[str, List[CliCommand]] = {}
-    for command in cli_commands:
-        if command.group_key not in command_map:
-            command_map[command.group_key] = [command]
-        else:
-            command_map[command.group_key].append(command)
-
-    # Return the command map.
-    return command_map
-
-
-# ** blueprint: get_parent_arguments
-def get_parent_arguments(registry: Dict[str, Any]) -> List:
-    '''
-    Retrieve the parent-level CLI arguments.
-
-    :param registry: The wiring registry of instantiated services keyed by id.
-    :type registry: Dict[str, Any]
-    :return: A list of parent-level CLI arguments.
-    :rtype: List
-    '''
-
-    # Resolve the parent arguments event and execute it.
-    get_parent_args_evt = registry['get_parent_args_evt']
-    return get_parent_args_evt.execute()
-
-
-# ** blueprint: build_argument_kwargs
-def build_argument_kwargs(argument: CliArgument) -> Dict[str, Any]:
-    '''
-    Build the ``argparse.add_argument`` keyword arguments for a CLI argument.
-
-    Value-only keywords (``type``, ``nargs``, ``choices``) are included only for
-    value-consuming actions (``store``, ``append``, or the default).  Flag and
-    const actions such as ``store_true`` reject those keywords, so they are
-    omitted to keep parser construction valid.
-
-    :param argument: The CLI argument definition.
-    :type argument: CliArgument
-    :return: The keyword arguments for ``add_argument``.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Start with keywords accepted by every argparse action.
-    kwargs: Dict[str, Any] = dict(help=argument.description)
-
-    # Include the action only when explicitly configured.
-    if argument.action is not None:
-        kwargs['action'] = argument.action
-
-    # Value-consuming actions accept type, nargs, and choices.
-    if argument.action in (None, 'store', 'append'):
-        kwargs['type'] = argument.get_type()
-        kwargs['nargs'] = argument.nargs
-        kwargs['choices'] = argument.choices
-
-    # Include an explicit default only when configured so flag actions keep
-    # their argparse-native defaults (e.g. store_true defaults to False).
-    if argument.default is not None:
-        kwargs['default'] = argument.default
-
-    # Required is only meaningful for optional (flagged) arguments.
-    if argument.required is not None:
-        kwargs['required'] = argument.required
-
-    # Return the assembled keyword arguments.
-    return kwargs
-
-
-# ** blueprint: build_parser
-def build_parser(
-    cli_commands: Dict[str, List[CliCommand]],
-    parent_arguments: List,
-) -> argparse.ArgumentParser:
-    '''
-    Build an argparse.ArgumentParser from grouped CLI commands and parent arguments.
-
-    :param cli_commands: The CLI commands grouped by group_key.
-    :type cli_commands: Dict[str, List[CliCommand]]
-    :param parent_arguments: The parent-level CLI arguments.
-    :type parent_arguments: List
-    :return: A configured argument parser.
-    :rtype: argparse.ArgumentParser
-    '''
-
-    # Create the root parser.
-    parser = argparse.ArgumentParser()
-
-    # Add command subparsers for the command groups.
-    group_subparsers = parser.add_subparsers(dest='group')
-
-    # Loop through the command map and create a parser for each command.
-    for group_key in cli_commands:
-        group_subparser = group_subparsers.add_parser(
-            group_key,
-            help=f'Commands for the {group_key} group.'
-        )
-        cli_group_commands = cli_commands[group_key]
-        cmd_subparsers = group_subparser.add_subparsers(dest='command')
-
-        # Add each command's parser with its arguments.
-        for cli_command in cli_group_commands:
-            cli_command_parser = cmd_subparsers.add_parser(
-                cli_command.key,
-                help=cli_command.description
-            )
-
-            # Add the command-level arguments.
-            for argument in cli_command.arguments:
-                cli_command_parser.add_argument(
-                    *argument.name_or_flags,
-                    **build_argument_kwargs(argument),
-                )
-
-            # Add parent arguments that don't collide with declared command arguments.
-            for argument in parent_arguments:
-                if not cli_command.has_argument(argument.name_or_flags):
-                    cli_command_parser.add_argument(
-                        *argument.name_or_flags,
-                        **build_argument_kwargs(argument),
-                    )
-
-    # Return the configured parser.
-    return parser
-
-
-# ** blueprint: parse_argv
-def parse_argv(
-    parser: argparse.ArgumentParser,
-    argv: Optional[List[str]] = None,
-) -> Dict[str, Any]:
-    '''
-    Parse CLI arguments from the given parser, exiting on failure.
-
-    :param parser: The configured argument parser.
-    :type parser: argparse.ArgumentParser
-    :param argv: Optional argument list; defaults to sys.argv[1:] when None.
-    :type argv: Optional[List[str]]
-    :return: The parsed arguments as a dictionary.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Parse the CLI arguments; on failure, print to stderr and exit with code 2.
-    try:
-        return vars(parser.parse_args(argv))
-    except Exception as e:
-        print(e, file=sys.stderr)
-        sys.exit(2)
-
-
-# ** blueprint: derive_feature_request
-def derive_feature_request(
-    parsed: Dict[str, Any],
-) -> Tuple[str, Dict[str, str]]:
-    '''
-    Derive the feature ID and request headers from parsed CLI arguments.
-
-    :param parsed: The parsed argument namespace as a dictionary.
-    :type parsed: Dict[str, Any]
-    :return: A tuple of (feature_id, headers).
-    :rtype: Tuple[str, Dict[str, str]]
-    '''
-
-    # Extract the group and command from the parsed arguments.
-    group = parsed.get('group')
-    command = parsed.get('command')
-
-    # Derive the feature id by normalizing hyphens to underscores.
-    feature_id = '{}.{}'.format(
-        group.replace('-', '_'),
-        command.replace('-', '_'),
-    )
-
-    # Build the request headers from the raw group and command values.
-    headers = dict(
-        command_group=group,
-        command_key=command,
-    )
-
-    # Return the derived feature id and headers.
-    return feature_id, headers
-
 
 # ** blueprint: build_app
 def build_app(
@@ -230,14 +23,18 @@ def build_app(
     **parameters
 ) -> Any:
     '''
-    Build the CLI application, parse arguments, and dispatch to the interface feature.
+    Build the CLI application context and dispatch argv through its CLI pipeline.
 
-    Loads the app service, resolves the interface, builds the CLI parser from
-    configured commands, parses argv, and executes the corresponding feature.
+    Resolves the interface definition, realizes the configured context (which
+    must be a ``CliContext`` to expose ``run_cli``), and delegates argument
+    parsing, feature dispatch, exit-code handling (2 on parse failure, 1 on a
+    ``TiferetAPIError``), and response printing to ``CliContext.run_cli``.
+    Consumer CLI interfaces opt in by pointing their interface config at
+    ``tiferet.contexts.cli`` / ``CliContext``.
 
     :param interface_id: The CLI interface identifier.
     :type interface_id: str
-    :param argv: Optional argument list; defaults to sys.argv[1:] when None.
+    :param argv: Optional argument list; defaults to ``sys.argv[1:]`` when None.
     :type argv: Optional[List[str]]
     :param module_path: The module path of the app service implementation.
     :type module_path: str
@@ -250,46 +47,11 @@ def build_app(
     '''
 
     # Resolve the interface definition in a single pass.
-    app_interface, default_services = resolve_interface(
+    app_interface, _ = resolve_interface(
         interface_id, module_path, class_name, **parameters)
 
-    # Merge constants in priority order: defaults < interface < user parameters.
-    merged_constants = {
-        **{k: v for dep in default_services for k, v in dep.parameters.items()},
-        **a.bps.DEFAULT_CONSTANTS,
-        **(app_interface.constants or {}),
-        **parameters,
-    }
+    # Realize the CLI interface context from the resolved definition.
+    cli_context = realize_interface(app_interface, interface_id)
 
-    # Declaratively wire the default service dependencies with the merged
-    # constants so the CLI events can resolve without an app-level container.
-    registry = wire_services(default_services, merged_constants)
-
-    # Build the CLI parser from the resolved commands and parent arguments.
-    cli_commands = get_commands(registry)
-    parent_arguments = get_parent_arguments(registry)
-    parser = build_parser(cli_commands, parent_arguments)
-
-    # Parse the CLI arguments.
-    parsed = parse_argv(parser, argv)
-
-    # Derive the feature id and headers from the parsed arguments.
-    feature_id, headers = derive_feature_request(parsed)
-
-    # Realize the app interface context from the already-resolved definition.
-    interface_context = realize_interface(app_interface, interface_id)
-
-    # Execute the feature via the interface context; on API error, exit 1.
-    try:
-        response = interface_context.run(
-            feature_id=feature_id,
-            headers=headers,
-            data=parsed,
-        )
-    except TiferetAPIError as e:
-        print(e, file=sys.stderr)
-        sys.exit(1)
-
-    # Print and return the response.
-    print(response)
-    return response
+    # Delegate parsing, dispatch, exit codes, and response printing to the context.
+    return cli_context.run_cli(argv)

--- a/tiferet/blueprints/main.py
+++ b/tiferet/blueprints/main.py
@@ -22,17 +22,6 @@ from ..events import (
 from ..events.app import GetAppInterface
 from ..events.blueprint import CreateServiceResolver
 
-# *** constants
-
-# ** constant: app_context_collaborators
-# Service IDs of the hub's event collaborators resolved by name from the
-# declarative wiring registry when constructing the app interface context.
-APP_CONTEXT_COLLABORATORS = (
-    'get_feature_evt',
-    'get_error_evt',
-    'logging_list_all_evt',
-)
-
 # *** functions
 
 # ** function: resolve_ctor_kwargs
@@ -97,20 +86,37 @@ def build_wiring_constants(app_interface: AppInterface) -> Dict[str, Any]:
 
 
 # ** function: resolve_collaborators
-def resolve_collaborators(registry: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_collaborators(context_cls: type, registry: Dict[str, Any]) -> Dict[str, Any]:
     '''
-    Resolve the hub's event collaborators by name from a wiring registry.
+    Resolve a context class's event collaborators by name from a wiring registry.
 
+    Inspects the context class's own injectable constructor parameters and
+    pulls each matching id from the registry, skipping the arguments that
+    ``load_app_instance`` supplies explicitly (``get_dependency``, ``cache``)
+    and the bootstrap ``default_*`` kwargs forwarded via ``context_kwargs``.
+    This injects the CLI events for a ``CliContext`` and supports any custom
+    context's collaborators without hard-coding collaborator names, while the
+    generic ``AppInterfaceContext`` still resolves only its original three.
+
+    :param context_cls: The context class whose collaborators are resolved.
+    :type context_cls: type
     :param registry: The name-to-value registry of constants and built services.
     :type registry: Dict[str, Any]
-    :return: The resolved collaborators keyed by service id (missing ids map to None).
+    :return: The resolved collaborators keyed by constructor parameter name.
     :rtype: Dict[str, Any]
     '''
 
-    # Resolve each declared collaborator id from the registry.
+    # Arguments supplied explicitly during construction are never collaborators.
+    reserved = {'get_dependency', 'cache'}
+
+    # Match each injectable constructor parameter to a registry entry, skipping
+    # the explicitly-supplied args and the bootstrap default_* kwargs.
     return {
-        name: registry.get(name)
-        for name in APP_CONTEXT_COLLABORATORS
+        name: registry[name]
+        for name in injectable_parameter_names(context_cls)
+        if name not in reserved
+        and not name.startswith('default_')
+        and name in registry
     }
 
 
@@ -273,14 +279,14 @@ def load_app_instance(
         default_constants=context_kwargs.pop('default_constants', None),
     )
 
-    # Resolve the hub's event collaborators by name from the registry.
-    resolved = resolve_collaborators(registry)
-
     # Import the context class declared by the interface (supports custom contexts).
     context_cls = ImportDependency.execute(
         app_interface.module_path,
         app_interface.class_name,
     )
+
+    # Resolve the context class's event collaborators by name from the registry.
+    resolved = resolve_collaborators(context_cls, registry)
 
     # Construct the context declaratively, injecting the resolution handler.
     return context_cls.from_domain(

--- a/tiferet/blueprints/tiferet_cli.py
+++ b/tiferet/blueprints/tiferet_cli.py
@@ -16,38 +16,8 @@ from .main import (
     resolve_interface,
     realize_interface,
 )
-from .cli import (
-    build_parser,
-    parse_argv,
-    derive_feature_request,
-)
 
 # *** blueprints
-
-# ** blueprint: _build_tiferet_command_map
-def _build_tiferet_command_map() -> Dict[str, List]:
-    '''
-    Build a CLI command map directly from ``DEFAULT_TIFERET_CLI_COMMANDS``,
-    bypassing the CLI config repository.
-
-    :return: A dict mapping group keys to lists of ``CliCommandAggregate`` instances.
-    :rtype: Dict[str, List]
-    '''
-
-    from ..mappers import CliCommandAggregate
-
-    # Build the command map from the bootstrap command dicts.
-    command_map: Dict[str, List] = {}
-    for cmd_data in a.cli_cmd.DEFAULT_TIFERET_CLI_COMMANDS:
-        cmd = CliCommandAggregate(**cmd_data)
-        if cmd.group_key not in command_map:
-            command_map[cmd.group_key] = [cmd]
-        else:
-            command_map[cmd.group_key].append(cmd)
-
-    # Return the grouped command map.
-    return command_map
-
 
 # ** blueprint: _decode_json_arguments
 def _decode_json_arguments(parsed: Dict[str, Any]) -> Dict[str, Any]:
@@ -97,6 +67,10 @@ def build_tiferet_cli(
     All CRUD operations performed by domain events target the consumer's
     ``app_config`` file.  The CLI commands and feature workflows are bootstrapped
     from framework asset modules — they are never loaded from the config file.
+    The built-in ``tiferet_cli`` interface resolves to :class:`CliContext`, so
+    parser construction, request parsing, exit-code handling, and dispatch are
+    owned by the context; this blueprint only seeds bootstrap defaults and
+    decodes the management CLI's JSON-valued arguments.
 
     :param app_config: Required path to the consumer's configuration file.
         All domain events that read or write configuration data use this path.
@@ -107,19 +81,6 @@ def build_tiferet_cli(
     :return: The response from the feature execution.
     :rtype: Any
     '''
-
-    # Build the CLI command map directly from bootstrap defaults, bypassing
-    # the CLI config repository entirely for parser construction.
-    cli_command_map = _build_tiferet_command_map()
-
-    # Build the argparse parser from the bootstrapped command map.
-    parser = build_parser(cli_command_map, [])
-
-    # Parse CLI arguments from argv (or sys.argv[1:] when None).
-    parsed = parse_argv(parser, argv)
-
-    # Derive the feature ID and request headers from the parsed arguments.
-    feature_id, headers = derive_feature_request(parsed)
 
     # Resolve the interface definition, using the built-in tiferet_cli
     # defaults when the consumer's config file does not define the interface.
@@ -189,12 +150,12 @@ def build_tiferet_cli(
     # app_config file rather than the seeded 'config.yml' placeholders.
     app_interface.set_constants(merged_constants)
 
-    # Realize the app interface context. The interface constants (re-seeded
+    # Realize the built-in CLI context. The interface constants (re-seeded
     # above with the consumer's app_config) drive declarative service wiring,
-    # and the bootstrap defaults are seeded onto the service resolver so the
-    # bootstrap features, configurations, and commands resolve even when they
-    # are not present in the consumer's config file.
-    interface_context = realize_interface(
+    # and the bootstrap defaults are seeded onto the context and service
+    # resolver so the bootstrap commands, features, and configurations resolve
+    # even when they are not present in the consumer's config file.
+    cli_context = realize_interface(
         app_interface,
         'tiferet_cli',
         default_features=a.cli_feat.DEFAULT_TIFERET_CLI_FEATURES,
@@ -203,18 +164,23 @@ def build_tiferet_cli(
         default_constants=bootstrap_constants,
     )
 
-    # Decode JSON-valued CLI arguments before dispatching to the feature.
-    parsed = _decode_json_arguments(parsed)
+    # Parse the CLI request through the context. The parser is built from the
+    # seeded bootstrap commands (CliContext.get_commands() falls back to the
+    # default command list); argparse exits with code 2 on invalid arguments.
+    request = cli_context.parse_cli_request(argv)
 
-    # Execute the feature via the interface context; on API error, exit 1.
+    # Decode the management CLI's JSON-valued arguments before dispatch,
+    # keeping the JSON concern in this blueprint rather than in CliContext.
+    request.data = _decode_json_arguments(request.data)
+
+    # Execute the feature via the context; on a TiferetAPIError, print the
+    # message to stderr and exit with code 1.
     try:
-        response = interface_context.run(
-            feature_id=feature_id,
-            headers=headers,
-            data=parsed,
+        response = cli_context.run(
+            feature_id=request.feature_id,
+            headers=request.headers,
+            data=request.data,
         )
-
-    # On a TiferetAPIError, print the message to stderr and exit with code 1.
     except TiferetAPIError as e:
         print(e, file=sys.stderr)
         sys.exit(1)

--- a/tiferet/contexts/cli.py
+++ b/tiferet/contexts/cli.py
@@ -1,0 +1,333 @@
+"""Tiferet CLI Context"""
+
+# *** imports
+
+# ** core
+import sys
+import argparse
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# ** app
+from ..assets import TiferetAPIError
+from ..domain import CliArgument, CliCommand
+from ..events import DomainEvent
+from .app import AppInterfaceContext
+from .cache import CacheContext
+from .request import RequestContext
+
+# *** functions
+
+# ** function: group_commands_by_key
+def group_commands_by_key(cli_commands: List[CliCommand]) -> Dict[str, List[CliCommand]]:
+    '''
+    Group CLI commands by their group key, preserving encounter order.
+
+    :param cli_commands: The CLI commands to group.
+    :type cli_commands: List[CliCommand]
+    :return: A mapping of group keys to lists of CLI commands.
+    :rtype: Dict[str, List[CliCommand]]
+    '''
+
+    # Group the commands by their group key.
+    command_map: Dict[str, List[CliCommand]] = {}
+    for command in cli_commands:
+        command_map.setdefault(command.group_key, []).append(command)
+
+    # Return the grouped command map.
+    return command_map
+
+
+# ** function: build_argument_kwargs
+def build_argument_kwargs(argument: CliArgument) -> Dict[str, Any]:
+    '''
+    Build the ``argparse.add_argument`` keyword arguments for a CLI argument.
+
+    Value-only keywords (``type``, ``nargs``, ``choices``) are included only
+    for value-consuming actions (``store``, ``append``, or the default).
+    Flag and const actions such as ``store_true`` reject those keywords, so
+    they are omitted to keep parser construction valid.
+
+    :param argument: The CLI argument definition.
+    :type argument: CliArgument
+    :return: The keyword arguments for ``add_argument``.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Start with keywords accepted by every argparse action.
+    kwargs: Dict[str, Any] = dict(help=argument.description)
+
+    # Include the action only when explicitly configured.
+    if argument.action is not None:
+        kwargs['action'] = argument.action
+
+    # Value-consuming actions accept type, nargs, and choices.
+    if argument.action in (None, 'store', 'append'):
+        kwargs['type'] = argument.get_type()
+        kwargs['nargs'] = argument.nargs
+        kwargs['choices'] = argument.choices
+
+    # Include an explicit default only when configured so flag actions keep
+    # their argparse-native defaults (e.g. store_true defaults to False).
+    if argument.default is not None:
+        kwargs['default'] = argument.default
+
+    # Required is only meaningful for optional (flagged) arguments.
+    if argument.required is not None:
+        kwargs['required'] = argument.required
+
+    # Return the assembled keyword arguments.
+    return kwargs
+
+
+# ** function: build_parser
+def build_parser(
+        commands: Dict[str, List[CliCommand]],
+        parent_arguments: List[CliArgument],
+    ) -> argparse.ArgumentParser:
+    '''
+    Build an argparse parser from grouped CLI commands and parent arguments.
+
+    :param commands: The CLI commands grouped by group key.
+    :type commands: Dict[str, List[CliCommand]]
+    :param parent_arguments: The parent-level arguments merged into each command.
+    :type parent_arguments: List[CliArgument]
+    :return: A configured argument parser.
+    :rtype: argparse.ArgumentParser
+    '''
+
+    # Create the root parser and the group subparsers.
+    parser = argparse.ArgumentParser()
+    group_subparsers = parser.add_subparsers(dest='group')
+
+    # Create a subparser for each command group.
+    for group_key in commands:
+        group_subparser = group_subparsers.add_parser(
+            group_key,
+            help=f'Commands for the {group_key} group.',
+        )
+        cmd_subparsers = group_subparser.add_subparsers(dest='command')
+
+        # Create a subparser for each command in the group.
+        for cli_command in commands[group_key]:
+            cli_command_parser = cmd_subparsers.add_parser(
+                cli_command.key,
+                help=cli_command.description,
+            )
+
+            # Add the command-level arguments.
+            for argument in cli_command.arguments:
+                cli_command_parser.add_argument(
+                    *argument.name_or_flags,
+                    **build_argument_kwargs(argument),
+                )
+
+            # Add parent arguments that don't collide with command arguments.
+            for argument in parent_arguments:
+                if not cli_command.has_argument(argument.name_or_flags):
+                    cli_command_parser.add_argument(
+                        *argument.name_or_flags,
+                        **build_argument_kwargs(argument),
+                    )
+
+    # Return the configured parser.
+    return parser
+
+
+# ** function: derive_feature_request
+def derive_feature_request(parsed: Dict[str, Any]) -> Tuple[str, Dict[str, str]]:
+    '''
+    Derive the feature id and request headers from parsed CLI arguments.
+
+    The feature id normalizes hyphens to underscores; the headers retain the
+    raw group and command values.
+
+    :param parsed: The parsed argument namespace as a dictionary.
+    :type parsed: Dict[str, Any]
+    :return: A tuple of (feature_id, headers).
+    :rtype: Tuple[str, Dict[str, str]]
+    '''
+
+    # Extract the group and command from the parsed arguments.
+    group = parsed.get('group')
+    command = parsed.get('command')
+
+    # Derive the feature id by normalizing hyphens to underscores.
+    feature_id = '{}.{}'.format(
+        group.replace('-', '_'),
+        command.replace('-', '_'),
+    )
+
+    # Build the request headers from the raw group and command values.
+    headers = dict(
+        command_group=group,
+        command_key=command,
+    )
+
+    # Return the derived feature id and headers.
+    return feature_id, headers
+
+# *** contexts
+
+# ** context: cli_context
+class CliContext(AppInterfaceContext):
+    '''
+    The CLI context extends the application interface hub with command-line
+    concerns: it retrieves CLI commands, builds and parses an argparse parser,
+    derives a feature request from the parsed arguments, and dispatches the
+    request through the inherited run pipeline.
+
+    Stateless parsing helpers (command grouping, argument-kwarg assembly,
+    parser construction, and request derivation) live as side-effect-free
+    module-level functions; the context methods orchestrate them with the
+    injected event collaborators.
+
+    It intentionally omits ``domain_type`` so the ``ContextMeta`` registry
+    keeps mapping ``AppInterface`` to :class:`AppInterfaceContext`; the CLI
+    context is selected explicitly through an interface's configured
+    ``module_path`` / ``class_name``.
+    '''
+
+    # * attribute: list_commands_evt
+    list_commands_evt: DomainEvent
+
+    # * attribute: get_parent_args_evt
+    get_parent_args_evt: DomainEvent
+
+    # * init
+    def __init__(self,
+            get_feature_evt: DomainEvent,
+            get_error_evt: DomainEvent,
+            logging_list_all_evt: DomainEvent,
+            get_dependency: Callable,
+            list_commands_evt: DomainEvent,
+            get_parent_args_evt: DomainEvent,
+            cache: CacheContext = None,
+            default_features: List[Dict[str, Any]] = None,
+            default_commands: List[Dict[str, Any]] = None,
+        ):
+        '''
+        Initialize the CLI context.
+
+        :param get_feature_evt: The event used to retrieve features.
+        :type get_feature_evt: DomainEvent
+        :param get_error_evt: The event used to retrieve errors.
+        :type get_error_evt: DomainEvent
+        :param logging_list_all_evt: The event used to list logging configurations.
+        :type logging_list_all_evt: DomainEvent
+        :param get_dependency: The injected service-resolution handler used to
+            resolve feature step events and middleware.
+        :type get_dependency: Callable
+        :param list_commands_evt: The event used to list CLI commands.
+        :type list_commands_evt: DomainEvent
+        :param get_parent_args_evt: The event used to retrieve parent-level CLI arguments.
+        :type get_parent_args_evt: DomainEvent
+        :param cache: The shared cache context for all sub-contexts.
+        :type cache: CacheContext
+        :param default_features: Optional raw feature dicts for bootstrap fallback.
+        :type default_features: List[Dict[str, Any]]
+        :param default_commands: Optional raw CLI command dicts for bootstrap fallback.
+        :type default_commands: List[Dict[str, Any]]
+        '''
+
+        # Initialize the base application interface hub.
+        super().__init__(
+            get_feature_evt=get_feature_evt,
+            get_error_evt=get_error_evt,
+            logging_list_all_evt=logging_list_all_evt,
+            get_dependency=get_dependency,
+            cache=cache,
+            default_features=default_features,
+            default_commands=default_commands,
+        )
+
+        # Store the CLI-specific event collaborators.
+        self.list_commands_evt = list_commands_evt
+        self.get_parent_args_evt = get_parent_args_evt
+
+    # * method: get_commands
+    def get_commands(self) -> Dict[str, List[CliCommand]]:
+        '''
+        Retrieve all CLI commands grouped by their group key.
+
+        :return: A mapping of group keys to lists of CLI commands.
+        :rtype: Dict[str, List[CliCommand]]
+        '''
+
+        # Retrieve the commands via the event, passing the bootstrap defaults.
+        cli_commands = self.list_commands_evt.execute(
+            default_commands_list=self.default_commands_list,
+        )
+
+        # Group the commands by their group key.
+        return group_commands_by_key(cli_commands)
+
+    # * method: parse_cli_request
+    def parse_cli_request(self, argv: Optional[List[str]] = None) -> RequestContext:
+        '''
+        Parse CLI arguments into a request context.
+
+        Retrieves the grouped commands and parent arguments, builds the parser,
+        parses ``argv``, derives the feature id from the command group and key,
+        and delegates to the base request parsing to build the request context.
+
+        :param argv: Optional argument list; defaults to ``sys.argv[1:]`` when None.
+        :type argv: Optional[List[str]]
+        :return: The parsed request context.
+        :rtype: RequestContext
+        '''
+
+        # Retrieve the grouped commands and the parent-level arguments.
+        commands = self.get_commands()
+        parent_arguments = self.get_parent_args_evt.execute()
+
+        # Build the parser and parse the provided argv into a namespace dict.
+        parser = build_parser(commands, parent_arguments)
+        parsed = vars(parser.parse_args(argv))
+
+        # Derive the feature id and headers from the parsed arguments.
+        feature_id, headers = derive_feature_request(parsed)
+
+        # Delegate to the base request parsing to build the request context.
+        return super().parse_request(
+            headers=headers,
+            data=parsed,
+            feature_id=feature_id,
+        )
+
+    # * method: run_cli
+    def run_cli(self, argv: Optional[List[str]] = None) -> Any:
+        '''
+        Parse CLI arguments and dispatch execution through the inherited run.
+
+        Parser failures exit with code 2; a ``TiferetAPIError`` raised during
+        execution is printed to stderr and exits with code 1. On success the
+        response is printed and returned.
+
+        :param argv: Optional argument list; defaults to ``sys.argv[1:]`` when None.
+        :type argv: Optional[List[str]]
+        :return: The response from the feature execution.
+        :rtype: Any
+        '''
+
+        # Parse the CLI request; argparse exits 2 on invalid arguments, and any
+        # other parsing failure is reported to stderr and exits with code 2.
+        try:
+            request = self.parse_cli_request(argv)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            sys.exit(2)
+
+        # Delegate execution to the inherited hub run; convert API errors to exit 1.
+        try:
+            response = self.run(
+                feature_id=request.feature_id,
+                headers=request.headers,
+                data=request.data,
+            )
+        except TiferetAPIError as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+
+        # Print and return the response.
+        print(response)
+        return response

--- a/tiferet/contexts/cli.py
+++ b/tiferet/contexts/cli.py
@@ -37,48 +37,6 @@ def group_commands_by_key(cli_commands: List[CliCommand]) -> Dict[str, List[CliC
     return command_map
 
 
-# ** function: build_argument_kwargs
-def build_argument_kwargs(argument: CliArgument) -> Dict[str, Any]:
-    '''
-    Build the ``argparse.add_argument`` keyword arguments for a CLI argument.
-
-    Value-only keywords (``type``, ``nargs``, ``choices``) are included only
-    for value-consuming actions (``store``, ``append``, or the default).
-    Flag and const actions such as ``store_true`` reject those keywords, so
-    they are omitted to keep parser construction valid.
-
-    :param argument: The CLI argument definition.
-    :type argument: CliArgument
-    :return: The keyword arguments for ``add_argument``.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Start with keywords accepted by every argparse action.
-    kwargs: Dict[str, Any] = dict(help=argument.description)
-
-    # Include the action only when explicitly configured.
-    if argument.action is not None:
-        kwargs['action'] = argument.action
-
-    # Value-consuming actions accept type, nargs, and choices.
-    if argument.action in (None, 'store', 'append'):
-        kwargs['type'] = argument.get_type()
-        kwargs['nargs'] = argument.nargs
-        kwargs['choices'] = argument.choices
-
-    # Include an explicit default only when configured so flag actions keep
-    # their argparse-native defaults (e.g. store_true defaults to False).
-    if argument.default is not None:
-        kwargs['default'] = argument.default
-
-    # Required is only meaningful for optional (flagged) arguments.
-    if argument.required is not None:
-        kwargs['required'] = argument.required
-
-    # Return the assembled keyword arguments.
-    return kwargs
-
-
 # ** function: build_parser
 def build_parser(
         commands: Dict[str, List[CliCommand]],
@@ -118,7 +76,7 @@ def build_parser(
             for argument in cli_command.arguments:
                 cli_command_parser.add_argument(
                     *argument.name_or_flags,
-                    **build_argument_kwargs(argument),
+                    **argument.to_argparse_kwargs(),
                 )
 
             # Add parent arguments that don't collide with command arguments.
@@ -126,7 +84,7 @@ def build_parser(
                 if not cli_command.has_argument(argument.name_or_flags):
                     cli_command_parser.add_argument(
                         *argument.name_or_flags,
-                        **build_argument_kwargs(argument),
+                        **argument.to_argparse_kwargs(),
                     )
 
     # Return the configured parser.
@@ -176,10 +134,10 @@ class CliContext(AppInterfaceContext):
     derives a feature request from the parsed arguments, and dispatches the
     request through the inherited run pipeline.
 
-    Stateless parsing helpers (command grouping, argument-kwarg assembly,
-    parser construction, and request derivation) live as side-effect-free
-    module-level functions; the context methods orchestrate them with the
-    injected event collaborators.
+    Stateless parsing helpers (command grouping, parser construction, and
+    request derivation) live as side-effect-free module-level functions, and
+    per-argument argparse translation lives on ``CliArgument.to_argparse_kwargs``;
+    the context methods orchestrate them with the injected event collaborators.
 
     It intentionally omits ``domain_type`` so the ``ContextMeta`` registry
     keeps mapping ``AppInterface`` to :class:`AppInterfaceContext`; the CLI

--- a/tiferet/domain/cli.py
+++ b/tiferet/domain/cli.py
@@ -3,7 +3,7 @@
 # *** imports
 
 # ** core
-from typing import Any, List, Literal
+from typing import Any, Dict, List, Literal
 
 # ** infra
 from pydantic import Field, model_validator
@@ -97,6 +97,43 @@ class CliArgument(DomainObject):
         # If the type is not recognized, return str as a default.
         else:
             return str
+
+    # * method: to_argparse_kwargs
+    def to_argparse_kwargs(self) -> Dict[str, Any]:
+        '''
+        Build the ``argparse.add_argument`` keyword arguments for this argument.
+
+        Trivial fields are produced by a pydantic ``model_dump`` (excluding the
+        positional ``name_or_flags`` and the bespoke ``description`` / ``type``
+        fields), and ``help`` is mapped from ``description``. Value-consuming
+        actions (the default, ``store``, ``append``) receive a resolved ``type``
+        callable and retain ``nargs`` / ``choices``; flag and const actions such
+        as ``store_true`` reject those keywords, so they are omitted to keep
+        parser construction valid.
+
+        :return: The keyword arguments for ``add_argument``.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Dump the trivial fields, excluding those with bespoke translation.
+        kwargs = self.model_dump(
+            exclude_none=True,
+            exclude={'name_or_flags', 'description', 'type'},
+        )
+
+        # argparse expects 'help' rather than 'description'.
+        kwargs['help'] = self.description
+
+        # Value-consuming actions accept a resolved type and retain nargs/choices;
+        # flag and const actions reject those keywords, so drop them.
+        if self.action in (None, 'store', 'append'):
+            kwargs['type'] = self.get_type()
+        else:
+            kwargs.pop('nargs', None)
+            kwargs.pop('choices', None)
+
+        # Return the assembled keyword arguments.
+        return kwargs
 
 # ** model: cli_command
 class CliCommand(DomainObject):


### PR DESCRIPTION
## Summary

Reincorporates `CliContext` as a high-level context and slims both CLI blueprints to thin entrypoints (b11 Phase 3). Implements items 1–5 of the Phase 3 handoff.

### Functional
- **`CliArgument.to_argparse_kwargs()`** — per-argument argparse translation moved onto the domain model (co-located with `get_type()`); the module-level `build_argument_kwargs` was removed from `contexts/cli.py`, and `build_parser` now calls `argument.to_argparse_kwargs()`.
- **Generalized collaborator wiring** — `resolve_collaborators(context_cls, registry)` inspects the context class's injectable constructor params (skipping `get_dependency`/`cache` and `default_*`), so `CliContext` receives `list_commands_evt`/`get_parent_args_evt` while the generic hub still resolves only its three. `APP_CONTEXT_COLLABORATORS` removed; `load_app_instance` imports the context class before resolving collaborators.
- **Slim generic CLI blueprint** (`blueprints/cli.py`) — `build_app` reduces to resolve → realize → `cli_context.run_cli(argv)`.
- **Built-in CLI interface** — `DEFAULT_TIFERET_CLI_INTERFACE` now points at `tiferet.contexts.cli` / `CliContext`.
- **Slim built-in CLI blueprint** (`blueprints/tiferet_cli.py`) — drops `_build_tiferet_command_map` and the mapper import; bootstrap commands flow via `default_commands`; JSON args are decoded after `parse_cli_request` then dispatched via `run`. Exit codes preserved (2 = parse failure, 1 = `TiferetAPIError`).

### Tests
- Moved kwarg tests to `tests/domain/test_cli.py`; rewrote `tests/blueprints/test_cli.py` for delegation; added `tests/blueprints/test_tiferet_cli.py`; added `load_app_instance` / `resolve_collaborators` coverage to `tests/blueprints/test_main.py`; opted the integration CLI interface into `CliContext`.
- Full suite green: **805 passed, 11 skipped**. Smoke-tested the built-in CLI end-to-end and the `tiferet` console script (parse failure → exit 2).

### Docs
- Updated `AGENTS.md` (with a v2.0.0b11 migration note), `docs/core/{blueprints,contexts,di}.md`, `docs/guides/{blueprints,contexts}.md`, `docs/guides/domain/{app,cli}.md`, and the basic_calculator CLI tutorial.

### Release
- Bumped `__version__` to `2.0.0b11`.

### Commits
- `7c8e4f2` — functional (code + tests)
- `d080c07` — docs
- `ac4e6d9` — version bump

### Review references
- https://github.com/greatstrength/tiferet/pull/841#discussion_r3409697156
- https://github.com/greatstrength/tiferet/pull/841#discussion_r3409794191

---
Warp conversation: https://app.warp.dev/conversation/e28e91d0-ee28-43fd-92d9-48b901d05f47

Co-Authored-By: Oz <oz-agent@warp.dev>
