### PR TITLE
RFP #838 – Built-in request validation schema

### DIFF
--- a/examples/basic_calculator/config.yml
+++ b/examples/basic_calculator/config.yml
@@ -28,6 +28,9 @@ features:
     add:
       name: Add Number
       description: Adds one number to another
+      params_schema:
+        a: int
+        b: int
       commands:
         - service_id: add_number_event
           name: Add `a` and `b`
@@ -46,6 +49,11 @@ features:
     divide:
       name: Divide Number
       description: Divides one number by another
+      params_schema:
+        a: int
+        b:
+          type: float
+          description: The denominator; must be non-zero.
       commands:
         - service_id: divide_number_event
           name: Divide `a` by `b`

--- a/tests/contexts/test_feature.py
+++ b/tests/contexts/test_feature.py
@@ -858,3 +858,146 @@ def test_async_feature_context_subclasses_feature_context():
     assert hasattr(AsyncFeatureContext, 'execute_feature_async')
     assert not hasattr(FeatureContext, 'handle_feature_step_async')
     assert not hasattr(FeatureContext, 'execute_feature_async')
+
+# ** test: feature_context_validate_request_no_schema_is_noop
+def test_feature_context_validate_request_no_schema_is_noop(feature_context, feature):
+    """Test that validate_request leaves data unchanged when no schema is set."""
+
+    # Create a request with raw string data.
+    request = RequestContext(data={'a': '5'})
+
+    # Validate against a schema-less feature.
+    feature_context.validate_request(feature, request)
+
+    # Assert the data is unchanged.
+    assert request.data == {'a': '5'}
+
+# ** test: feature_context_execute_feature_validates_and_coerces
+def test_feature_context_execute_feature_validates_and_coerces(feature_context, services_context):
+    """Test that execute_feature coerces request data before steps run."""
+
+    # Capture the kwargs the command receives.
+    captured = {}
+
+    class CaptureEvent(DomainEvent):
+        def execute(self, a=None, b=None, **kwargs):
+            captured['a'] = a
+            captured['b'] = b
+            return {'a': a, 'b': b}
+
+    # Resolve the capturing command for the step.
+    services_context.get_dependency.return_value = CaptureEvent()
+
+    # Build a feature with a params schema and a single step.
+    feature = Feature(
+        id='calc.add',
+        name='Add',
+        params_schema={'a': 'int', 'b': 'float'},
+        steps=[EventFeatureStep(name='cap', service_id='cap')],
+    )
+    request = RequestContext(data={'a': '5', 'b': '2'})
+
+    # Execute the feature.
+    feature_context.execute_feature(feature, request)
+
+    # Assert request data was coerced and the command received coerced values.
+    assert request.data['a'] == 5
+    assert request.data['b'] == 2.0
+    assert captured['a'] == 5
+    assert captured['b'] == 2.0
+
+# ** test: feature_context_execute_feature_invalid_request_fails_fast
+def test_feature_context_execute_feature_invalid_request_fails_fast(feature_context, services_context):
+    """Test that invalid request data fails before any step executes."""
+
+    # Track command executions.
+    calls = {'count': 0}
+
+    class CountEvent(DomainEvent):
+        def execute(self, **kwargs):
+            calls['count'] += 1
+            return None
+
+    # Resolve the counting command for the step.
+    services_context.get_dependency.return_value = CountEvent()
+
+    # Build a feature whose schema rejects the request.
+    feature = Feature(
+        id='calc.add',
+        name='Add',
+        params_schema={'a': 'int'},
+        steps=[EventFeatureStep(name='cap', service_id='cap')],
+    )
+    request = RequestContext(data={'a': 'notint'})
+
+    # Assert the validation error is raised and no command ran.
+    with pytest.raises(TiferetError) as exc_info:
+        feature_context.execute_feature(feature, request)
+
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert calls['count'] == 0
+
+# ** test: async_feature_context_execute_feature_async_validates
+@pytest.mark.asyncio
+async def test_async_feature_context_execute_feature_async_validates(async_services_context):
+    """Test that execute_feature_async coerces request data before steps run."""
+
+    # Capture the kwargs the command receives.
+    captured = {}
+
+    class CaptureEvent(DomainEvent):
+        def execute(self, a=None, **kwargs):
+            captured['a'] = a
+            return a
+
+    # Resolve the capturing command and build an async context.
+    async_services_context.get_dependency.return_value = CaptureEvent()
+    ctx = AsyncFeatureContext(get_dependency=async_services_context.get_dependency)
+
+    # Build a feature with a params schema and a single step.
+    feature = Feature(
+        id='calc.add',
+        name='Add',
+        params_schema={'a': 'int'},
+        steps=[EventFeatureStep(name='cap', service_id='cap')],
+    )
+    request = RequestContext(data={'a': '7'})
+
+    # Execute the feature asynchronously.
+    await ctx.execute_feature_async(feature, request)
+
+    # Assert coercion happened before the step ran.
+    assert request.data['a'] == 7
+    assert captured['a'] == 7
+
+# ** test: async_feature_context_execute_feature_async_invalid_fails_fast
+@pytest.mark.asyncio
+async def test_async_feature_context_execute_feature_async_invalid_fails_fast(async_services_context):
+    """Test that invalid request data fails before any async step executes."""
+
+    # Track command executions.
+    calls = {'count': 0}
+
+    class CountEvent(DomainEvent):
+        def execute(self, **kwargs):
+            calls['count'] += 1
+
+    # Resolve the counting command and build an async context.
+    async_services_context.get_dependency.return_value = CountEvent()
+    ctx = AsyncFeatureContext(get_dependency=async_services_context.get_dependency)
+
+    # Build a feature whose schema rejects the request.
+    feature = Feature(
+        id='calc.add',
+        name='Add',
+        params_schema={'a': 'int'},
+        steps=[EventFeatureStep(name='cap', service_id='cap')],
+    )
+    request = RequestContext(data={'a': 'bad'})
+
+    # Assert the validation error is raised and no command ran.
+    with pytest.raises(TiferetError) as exc_info:
+        await ctx.execute_feature_async(feature, request)
+
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert calls['count'] == 0

--- a/tests/contexts/test_request.py
+++ b/tests/contexts/test_request.py
@@ -5,7 +5,8 @@ import pytest
 
 # ** app
 from pydantic import Field
-from tiferet.domain import DomainObject
+from tiferet.domain import DomainObject, Request
+from tiferet.contexts.base import BaseContext
 from tiferet.contexts.request import *
 
 # *** fixtures
@@ -197,3 +198,55 @@ def test_request_context_set_result_with_data_key(request_context):
     # Check that the result has been updated correctly in the data dictionary.
     assert request_context.result == None
     assert request_context.data[data_key] == new_result
+
+# ** test: request_context_binds_request_domain
+def test_request_context_binds_request_domain(request_context):
+    """Test that RequestContext binds a Request domain object."""
+
+    # Assert the bound domain is a Request.
+    assert isinstance(request_context.domain, Request)
+
+# ** test: request_context_proxies_read_through
+def test_request_context_proxies_read_through(request_context):
+    """Test that proxy properties read through to the bound Request."""
+
+    # Assert each proxy property reflects the bound request.
+    assert request_context.data == request_context.domain.data
+    assert request_context.headers == request_context.domain.headers
+    assert request_context.feature_id == request_context.domain.feature_id
+    assert request_context.session_id == request_context.domain.session_id
+
+# ** test: request_context_proxies_write_through
+def test_request_context_proxies_write_through(request_context):
+    """Test that proxy property assignment writes through to the bound Request."""
+
+    # Reassigning data writes through to the bound request.
+    request_context.data = {'new': 'data'}
+    assert request_context.domain.data == {'new': 'data'}
+
+    # In-place mutation persists on the bound request.
+    request_context.data['more'] = 'value'
+    assert request_context.domain.data['more'] == 'value'
+
+    # Headers and feature_id also write through.
+    request_context.headers = {'x': 'y'}
+    assert request_context.domain.headers == {'x': 'y'}
+    request_context.feature_id = 'g.f2'
+    assert request_context.domain.feature_id == 'g.f2'
+
+# ** test: request_context_registered_for_request_domain
+def test_request_context_registered_for_request_domain():
+    """Test that the context registry resolves Request to RequestContext."""
+
+    # Assert the registry maps Request to RequestContext.
+    assert BaseContext.for_domain(Request) is RequestContext
+
+# ** test: request_context_session_id_auto_generated
+def test_request_context_session_id_auto_generated():
+    """Test that a session id is generated when not supplied."""
+
+    # Create a request context without a session id.
+    rc = RequestContext(data={})
+
+    # Assert a session id was generated.
+    assert rc.session_id

--- a/tests/domain/test_feature.py
+++ b/tests/domain/test_feature.py
@@ -10,7 +10,10 @@ from tiferet.domain.feature import (
     Feature,
     FeatureStep,
     EventFeatureStep,
+    ParameterSpecification,
+    RequestSpecification,
 )
+from tiferet.assets import TiferetError
 
 # *** fixtures
 
@@ -310,3 +313,181 @@ def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
 
     # Assert invalid type returns None.
     assert feature.get_step('invalid') is None
+
+# ** test: parameter_specification_get_type_mapping
+def test_parameter_specification_get_type_mapping() -> None:
+    '''
+    Test that ParameterSpecification.get_type maps declared type strings to Python types.
+    '''
+
+    # Assert each supported type string maps to its Python type.
+    assert ParameterSpecification(name='a', type='str').get_type() is str
+    assert ParameterSpecification(name='a', type='int').get_type() is int
+    assert ParameterSpecification(name='a', type='float').get_type() is float
+    assert ParameterSpecification(name='a', type='bool').get_type() is bool
+    assert ParameterSpecification(name='a', type='list').get_type() is list
+    assert ParameterSpecification(name='a', type='dict').get_type() is dict
+
+# ** test: parameter_specification_field_definition_required
+def test_parameter_specification_field_definition_required() -> None:
+    '''
+    Test that a required parameter produces a required field definition.
+    '''
+
+    # Build the field definition for a required parameter.
+    annotation, field = ParameterSpecification(name='a', type='int').field_definition()
+
+    # Assert the annotation and requiredness.
+    assert annotation is int
+    assert field.is_required()
+
+# ** test: parameter_specification_field_definition_optional_with_default
+def test_parameter_specification_field_definition_optional_with_default() -> None:
+    '''
+    Test that an optional parameter with a default is not required and carries the default.
+    '''
+
+    # Build the field definition for an optional parameter with a default.
+    spec = ParameterSpecification(name='b', type='float', required=False, default=1.0)
+    _annotation, field = spec.field_definition()
+
+    # Assert the field is optional with the configured default.
+    assert not field.is_required()
+    assert field.default == 1.0
+
+# ** test: request_specification_normalizes_shorthand
+def test_request_specification_normalizes_shorthand() -> None:
+    '''
+    Test that the shorthand keyed form expands to a required parameter.
+    '''
+
+    # Normalize a shorthand keyed mapping.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+
+    # Assert the expanded parameter is required.
+    assert len(spec.parameters) == 1
+    assert spec.parameters[0].name == 'a'
+    assert spec.parameters[0].type == 'int'
+    assert spec.parameters[0].required is True
+
+# ** test: request_specification_normalizes_expanded
+def test_request_specification_normalizes_expanded() -> None:
+    '''
+    Test that the expanded keyed form preserves constraints and defaults.
+    '''
+
+    # Normalize an expanded keyed mapping.
+    spec = RequestSpecification.model_validate(
+        {'b': {'type': 'float', 'required': False, 'default': 1.0, 'minimum': 0}}
+    )
+    param = spec.parameters[0]
+
+    # Assert the parameter constraints are preserved.
+    assert param.name == 'b'
+    assert param.type == 'float'
+    assert param.required is False
+    assert param.default == 1.0
+    assert param.minimum == 0.0
+
+# ** test: request_specification_validate_coerces_and_preserves_extra
+def test_request_specification_validate_coerces_and_preserves_extra() -> None:
+    '''
+    Test that validate coerces typed fields, applies defaults, and preserves extra keys.
+    '''
+
+    # Validate a payload against a schema with a defaulted optional field.
+    spec = RequestSpecification.model_validate(
+        {'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}}
+    )
+    result = spec.validate({'a': '5', 'extra': 'keep'})
+
+    # Assert coercion, default application, and extra-key preservation.
+    assert result['a'] == 5
+    assert isinstance(result['a'], int)
+    assert result['b'] == 1.0
+    assert result['extra'] == 'keep'
+
+# ** test: request_specification_validate_missing_required_raises
+def test_request_specification_validate_missing_required_raises() -> None:
+    '''
+    Test that missing required parameters raise a single REQUEST_VALIDATION_FAILED error.
+    '''
+
+    # Validate an empty payload against a required schema.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+    with pytest.raises(TiferetError) as exc_info:
+        spec.validate({}, feature_id='calc.add')
+
+    # Assert the structured validation error with one violation.
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert exc_info.value.kwargs.get('feature_id') == 'calc.add'
+    assert len(exc_info.value.kwargs.get('violations')) == 1
+
+# ** test: request_specification_validate_aggregates_multiple_errors
+def test_request_specification_validate_aggregates_multiple_errors() -> None:
+    '''
+    Test that multiple validation failures are aggregated into one error.
+    '''
+
+    # Validate a payload that fails two fields.
+    spec = RequestSpecification.model_validate({'a': 'int', 'b': 'int'})
+    with pytest.raises(TiferetError) as exc_info:
+        spec.validate({'a': 'x', 'b': 'y'}, feature_id='calc.add')
+
+    # Assert both violations are aggregated.
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert len(exc_info.value.kwargs.get('violations')) == 2
+
+# ** test: request_specification_validate_choices
+def test_request_specification_validate_choices() -> None:
+    '''
+    Test that choices restrict values via a Literal annotation.
+    '''
+
+    # Validate a payload constrained by choices.
+    spec = RequestSpecification.model_validate(
+        {'mode': {'type': 'str', 'choices': ['add', 'sub']}}
+    )
+
+    # Assert a valid choice passes and an invalid choice fails.
+    assert spec.validate({'mode': 'add'})['mode'] == 'add'
+    with pytest.raises(TiferetError):
+        spec.validate({'mode': 'bad'})
+
+# ** test: request_specification_is_satisfied_by
+def test_request_specification_is_satisfied_by() -> None:
+    '''
+    Test the convenience is_satisfied_by predicate.
+    '''
+
+    # Build a simple required schema.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+
+    # Assert satisfied and unsatisfied payloads.
+    assert spec.is_satisfied_by({'a': 3}) is True
+    assert spec.is_satisfied_by({}) is False
+
+# ** test: feature_params_schema_defaults_to_none
+def test_feature_params_schema_defaults_to_none() -> None:
+    '''
+    Test that Feature.params_schema defaults to None.
+    '''
+
+    # Create a Feature without a params schema.
+    feature = Feature(id='calc.add', name='Add')
+
+    # Assert the schema defaults to None.
+    assert feature.params_schema is None
+
+# ** test: feature_params_schema_construction
+def test_feature_params_schema_construction() -> None:
+    '''
+    Test that Feature.params_schema is built from keyed config.
+    '''
+
+    # Create a Feature with a keyed params schema.
+    feature = Feature(id='calc.add', name='Add', params_schema={'a': 'int', 'b': 'int'})
+
+    # Assert the schema parsed into a RequestSpecification.
+    assert isinstance(feature.params_schema, RequestSpecification)
+    assert [p.name for p in feature.params_schema.parameters] == ['a', 'b']

--- a/tests/domain/test_request.py
+++ b/tests/domain/test_request.py
@@ -1,0 +1,85 @@
+"""Tests for Tiferet Domain Request"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.domain.request import Request
+
+# *** tests
+
+# ** test: request_defaults
+def test_request_defaults() -> None:
+    '''
+    Test that Request defaults headers/data to empty dicts and feature_id to None.
+    '''
+
+    # Create a Request with no arguments.
+    request = Request()
+
+    # Assert the defaults.
+    assert request.headers == {}
+    assert request.data == {}
+    assert request.feature_id is None
+
+# ** test: request_session_id_auto_derived
+def test_request_session_id_auto_derived() -> None:
+    '''
+    Test that a session_id is auto-generated when not supplied.
+    '''
+
+    # Create a Request without a session id.
+    request = Request()
+
+    # Assert a session id was generated.
+    assert isinstance(request.session_id, str)
+    assert request.session_id
+
+    # Assert two requests receive distinct session ids.
+    assert Request().session_id != request.session_id
+
+# ** test: request_session_id_preserved
+def test_request_session_id_preserved() -> None:
+    '''
+    Test that an explicit session_id is preserved.
+    '''
+
+    # Create a Request with an explicit session id.
+    request = Request(session_id='fixed-session')
+
+    # Assert the session id is preserved.
+    assert request.session_id == 'fixed-session'
+
+# ** test: request_construction_with_fields
+def test_request_construction_with_fields() -> None:
+    '''
+    Test that Request stores supplied fields.
+    '''
+
+    # Create a fully-specified Request.
+    request = Request(feature_id='calc.add', headers={'h': '1'}, data={'a': 1})
+
+    # Assert the fields are stored.
+    assert request.feature_id == 'calc.add'
+    assert request.headers == {'h': '1'}
+    assert request.data == {'a': 1}
+
+# ** test: request_model_dump_round_trip
+def test_request_model_dump_round_trip() -> None:
+    '''
+    Test that a Request round-trips through model_dump.
+    '''
+
+    # Create a Request and serialize it.
+    request = Request(feature_id='calc.add', data={'a': 1})
+    primitive = request.model_dump()
+
+    # Reload the Request from the serialized data.
+    reloaded = Request(**primitive)
+
+    # Assert the round-trip preserves the fields.
+    assert reloaded.feature_id == 'calc.add'
+    assert reloaded.data == {'a': 1}
+    assert reloaded.session_id == request.session_id

--- a/tests/mappers/test_feature.py
+++ b/tests/mappers/test_feature.py
@@ -529,3 +529,78 @@ class TestFeatureYamlObject(TransferObjectTestBase):
         # Verify the middleware is attached to the step.
         assert step.middleware == ['timing_middleware']
         assert agg.steps[0].middleware == ['timing_middleware']
+
+
+# *** params_schema tests
+
+# ** test: feature_yaml_object_maps_params_schema
+def test_feature_yaml_object_maps_params_schema():
+    '''
+    Test that FeatureYamlObject maps a keyed params_schema into the aggregate.
+    '''
+
+    # Create a YAML object with a keyed params_schema and map it.
+    yaml_obj = FeatureYamlObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    ))
+    aggregate = yaml_obj.map()
+
+    # Verify the params_schema mapped onto the aggregate with constraints intact.
+    params = {p.name: p for p in aggregate.params_schema.parameters}
+    assert params['a'].type == 'int'
+    assert params['a'].required is True
+    assert params['b'].type == 'float'
+    assert params['b'].required is False
+    assert params['b'].default == 1.0
+
+# ** test: feature_yaml_object_serializes_params_schema_keyed
+def test_feature_yaml_object_serializes_params_schema_keyed():
+    '''
+    Test that params_schema serializes to the ergonomic keyed mapping.
+    '''
+
+    # Build an aggregate carrying a params_schema.
+    aggregate = FeatureYamlObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    )).map()
+
+    # Serialize the aggregate back to data form.
+    data = FeatureYamlObject.from_model(aggregate).to_primitive('to_data')
+
+    # Verify shorthand and expanded keyed forms.
+    assert data['params_schema']['a'] == 'int'
+    assert data['params_schema']['b']['type'] == 'float'
+    assert data['params_schema']['b']['default'] == 1.0
+    assert data['params_schema']['b']['required'] is False
+
+# ** test: feature_yaml_object_params_schema_round_trip
+def test_feature_yaml_object_params_schema_round_trip():
+    '''
+    Test that params_schema is preserved through a map/from_model round-trip.
+    '''
+
+    # Map then reverse-map the feature.
+    aggregate = FeatureYamlObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    )).map()
+    aggregate2 = FeatureYamlObject.from_model(aggregate).map()
+
+    # Verify the params survive the round-trip.
+    params = {p.name: (p.type, p.required, p.default) for p in aggregate2.params_schema.parameters}
+    assert params['a'] == ('int', True, None)
+    assert params['b'] == ('float', False, 1.0)

--- a/tests/repos/test_feature.py
+++ b/tests/repos/test_feature.py
@@ -281,3 +281,32 @@ def test_int_feature_config_repo_delete(
     feature_config_repo.delete(TEST_FEATURE_ID)
     remaining_features = feature_config_repo.list(group_id='test_group')
     assert remaining_features == []
+
+# ** test_int: feature_config_repo_params_schema_round_trip
+def test_int_feature_config_repo_params_schema_round_trip(
+        feature_config_repo: FeatureConfigRepository,
+    ) -> None:
+    '''
+    Test that a params_schema block round-trips through save and get.
+
+    :param feature_config_repo: The feature configuration repository.
+    :type feature_config_repo: FeatureConfigRepository
+    '''
+
+    # Create a feature carrying a params_schema and save it.
+    schema_feature_id = 'schema_group.schema_feature'
+    feature = FeatureYamlObject.model_validate(dict(
+        id=schema_feature_id,
+        name='Schema Feature',
+        description='A feature with a request schema.',
+        commands=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+        log_params={},
+    )).map()
+    feature_config_repo.save(feature)
+
+    # Reload the feature and verify the params_schema survived persistence.
+    reloaded = feature_config_repo.get(schema_feature_id)
+    params = {p.name: (p.type, p.required, p.default) for p in reloaded.params_schema.parameters}
+    assert params['a'] == ('int', True, None)
+    assert params['b'] == ('float', False, 1.0)

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -58,6 +58,9 @@ REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
 # ** constant: parameter_not_found_id
 PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
 
+# ** constant: request_validation_failed_id
+REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
+
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
@@ -395,6 +398,15 @@ DEFAULT_ERRORS = {
         'name': 'Parameter Not Found',
         'message': [
             {'lang': 'en_US', 'text': 'Parameter {parameter} not found in request data.'}
+        ]
+    },
+
+    # * error: REQUEST_VALIDATION_FAILED
+    REQUEST_VALIDATION_FAILED_ID: {
+        'id': REQUEST_VALIDATION_FAILED_ID,
+        'name': 'Request Validation Failed',
+        'message': [
+            {'lang': 'en_US', 'text': 'Request validation failed for feature {feature_id}: {violations}.'}
         ]
     },
 

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -18,6 +18,14 @@ from typing import Any, Dict, List
 # ** config: default_tiferet_cli_features
 # Each dict matches the Feature domain object constructor fields.
 # Steps use EventFeatureStep field names: service_id, name, parameters, data_key.
+# ``params_schema`` declares the feature-level request validation schema
+# (RFP #838) for each feature, mapping the underlying event's expected request
+# parameters to declared types and defaults. It uses the ergonomic keyed form:
+# the shorthand ``name: type`` for required parameters and the expanded form
+# ``name: {type, required, default}`` for optional parameters. Framework
+# context parameters (e.g. default_* fallbacks), free-form ``value`` arguments,
+# and comma-separated list arguments (handlers, name_or_flags) are intentionally
+# omitted so existing request behavior is preserved.
 DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
 
     # * features: feature domain
@@ -27,6 +35,15 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add',
         'name': 'Add Feature',
         'description': 'Add a new feature configuration.',
+        'params_schema': {
+            'name': 'str',
+            'group_id': 'str',
+            'feature_key': {'type': 'str', 'required': False},
+            'id': {'type': 'str', 'required': False},
+            'description': {'type': 'str', 'required': False},
+            'steps': {'type': 'list', 'required': False},
+            'log_params': {'type': 'dict', 'required': False},
+        },
         'steps': [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
     },
     {
@@ -35,6 +52,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'get',
         'name': 'Get Feature',
         'description': 'Retrieve a feature by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
     },
     {
@@ -43,6 +63,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'list',
         'name': 'List Features',
         'description': 'List all features, optionally filtered by group.',
+        'params_schema': {
+            'group_id': {'type': 'str', 'required': False},
+        },
         'steps': [{'service_id': 'list_features_evt', 'name': 'List features'}],
     },
     {
@@ -51,6 +74,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove',
         'name': 'Remove Feature',
         'description': 'Remove a feature configuration by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
     },
     {
@@ -59,6 +85,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'update',
         'name': 'Update Feature',
         'description': 'Update a feature attribute (name or description).',
+        'params_schema': {
+            'id': 'str',
+            'attribute': 'str',
+        },
         'steps': [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
     },
     {
@@ -67,6 +97,15 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_step',
         'name': 'Add Feature Step',
         'description': 'Add a step to an existing feature workflow.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'service_id': 'str',
+            'parameters': {'type': 'dict', 'required': False},
+            'data_key': {'type': 'str', 'required': False},
+            'pass_on_error': {'type': 'bool', 'required': False, 'default': False},
+            'position': {'type': 'int', 'required': False},
+        },
         'steps': [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
     },
     {
@@ -75,6 +114,11 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'update_step',
         'name': 'Update Feature Step',
         'description': 'Update an attribute on a feature step.',
+        'params_schema': {
+            'id': 'str',
+            'position': 'int',
+            'attribute': 'str',
+        },
         'steps': [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
     },
     {
@@ -83,6 +127,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_step',
         'name': 'Remove Feature Step',
         'description': 'Remove a step from a feature by position.',
+        'params_schema': {
+            'id': 'str',
+            'position': 'int',
+        },
         'steps': [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
     },
     {
@@ -91,6 +139,11 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'reorder_step',
         'name': 'Reorder Feature Step',
         'description': 'Move a feature step from one position to another.',
+        'params_schema': {
+            'id': 'str',
+            'start_position': 'int',
+            'end_position': 'int',
+        },
         'steps': [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
     },
 
@@ -101,6 +154,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add',
         'name': 'Add Error',
         'description': 'Add a new error definition.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'message': 'str',
+            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+            'additional_messages': {'type': 'list', 'required': False, 'default': []},
+        },
         'steps': [{'service_id': 'add_error_evt', 'name': 'Add error'}],
     },
     {
@@ -109,6 +169,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'get',
         'name': 'Get Error',
         'description': 'Retrieve an error by ID.',
+        'params_schema': {
+            'id': 'str',
+            'include_defaults': {'type': 'bool', 'required': False, 'default': False},
+        },
         'steps': [{'service_id': 'get_error_evt', 'name': 'Get error'}],
     },
     {
@@ -117,6 +181,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'list',
         'name': 'List Errors',
         'description': 'List all error definitions.',
+        'params_schema': {
+            'include_defaults': {'type': 'bool', 'required': False, 'default': False},
+        },
         'steps': [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
     },
     {
@@ -125,6 +192,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'rename',
         'name': 'Rename Error',
         'description': 'Rename an existing error.',
+        'params_schema': {
+            'id': 'str',
+            'new_name': 'str',
+        },
         'steps': [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
     },
     {
@@ -133,6 +204,11 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_message',
         'name': 'Set Error Message',
         'description': 'Set or update an error message for a language.',
+        'params_schema': {
+            'id': 'str',
+            'message': 'str',
+            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+        },
         'steps': [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
     },
     {
@@ -141,6 +217,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_message',
         'name': 'Remove Error Message',
         'description': 'Remove an error message by language.',
+        'params_schema': {
+            'id': 'str',
+            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+        },
         'steps': [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
     },
     {
@@ -149,6 +229,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove',
         'name': 'Remove Error',
         'description': 'Remove an error definition by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
     },
 
@@ -159,6 +242,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add',
         'name': 'Add Service Configuration',
         'description': 'Add a new service configuration.',
+        'params_schema': {
+            'id': 'str',
+            'module_path': {'type': 'str', 'required': False},
+            'class_name': {'type': 'str', 'required': False},
+            'parameters': {'type': 'dict', 'required': False, 'default': {}},
+            'flagged_dependencies': {'type': 'list', 'required': False, 'default': []},
+        },
         'steps': [{'service_id': 'add_service_configuration_evt', 'name': 'Add service configuration'}],
     },
     {
@@ -175,6 +265,12 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_default',
         'name': 'Set Default Service Configuration',
         'description': 'Set or update the default type for a service configuration.',
+        'params_schema': {
+            'id': 'str',
+            'module_path': {'type': 'str', 'required': False},
+            'class_name': {'type': 'str', 'required': False},
+            'parameters': {'type': 'dict', 'required': False},
+        },
         'steps': [{'service_id': 'set_default_service_configuration_evt', 'name': 'Set default service configuration'}],
     },
     {
@@ -183,6 +279,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_dependency',
         'name': 'Set Service Dependency',
         'description': 'Set or update a flagged dependency on a service configuration.',
+        'params_schema': {
+            'id': 'str',
+            'flag': 'str',
+            'module_path': 'str',
+            'class_name': 'str',
+            'parameters': {'type': 'dict', 'required': False, 'default': {}},
+        },
         'steps': [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
     },
     {
@@ -191,6 +294,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_dependency',
         'name': 'Remove Service Dependency',
         'description': 'Remove a flagged dependency from a service configuration.',
+        'params_schema': {
+            'id': 'str',
+            'flag': 'str',
+        },
         'steps': [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
     },
     {
@@ -199,6 +306,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove',
         'name': 'Remove Service Configuration',
         'description': 'Remove a service configuration by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_service_configuration_evt', 'name': 'Remove service configuration'}],
     },
     {
@@ -207,6 +317,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_constants',
         'name': 'Set Service Constants',
         'description': 'Set or clear service-level constants.',
+        'params_schema': {
+            'constants': {'type': 'dict', 'required': False, 'default': {}},
+        },
         'steps': [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
     },
 
@@ -217,6 +330,17 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add',
         'name': 'Add App Interface',
         'description': 'Add a new application interface configuration.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'module_path': 'str',
+            'class_name': 'str',
+            'description': {'type': 'str', 'required': False},
+            'logger_id': {'type': 'str', 'required': False, 'default': 'default'},
+            'flags': {'type': 'list', 'required': False, 'default': ['default']},
+            'services': {'type': 'list', 'required': False, 'default': []},
+            'constants': {'type': 'dict', 'required': False, 'default': {}},
+        },
         'steps': [{'service_id': 'add_app_interface_evt', 'name': 'Add app interface'}],
     },
     {
@@ -225,6 +349,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'get',
         'name': 'Get App Interface',
         'description': 'Retrieve an app interface by ID.',
+        'params_schema': {
+            'interface_id': 'str',
+        },
         'steps': [{'service_id': 'get_app_interface_evt', 'name': 'Get app interface'}],
     },
     {
@@ -241,6 +368,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'update',
         'name': 'Update App Interface',
         'description': 'Update a scalar attribute on an app interface.',
+        'params_schema': {
+            'id': 'str',
+            'attribute': 'str',
+        },
         'steps': [{'service_id': 'update_app_interface_evt', 'name': 'Update app interface'}],
     },
     {
@@ -249,6 +380,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_constants',
         'name': 'Set App Constants',
         'description': 'Set or clear constants on an app interface.',
+        'params_schema': {
+            'id': 'str',
+            'constants': {'type': 'dict', 'required': False},
+        },
         'steps': [{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
     },
     {
@@ -257,6 +392,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'set_service',
         'name': 'Set App Service Dependency',
         'description': 'Set or update a service dependency on an app interface.',
+        'params_schema': {
+            'id': 'str',
+            'service_id': 'str',
+            'module_path': 'str',
+            'class_name': 'str',
+            'parameters': {'type': 'dict', 'required': False},
+        },
         'steps': [{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
     },
     {
@@ -265,6 +407,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_service',
         'name': 'Remove App Service Dependency',
         'description': 'Remove a service dependency from an app interface.',
+        'params_schema': {
+            'id': 'str',
+            'service_id': 'str',
+        },
         'steps': [{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
     },
     {
@@ -273,6 +419,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove',
         'name': 'Remove App Interface',
         'description': 'Remove an app interface by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_app_interface_evt', 'name': 'Remove app interface'}],
     },
 
@@ -283,6 +432,14 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_command',
         'name': 'Add CLI Command',
         'description': 'Add a new CLI command definition.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'key': 'str',
+            'group_key': 'str',
+            'description': {'type': 'str', 'required': False},
+            'arguments': {'type': 'list', 'required': False, 'default': []},
+        },
         'steps': [{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
     },
     {
@@ -299,6 +456,10 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_argument',
         'name': 'Add CLI Argument',
         'description': 'Add an argument to an existing CLI command.',
+        'params_schema': {
+            'command_id': 'str',
+            'description': {'type': 'str', 'required': False},
+        },
         'steps': [{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
     },
 
@@ -309,6 +470,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_formatter',
         'name': 'Add Formatter',
         'description': 'Add a new logging formatter configuration.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'format': 'str',
+            'description': {'type': 'str', 'required': False},
+            'datefmt': {'type': 'str', 'required': False},
+        },
         'steps': [{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
     },
     {
@@ -317,6 +485,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_formatter',
         'name': 'Remove Formatter',
         'description': 'Remove a logging formatter by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
     },
     {
@@ -325,6 +496,17 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_handler',
         'name': 'Add Handler',
         'description': 'Add a new logging handler configuration.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'module_path': 'str',
+            'class_name': 'str',
+            'level': 'str',
+            'formatter': 'str',
+            'description': {'type': 'str', 'required': False},
+            'stream': {'type': 'str', 'required': False},
+            'filename': {'type': 'str', 'required': False},
+        },
         'steps': [{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
     },
     {
@@ -333,6 +515,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_handler',
         'name': 'Remove Handler',
         'description': 'Remove a logging handler by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
     },
     {
@@ -341,6 +526,13 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'add_logger',
         'name': 'Add Logger',
         'description': 'Add a new logger configuration.',
+        'params_schema': {
+            'id': 'str',
+            'name': 'str',
+            'level': 'str',
+            'description': {'type': 'str', 'required': False},
+            'propagate': {'type': 'bool', 'required': False, 'default': True},
+        },
         'steps': [{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
     },
     {
@@ -349,6 +541,9 @@ DEFAULT_TIFERET_CLI_FEATURES: List[Dict[str, Any]] = [
         'feature_key': 'remove_logger',
         'name': 'Remove Logger',
         'description': 'Remove a logger by ID.',
+        'params_schema': {
+            'id': 'str',
+        },
         'steps': [{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
     },
     {

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -325,6 +325,34 @@ class FeatureContext(BaseContext):
             # Yield the resolved step.
             yield cmd, feature_event, params
 
+    # * method: validate_request
+    def validate_request(self, feature: Feature, request: RequestContext) -> None:
+        '''
+        Validate and coerce request data against the feature's request schema
+        before any step executes.
+
+        When the feature declares no ``params_schema`` the request is left
+        unchanged; otherwise the coerced result replaces ``request.data`` so all
+        downstream steps receive validated, type-coerced inputs. A schema
+        failure raises a single ``REQUEST_VALIDATION_FAILED`` error before any
+        step runs.
+
+        :param feature: The pre-loaded feature domain object.
+        :type feature: Feature
+        :param request: The request context whose data is validated in place.
+        :type request: RequestContext
+        '''
+
+        # Skip validation when the feature declares no request schema.
+        if feature.params_schema is None:
+            return
+
+        # Validate and coerce the request data, assigning the merged result back.
+        request.data = feature.params_schema.validate(
+            request.data,
+            feature_id=feature.id,
+        )
+
     # * method: execute_feature
     def execute_feature(self, feature: Feature, request: RequestContext, **kwargs):
         '''
@@ -337,6 +365,10 @@ class FeatureContext(BaseContext):
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         '''
+
+        # Validate and coerce request data against the feature schema first,
+        # failing fast before any step executes.
+        self.validate_request(feature, request)
 
         # Resolve feature-level middleware once for all steps.
         feature_middleware = self.load_feature_middleware(feature.middleware)
@@ -459,6 +491,10 @@ class AsyncFeatureContext(FeatureContext):
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         '''
+
+        # Validate and coerce request data against the feature schema first,
+        # failing fast before any step executes.
+        self.validate_request(feature, request)
 
         # Resolve feature-level middleware once for all steps.
         feature_middleware = self.load_feature_middleware(feature.middleware)

--- a/tiferet/contexts/request.py
+++ b/tiferet/contexts/request.py
@@ -3,62 +3,126 @@
 # *** imports
 
 # ** core
-from typing import Dict, Any
-from uuid import uuid4
+from typing import Any, Dict
+
+# ** app
+from .base import BaseContext
+from ..domain import Request
 
 # *** contexts
 
 # ** context: request_context
-class RequestContext(object):
+class RequestContext(BaseContext):
     '''
     The request context carries the session, feature, headers, data, and result
-    for a single feature execution.
+    for a single feature execution. It binds a :class:`Request` domain value
+    object as ``domain`` and exposes the request fields as read/write proxy
+    properties, while ``result`` remains runtime-only context state.
     '''
 
-    # * attribute: session_id
-    session_id: str
-
-    # * attribute: feature_id
-    feature_id: str
-
-    # * attribute: headers
-    headers: Dict[str, str]
-
-    # * attribute: data
-    data: Dict[str, Any]
+    # * attribute: domain_type
+    domain_type = Request
 
     # * attribute: result
     result: Any
 
     # * init
-    def __init__(self, headers: Dict[str, str] = {}, data: Dict[str, Any] = {}, session_id: str = None, feature_id: str = None):
+    def __init__(self,
+            headers: Dict[str, str] = None,
+            data: Dict[str, Any] = None,
+            session_id: str = None,
+            feature_id: str = None,
+            services: Any = None,
+            cache: Any = None):
         '''
-        Initialize the AppRequestContext.
+        Initialize the request context, building and binding a Request domain
+        value object from the supplied request fields.
 
         :param headers: The request headers.
         :type headers: dict
         :param data: The request data.
         :type data: dict
-        :param session_id: The session ID.
+        :param session_id: The session ID; a uuid4 is generated when absent.
         :type session_id: str
         :param feature_id: The feature ID.
         :type feature_id: str
+        :param services: The shared DI context (service resolver), if any.
+        :type services: Any
+        :param cache: The shared cache context.
+        :type cache: Any
         '''
 
-        # Set the session id or generate a new one if not provided.
-        self.session_id = session_id if session_id else str(uuid4())
+        # Initialize shared services and cache via the base context.
+        super().__init__(services=services, cache=cache)
 
-        # Set the feature id or None if not provided.
-        self.feature_id = feature_id if feature_id else None
+        # Build and bind the request domain value object.
+        self.domain = Request(
+            session_id=session_id,
+            feature_id=feature_id,
+            headers=headers if headers is not None else {},
+            data=data if data is not None else {},
+        )
 
-        # Set the headers and data.
-        self.headers = headers
-        self.data = data
-
-        # Initialize the result to None.
+        # Initialize the runtime result to None.
         self.result = None
 
-    # * handle_response (obsolete)
+    # * attribute: session_id
+    @property
+    def session_id(self) -> str:
+        '''The request session identifier, proxied to the bound Request.'''
+
+        # Return the bound request's session id.
+        return self.domain.session_id
+
+    @session_id.setter
+    def session_id(self, value: str) -> None:
+
+        # Write the session id through to the bound request.
+        self.domain.session_id = value
+
+    # * attribute: feature_id
+    @property
+    def feature_id(self) -> str | None:
+        '''The executing feature identifier, proxied to the bound Request.'''
+
+        # Return the bound request's feature id.
+        return self.domain.feature_id
+
+    @feature_id.setter
+    def feature_id(self, value: str | None) -> None:
+
+        # Write the feature id through to the bound request.
+        self.domain.feature_id = value
+
+    # * attribute: headers
+    @property
+    def headers(self) -> Dict[str, str]:
+        '''The request headers, proxied to the bound Request.'''
+
+        # Return the bound request's headers.
+        return self.domain.headers
+
+    @headers.setter
+    def headers(self, value: Dict[str, str]) -> None:
+
+        # Write the headers through to the bound request.
+        self.domain.headers = value
+
+    # * attribute: data
+    @property
+    def data(self) -> Dict[str, Any]:
+        '''The request data payload, proxied to the bound Request.'''
+
+        # Return the bound request's data payload.
+        return self.domain.data
+
+    @data.setter
+    def data(self, value: Dict[str, Any]) -> None:
+
+        # Write the data payload through to the bound request.
+        self.domain.data = value
+
+    # * method: handle_response
     def handle_response(self) -> Any:
         '''
         Handle the response from the request.

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -15,6 +15,9 @@ __all__ = [
     'Feature',
     'FeatureStep',
     'EventFeatureStep',
+    'ParameterSpecification',
+    'RequestSpecification',
+    'Request',
     'Formatter',
     'Handler',
     'Logger',
@@ -42,6 +45,11 @@ from .feature import (
     Feature,
     FeatureStep,
     EventFeatureStep,
+    ParameterSpecification,
+    RequestSpecification,
+)
+from .request import (
+    Request,
 )
 from .logging import (
     Formatter,

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -3,13 +3,15 @@
 # *** imports
 
 # ** core
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 # ** infra
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, ValidationError, create_model, model_validator
 
 # ** app
 from .settings import DomainObject
+from .. import assets as a
+from ..assets import TiferetError
 
 # *** models
 
@@ -62,6 +64,257 @@ class EventFeatureStep(FeatureStep):
     )
 
 
+# ** model: parameter_specification
+class ParameterSpecification(DomainObject):
+    '''
+    A value object describing one expected request parameter, including its
+    declared type, requiredness, default, and validation constraints.
+    '''
+
+    # * attribute: name
+    name: str = Field(..., description='The name of the request parameter.')
+
+    # * attribute: type
+    type: Literal['str', 'int', 'float', 'bool', 'list', 'dict'] = Field(
+        default='str',
+        description='The declared type of the parameter.',
+    )
+
+    # * attribute: required
+    required: bool = Field(default=True, description='Whether the parameter is required.')
+
+    # * attribute: default
+    default: Any | None = Field(default=None, description='The default value applied when the parameter is absent.')
+
+    # * attribute: description
+    description: str | None = Field(default=None, description='A human-readable description of the parameter.')
+
+    # * attribute: minimum
+    minimum: float | None = Field(default=None, description='Inclusive lower bound for numeric values (maps to ge).')
+
+    # * attribute: maximum
+    maximum: float | None = Field(default=None, description='Inclusive upper bound for numeric values (maps to le).')
+
+    # * attribute: min_length
+    min_length: int | None = Field(default=None, description='Minimum length for string or list values.')
+
+    # * attribute: max_length
+    max_length: int | None = Field(default=None, description='Maximum length for string or list values.')
+
+    # * attribute: pattern
+    pattern: str | None = Field(default=None, description='Regex pattern the value must match.')
+
+    # * attribute: choices
+    choices: List[Any] | None = Field(default=None, description='Enumerated set of valid values.')
+
+    # * method: get_type
+    def get_type(self) -> type:
+        '''
+        Map the declared type string to a Python type.
+
+        :return: The corresponding Python type.
+        :rtype: type
+        '''
+
+        # Map the supported type strings to Python types.
+        type_map = {
+            'str': str,
+            'int': int,
+            'float': float,
+            'bool': bool,
+            'list': list,
+            'dict': dict,
+        }
+
+        # Return the mapped type, defaulting to str.
+        return type_map.get(self.type, str)
+
+    # * method: field_definition
+    def field_definition(self) -> Tuple[Any, Any]:
+        '''
+        Build the ``(annotation, default)`` pair consumed by
+        ``pydantic.create_model``, applying constraints via ``Field`` and using
+        ``Literal`` when ``choices`` is present.
+
+        :return: The annotation and field-default pair.
+        :rtype: Tuple[Any, Any]
+        '''
+
+        # Resolve the base annotation, preferring a Literal of the choices.
+        annotation = Literal[tuple(self.choices)] if self.choices else self.get_type()
+
+        # A parameter is effectively required only when flagged required with no default.
+        effective_required = self.required and self.default is None
+
+        # Optional parameters must also accept None.
+        if not effective_required:
+            annotation = Optional[annotation]
+
+        # Translate friendly constraint keys into pydantic Field keywords.
+        constraints: Dict[str, Any] = {}
+        if self.minimum is not None:
+            constraints['ge'] = self.minimum
+        if self.maximum is not None:
+            constraints['le'] = self.maximum
+        if self.min_length is not None:
+            constraints['min_length'] = self.min_length
+        if self.max_length is not None:
+            constraints['max_length'] = self.max_length
+        if self.pattern is not None:
+            constraints['pattern'] = self.pattern
+        if self.description is not None:
+            constraints['description'] = self.description
+
+        # Required fields use Ellipsis; optional fields use the configured default.
+        default = ... if effective_required else self.default
+
+        # Return the annotation/field pair for dynamic model construction.
+        return (annotation, Field(default, **constraints))
+
+
+# ** model: request_specification
+class RequestSpecification(DomainObject):
+    '''
+    A feature-level Specification object that dynamically reconstitutes the
+    request configuration as a Pydantic model to validate and coerce request
+    data, failing fast with a single aggregated error.
+    '''
+
+    # * attribute: parameters
+    parameters: List[ParameterSpecification] = Field(
+        default_factory=list,
+        description='The expected request parameters.',
+    )
+
+    # * method: normalize_parameters (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def normalize_parameters(cls, data: Any) -> Any:
+        '''
+        Normalize ergonomic config forms into the canonical ``parameters`` list.
+
+        Accepts the canonical ``{'parameters': [...]}`` form, the shorthand
+        keyed form ``{'a': 'int'}``, and the expanded keyed form
+        ``{'b': {'type': 'float', 'required': False}}``.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The canonicalized input data.
+        :rtype: Any
+        '''
+
+        # Only normalize dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+
+        # Treat a list-valued ``parameters`` key as already canonical. The keyed
+        # form only ever maps a name to a type string or a spec dict, so a list
+        # here unambiguously indicates the canonical ``{'parameters': [...]}``
+        # shape. This lets a feature declare a request parameter literally named
+        # ``parameters`` (e.g. service.add) without colliding with canonical form.
+        if isinstance(data.get('parameters'), list):
+            return data
+
+        # Expand each keyed entry into a parameter specification dict.
+        parameters: List[Dict[str, Any]] = []
+        for name, spec in data.items():
+            if isinstance(spec, str):
+                parameters.append({'name': name, 'type': spec, 'required': True})
+            elif isinstance(spec, dict):
+                parameters.append({'name': name, **spec})
+
+        # Return the canonical parameters mapping.
+        return {'parameters': parameters}
+
+    # * method: build_model
+    def build_model(self, model_name: str = 'RequestModel') -> type:
+        '''
+        Dynamically create a standalone Pydantic model from the parameter
+        specifications.
+
+        The model is a plain ``pydantic.BaseModel`` (not a ``DomainObject``) so
+        ``coerce_numbers_to_str`` does not corrupt numeric coercion.
+
+        :param model_name: The name for the generated model.
+        :type model_name: str
+        :return: The dynamically built Pydantic model class.
+        :rtype: type
+        '''
+
+        # Build the field definitions from each parameter specification.
+        field_definitions = {
+            param.name: param.field_definition()
+            for param in self.parameters
+        }
+
+        # Create a standalone model that ignores unspecified extra keys.
+        return create_model(
+            model_name,
+            __config__=ConfigDict(extra='ignore'),
+            **field_definitions,
+        )
+
+    # * method: validate
+    def validate(self, data: Dict[str, Any], feature_id: str = None) -> Dict[str, Any]:
+        '''
+        Validate and coerce ``data`` against the schema, returning the original
+        request data merged with coerced schema-covered fields and defaults.
+        Unspecified extra request keys are preserved.
+
+        :param data: The request data to validate.
+        :type data: Dict[str, Any]
+        :param feature_id: The feature id used for error context.
+        :type feature_id: str
+        :return: The merged, coerced request data.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Build the dynamic validation model.
+        model_cls = self.build_model()
+
+        # Validate and coerce the request data, aggregating all field errors.
+        try:
+            validated = model_cls(**(data or {}))
+
+        # Convert Pydantic validation errors into a single structured error.
+        except ValidationError as error:
+            violations = [
+                {
+                    'field': '.'.join(str(loc) for loc in err.get('loc', ())),
+                    'type': err.get('type'),
+                    'message': err.get('msg'),
+                }
+                for err in error.errors()
+            ]
+            raise TiferetError(
+                a.const.REQUEST_VALIDATION_FAILED_ID,
+                f'Request validation failed for feature {feature_id}: {violations}.',
+                feature_id=feature_id,
+                violations=violations,
+            )
+
+        # Merge coerced schema fields and defaults over the original data.
+        return {**(data or {}), **validated.model_dump()}
+
+    # * method: is_satisfied_by
+    def is_satisfied_by(self, data: Dict[str, Any]) -> bool:
+        '''
+        Report whether ``data`` satisfies the specification.
+
+        :param data: The request data to test.
+        :type data: Dict[str, Any]
+        :return: True when the data validates, otherwise False.
+        :rtype: bool
+        '''
+
+        # Attempt validation, treating a validation error as not satisfied.
+        try:
+            self.validate(data)
+            return True
+        except TiferetError:
+            return False
+
+
 # ** model: feature
 class Feature(DomainObject):
     '''
@@ -103,6 +356,12 @@ class Feature(DomainObject):
 
     # * attribute: log_params
     log_params: Dict[str, str] = Field(default_factory=dict, description='The parameters to log for the feature.')
+
+    # * attribute: params_schema
+    params_schema: RequestSpecification | None = Field(
+        default=None,
+        description='Optional feature-level request validation schema applied to request data before step execution.',
+    )
 
     # * method: derive_keys (validator)
     @model_validator(mode='before')

--- a/tiferet/domain/request.py
+++ b/tiferet/domain/request.py
@@ -1,0 +1,73 @@
+"""Tiferet Request Domain Models"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict
+from uuid import uuid4
+
+# ** infra
+from pydantic import Field, model_validator
+
+# ** app
+from .settings import DomainObject
+
+# *** models
+
+# ** model: request
+class Request(DomainObject):
+    '''
+    A request value object carrying the session, feature, headers, and data for
+    a single feature execution. Runtime output (``result``) is intentionally not
+    modeled here; it is owned by the operational request context.
+    '''
+
+    # * attribute: session_id
+    session_id: str = Field(
+        ...,
+        description='The unique session identifier for the request.',
+    )
+
+    # * attribute: feature_id
+    feature_id: str | None = Field(
+        default=None,
+        description='The identifier of the feature being executed.',
+    )
+
+    # * attribute: headers
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description='The request headers.',
+    )
+
+    # * attribute: data
+    data: Dict[str, Any] = Field(
+        default_factory=dict,
+        description='The request data payload.',
+    )
+
+    # * method: derive_session_id (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def derive_session_id(cls, data: Any) -> Any:
+        '''
+        Generate a ``uuid4`` ``session_id`` when one is not supplied, mirroring
+        the derivation validators on other domain objects.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The (possibly augmented) input data.
+        :rtype: Any
+        '''
+
+        # Only mutate dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        # Generate a session id when missing or None.
+        if not data.get('session_id'):
+            data['session_id'] = str(uuid4())
+
+        # Return the (possibly augmented) input data.
+        return data

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -6,7 +6,7 @@
 from typing import Any, ClassVar, Dict, List
 
 # ** infra
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_serializer
 
 # ** app
 from ..domain import (
@@ -356,6 +356,60 @@ class FeatureYamlObject(Feature, TransferObject):
         validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
         description='The step workflow for the feature.',
     )
+
+    # * method: serialize_params_schema
+    @field_serializer('params_schema')
+    def serialize_params_schema(self, value: Any, _info: Any) -> Any:
+        '''
+        Serialize ``params_schema`` into the ergonomic keyed mapping used in
+        configuration files, emitting shorthand ``name: type`` when a parameter
+        has no extra constraints and the expanded mapping otherwise.
+
+        :param value: The request specification to serialize.
+        :type value: Any
+        :param _info: The pydantic serialization info (unused).
+        :type _info: Any
+        :return: The keyed parameter mapping, or None when unset.
+        :rtype: Any
+        '''
+
+        # Emit nothing when no schema is configured.
+        if value is None:
+            return None
+
+        # Build a keyed mapping of parameter name to its specification.
+        result: Dict[str, Any] = {}
+        for param in value.parameters:
+
+            # Collect non-default constraint fields beyond name and type.
+            extras: Dict[str, Any] = {}
+            if param.default is not None:
+                extras['default'] = param.default
+            if not param.required:
+                extras['required'] = param.required
+            if param.description is not None:
+                extras['description'] = param.description
+            if param.minimum is not None:
+                extras['minimum'] = param.minimum
+            if param.maximum is not None:
+                extras['maximum'] = param.maximum
+            if param.min_length is not None:
+                extras['min_length'] = param.min_length
+            if param.max_length is not None:
+                extras['max_length'] = param.max_length
+            if param.pattern is not None:
+                extras['pattern'] = param.pattern
+            if param.choices is not None:
+                extras['choices'] = param.choices
+
+            # Use shorthand when only the type is meaningful, else the expanded form.
+            if not extras:
+                result[param.name] = param.type
+            else:
+                result[param.name] = {'type': param.type, **extras}
+
+        # Return the keyed parameter mapping.
+        return result
 
     # * method: map
     def map(self, **overrides) -> FeatureAggregate:


### PR DESCRIPTION
## Summary
Implements RFP #838: a feature-level request validation schema for the v2.0b12 prototype. A feature declares its expected request parameters, types, defaults, and constraints; `FeatureContext` coerces and validates `request.data` before the step loop runs, failing fast with a single aggregated `TiferetError` (`REQUEST_VALIDATION_FAILED`) instead of failing midway through a multi-step workflow.

Targets `v2.0-proto` from `v2.0b12-proto` (cut from `v2.0-proto` at tag `v2.0.0b11`).

## Changes
- **Domain** (`tiferet/domain/feature.py`): add `ParameterSpecification` and `RequestSpecification` value objects plus `Feature.params_schema`. `RequestSpecification` dynamically reconstitutes the request config as a standalone Pydantic model (not a `DomainObject`, so `coerce_numbers_to_str` does not corrupt numeric coercion) to coerce/validate and merge request data, preserving unspecified extra keys.
- **Request value object** (`tiferet/domain/request.py`): new `Request` domain object; `RequestContext` migrated onto `BaseContext` (`domain_type = Request`) with read/write proxy properties; `result` stays as runtime context output.
- **FeatureContext** (`tiferet/contexts/feature.py`): `validate_request` runs as the first statement of `execute_feature` / `execute_feature_async`, so invalid input prevents every step from executing.
- **Mappers** (`tiferet/mappers/feature.py`): round-trip `params_schema` in the ergonomic keyed config form.
- **Errors** (`tiferet/assets/constants.py`): add `REQUEST_VALIDATION_FAILED` id and default error message.
- **Built-in CLI features** (`tiferet/assets/feature.py`): each management feature now declares a `params_schema` derived from its event's request contract (37 of 41 features; the four list-only features have no user input). Optional defaults mirror each event's signature defaults so behavior is preserved; free-form `value`, comma-separated list args (`handlers`, `name_or_flags`), and framework context params are intentionally omitted.
- **Normalizer fix**: `RequestSpecification.normalize_parameters` now detects canonical form by a list-valued `parameters`, so a feature can declare a request parameter literally named `parameters` (e.g. `service.add`) without colliding with canonical form.
- **Example** (`examples/basic_calculator/config.yml`): demonstrate `params_schema` on `calc.add` and `calc.divide`.
- Tests across domain, mappers, contexts, repos, and the new `Request` value object.

## Validation
- `pytest tests/` → **823 passed, 11 skipped**.

🔗 [Warp conversation](https://app.warp.dev/conversation/83359b06-3684-455b-8d16-5228b615c50b)

Co-Authored-By: Oz <oz-agent@warp.dev>
