### PR TITLE
Example & Tutorial – Calculator persistence: file-loader history + saved/variablized formulas

### DIFF
--- a/docs/tutorial/basic_calculator/07-persisting-recent-formulas.md
+++ b/docs/tutorial/basic_calculator/07-persisting-recent-formulas.md
@@ -1,0 +1,172 @@
+# Step 7: Persisting Recent Formulas with the File Loader
+
+Our calculator works great — but the moment it finishes, every calculation vanishes.
+Let's give it a little memory by saving the **most recently executed formulas** to a file.
+
+This is the perfect excuse to meet one of Tiferet's handy infrastructure helpers: the **file loader**.
+
+### 7.1 Why a file loader?
+
+Tiferet ships small, reusable utilities for reading and writing files. They all build on a base `FileLoader` that manages the open/close lifecycle for you, plus format-specific loaders on top:
+
+- `File` / `FileLoader` — raw stream handling
+- `Json` / `JsonLoader` — read/write JSON (what we'll use here)
+- `Yaml`, `Csv`, `Sqlite`, … — more of the same idea
+
+Because `Json` builds on `FileLoader`, we get safe, structured reads and writes in one line — no manual `open()`/`close()` juggling.
+
+### 7.2 Add the history events
+
+We'll add two domain events: one to **record** a calculation, one to **list** recent calculations. They use `Json` directly and inject no service, so they simply extend `DomainEvent`.
+
+**app/events/history.py**
+
+```python
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tiferet.events import *
+from tiferet import Json
+
+
+class RecordCalculation(DomainEvent):
+    """Append the most recent calculation to a JSON history file."""
+
+    def execute(self, result: Any, operator: str, a: Any = None, b: Any = None,
+                history_file: str = 'history.json', max_entries: int = 10, **kwargs) -> Any:
+        # Build a friendly expression string.
+        expression = f'{operator}{a}' if b is None else f'{a} {operator} {b}'
+
+        # Read existing entries (if any), append, and trim to the most recent.
+        entries = Json(history_file).load() if Path(history_file).exists() else []
+        entries.append(dict(
+            expression=expression, a=a, b=b, operator=operator,
+            result=result, timestamp=datetime.now(timezone.utc).isoformat(),
+        ))
+        entries = entries[-max_entries:]
+
+        # Persist via the file loader and return the result unchanged.
+        Json(history_file, mode='w').save(entries)
+        return result
+
+
+class ListRecentFormulas(DomainEvent):
+    """Render the most recently executed calculations as a friendly string."""
+
+    def execute(self, history_file: str = 'history.json', limit: int | None = None, **kwargs) -> str:
+        if not Path(history_file).exists():
+            return 'No recent calculations yet.'
+        entries = Json(history_file).load()
+        if limit:
+            entries = entries[-limit:]
+        if not entries:
+            return 'No recent calculations yet.'
+        return '\n'.join(f"{e['expression']} = {e['result']}" for e in entries)
+```
+
+Notice `RecordCalculation` **returns `result` unchanged** — that's important, and we'll see why in a second.
+
+### 7.3 Wire it up in config.yml
+
+First, register the two events under `services`:
+
+```yaml
+services:
+  # ... existing calc events ...
+  record_calculation_event:
+    module_path: app.events.history
+    class_name: RecordCalculation
+  list_recent_formulas_event:
+    module_path: app.events.history
+    class_name: ListRecentFormulas
+```
+
+Now the fun part. We turn each arithmetic feature into a **two-step workflow**: compute, then record. The trick is `data_key`:
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Number
+      description: Adds one number to another
+      params_schema:
+        a: int
+        b: int
+      steps:
+        - service_id: add_number_event
+          name: Add `a` and `b`
+          data_key: result          # store this step's result in request data
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '+'           # a literal passed to the record step
+```
+
+How it flows:
+
+- The compute step stores its result under `data_key: result`, so it lands in the request data instead of becoming the final response.
+- The record step has **no** `data_key`, so *its* return value becomes what `app.run(...)` gives back. Since `RecordCalculation` returns `result` unchanged, the feature still returns the number — we just persisted a history entry along the way.
+- The record step reads `a`, `b`, and `result` straight from the request data; `operator` is a literal step param.
+
+Add the same compute-then-record pair to `subtract`, `multiply`, `divide`, `exp`, and `sqrt` (use operators `-`, `*`, `/`, `**`, and `√`).
+
+Finally, add a feature to read the history back:
+
+```yaml
+    history:
+      name: Recent Calculations
+      description: Lists the most recently executed calculations
+      steps:
+        - service_id: list_recent_formulas_event
+          name: List recent calculations
+```
+
+> **Tip:** `params_schema` (added in v2.0.0b12) validates and coerces request data before any step runs — that's why `a` and `b` arrive as real numbers.
+
+### 7.4 Add a CLI command (optional)
+
+```yaml
+cli:
+  cmds:
+    calc:
+      # ... existing commands ...
+      history:
+        group_key: calc
+        key: history
+        name: Recent Calculations Command
+        description: Lists the most recently executed calculations.
+```
+
+### 7.5 See it work
+
+```bash
+python basic_calc.py
+```
+
+After the arithmetic output, you'll see:
+
+```
+Recent calculations:
+1 + 2 = 3
+5 - 3 = 2
+4 * 3 = 12
+8 / 2.0 = 4.0
+2 ** 3 = 8
+√16 = 4.0
+```
+
+And a `history.json` file appears next to your script. From the CLI:
+
+```bash
+python calc_cli.py calc history
+```
+
+### 7.6 Why this is nice
+
+- Persistence with zero boilerplate — the file loader handles the file lifecycle.
+- The compute-then-record pattern shows how `data_key` lets steps share data without changing the feature's return value.
+- Failed calculations (like divide-by-zero) raise before the record step, so they never pollute the history.
+
+→ Next, let's go from remembering calculations to **saving reusable, variablized formulas** with domain models and a repository.
+Head to **[Step 8: Saving & Variablizing Formulas](08-saving-and-variablizing-formulas.md)**

--- a/docs/tutorial/basic_calculator/08-saving-and-variablizing-formulas.md
+++ b/docs/tutorial/basic_calculator/08-saving-and-variablizing-formulas.md
@@ -1,0 +1,367 @@
+# Step 8: Saving & Variablizing Formulas
+
+Recording recent calculations was fun — but what if we want to save a **reusable, named formula** like `width * height` and evaluate it later with different values?
+
+That's a real domain concept, so this time we'll use the full Tiferet stack: a **domain model**, a **mapper**, a **service interface**, a **repository**, and a few **domain events**. We'll persist everything to a `formulas.yml` file.
+
+This chapter mirrors how the framework's own domains (errors, features, …) are built, so it's a great template for your own data.
+
+### 8.1 The domain model
+
+A `Formula` has a name, an expression, and the variables it depends on. We derive the `id` from the name and infer the variables from the expression, so callers only have to supply the essentials.
+
+**app/domain/formula.py**
+
+```python
+import re
+from typing import Any, List
+
+from pydantic import Field, model_validator
+from tiferet import DomainObject
+
+
+class Formula(DomainObject):
+    """A saved, variablized calculator formula (e.g. width * height)."""
+
+    id: str = Field(..., description='The unique identifier of the formula.')
+    name: str = Field(..., description='The human-readable name of the formula.')
+    expression: str = Field(..., description='The arithmetic expression using named variables.')
+    variables: List[str] = Field(default_factory=list, description='The named variables the expression depends on.')
+    description: str | None = Field(default=None, description='An optional description of the formula.')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _derive_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        # Derive a snake_case id from the name.
+        if not data.get('id') and data.get('name'):
+            data['id'] = str(data['name']).strip().lower().replace(' ', '_')
+
+        # Infer the variables from the expression identifiers.
+        if not data.get('variables') and data.get('expression'):
+            identifiers = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', str(data['expression']))
+            data['variables'] = list(dict.fromkeys(identifiers))
+
+        return data
+
+    # Read-only presentation: a friendly one-liner, also used as __str__.
+    def display(self) -> str:
+        summary = f'{self.name}: {self.expression}'
+        if self.variables:
+            summary += f" (variables: {', '.join(self.variables)})"
+        return summary
+
+    def __str__(self) -> str:
+        return self.display()
+```
+
+### 8.2 The mappers
+
+Domain objects are read-only. Mutation lives in an **Aggregate**, and serialization lives in a **ConfigObject** (this is the v2.0.0b13 naming — earlier betas called these `*YamlObject`).
+
+**app/mappers/formula.py**
+
+```python
+import re
+from typing import Any, ClassVar, Dict
+
+from tiferet.mappers import Aggregate, TransferObject
+from ..domain.formula import Formula
+
+
+class FormulaAggregate(Formula, Aggregate):
+    """A mutable formula aggregate."""
+
+    def rename(self, new_name: str) -> None:
+        self.name = new_name
+
+    def set_expression(self, expression: str) -> None:
+        self.expression = expression
+        identifiers = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', expression)
+        self.variables = list(dict.fromkeys(identifiers))
+
+
+class FormulaConfigObject(Formula, TransferObject):
+    """A configuration (YAML/JSON) representation of a formula."""
+
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},   # id is the mapping key
+    }
+
+    def map(self, **overrides) -> FormulaAggregate:
+        return super().map(FormulaAggregate, **overrides)
+```
+
+### 8.3 The service interface
+
+The contract our events depend on — five familiar operations:
+
+**app/interfaces/formula.py**
+
+```python
+from abc import abstractmethod
+from typing import List
+
+from tiferet.interfaces import Service
+from ..mappers.formula import FormulaAggregate
+
+
+class FormulaService(Service):
+    """Service interface for managing saved formulas."""
+
+    @abstractmethod
+    def exists(self, id: str) -> bool: ...
+
+    @abstractmethod
+    def get(self, id: str) -> FormulaAggregate | None: ...
+
+    @abstractmethod
+    def list(self) -> List[FormulaAggregate]: ...
+
+    @abstractmethod
+    def save(self, formula: FormulaAggregate) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...
+```
+
+### 8.4 The repository
+
+`ConfigurationRepository` gives us format-agnostic load/save. We store formulas under a `formulas` root node and tolerate a missing file so the example just works the first time.
+
+**app/repos/formula.py** (the essentials)
+
+```python
+from pathlib import Path
+from typing import List
+
+from tiferet.repos.settings import ConfigurationRepository
+from ..interfaces.formula import FormulaService
+from ..mappers.formula import FormulaAggregate, FormulaConfigObject
+
+
+class FormulaConfigRepository(FormulaService, ConfigurationRepository):
+    """Persists formulas under the `formulas` node of a config file."""
+
+    def __init__(self, formula_config: str, encoding: str = 'utf-8') -> None:
+        ConfigurationRepository.__init__(self, config_file=formula_config, encoding=encoding)
+
+    def _load_full(self) -> dict:
+        if not Path(self.config_file).exists():
+            return {}
+        return self._load() or {}
+
+    def _load_formulas(self) -> dict:
+        return (self._load_full().get('formulas') or {})
+
+    def get(self, id: str) -> FormulaAggregate | None:
+        data = self._load_formulas().get(id)
+        if not data:
+            return None
+        return FormulaConfigObject.model_validate({**data, 'id': id}).map()
+
+    def save(self, formula: FormulaAggregate) -> None:
+        full = self._load_full()
+        full.setdefault('formulas', {})[formula.id] = \
+            FormulaConfigObject.from_model(formula).to_primitive(self.default_role)
+        self._save(data=full)
+
+    # exists / list / delete follow the same pattern.
+```
+
+Seed an empty store so the file exists from the start:
+
+**formulas.yml**
+
+```yaml
+formulas: {}
+```
+
+### 8.5 The events
+
+Each single-service event module defines a small **base event** that holds the shared service (this is the v2.0.0b13 per-module base-event pattern). Concrete events extend it and define only `execute`.
+
+**app/events/formula.py** (highlights)
+
+```python
+import json
+from typing import Any, Dict, List
+
+from tiferet.events import DomainEvent
+from ..interfaces.formula import FormulaService
+from ..mappers.formula import FormulaAggregate
+
+
+class FormulaEvent(DomainEvent):
+    """Base event holding the shared FormulaService."""
+
+    def __init__(self, formula_service: FormulaService):
+        self.formula_service = formula_service
+
+
+class SaveFormula(FormulaEvent):
+    @DomainEvent.parameters_required(['name', 'expression'])
+    def execute(self, name, expression, description=None, **kwargs) -> FormulaAggregate:
+        formula = FormulaAggregate(name=name, expression=expression, description=description)
+        self.formula_service.save(formula)   # save is an upsert
+        return formula
+
+
+class EvaluateFormula(FormulaEvent):
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id, values=None, **kwargs) -> int | float:
+        formula = self.formula_service.get(id)
+        self.verify(formula is not None, 'FORMULA_NOT_FOUND', f'Formula not found: {id}', id=id)
+
+        if isinstance(values, str):
+            values = json.loads(values)          # CLI passes JSON text
+        provided: Dict[str, Any] = dict(values or {})
+
+        resolved: Dict[str, Any] = {}
+        for variable in formula.variables:
+            self.verify(variable in provided, 'MISSING_VARIABLE',
+                        f'Missing value for variable: {variable}', variable=variable)
+            resolved[variable] = self.coerce_number(provided[variable])
+
+        # Evaluate with no builtins exposed — only the formula's variables.
+        return eval(formula.expression, {'__builtins__': {}}, resolved)
+```
+
+`GetFormula` returns the formula entity (which prints nicely thanks to `__str__`). `ListFormulas` is a **view** — it renders the saved formulas into a friendly string (`'\n'.join(f.display() for f in …)`) so the CLI prints clean lines instead of raw objects. `coerce_number` lives on the base event and turns inputs into ints/floats, raising `INVALID_INPUT` on junk.
+
+> **Heads up on `eval`:** this is tutorial-grade. We lock it down by exposing no builtins and only the formula's own variables. For untrusted input in production, prefer a real expression parser.
+
+### 8.6 Wire it all up in config.yml
+
+Register the repository (with its file path as a parameter) and the events under `services`:
+
+```yaml
+services:
+  # ... existing events ...
+  formula_service:
+    module_path: app.repos.formula
+    class_name: FormulaConfigRepository
+    params:
+      formula_config: formulas.yml
+  save_formula_event:
+    module_path: app.events.formula
+    class_name: SaveFormula
+  get_formula_event:
+    module_path: app.events.formula
+    class_name: GetFormula
+  list_formulas_event:
+    module_path: app.events.formula
+    class_name: ListFormulas
+  evaluate_formula_event:
+    module_path: app.events.formula
+    class_name: EvaluateFormula
+```
+
+The `params` block becomes a DI constant, so `formula_config` is injected straight into the repository's constructor.
+
+Now the features. Note `steps:` (Tiferet accepts `steps` for the workflow list) and `params_schema` for validation:
+
+```yaml
+features:
+  formula:
+    save:
+      name: Save Formula
+      description: Saves a named, variablized formula
+      params_schema:
+        name: str
+        expression: str
+        description:
+          type: str
+          required: false
+      steps:
+        - service_id: save_formula_event
+          name: Save the formula
+    list:
+      name: List Formulas
+      description: Lists all saved formulas
+      steps:
+        - service_id: list_formulas_event
+          name: List the formulas
+    eval:
+      name: Evaluate Formula
+      description: Evaluates a saved formula with variable values
+      params_schema:
+        id: str
+      steps:
+        - service_id: evaluate_formula_event
+          name: Evaluate the formula
+```
+
+(Add a `get` feature the same way, with `params_schema: {id: str}`.)
+
+Add the error messages our events raise:
+
+```yaml
+errors:
+  FORMULA_NOT_FOUND:
+    name: Formula Not Found
+    message:
+      - lang: en_US
+        text: 'Formula not found: {id}'
+  MISSING_VARIABLE:
+    name: Missing Variable
+    message:
+      - lang: en_US
+        text: 'Missing value for variable: {variable}'
+  FORMULA_EVALUATION_FAILED:
+    name: Formula Evaluation Failed
+    message:
+      - lang: en_US
+        text: 'Could not evaluate formula {id}: {error}'
+```
+
+And, optionally, CLI commands under `cli.cmds` (the `eval` command takes the values as a JSON string):
+
+```yaml
+      eval:
+        group_key: formula
+        key: eval
+        name: Evaluate Formula Command
+        description: Evaluates a saved formula with variable values.
+        args:
+          - name_or_flags:
+              - id
+            description: The formula identifier.
+          - name_or_flags:
+              - values
+            description: A JSON object mapping variable names to values.
+```
+
+### 8.7 See it work
+
+From the script:
+
+```
+Formulas:
+Saved Rectangle Area: width * height (variables: width, height)
+Rectangle Area: width * height (variables: width, height)
+rectangle_area(width=3, height=4) = 12
+```
+
+From the CLI:
+
+```bash
+python calc_cli.py formula save "Rectangle Area" "width * height"
+python calc_cli.py formula list
+python calc_cli.py formula eval rectangle_area '{"width": 3, "height": 4}'
+# → 12
+```
+
+### 8.8 Recap
+
+- A **domain model** (`Formula`) captures the concept; an **aggregate** handles mutation; a **config object** handles serialization.
+- A **service interface** + **repository** persist formulas to `formulas.yml` with the same pattern the framework uses internally.
+- **Events** orchestrate the domain logic, and `params_schema` validates input before they run.
+
+You've now seen both styles of persistence in Tiferet: lightweight file-loader storage (Step 7) and a full domain-model repository (Step 8). From here, try adding `formula delete`, richer expressions, or a SQLite-backed repository.
+
+→ Back to the **[tutorial index](index.md)**.

--- a/docs/tutorial/basic_calculator/index.md
+++ b/docs/tutorial/basic_calculator/index.md
@@ -10,28 +10,26 @@ By the time we're done, you'll have:
 - A reusable utility class for number verification (in `app/utils/`)
 - Everything wired together through simple YAML configuration files
 - Two ways to use it: a quick script for testing and a proper command-line interface
+- Persist your most recently executed formulas to a file
+- Save and re-evaluate named, variablized formulas
 
 And best of all — each step is small, satisfying, and shows real progress.
 
 ### What we'll build (final project layout)
 
 ```
-basic-calculator/
-├── basic_calc.py               # quick script runner for testing
-├── calc_cli.py                 # full-featured command-line calculator
+basic_calculator/
+├── basic_calc.py          # quick script runner for testing
+├── calc_cli.py            # full-featured command-line calculator
+├── config.yml             # consolidated configuration
+├── formulas.yml           # saved formulas store (Step 8)
+├── history.json           # recent calculations, generated at runtime (Step 7)
 └── app/
-    ├── configs/                # where all the YAML magic lives
-    │   ├── app.yml
-    │   ├── container.yml
-    │   ├── error.yml
-    │   ├── feature.yml
-    │   └── cli.yml             # only needed for the CLI
-    ├── events/
-    │   ├── __init__.py
-    │   └── calc.py             # our arithmetic domain events
-    └── utils/
-        ├── __init__.py
-        └── calc.py             # reusable validation helpers
+    ├── domain/            # Formula domain model (Step 8)
+    ├── events/            # arithmetic, history, and formula events
+    ├── interfaces/        # FormulaService contract (Step 8)
+    ├── mappers/           # Formula aggregate + config object (Step 8)
+    └── repos/             # FormulaConfigRepository (Step 8)
 ```
 
 ### The step-by-step path
@@ -53,6 +51,12 @@ basic-calculator/
 
 6. **[CLI Interface & Commands](06-cli-interface.md)**  
    Add the command-line polish so you can type `calc add 19 23` like a pro.
+
+7. **[Persisting Recent Formulas](07-persisting-recent-formulas.md)**  
+   Use the file loader to remember the most recently executed calculations.
+
+8. **[Saving & Variablizing Formulas](08-saving-and-variablizing-formulas.md)**  
+   Save reusable, named formulas with a domain model and repository, then evaluate them.
 
 This tutorial is designed to feel like we're building together — short steps, quick wins, and no walls of text.
 

--- a/examples/basic_calculator/README.md
+++ b/examples/basic_calculator/README.md
@@ -14,12 +14,24 @@ basic_calculator/
 ├── basic_calc.py          # App blueprint entry point
 ├── calc_cli.py            # CLI blueprint entry point
 ├── config.yml             # Consolidated application configuration
+├── formulas.yml           # Saved formulas store
 └── app/
-    └── events/
-        ├── __init__.py
-        ├── settings.py    # BasicCalcEvent (numeric validation)
-        └── calc.py        # Arithmetic domain events
+    ├── domain/            # Formula domain model
+    │   └── formula.py
+    ├── events/
+    │   ├── settings.py    # BasicCalcEvent (numeric validation)
+    │   ├── calc.py        # Arithmetic domain events
+    │   ├── history.py     # Recent-calculation events
+    │   └── formula.py     # Formula domain events
+    ├── interfaces/        # FormulaService contract
+    │   └── formula.py
+    ├── mappers/           # Formula aggregate + config object
+    │   └── formula.py
+    └── repos/             # FormulaConfigRepository
+        └── formula.py
 ```
+
+`history.json` is created automatically at runtime to store the most recent calculations.
 
 ## Running the Application
 
@@ -65,6 +77,14 @@ python calc_cli.py calc exp 2 3
 
 # Square root
 python calc_cli.py calc sqrt 4
+
+# Recent calculations
+python calc_cli.py calc history
+
+# Save, list, and evaluate a variablized formula
+python calc_cli.py formula save "Rectangle Area" "width * height"
+python calc_cli.py formula list
+python calc_cli.py formula eval rectangle_area '{"width": 3, "height": 4}'
 ```
 
 ## Features
@@ -75,6 +95,11 @@ python calc_cli.py calc sqrt 4
 - **Division** (`calc.divide`) — Divides two numbers with zero-check
 - **Exponentiation** (`calc.exp`) — Raises a number to a power
 - **Square Root** (`calc.sqrt`) — Calculates square root (reuses exponentiation with `b=0.5`)
+- **Recent Calculations** (`calc.history`) — Lists the most recently executed calculations, persisted to `history.json` via the file loader
+- **Save Formula** (`formula.save`) — Saves a named, variablized formula to `formulas.yml`
+- **Get Formula** (`formula.get`) — Retrieves a saved formula by id
+- **List Formulas** (`formula.list`) — Lists all saved formulas
+- **Evaluate Formula** (`formula.eval`) — Evaluates a saved formula with concrete variable values
 
 ## Tutorial
 

--- a/examples/basic_calculator/app/domain/__init__.py
+++ b/examples/basic_calculator/app/domain/__init__.py
@@ -1,0 +1,6 @@
+"""Calculator example domain models."""
+
+# *** exports
+
+# ** app
+from .formula import Formula

--- a/examples/basic_calculator/app/domain/formula.py
+++ b/examples/basic_calculator/app/domain/formula.py
@@ -1,0 +1,96 @@
+# *** imports
+
+# ** core
+import re
+from typing import Any, List
+
+# ** infra
+from pydantic import Field, model_validator
+
+# ** app
+from tiferet import DomainObject
+
+# *** models
+
+# ** model: formula
+class Formula(DomainObject):
+    '''
+    A saved, variablized calculator formula (e.g. ``width * height``).
+    '''
+
+    # * attribute: id
+    id: str = Field(..., description='The unique identifier of the formula.')
+
+    # * attribute: name
+    name: str = Field(..., description='The human-readable name of the formula.')
+
+    # * attribute: expression
+    expression: str = Field(..., description='The arithmetic expression using named variables.')
+
+    # * attribute: variables
+    variables: List[str] = Field(default_factory=list, description='The named variables the expression depends on.')
+
+    # * attribute: description
+    description: str | None = Field(default=None, description='An optional description of the formula.')
+
+    # * method: _derive_fields (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def _derive_fields(cls, data: Any) -> Any:
+        '''
+        Derive ``id`` from ``name`` and infer ``variables`` from the
+        ``expression`` identifiers when they are not explicitly provided.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The (possibly augmented) input data.
+        :rtype: Any
+        '''
+
+        # Only mutate dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        # Derive a snake_case id from the name when id is missing.
+        if not data.get('id') and data.get('name'):
+            data['id'] = str(data['name']).strip().lower().replace(' ', '_')
+
+        # Infer variables from the expression identifiers when none are given.
+        if not data.get('variables') and data.get('expression'):
+            identifiers = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', str(data['expression']))
+            data['variables'] = list(dict.fromkeys(identifiers))
+
+        # Return the (possibly augmented) input data.
+        return data
+
+    # * method: display
+    def display(self) -> str:
+        '''
+        Render a friendly, human-readable summary of the formula.
+
+        :return: A single-line description of the formula.
+        :rtype: str
+        '''
+
+        # Build the base "name: expression" summary.
+        summary = f'{self.name}: {self.expression}'
+
+        # Append the variable list when present.
+        if self.variables:
+            summary += f" (variables: {', '.join(self.variables)})"
+
+        # Return the rendered summary.
+        return summary
+
+    # * method: __str__
+    def __str__(self) -> str:
+        '''
+        Return the friendly display string for the formula.
+
+        :return: The human-readable formula summary.
+        :rtype: str
+        '''
+
+        # Delegate to the display method.
+        return self.display()

--- a/examples/basic_calculator/app/events/formula.py
+++ b/examples/basic_calculator/app/events/formula.py
@@ -1,0 +1,235 @@
+# *** imports
+
+# ** core
+import json
+from typing import Any, Dict
+
+# ** infra
+from tiferet.events import DomainEvent
+
+# ** app
+from ..interfaces.formula import FormulaService
+from ..mappers.formula import FormulaAggregate
+
+# *** events
+
+# ** event: formula_event
+class FormulaEvent(DomainEvent):
+    '''
+    Base event providing the shared FormulaService dependency for formula
+    domain events.
+    '''
+
+    # * attribute: formula_service
+    formula_service: FormulaService
+
+    # * init
+    def __init__(self, formula_service: FormulaService):
+        '''
+        Initialize the formula event with its shared service dependency.
+
+        :param formula_service: The formula service shared across formula events.
+        :type formula_service: FormulaService
+        '''
+
+        # Set the formula service dependency.
+        self.formula_service = formula_service
+
+    # * method: coerce_number
+    def coerce_number(self, value: Any) -> int | float:
+        '''
+        Convert a value to an int or float, raising INVALID_INPUT on failure.
+
+        :param value: The value to convert.
+        :type value: Any
+        :return: The numeric value.
+        :rtype: int | float
+        '''
+
+        # Attempt to convert the value to an int or float.
+        try:
+            text = str(value)
+            return float(text) if '.' in text else int(text)
+
+        # Raise a structured error when the value is not numeric.
+        except (ValueError, TypeError):
+            self.raise_error(
+                'INVALID_INPUT',
+                f'Value {value} must be a number',
+                value=value,
+            )
+
+
+# ** event: save_formula
+class SaveFormula(FormulaEvent):
+    '''
+    Event to save (create or update) a formula.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['name', 'expression'])
+    def execute(self,
+            name: str,
+            expression: str,
+            description: str | None = None,
+            **kwargs,
+        ) -> FormulaAggregate:
+        '''
+        Save a formula and return it.
+
+        :param name: The human-readable name of the formula.
+        :type name: str
+        :param expression: The arithmetic expression using named variables.
+        :type expression: str
+        :param description: An optional description of the formula.
+        :type description: str | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The saved formula aggregate.
+        :rtype: FormulaAggregate
+        '''
+
+        # Create the formula aggregate (id and variables are derived).
+        formula = FormulaAggregate(
+            name=name,
+            expression=expression,
+            description=description,
+        )
+
+        # Persist the formula (save is an upsert).
+        self.formula_service.save(formula)
+
+        # Return the saved formula.
+        return formula
+
+
+# ** event: get_formula
+class GetFormula(FormulaEvent):
+    '''
+    Event to retrieve a formula by its ID.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> FormulaAggregate:
+        '''
+        Retrieve a formula by ID.
+
+        :param id: The unique identifier of the formula.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The formula aggregate.
+        :rtype: FormulaAggregate
+        '''
+
+        # Retrieve the formula from the service.
+        formula = self.formula_service.get(id)
+
+        # Verify that the formula exists.
+        self.verify(
+            formula is not None,
+            'FORMULA_NOT_FOUND',
+            f'Formula not found: {id}',
+            id=id,
+        )
+
+        # Return the retrieved formula.
+        return formula
+
+
+# ** event: list_formulas
+class ListFormulas(FormulaEvent):
+    '''
+    Event to list all saved formulas as a friendly, human-readable view.
+    '''
+
+    # * method: execute
+    def execute(self, **kwargs) -> str:
+        '''
+        List all saved formulas as a rendered, human-readable string.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A newline-separated summary of the saved formulas.
+        :rtype: str
+        '''
+
+        # Retrieve all formulas from the service.
+        formulas = self.formula_service.list()
+
+        # Return a friendly message when there are no saved formulas.
+        if not formulas:
+            return 'No formulas saved yet.'
+
+        # Render each formula on its own line.
+        return '\n'.join(formula.display() for formula in formulas)
+
+
+# ** event: evaluate_formula
+class EvaluateFormula(FormulaEvent):
+    '''
+    Event to evaluate a saved formula with concrete variable values.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, values: Any = None, **kwargs) -> int | float:
+        '''
+        Evaluate a saved formula by substituting concrete variable values.
+
+        :param id: The unique identifier of the formula.
+        :type id: str
+        :param values: A mapping (or JSON string) of variable names to values.
+        :type values: Any
+        :param kwargs: Additional keyword arguments (may carry variables directly).
+        :type kwargs: dict
+        :return: The evaluated numeric result.
+        :rtype: int | float
+        '''
+
+        # Retrieve the formula and verify it exists.
+        formula = self.formula_service.get(id)
+        self.verify(
+            formula is not None,
+            'FORMULA_NOT_FOUND',
+            f'Formula not found: {id}',
+            id=id,
+        )
+
+        # Parse a JSON-encoded values mapping when provided as a string.
+        if isinstance(values, str):
+            values = json.loads(values)
+
+        # Collect provided values from the mapping and any direct kwargs.
+        provided: Dict[str, Any] = dict(values or {})
+        for variable in formula.variables:
+            if variable not in provided and variable in kwargs:
+                provided[variable] = kwargs[variable]
+
+        # Verify every required variable is present and coerce it to a number.
+        resolved: Dict[str, int | float] = {}
+        for variable in formula.variables:
+            self.verify(
+                variable in provided,
+                'MISSING_VARIABLE',
+                f'Missing value for variable: {variable}',
+                variable=variable,
+            )
+            resolved[variable] = self.coerce_number(provided[variable])
+
+        # Evaluate the expression with restricted globals (no builtins exposed).
+        try:
+            result = eval(formula.expression, {'__builtins__': {}}, resolved)  # noqa: S307
+
+        # Wrap evaluation failures in a structured error.
+        except Exception as e:
+            self.raise_error(
+                'FORMULA_EVALUATION_FAILED',
+                f'Could not evaluate formula {id}: {e}',
+                id=id,
+                error=str(e),
+            )
+
+        # Return the evaluated result.
+        return result

--- a/examples/basic_calculator/app/events/history.py
+++ b/examples/basic_calculator/app/events/history.py
@@ -1,0 +1,137 @@
+# *** imports
+
+# ** core
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ** infra
+from tiferet.events import *
+from tiferet import Json
+
+# *** functions
+
+# ** function: format_history_entry
+def format_history_entry(entry: dict) -> str:
+    '''
+    Render a single history entry as a friendly one-line string.
+
+    :param entry: The stored calculation entry.
+    :type entry: dict
+    :return: A human-readable "expression = result" line.
+    :rtype: str
+    '''
+
+    # Render the entry as "expression = result".
+    return f"{entry.get('expression')} = {entry.get('result')}"
+
+# *** events
+
+# ** event: record_calculation
+class RecordCalculation(DomainEvent):
+    '''
+    A domain event that appends the most recently executed calculation to a
+    JSON history file using the Tiferet file loader, keeping only the most
+    recent entries.
+    '''
+
+    # * method: execute
+    def execute(self,
+            result: Any,
+            operator: str,
+            a: Any = None,
+            b: Any = None,
+            history_file: str = 'history.json',
+            max_entries: int = 10,
+            **kwargs,
+        ) -> Any:
+        '''
+        Record a calculation entry and return the original result unchanged.
+
+        :param result: The computed result of the calculation.
+        :type result: Any
+        :param operator: The operator symbol describing the operation.
+        :type operator: str
+        :param a: The first operand, if any.
+        :type a: Any
+        :param b: The second operand, if any.
+        :type b: Any
+        :param history_file: The JSON file used to store recent calculations.
+        :type history_file: str
+        :param max_entries: The maximum number of entries to retain.
+        :type max_entries: int
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The original result, unchanged.
+        :rtype: Any
+        '''
+
+        # Build a human-readable expression for the entry.
+        expression = f'{operator}{a}' if b is None else f'{a} {operator} {b}'
+
+        # Read existing entries when the history file already exists.
+        entries = Json(history_file).load() if Path(history_file).exists() else []
+
+        # Append the new calculation entry with an ISO timestamp.
+        entries.append(dict(
+            expression=expression,
+            a=a,
+            b=b,
+            operator=operator,
+            result=result,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        ))
+
+        # Trim the list to the most recent entries.
+        entries = entries[-max_entries:]
+
+        # Persist the updated history via the file loader.
+        Json(history_file, mode='w').save(entries)
+
+        # Return the result unchanged so the feature response is preserved.
+        return result
+
+
+# ** event: list_recent_formulas
+class ListRecentFormulas(DomainEvent):
+    '''
+    A domain event that returns the most recently executed calculations from
+    the JSON history file.
+    '''
+
+    # * method: execute
+    def execute(self,
+            history_file: str = 'history.json',
+            limit: int | None = None,
+            **kwargs,
+        ) -> str:
+        '''
+        Return the recent calculation history as a rendered, human-readable string.
+
+        :param history_file: The JSON file used to store recent calculations.
+        :type history_file: str
+        :param limit: Optional maximum number of entries to return.
+        :type limit: int | None
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A newline-separated summary of the recent calculations.
+        :rtype: str
+        '''
+
+        # Return a friendly message when no history file exists yet.
+        if not Path(history_file).exists():
+            return 'No recent calculations yet.'
+
+        # Load the stored entries via the file loader.
+        entries = Json(history_file).load()
+
+        # Apply an optional limit to the most recent entries.
+        if limit:
+            entries = entries[-limit:]
+
+        # Return a friendly message when there are no entries.
+        if not entries:
+            return 'No recent calculations yet.'
+
+        # Render each entry on its own line.
+        return '\n'.join(format_history_entry(entry) for entry in entries)

--- a/examples/basic_calculator/app/interfaces/__init__.py
+++ b/examples/basic_calculator/app/interfaces/__init__.py
@@ -1,0 +1,6 @@
+"""Calculator example service interfaces."""
+
+# *** exports
+
+# ** app
+from .formula import FormulaService

--- a/examples/basic_calculator/app/interfaces/formula.py
+++ b/examples/basic_calculator/app/interfaces/formula.py
@@ -1,0 +1,80 @@
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** app
+from tiferet.interfaces import Service
+from ..mappers.formula import FormulaAggregate
+
+# *** interfaces
+
+# ** interface: formula_service
+class FormulaService(Service):
+    '''
+    Service interface for managing saved formulas.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a formula exists by ID.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: True if the formula exists, otherwise False.
+        :rtype: bool
+        '''
+        raise NotImplementedError('exists method is required for FormulaService.')
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> FormulaAggregate | None:
+        '''
+        Retrieve a formula by ID.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: The formula aggregate or None if not found.
+        :rtype: FormulaAggregate | None
+        '''
+        raise NotImplementedError('get method is required for FormulaService.')
+
+    # * method: list
+    @abstractmethod
+    def list(self) -> List[FormulaAggregate]:
+        '''
+        List all formulas.
+
+        :return: A list of formula aggregates.
+        :rtype: List[FormulaAggregate]
+        '''
+        raise NotImplementedError('list method is required for FormulaService.')
+
+    # * method: save
+    @abstractmethod
+    def save(self, formula: FormulaAggregate) -> None:
+        '''
+        Save or update a formula.
+
+        :param formula: The formula aggregate to save.
+        :type formula: FormulaAggregate
+        :return: None
+        :rtype: None
+        '''
+        raise NotImplementedError('save method is required for FormulaService.')
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete a formula by ID. This operation should be idempotent.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+        raise NotImplementedError('delete method is required for FormulaService.')

--- a/examples/basic_calculator/app/mappers/__init__.py
+++ b/examples/basic_calculator/app/mappers/__init__.py
@@ -1,0 +1,6 @@
+"""Calculator example mappers."""
+
+# *** exports
+
+# ** app
+from .formula import FormulaAggregate, FormulaConfigObject

--- a/examples/basic_calculator/app/mappers/formula.py
+++ b/examples/basic_calculator/app/mappers/formula.py
@@ -1,0 +1,76 @@
+# *** imports
+
+# ** core
+import re
+from typing import Any, ClassVar, Dict
+
+# ** app
+from tiferet.mappers import Aggregate, TransferObject
+from ..domain.formula import Formula
+
+# *** mappers
+
+# ** mapper: formula_aggregate
+class FormulaAggregate(Formula, Aggregate):
+    '''
+    An aggregate representation of a formula.
+    '''
+
+    # * method: rename
+    def rename(self, new_name: str) -> None:
+        '''
+        Renames the formula.
+
+        :param new_name: The new name for the formula.
+        :type new_name: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Update the name; validate_assignment=True handles re-validation.
+        self.name = new_name
+
+    # * method: set_expression
+    def set_expression(self, expression: str) -> None:
+        '''
+        Updates the expression and re-derives the variable list.
+
+        :param expression: The new arithmetic expression.
+        :type expression: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Update the expression.
+        self.expression = expression
+
+        # Re-derive the variables from the new expression identifiers.
+        identifiers = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', expression)
+        self.variables = list(dict.fromkeys(identifiers))
+
+
+# ** mapper: formula_config_object
+class FormulaConfigObject(Formula, TransferObject):
+    '''
+    A configuration data representation of a formula object.
+    '''
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
+    }
+
+    # * method: map
+    def map(self, **overrides) -> FormulaAggregate:
+        '''
+        Maps the formula data to a formula aggregate.
+
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new formula aggregate.
+        :rtype: FormulaAggregate
+        '''
+
+        # Map the formula data to the aggregate.
+        return super().map(FormulaAggregate, **overrides)

--- a/examples/basic_calculator/app/repos/__init__.py
+++ b/examples/basic_calculator/app/repos/__init__.py
@@ -1,0 +1,6 @@
+"""Calculator example repositories."""
+
+# *** exports
+
+# ** app
+from .formula import FormulaConfigRepository

--- a/examples/basic_calculator/app/repos/formula.py
+++ b/examples/basic_calculator/app/repos/formula.py
@@ -1,0 +1,158 @@
+# *** imports
+
+# ** core
+from pathlib import Path
+from typing import List
+
+# ** app
+from tiferet.repos.settings import ConfigurationRepository
+from ..interfaces.formula import FormulaService
+from ..mappers.formula import FormulaAggregate, FormulaConfigObject
+
+# *** repos
+
+# ** repo: formula_config_repository
+class FormulaConfigRepository(FormulaService, ConfigurationRepository):
+    '''
+    The formula configuration repository, persisting formulas to a YAML/JSON
+    configuration file under the ``formulas`` root node.
+    '''
+
+    # * init
+    def __init__(self, formula_config: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the formula configuration repository.
+
+        :param formula_config: The configuration file path.
+        :type formula_config: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=formula_config, encoding=encoding)
+
+    # * method: _load_full
+    def _load_full(self) -> dict:
+        '''
+        Load the full configuration mapping, tolerating a missing file.
+
+        :return: The full configuration data, or an empty dict.
+        :rtype: dict
+        '''
+
+        # Return an empty mapping when the configuration file does not exist yet.
+        if not Path(self.config_file).exists():
+            return {}
+
+        # Load and return the full configuration data.
+        return self._load() or {}
+
+    # * method: _load_formulas
+    def _load_formulas(self) -> dict:
+        '''
+        Load the ``formulas`` mapping, tolerating a missing file or node.
+
+        :return: The formulas mapping keyed by formula id.
+        :rtype: dict
+        '''
+
+        # Return the formulas node, defaulting to an empty mapping.
+        return (self._load_full().get('formulas') or {})
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if a formula exists by ID.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: True if the formula exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Return whether the formula id exists in the mapping.
+        return id in self._load_formulas()
+
+    # * method: get
+    def get(self, id: str) -> FormulaAggregate | None:
+        '''
+        Retrieve a formula by ID.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: The formula aggregate or None if not found.
+        :rtype: FormulaAggregate | None
+        '''
+
+        # Load the specific formula data from the configuration file.
+        formula_data = self._load_formulas().get(id)
+
+        # If no data is found, return None.
+        if not formula_data:
+            return None
+
+        # Map the data to a FormulaAggregate and return it.
+        return FormulaConfigObject.model_validate(
+            {**formula_data, 'id': id}
+        ).map()
+
+    # * method: list
+    def list(self) -> List[FormulaAggregate]:
+        '''
+        List all formulas.
+
+        :return: A list of formula aggregates.
+        :rtype: List[FormulaAggregate]
+        '''
+
+        # Map each formula entry to a FormulaAggregate.
+        return [
+            FormulaConfigObject.model_validate(
+                {**formula_data, 'id': formula_id}
+            ).map()
+            for formula_id, formula_data in self._load_formulas().items()
+        ]
+
+    # * method: save
+    def save(self, formula: FormulaAggregate) -> None:
+        '''
+        Save or update a formula.
+
+        :param formula: The formula aggregate to save.
+        :type formula: FormulaAggregate
+        :return: None
+        :rtype: None
+        '''
+
+        # Convert the formula model to configuration data.
+        formula_data = FormulaConfigObject.from_model(formula)
+
+        # Load the full configuration file.
+        full_data = self._load_full()
+
+        # Update or insert the formula entry.
+        full_data.setdefault('formulas', {})[formula.id] = formula_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration file.
+        self._save(data=full_data)
+
+    # * method: delete
+    def delete(self, id: str) -> None:
+        '''
+        Delete a formula by ID. This operation is idempotent.
+
+        :param id: The formula identifier.
+        :type id: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Load the full configuration file.
+        full_data = self._load_full()
+
+        # Remove the formula entry if it exists (idempotent).
+        full_data.get('formulas', {}).pop(id, None)
+
+        # Persist the updated configuration file.
+        self._save(data=full_data)

--- a/examples/basic_calculator/basic_calc.py
+++ b/examples/basic_calculator/basic_calc.py
@@ -25,3 +25,23 @@ for feature_id, data, format_str in test_cases:
             print(format_str.format(a, result))
     except TiferetError as e:
         print(f'Error: {e.message}')
+
+# Show the most recently executed calculations (persisted via the file loader).
+print('\nRecent calculations:')
+print(app.run('calc.history', data={}))
+
+# Save, list, and evaluate a variablized formula (persisted via the repository).
+print('\nFormulas:')
+try:
+    saved = app.run('formula.save', data=dict(
+        name='Rectangle Area',
+        expression='width * height',
+    ))
+    print(f'Saved {saved.display()}')
+
+    print(app.run('formula.list', data={}))
+
+    area = app.run('formula.eval', data=dict(id='rectangle_area', values=dict(width=3, height=4)))
+    print(f'rectangle_area(width=3, height=4) = {area}')
+except TiferetError as e:
+    print(f'Error: {e.message}')

--- a/examples/basic_calculator/config.yml
+++ b/examples/basic_calculator/config.yml
@@ -5,6 +5,8 @@ interfaces:
   calc_cli:
     name: Calculator CLI
     description: Perform basic calculator operations via CLI
+    module_path: tiferet.contexts.cli
+    class_name: CliContext
 
 services:
   add_number_event:
@@ -22,6 +24,29 @@ services:
   exponentiate_number_event:
     module_path: app.events.calc
     class_name: ExponentiateNumber
+  record_calculation_event:
+    module_path: app.events.history
+    class_name: RecordCalculation
+  list_recent_formulas_event:
+    module_path: app.events.history
+    class_name: ListRecentFormulas
+  formula_service:
+    module_path: app.repos.formula
+    class_name: FormulaConfigRepository
+    params:
+      formula_config: formulas.yml
+  save_formula_event:
+    module_path: app.events.formula
+    class_name: SaveFormula
+  get_formula_event:
+    module_path: app.events.formula
+    class_name: GetFormula
+  list_formulas_event:
+    module_path: app.events.formula
+    class_name: ListFormulas
+  evaluate_formula_event:
+    module_path: app.events.formula
+    class_name: EvaluateFormula
 
 features:
   calc:
@@ -31,21 +56,42 @@ features:
       params_schema:
         a: int
         b: int
-      commands:
+      steps:
         - service_id: add_number_event
           name: Add `a` and `b`
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '+'
     subtract:
       name: Subtract Number
       description: Subtracts one number from another
-      commands:
+      params_schema:
+        a: int
+        b: int
+      steps:
         - service_id: subtract_number_event
           name: Subtract `b` from `a`
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '-'
     multiply:
       name: Multiply Number
       description: Multiplies one number by another
-      commands:
+      params_schema:
+        a: int
+        b: int
+      steps:
         - service_id: multiply_number_event
           name: Multiply `a` and `b`
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '*'
     divide:
       name: Divide Number
       description: Divides one number by another
@@ -54,39 +100,95 @@ features:
         b:
           type: float
           description: The denominator; must be non-zero.
-      commands:
+      steps:
         - service_id: divide_number_event
           name: Divide `a` by `b`
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '/'
     exp:
       name: Exponentiate Number
       description: Raises one number to the power of another
-      commands:
+      steps:
         - service_id: exponentiate_number_event
           name: Raise `a` to the power of `b`
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '**'
     sqrt:
       name: Square Root
       description: Calculates the square root of a number
-      commands:
+      steps:
         - service_id: exponentiate_number_event
           name: Calculate square root of `a`
           params:
             b: '0.5'
+          data_key: result
+        - service_id: record_calculation_event
+          name: Record the calculation
+          params:
+            operator: '√'
     safe_divide:
       name: Safe Divide
       description: Divides only when denominator is non-zero
-      commands:
+      steps:
         - service_id: divide_number_event
           name: Divide `a` by `b` (skipped when b is 0)
           condition: '$r.b != 0'
+    history:
+      name: Recent Calculations
+      description: Lists the most recently executed calculations
+      steps:
+        - service_id: list_recent_formulas_event
+          name: List recent calculations
+  formula:
+    save:
+      name: Save Formula
+      description: Saves a named, variablized formula
+      params_schema:
+        name: str
+        expression: str
+        description:
+          type: str
+          required: false
+      steps:
+        - service_id: save_formula_event
+          name: Save the formula
+    get:
+      name: Get Formula
+      description: Retrieves a saved formula by id
+      params_schema:
+        id: str
+      steps:
+        - service_id: get_formula_event
+          name: Get the formula
+    list:
+      name: List Formulas
+      description: Lists all saved formulas
+      steps:
+        - service_id: list_formulas_event
+          name: List the formulas
+    eval:
+      name: Evaluate Formula
+      description: Evaluates a saved formula with variable values
+      params_schema:
+        id: str
+      steps:
+        - service_id: evaluate_formula_event
+          name: Evaluate the formula
 
 errors:
   INVALID_INPUT:
     name: Invalid Numeric Input
     message:
       - lang: en_US
-        text: 'Value {} must be a number'
+        text: 'Value {value} must be a number'
       - lang: es_ES
-        text: 'El valor {} debe ser un número'
+        text: 'El valor {value} debe ser un número'
   DIVISION_BY_ZERO:
     name: Division By Zero
     message:
@@ -94,6 +196,21 @@ errors:
         text: 'Cannot divide by zero'
       - lang: es_ES
         text: 'No se puede dividir por cero'
+  FORMULA_NOT_FOUND:
+    name: Formula Not Found
+    message:
+      - lang: en_US
+        text: 'Formula not found: {id}'
+  MISSING_VARIABLE:
+    name: Missing Variable
+    message:
+      - lang: en_US
+        text: 'Missing value for variable: {variable}'
+  FORMULA_EVALUATION_FAILED:
+    name: Formula Evaluation Failed
+    message:
+      - lang: en_US
+        text: 'Could not evaluate formula {id}: {error}'
 
 cli:
   cmds:
@@ -167,6 +284,50 @@ cli:
           - name_or_flags:
               - a
             description: The number to square root.
+      history:
+        group_key: calc
+        key: history
+        name: Recent Calculations Command
+        description: Lists the most recently executed calculations.
+    formula:
+      save:
+        group_key: formula
+        key: save
+        name: Save Formula Command
+        description: Saves a named, variablized formula.
+        args:
+          - name_or_flags:
+              - name
+            description: The name of the formula.
+          - name_or_flags:
+              - expression
+            description: The arithmetic expression using named variables.
+      get:
+        group_key: formula
+        key: get
+        name: Get Formula Command
+        description: Retrieves a saved formula by id.
+        args:
+          - name_or_flags:
+              - id
+            description: The formula identifier.
+      list:
+        group_key: formula
+        key: list
+        name: List Formulas Command
+        description: Lists all saved formulas.
+      eval:
+        group_key: formula
+        key: eval
+        name: Evaluate Formula Command
+        description: Evaluates a saved formula with variable values.
+        args:
+          - name_or_flags:
+              - id
+            description: The formula identifier.
+          - name_or_flags:
+              - values
+            description: A JSON object mapping variable names to values.
 
 logging:
   formatters:

--- a/examples/basic_calculator/formulas.yml
+++ b/examples/basic_calculator/formulas.yml
@@ -1,0 +1,1 @@
+formulas: {}

--- a/examples/basic_calculator/tests/__init__.py
+++ b/examples/basic_calculator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Basic calculator example tests."""

--- a/examples/basic_calculator/tests/conftest.py
+++ b/examples/basic_calculator/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for the basic calculator example tests."""
+
+# *** imports
+
+# ** core
+import sys
+from pathlib import Path
+
+# *** setup
+
+# Add the example root to sys.path so the `app` package is importable
+# regardless of the directory pytest is invoked from.
+EXAMPLE_ROOT = Path(__file__).resolve().parent.parent
+if str(EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_ROOT))

--- a/examples/basic_calculator/tests/test_formula_events.py
+++ b/examples/basic_calculator/tests/test_formula_events.py
@@ -1,0 +1,176 @@
+"""Tiferet Basic Calculator Formula Event Tests"""
+
+# *** imports
+
+# ** core
+from unittest import mock
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet import TiferetError
+from tiferet.events import DomainEvent
+from app.interfaces.formula import FormulaService
+from app.mappers.formula import FormulaAggregate
+from app.events.formula import (
+    SaveFormula,
+    GetFormula,
+    ListFormulas,
+    EvaluateFormula,
+)
+
+# *** fixtures
+
+# ** fixture: mock_formula_service
+@pytest.fixture
+def mock_formula_service() -> FormulaService:
+    '''
+    A mocked formula service.
+    '''
+
+    # Return a mock conforming to the FormulaService interface.
+    return mock.Mock(spec=FormulaService)
+
+# ** fixture: sample_formula
+@pytest.fixture
+def sample_formula() -> FormulaAggregate:
+    '''
+    A sample rectangle-area formula aggregate.
+    '''
+
+    # Build a sample formula with inferred id and variables.
+    return FormulaAggregate(name='Rectangle Area', expression='width * height')
+
+# *** tests
+
+# ** test: save_formula
+def test_save_formula(mock_formula_service):
+    '''
+    Saving a formula creates an aggregate and persists it.
+    '''
+
+    # Execute the save event via the static handle interface.
+    result = DomainEvent.handle(
+        SaveFormula,
+        dependencies={'formula_service': mock_formula_service},
+        name='Rectangle Area',
+        expression='width * height',
+    )
+
+    # The aggregate is created, persisted, and returned.
+    assert result.id == 'rectangle_area'
+    assert result.variables == ['width', 'height']
+    mock_formula_service.save.assert_called_once()
+
+# ** test: get_formula_success
+def test_get_formula_success(mock_formula_service, sample_formula):
+    '''
+    Retrieving an existing formula returns it.
+    '''
+
+    # Arrange the service to return the sample formula.
+    mock_formula_service.get.return_value = sample_formula
+
+    # Execute the get event.
+    result = DomainEvent.handle(
+        GetFormula,
+        dependencies={'formula_service': mock_formula_service},
+        id='rectangle_area',
+    )
+
+    # The sample formula is returned.
+    assert result is sample_formula
+
+# ** test: get_formula_not_found
+def test_get_formula_not_found(mock_formula_service):
+    '''
+    Retrieving a missing formula raises FORMULA_NOT_FOUND.
+    '''
+
+    # Arrange the service to return None.
+    mock_formula_service.get.return_value = None
+
+    # Executing the get event raises a structured error.
+    with pytest.raises(TiferetError) as exc_info:
+        DomainEvent.handle(
+            GetFormula,
+            dependencies={'formula_service': mock_formula_service},
+            id='nope',
+        )
+    assert exc_info.value.error_code == 'FORMULA_NOT_FOUND'
+
+# ** test: list_formulas
+def test_list_formulas(mock_formula_service, sample_formula):
+    '''
+    Listing formulas renders a friendly summary of the service results.
+    '''
+
+    # Arrange the service to return a list with one formula.
+    mock_formula_service.list.return_value = [sample_formula]
+
+    # Execute the list event.
+    result = DomainEvent.handle(
+        ListFormulas,
+        dependencies={'formula_service': mock_formula_service},
+    )
+
+    # The rendered summary includes the formula name and expression.
+    assert result == 'Rectangle Area: width * height (variables: width, height)'
+
+# ** test: list_formulas_empty
+def test_list_formulas_empty(mock_formula_service):
+    '''
+    Listing formulas returns a friendly message when none are saved.
+    '''
+
+    # Arrange the service to return no formulas.
+    mock_formula_service.list.return_value = []
+
+    # Execute the list event.
+    result = DomainEvent.handle(
+        ListFormulas,
+        dependencies={'formula_service': mock_formula_service},
+    )
+
+    # A friendly empty message is returned.
+    assert result == 'No formulas saved yet.'
+
+# ** test: evaluate_formula_success
+def test_evaluate_formula_success(mock_formula_service, sample_formula):
+    '''
+    Evaluating a formula substitutes values and returns the numeric result.
+    '''
+
+    # Arrange the service to return the sample formula.
+    mock_formula_service.get.return_value = sample_formula
+
+    # Execute the evaluate event with concrete values.
+    result = DomainEvent.handle(
+        EvaluateFormula,
+        dependencies={'formula_service': mock_formula_service},
+        id='rectangle_area',
+        values={'width': 3, 'height': 4},
+    )
+
+    # The expression evaluates with the substituted values.
+    assert result == 12
+
+# ** test: evaluate_formula_missing_variable
+def test_evaluate_formula_missing_variable(mock_formula_service, sample_formula):
+    '''
+    Evaluating without all variables raises MISSING_VARIABLE.
+    '''
+
+    # Arrange the service to return the sample formula.
+    mock_formula_service.get.return_value = sample_formula
+
+    # Executing without a required variable raises a structured error.
+    with pytest.raises(TiferetError) as exc_info:
+        DomainEvent.handle(
+            EvaluateFormula,
+            dependencies={'formula_service': mock_formula_service},
+            id='rectangle_area',
+            values={'width': 3},
+        )
+    assert exc_info.value.error_code == 'MISSING_VARIABLE'

--- a/examples/basic_calculator/tests/test_formula_mappers.py
+++ b/examples/basic_calculator/tests/test_formula_mappers.py
@@ -1,0 +1,104 @@
+"""Tiferet Basic Calculator Formula Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet import TiferetError
+from app.mappers.formula import FormulaAggregate, FormulaConfigObject
+
+# *** tests
+
+# ** test: aggregate_derives_id_and_variables
+def test_aggregate_derives_id_and_variables():
+    '''
+    Constructing an aggregate derives the id and infers the variables.
+    '''
+
+    # Build an aggregate from a name and expression.
+    formula = FormulaAggregate(name='Rectangle Area', expression='width * height')
+
+    # The id is snake_cased and the variables are inferred from the expression.
+    assert formula.id == 'rectangle_area'
+    assert formula.variables == ['width', 'height']
+
+# ** test: aggregate_set_expression_reinfers_variables
+def test_aggregate_set_expression_reinfers_variables():
+    '''
+    Updating the expression re-derives the variable list.
+    '''
+
+    # Update the expression on an existing aggregate.
+    formula = FormulaAggregate(name='Rectangle Area', expression='width * height')
+    formula.set_expression('base + offset')
+
+    # The variables reflect the new expression.
+    assert formula.variables == ['base', 'offset']
+
+# ** test: aggregate_set_attribute_invalid
+def test_aggregate_set_attribute_invalid():
+    '''
+    Setting an unknown attribute raises a structured error.
+    '''
+
+    # Attempt to set an unknown attribute.
+    formula = FormulaAggregate(name='Rectangle Area', expression='width * height')
+    with pytest.raises(TiferetError) as exc_info:
+        formula.set_attribute('not_a_field', 'value')
+
+    # The error code identifies the invalid attribute.
+    assert exc_info.value.error_code == 'INVALID_MODEL_ATTRIBUTE'
+
+# ** test: config_object_map
+def test_config_object_map():
+    '''
+    A config object maps to an aggregate with the id supplied externally.
+    '''
+
+    # Validate YAML-shaped data (id provided by the repository key).
+    config = FormulaConfigObject.model_validate({
+        'id': 'rectangle_area',
+        'name': 'Rectangle Area',
+        'expression': 'width * height',
+        'variables': ['width', 'height'],
+    })
+
+    # Mapping produces a FormulaAggregate with matching fields.
+    formula = config.map()
+    assert isinstance(formula, FormulaAggregate)
+    assert formula.id == 'rectangle_area'
+    assert formula.expression == 'width * height'
+
+# ** test: config_object_round_trip
+def test_config_object_round_trip():
+    '''
+    Aggregate -> config object -> aggregate preserves the formula data.
+    '''
+
+    # Start from an aggregate and convert it to persisted data.
+    original = FormulaAggregate(name='Rectangle Area', expression='width * height')
+    data = FormulaConfigObject.from_model(original).to_primitive('to_data')
+
+    # The id is excluded from the persisted data (it is the mapping key).
+    assert 'id' not in data
+
+    # Rebuild the aggregate from the persisted data plus the key id.
+    rebuilt = FormulaConfigObject.model_validate({**data, 'id': original.id}).map()
+    assert rebuilt.id == original.id
+    assert rebuilt.expression == original.expression
+    assert rebuilt.variables == original.variables
+
+# ** test: aggregate_display
+def test_aggregate_display():
+    '''
+    The display string is human-readable and backs __str__.
+    '''
+
+    # Build an aggregate and render its display string.
+    formula = FormulaAggregate(name='Rectangle Area', expression='width * height')
+
+    # The display reads naturally and __str__ matches it.
+    assert formula.display() == 'Rectangle Area: width * height (variables: width, height)'
+    assert str(formula) == formula.display()

--- a/examples/basic_calculator/tests/test_formula_repo.py
+++ b/examples/basic_calculator/tests/test_formula_repo.py
@@ -1,0 +1,77 @@
+"""Tiferet Basic Calculator Formula Repository Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from app.mappers.formula import FormulaAggregate
+from app.repos.formula import FormulaConfigRepository
+
+# *** fixtures
+
+# ** fixture: repo
+@pytest.fixture
+def repo(tmp_path) -> FormulaConfigRepository:
+    '''
+    A formula repository backed by a temporary YAML file.
+    '''
+
+    # Build the repository against a temp config file (created on first save).
+    return FormulaConfigRepository(formula_config=str(tmp_path / 'formulas.yml'))
+
+# *** tests
+
+# ** test: save_and_get
+def test_save_and_get(repo):
+    '''
+    A saved formula can be retrieved with its derived id and variables.
+    '''
+
+    # Save a formula, then retrieve it by its derived id.
+    repo.save(FormulaAggregate(name='Rectangle Area', expression='width * height'))
+    formula = repo.get('rectangle_area')
+
+    # The retrieved formula round-trips its fields.
+    assert formula is not None
+    assert formula.expression == 'width * height'
+    assert formula.variables == ['width', 'height']
+
+# ** test: exists_and_get_missing
+def test_exists_and_get_missing(repo):
+    '''
+    Missing formulas report absence and return None.
+    '''
+
+    # An unsaved formula does not exist and resolves to None.
+    assert repo.exists('nope') is False
+    assert repo.get('nope') is None
+
+# ** test: list_returns_all
+def test_list_returns_all(repo):
+    '''
+    Listing returns all saved formulas.
+    '''
+
+    # Save two formulas.
+    repo.save(FormulaAggregate(name='Rectangle Area', expression='width * height'))
+    repo.save(FormulaAggregate(name='Sum', expression='a + b'))
+
+    # Listing returns both formulas.
+    ids = {formula.id for formula in repo.list()}
+    assert ids == {'rectangle_area', 'sum'}
+
+# ** test: delete_is_idempotent
+def test_delete_is_idempotent(repo):
+    '''
+    Deleting removes a formula and is safe to repeat.
+    '''
+
+    # Save then delete a formula.
+    repo.save(FormulaAggregate(name='Rectangle Area', expression='width * height'))
+    repo.delete('rectangle_area')
+
+    # The formula is gone and a repeated delete does not raise.
+    assert repo.exists('rectangle_area') is False
+    repo.delete('rectangle_area')

--- a/examples/basic_calculator/tests/test_history.py
+++ b/examples/basic_calculator/tests/test_history.py
@@ -1,0 +1,90 @@
+"""Tiferet Basic Calculator History Event Tests"""
+
+# *** imports
+
+# ** core
+import json
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.events import DomainEvent
+from app.events.history import RecordCalculation, ListRecentFormulas
+
+# *** tests
+
+# ** test: record_calculation_creates_file
+def test_record_calculation_creates_file(tmp_path):
+    '''
+    Recording a calculation writes a new history file and returns the result.
+    '''
+
+    # Record a single calculation into a fresh history file.
+    history_file = tmp_path / 'history.json'
+    result = DomainEvent.handle(
+        RecordCalculation,
+        result=3,
+        operator='+',
+        a=1,
+        b=2,
+        history_file=str(history_file),
+    )
+
+    # The result is returned unchanged and the entry is persisted.
+    assert result == 3
+    entries = json.loads(history_file.read_text())
+    assert len(entries) == 1
+    assert entries[0]['expression'] == '1 + 2'
+    assert entries[0]['result'] == 3
+
+# ** test: record_calculation_appends_and_trims
+def test_record_calculation_appends_and_trims(tmp_path):
+    '''
+    Recording more than max_entries keeps only the most recent entries.
+    '''
+
+    # Record five calculations with a max of three retained entries.
+    history_file = tmp_path / 'history.json'
+    for i in range(5):
+        DomainEvent.handle(
+            RecordCalculation,
+            result=i,
+            operator='+',
+            a=i,
+            b=0,
+            history_file=str(history_file),
+            max_entries=3,
+        )
+
+    # Only the three most recent entries are retained.
+    entries = json.loads(history_file.read_text())
+    assert [entry['result'] for entry in entries] == [2, 3, 4]
+
+# ** test: list_recent_formulas_missing_file
+def test_list_recent_formulas_missing_file(tmp_path):
+    '''
+    Listing recent formulas returns a friendly message when no file exists.
+    '''
+
+    # Listing a non-existent history file yields a friendly message.
+    result = DomainEvent.handle(
+        ListRecentFormulas,
+        history_file=str(tmp_path / 'missing.json'),
+    )
+    assert result == 'No recent calculations yet.'
+
+# ** test: list_recent_formulas_returns_limited_entries
+def test_list_recent_formulas_returns_limited_entries(tmp_path):
+    '''
+    Listing recent formulas honors the optional limit, newest entries last.
+    '''
+
+    # Record two calculations.
+    history_file = tmp_path / 'history.json'
+    DomainEvent.handle(RecordCalculation, result=3, operator='+', a=1, b=2, history_file=str(history_file))
+    DomainEvent.handle(RecordCalculation, result=5, operator='+', a=2, b=3, history_file=str(history_file))
+
+    # Listing with a limit renders only the most recent entry.
+    result = DomainEvent.handle(ListRecentFormulas, history_file=str(history_file), limit=1)
+    assert result == '2 + 3 = 5'

--- a/examples/basic_calculator/tests/test_params_schema.py
+++ b/examples/basic_calculator/tests/test_params_schema.py
@@ -1,0 +1,41 @@
+"""Tiferet Basic Calculator Request Schema Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet import TiferetError
+from tiferet.domain.feature import RequestSpecification
+
+# *** tests
+
+# ** test: schema_validates_and_coerces
+def test_schema_validates_and_coerces():
+    '''
+    A request schema coerces declared parameters and preserves extras.
+    '''
+
+    # Build a schema mirroring the formula.save feature.
+    schema = RequestSpecification.model_validate({'name': 'str', 'expression': 'str'})
+
+    # Validation returns the coerced data, preserving unspecified keys.
+    validated = schema.validate({'name': 'Rect', 'expression': 'a * b', 'extra': 1})
+    assert validated['name'] == 'Rect'
+    assert validated['expression'] == 'a * b'
+    assert validated['extra'] == 1
+
+# ** test: schema_missing_required_raises
+def test_schema_missing_required_raises():
+    '''
+    Missing a required parameter raises REQUEST_VALIDATION_FAILED.
+    '''
+
+    # Build a schema requiring name and expression.
+    schema = RequestSpecification.model_validate({'name': 'str', 'expression': 'str'})
+
+    # Omitting a required parameter raises a structured validation error.
+    with pytest.raises(TiferetError) as exc_info:
+        schema.validate({'name': 'Rect'}, feature_id='formula.save')
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'


### PR DESCRIPTION
## Overview
Extends the `basic_calculator` example and its tutorial with two complementary persistence lessons:

- **Recent formula history** via the `Json` file loader (`RecordCalculation` / `ListRecentFormulas`), wired as compute-then-record feature steps (`data_key: result`).
- **Saved & variablized formulas** via the full Tiferet stack: `Formula` domain model, `FormulaAggregate` / `FormulaConfigObject` mappers, `FormulaService`, `FormulaConfigRepository` (backed by `formulas.yml`), and `Save`/`Get`/`List`/`Evaluate` events.

Both are wired into `config.yml` using `params_schema` validation and the `steps:` workflow key.

## User-friendly output
- Added a read-only `Formula.display()` plus `__str__` for clean single-object rendering.
- The list/history "view" events return rendered strings, so the CLI prints clean lines instead of raw objects/dicts.

## Notable fix
- Pointed the `calc_cli` interface at `tiferet.contexts.cli` / `CliContext` so `build_cli` can dispatch (the example was missing this opt-in).

## Tests
- New `examples/basic_calculator/tests/` suite (history events, formula mappers, repo, events, and a `params_schema` validation test) — 23 passing.

## Validation
- `python basic_calc.py`, the CLI commands (`calc add`, `calc history`, `formula save/list/eval`), and `pytest examples/basic_calculator/tests/` all pass.

## Docs
- New tutorial chapters `07-persisting-recent-formulas.md` and `08-saving-and-variablizing-formulas.md`; updated tutorial index and example README.

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/Rn3m4BZCp83awBLXSIVwwo
- Conversation: https://app.warp.dev/conversation/bdd710e0-9240-4359-a8f2-5cd9729085aa

Co-Authored-By: Oz <oz-agent@warp.dev>
