### PR TITLE
Docs – Agent rule, skill templates, and v2 milestone naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,19 @@ Upon completion of a story or issue, a **Collaboration Report** is published as 
 See the full report format guide:
 **[docs/collab/collab_report.md](docs/collab/collab_report.md)**
 
+## Working with AI Agents
+
+Warp/AI agents contributing to Tiferet follow the same conventions described above and in the [`docs/collab/`](docs/collab/) stream guides. The most common workflows are also packaged as reusable agent **skills** so they're applied consistently across all Tiferet-family repositories:
+
+- **`tiferet-create-milestone`** — create or format a GitHub milestone (title and description conventions).
+- **`tiferet-author-trd`** — author a TRD in the standard structure ([tech_requirements.md](docs/collab/tech_requirements.md)).
+- **`tiferet-collab-report`** — generate a Collaboration Report once an issue is confirmed complete ([collab_report.md](docs/collab/collab_report.md)).
+- **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop ([main.md](docs/collab/main.md)).
+
+A ready-to-apply **global agent rule** is preserved at [docs/collab/agent_rule.md](docs/collab/agent_rule.md) — copy it into your agent's global/user rules to apply these standards across every Tiferet repo.
+
+These skills and any AI rules treat `docs/collab/` and the [code style guides](docs/core/) as the **single source of truth** — they reference these documents rather than copying them, so the docs stay authoritative. The skills' canonical copies live in [docs/collab/agents/skills/](docs/collab/agents/skills/); follow that folder's README to copy them into `~/.agents/skills/` (global) or a repo's `.agents/skills/` (project) so your agent auto-discovers them.
+
 ## Code Style
 
 Tiferet enforces a structured code style across all modules. The essentials:

--- a/docs/collab/agent_rule.md
+++ b/docs/collab/agent_rule.md
@@ -1,0 +1,36 @@
+# Tiferet Contribution Standards — Global Agent Rule
+
+This file preserves the recommended **global AI rule** for working on Tiferet-family repositories. It is a *template*: each contributor who uses an AI agent applies it to their own agent, so the Tiferet conventions are followed consistently across every Tiferet repo (`greatstrength/tiferet`, `tiferet-*`, `Tiferet.*`).
+
+The rule is intentionally a **thin pointer** — it references the canonical documentation (`docs/collab/` and `docs/core/`) and the companion agent skills rather than copying their content, so those documents stay the single source of truth and the rule never drifts.
+
+## How to apply it
+
+**Warp:** run `/add-rule` (Auto or Agent mode), or open **Warp Drive → Personal → Rules → Global**, then paste the rule text below. See the [Warp Rules docs](https://docs.warp.dev/agent-platform/warp-agents/rules) for details.
+
+**Other agents/tools:** add the rule text to your tool's global/user-level rules, memory, or system instructions.
+
+> This is a *global* (cross-repo) rule, separate from this repository's `AGENTS.md`, which Warp applies automatically only when you're working inside this repo. Apply the global rule so the conventions also take effect in the other Tiferet repos.
+
+## The rule
+
+```text
+Applies to all Tiferet-family repositories (greatstrength/tiferet, and any tiferet-* / Tiferet.* project). Follow the documented Tiferet contribution standards instead of improvising process.
+
+Source of truth (read when relevant): start at CONTRIBUTING.md, which indexes docs/collab/ (stream guides) and docs/core/ (code style). Inside the tiferet repo use those local paths; from any other repo use the GitHub URLs under https://github.com/greatstrength/tiferet/blob/main/.
+
+For these workflows, use the matching skill (each carries the detailed conventions): tiferet-create-milestone (GitHub milestones), tiferet-author-trd (TRDs), tiferet-collab-report (completion reports), tiferet-milestone-session (per-issue release loop).
+
+Always: tie work to a GitHub issue; write a TRD before non-trivial changes; follow the structured code style (artifact comments, RST docstrings, spacing); keep functional vs docs/config commits separate; add a Co-Authored-By line when an AI agent collaborates; never commit or merge unless asked.
+```
+
+## Companion skills
+
+The workflows named in the rule are packaged as agent skills, with canonical copies kept in [agents/skills/](agents/skills/) (see that folder's README to activate them via `~/.agents/skills/` for global use, or a repo's `.agents/skills/` for one project):
+
+- `tiferet-create-milestone`
+- `tiferet-author-trd`
+- `tiferet-collab-report`
+- `tiferet-milestone-session`
+
+See the **Working with AI Agents** section of [CONTRIBUTING.md](../../CONTRIBUTING.md) for the overview.

--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -1,0 +1,37 @@
+# Tiferet Agent Skills
+
+Canonical, version-controlled copies of the reusable agent **skills** for Tiferet-family work. They live here so they're shareable and reviewable; to use them, each contributor copies them into an auto-discoverable skills directory.
+
+## Skills in this folder
+- **`tiferet-create-milestone`** — create or format a GitHub milestone.
+- **`tiferet-author-trd`** — author a Technical Requirements Document.
+- **`tiferet-collab-report`** — generate a Collaboration Report when an issue is confirmed complete.
+- **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop.
+
+Each is a directory with a `SKILL.md` (YAML frontmatter + instructions). The skills are thin wrappers that reference `docs/collab/` and `docs/core/` as the source of truth — they don't copy that content, so the docs stay authoritative.
+
+## Why they aren't active from here
+Agents only auto-discover skills in specific directories — notably `.agents/skills/` (note the leading dot) at a repository root or in your home folder. This `docs/collab/agents/skills/` path deliberately is **not** one of them, so the templates stay versioned without auto-loading. You activate them by copying into a discoverable location.
+
+## Activate them (auto-discoverable)
+Run these from the repository root.
+
+**Option A — Global (every repo on your machine):**
+```bash
+mkdir -p ~/.agents/skills
+cp -R docs/collab/agents/skills/tiferet-* ~/.agents/skills/
+```
+
+**Option B — This repository only (commit to share with the team):**
+```bash
+mkdir -p .agents/skills
+cp -R docs/collab/agents/skills/tiferet-* .agents/skills/
+```
+
+Other tools work the same way with their own folder names (`.claude/skills/`, `.warp/skills/`, `.codex/skills/`, etc.) — copy into whichever your agent uses.
+
+## Verify
+Start an agent and ask "what skills do I have?", or invoke one directly such as `/tiferet-create-milestone`. The four `tiferet-*` skills should appear.
+
+## Keep in sync
+These repo copies are canonical. When they change here, re-run the copy command above to refresh your active install. Pair the skills with the global rule template in [../../agent_rule.md](../../agent_rule.md).

--- a/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tiferet-author-trd
+description: Author a Technical Requirements Document (TRD) for the Tiferet framework or any Tiferet-family repo. Use this whenever the user asks to write, draft, or format a TRD or technical requirements doc, or before implementing any non-trivial Tiferet change (new feature, refactor, architectural update) that should be specified first. Covers the exact section structure, the Version field by stream, mandatory code-style links, and branch conventions.
+---
+
+# Author a Tiferet TRD
+
+## When to use
+Use this when drafting a TRD for a Tiferet-family repo (canonical repo: `greatstrength/tiferet`). A TRD is required before implementation for non-trivial changes (features, refactors, architectural updates).
+
+Canonical source of truth:
+https://github.com/greatstrength/tiferet/blob/main/docs/collab/tech_requirements.md
+
+## Required structure
+Follow this exact structure (pure Markdown — headers, tables, code blocks):
+
+```markdown
+# Technical Requirements Document: [Story Title]
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** [Current Date]  
+**Version:** [see Version field below]
+
+## 1. Overview
+[3-6 sentences: motivation, the change, key outcomes.]
+
+## 2. Scope
+### In Scope
+- ...
+### Out of Scope
+- ...
+
+## 3. Components Affected
+| Component | File/Path | Changes |
+|-----------|-----------|---------|
+| ... | ... | ... |
+
+## 4. Detailed Requirements
+[Numbered subsections with signatures, behavior, validation, error cases, return values.]
+
+## 5. Acceptance Criteria
+1. Numbered, verifiable outcomes.
+
+## 6. Non-Functional Requirements
+- Consistency with patterns, backward compatibility, maintainability.
+
+## 7. Prerequisites (optional)
+| Dependency | Description |
+|------------|-------------|
+
+## 8. Related Code Style Documentation
+- Always link code_style.md; add component guides only for components actually touched.
+```
+
+## Key rules
+- **Title:** the exact story title prefixed with its component group and an en-dash (e.g. `Domain – Naming Parity: ServiceRegistration and EventFeatureStep`).
+- **Date:** the current calendar date (e.g. June 23, 2026) — never "today".
+- **Version field — by stream:**
+  - **Main stream:** the milestone version. For a no-version domain-scoped parity milestone, use the milestone's descriptive name, e.g. `Core DDD Parity I — Domain Infrastructure (tracking milestone)`.
+  - **RFP stream:** `Request for Prototype`.
+  - **Doc stream:** the latest released version.
+- **Related Code Style Documentation** (section 8) is mandatory: always include `code_style.md`; include a component guide only when the story modifies that component. Link to `https://github.com/greatstrength/tiferet/blob/main/docs/core/<file>` — available guides: `code_style.md`, `domain.md`, `events.md`, `mappers.md`, `interfaces.md`, `contexts.md`, `repos.md`, `utils.md`.
+
+## Branch naming (by stream)
+- **Main:** `<issue-number>-<lowercase-hyphenated-title>`, from and targeting `main`.
+- **RFP:** `v<major>.<minor>.<patch>b<next_beta>-<context>`, from and targeting the prototype branch (e.g. `v2.0-proto`).
+- **Doc:** `docs-<lowercase-hyphenated-context>`, from and targeting `main`.
+
+## Before finalizing
+Verify: all sections present, tables well-formed, code blocks carry a language hint, acceptance criteria are verifiable, and no placeholder text remains. Keep it to ~1-3 pages.

--- a/docs/collab/agents/skills/tiferet-collab-report/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-collab-report/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: tiferet-collab-report
+description: Generate a Collaboration Report (AI ↔ Human summary) for a completed Tiferet GitHub issue. Use this ONLY when the human confirms an issue/story/subtask is complete (e.g. "issue is completed", "work is done", "merged and ready") and wants the wrap-up report. Do not generate it proactively. Covers the exact report structure and where to post it.
+---
+
+# Generate a Tiferet Collaboration Report
+
+## Trigger condition
+Generate this report **only** when the human explicitly confirms the GitHub issue (story or subtask) is complete — e.g. "issue is completed", "work is done", "merged and ready", or similar clear language. Never produce it proactively.
+
+Canonical source of truth:
+https://github.com/greatstrength/tiferet/blob/main/docs/collab/collab_report.md
+
+## Required structure
+Use pure Markdown with this exact structure and heading levels:
+
+```markdown
+# Collaboration Report: [Exact Story Title] (greatstrength/tiferet#[issue-number])
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Date:** [exact calendar date — e.g., June 23, 2026]  
+**Version:** [milestone version; "Request for Prototype" for RFP work]
+
+## 1. Story / TRD Summary
+- **Issue:** `[exact title]` (greatstrength/tiferet#[issue-number])
+- **Goal:** one concise sentence + a bullet list of the core TRD requirements.
+
+## 2. Code Components Touched
+### 2.1 [Component / Domain Area]
+**File:** `path/to/file.py`  
+**Class / Artifact:** `ClassName` (if applicable)  
+**Implements / Changes:**
+- Key methods/attributes/behavioral changes (bold method names + file paths; short snippets only for critical logic)
+
+(Repeat 2.1, 2.2, … per major area. Group logically — don't list every file.)
+
+## 3. Deviations / Clarifications vs TRD
+1. **TRD expectation:** … **Implemented behavior:** … **Rationale:** …
+(If none: "No deviations from the TRD were required.")
+
+## 4. Git / Branch State
+- **Branch:** full name
+- **Pull Request:** #NNN – link
+- **Commits:** short messages + 7-char hashes (with Co-Authored-By note where applicable)
+- **Current state:** pushed / merged / up-to-date / tagged, etc.
+(Include RFP-specific fields — prototype worktree branch, alpha tags, beta tag — for RFP work.)
+
+## 5. Collaboration Log (AI ↔ Human)
+1. **AI** – [proposal / suggestion / question]
+2. **Human** – [feedback / approval / clarification]
+3. **AI** – [how it was adjusted or implemented]
+
+End with: "This log captures the essential iterative collaboration between AI and human that produced the final implementation."
+```
+
+## Style
+Professional, concise, factual, neutral. Prefer bullets and numbered lists. Include only short, high-signal code snippets (never full files). The **Collaboration Log is mandatory**, even if short. Target 1-2 pages. Use exact calendar dates. Output **only** the report — no extra chat text.
+
+## Delivery
+- Post as a comment on the originating GitHub issue.
+- If the issue is locked / comments restricted → post to the associated PR with a cross-link to the issue.
+- If neither channel is available → return the report in chat and ask the human how they'd like it delivered.

--- a/docs/collab/agents/skills/tiferet-create-milestone/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-create-milestone/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: tiferet-create-milestone
+description: Create or format a GitHub milestone for the Tiferet framework or any Tiferet-family repo (greatstrength/tiferet, tiferet-*, Tiferet.*). Use this whenever the user wants to set up, create, or format a milestone, group TRD issues into a milestone, or kick off a new release or parity effort for Tiferet — even if they don't say the word "milestone" outright (e.g. "track this work on GitHub", "organize these issues for the next release"). Covers the title convention, description format, and the gh API command.
+---
+
+# Create a Tiferet GitHub Milestone
+
+## When to use
+Use this when creating or formatting a GitHub milestone in a Tiferet-family repository (canonical repo: `greatstrength/tiferet`). It encodes the Main-stream milestone conventions so a new milestone matches the repo's established style.
+
+Milestones are part of the **Main — Feature Release** stream. The canonical source of truth — read it for full detail or if the conventions may have changed:
+https://github.com/greatstrength/tiferet/blob/main/docs/collab/main.md (Milestones section)
+
+## Title convention
+Milestone titles **normally** use the version number only — no semantic subtitle:
+- Format: `v<version>` (examples: `v2.0.0b3`, `v1.9.0`, `v2.1.0`).
+
+**Exception — domain-scoped v2 milestones:** the current v2 parity milestones track an architectural area of the `v2.0.0` line rather than a single incremental alpha/beta pre-release. These use a **descriptive title with no version**:
+- Format: `<Descriptive Title>` (no version prefix).
+- Example: `Core DDD Parity I – Domain Infrastructure (Domain, Mappers, Interfaces, Utils)`.
+- If a version is needed at all, use `v2.0.0` only — never an alpha (`aN`) or beta (`bN`) suffix.
+
+Use an en-dash (`–`) where a title joins a label and its detail.
+
+## Description format
+The description carries all the semantic context. Structure it as (this mirrors milestone `v2.0.0a3 — Mappers Package`):
+1. A brief **overview paragraph**: the release/effort goal plus any tracking or dependency note.
+2. A **list of linked issues**, one per line, each formatted as `Area (#issue): short intent / artifacts`. Use the component group as the Area (Domain, Mappers, Interfaces, Utils, Events, Repos, Docs, Tests, …).
+3. Optionally (added on completion) a "What's Included" summary and a "Release" section with tag/PyPI links.
+
+If the issues don't exist yet, use `#TBD` placeholders and backfill the real numbers once the TRD issues are created.
+
+**Example (milestone #28, a domain-scoped parity milestone):**
+
+Title: `Core DDD Parity I – Domain Infrastructure (Domain, Mappers, Interfaces, Utils)`
+
+Description:
+```
+Establish v2.0-proto parity for Tiferet's core domain infrastructure in `main`: domain
+objects, mappers, service interfaces, and utilities. Delivers naming parity, the
+MiddlewareService contract, request-validation and logging-settings value objects, and
+the TOML loader, plus relocated tests and documentation. Tracking-only; Milestone 2
+(Events and Repos) depends on the contracts delivered here.
+
+TRD issues:
+- Domain Naming (#TBD): ServiceRegistration, EventFeatureStep, domain exports
+- Mapper Naming (#TBD): *ConfigObject transfer objects, registration aggregates
+- Interfaces (#TBD): MiddlewareService, DIService registration-method rename
+- ...
+```
+
+## Scope guidance
+- Minor releases: typically 3–7 issues per milestone.
+- Major releases: domain-scoped milestones (one per architectural area) are appropriate — that is exactly the descriptive-title case above.
+
+## Project assignment
+Each issue/TRD in a milestone is assigned to the **Tiferet Framework** project (#2) on GitHub.
+
+## How to create it
+Milestone management is **`gh` CLI only** (no MCP equivalent). Write the description to a file first so backticks and multi-line content survive shell escaping, then read it with `-F field=@file`:
+
+```bash
+# 1. Write the description to a temp file (preserves backticks / newlines), e.g. /tmp/milestone_desc.md
+
+# 2. Create the milestone
+gh api repos/greatstrength/tiferet/milestones \
+  -f title='<Title>' \
+  -F description=@/tmp/milestone_desc.md \
+  --jq '{number, title, state, html_url}'
+```
+
+For another Tiferet-family repo, swap `greatstrength/tiferet` accordingly.
+
+## After creating
+Report the milestone number and URL. If you used `#TBD` placeholders, remind the user to backfill issue numbers once the TRD issues exist (PATCH the milestone description). Related workflows: author TRDs with the `tiferet-author-trd` skill; work the milestone with `tiferet-milestone-session`.

--- a/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tiferet-milestone-session
+description: Run a Tiferet milestone implementation session — work a release/milestone's issues end-to-end on the Main stream. Use this whenever the user wants to start a milestone or release implementation session, references a release/version to implement, or asks to work through a milestone's issues one by one (feature branch → PR → merge → report → next). Covers the per-issue loop, project status transitions, milestone close, and release.
+---
+
+# Run a Tiferet Milestone Implementation Session
+
+## When to use
+Use this when implementing the issues of a Tiferet milestone/release on the **Main — Feature Release** stream (feature branches cut from `main`, PRs merged back into `main`).
+
+Canonical source of truth:
+https://github.com/greatstrength/tiferet/blob/main/docs/collab/main.md (Per-Issue Workflow, Closing the Milestone, and Release sections)
+
+## Project status states (project #2)
+`Backlog → Ready → In Progress → In Review → Done`. Move each issue's status as it progresses.
+
+## Per-issue loop
+For each issue in the milestone, in dependency-aware order:
+1. **Create a feature branch** from `main`: `<issue-number>-<lowercase-hyphenated-title>`.
+2. **Link** the branch to the issue and set the project status to **In Progress**.
+3. **Implement and test** following the structured code style; write/port tests with `pytest`.
+4. **Open a PR** targeting `main`, set status to **In Review**, and return the PR URL to the user.
+5. **If PR comments arrive:** set status back to **In Progress**, address the feedback, re-push, then set back to **In Review**.
+6. The **user squash-merges** the PR.
+7. **Post a Collaboration Report** as a comment on the issue (use the `tiferet-collab-report` skill).
+8. **Local cleanup:** check out `main`, pull latest, confirm the merge landed, delete the local feature branch.
+9. **Close the issue**, then repeat for the next one.
+
+## Guardrails
+- Never commit or merge unless the user asks — branch/PR work is yours; merging is the user's.
+- Confirm `git_head` matches the expected branch before starting each issue.
+- Tie every change to its GitHub issue.
+- Include a `Co-Authored-By: <name> <email>` line in commit messages when collaborating with an AI agent.
+
+## Closing the milestone
+Once all issues are merged, mark the milestone **closed**. A release tag and GitHub Release are created on `main` upon completion:
+- **Tag:** `v<version>`. Note: the no-version domain-scoped parity milestones do not tag an incremental pre-release — confirm with the user whether a `v2.0.0`-line tag applies.
+- **GitHub Release** title may add a semantic subtitle: `Tiferet v<version> – <Brief Title>`; the body follows the changelog format (highlights; what's changed grouped by area; breaking changes; upgrade notes; installation).
+
+## Optional release-branch flow
+For a multi-issue release the user may prefer a dedicated release branch (e.g. `v1.0a4-release`) from which feature branches are cut and into which PRs merge, rebased into `main` at the end. The documented default is to branch directly from `main`, so confirm the base-branch strategy with the user before starting.

--- a/docs/collab/main.md
+++ b/docs/collab/main.md
@@ -11,10 +11,16 @@ The Main stream is the primary contribution path for feature releases. Work is o
 
 ### Naming
 
-Milestone titles use the version number only — no semantic subtitle:
+Milestone titles **normally** use the version number only — no semantic subtitle:
 
 - Format: `v<version>`
 - Examples: `v2.0.0b3`, `v1.9.0`, `v2.1.0`
+
+**Exception — domain-scoped v2 milestones:** The current v2 parity milestones (see Scope below) use a **descriptive title with no version**, because they track an architectural area of the `v2.0.0` line rather than a single incremental alpha/beta pre-release:
+
+- Format: `<Descriptive Title>` (no version prefix)
+- Example: `Core DDD Parity I – Domain Infrastructure (Domain, Mappers, Interfaces, Utils)`
+- If a version is needed at all, use `v2.0.0` only — no alpha (`aN`) or beta (`bN`) suffix.
 
 ### Description
 


### PR DESCRIPTION
## Summary
Adds AI-agent collaboration assets to the contribution docs and documents the descriptive (no-version) naming convention for domain-scoped v2 milestones. Documentation-only (Doc stream); no functional code changes.

## Changes
- **`docs/collab/main.md`** — Document that domain-scoped v2 milestones use a descriptive title with no version (and `v2.0.0` only, never `aN`/`bN`, if a version is ever needed), as the exception to the version-only naming rule.
- **`docs/collab/agent_rule.md`** (new) — A preserved, ready-to-apply global agent rule template (a thin pointer to `docs/collab/` + `docs/core/`) that contributors copy into their own agent's global/user rules.
- **`docs/collab/agents/skills/`** (new) — Canonical copies of four reusable agent skills (`tiferet-create-milestone`, `tiferet-author-trd`, `tiferet-collab-report`, `tiferet-milestone-session`) plus a README on activating them for auto-discovery (`~/.agents/skills/` global or `.agents/skills/` project).
- **`CONTRIBUTING.md`** — New "Working with AI Agents" section linking the rule and skills, framing `docs/collab/` + `docs/core/` as the single source of truth.

## Notes
- Thin-pointer design: the rule and skills reference the canonical docs rather than copying them, so the guides stay authoritative and the templates don't drift.
- All cross-linked guides already exist on `main`; this PR only adds the new files and small edits.

Conversation: https://app.warp.dev/conversation/48b7f574-8923-4d5c-8821-96927153fe74

Co-Authored-By: Oz <oz-agent@warp.dev>
