### PR TITLE
Docs/Collab – Project fields strategy and status workflow

### DIFF
--- a/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
@@ -69,3 +69,5 @@ Follow this exact structure (pure Markdown — headers, tables, code blocks):
 
 ## Before finalizing
 Verify: all sections present, tables well-formed, code blocks carry a language hint, acceptance criteria are verifiable, and no placeholder text remains. Keep it to ~1-3 pages.
+
+The TRD also feeds the issue's project fields: Components Affected, Acceptance Criteria, and Prerequisites drive **Size**/**Estimate**, and the Prerequisites table drives **Priority** — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md).

--- a/docs/collab/agents/skills/tiferet-create-milestone/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-create-milestone/SKILL.md
@@ -54,7 +54,7 @@ TRD issues:
 - Major releases: domain-scoped milestones (one per architectural area) are appropriate — that is exactly the descriptive-title case above.
 
 ## Project assignment
-Each issue/TRD in a milestone is assigned to the **Tiferet Framework** project (#2) on GitHub.
+Each issue/TRD in a milestone is assigned to the **Tiferet Framework** project (#2) on GitHub, and triaged with **Priority**, **Size**, and **Estimate** plus an initial **Status** (Backlog or Ready) — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md) for the field strategy and status workflow.
 
 ## How to create it
 Milestone management is **`gh` CLI only** (no MCP equivalent). Write the description to a file first so backticks and multi-line content survive shell escaping, then read it with `-F field=@file`:

--- a/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
@@ -8,23 +8,26 @@ description: Run a Tiferet milestone implementation session — work a release/m
 ## When to use
 Use this when implementing the issues of a Tiferet milestone/release on the **Main — Feature Release** stream (feature branches cut from `main`, PRs merged back into `main`).
 
-Canonical source of truth:
-https://github.com/greatstrength/tiferet/blob/main/docs/collab/main.md (Per-Issue Workflow, Closing the Milestone, and Release sections)
+Canonical sources of truth:
+- https://github.com/greatstrength/tiferet/blob/main/docs/collab/main.md (Per-Issue Workflow, Closing the Milestone, and Release sections)
+- https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md (Status Workflow, Priority/Size/Estimate fields, Start/End dates)
 
 ## Project status states (project #2)
 `Backlog → Ready → In Progress → In Review → Done`. Move each issue's status as it progresses.
 
+At triage (Backlog → Ready) set the **Priority**, **Size**, and **Estimate** fields; set the **Start date** when work begins (In Progress) and the **End date** when the issue is Done — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md).
+
 ## Per-issue loop
 For each issue in the milestone, in dependency-aware order:
 1. **Create a feature branch** from `main`: `<issue-number>-<lowercase-hyphenated-title>`.
-2. **Link** the branch to the issue and set the project status to **In Progress**.
+2. **Link** the branch to the issue, set the project status to **In Progress**, and set the **Start date**.
 3. **Implement and test** following the structured code style; write/port tests with `pytest`.
 4. **Open a PR** targeting `main`, set status to **In Review**, and return the PR URL to the user.
 5. **If PR comments arrive:** set status back to **In Progress**, address the feedback, re-push, then set back to **In Review**.
 6. The **user squash-merges** the PR.
 7. **Post a Collaboration Report** as a comment on the issue (use the `tiferet-collab-report` skill).
 8. **Local cleanup:** check out `main`, pull latest, confirm the merge landed, delete the local feature branch.
-9. **Close the issue**, then repeat for the next one.
+9. **Mark Done:** set the project status to **Done**, set the **End date**, **close the issue**, then repeat for the next one.
 
 ## Guardrails
 - Never commit or merge unless the user asks — branch/PR work is yours; merging is the user's.

--- a/docs/collab/commands.md
+++ b/docs/collab/commands.md
@@ -91,6 +91,40 @@ gh project item-edit \
 - In Review: `4cc61d42`
 - Done: `98236657`
 
+## Project Field Updates
+
+**Tool availability:** **`gh` CLI only** — no MCP equivalent. See [project_fields.md](project_fields.md) for the semantics of each field (Priority, Size, Estimate/points, dates) and the cross-project strategy.
+
+**Project #2 (Tiferet Framework) node id:** `PVT_kwDOCKXjws4A7Y85`
+
+**Field IDs and single-select options** for project #2:
+
+- Status: `PVTSSF_lADOCKXjws4A7Y85zgvs_j4` — Backlog `f75ad846`, Ready `08afe404`, In progress `47fc9ee4`, In review `4cc61d42`, Done `98236657`
+- Priority: `PVTSSF_lADOCKXjws4A7Y85zgvs_no` — P0 `79628723`, P1 `0a877460`, P2 `da944a9c`
+- Size: `PVTSSF_lADOCKXjws4A7Y85zgvs_ns` — XS `eff732af`, S `9592a5a3`, M `9728cbdc`, L `c53df028`, XL `7b141a16`
+- Estimate (number / story points): `PVTF_lADOCKXjws4A7Y85zgvs_nw`
+- Start date: `PVTF_lADOCKXjws4A7Y85zgvs_n4`
+- End date: `PVTF_lADOCKXjws4A7Y85zgvs_n8`
+
+```bash
+# Resolve the project item id for an issue (item-add is idempotent — returns the existing id)
+gh project item-add 2 --owner greatstrength --url <issue-url> --format json --jq '.id'
+
+# Set a single-select field (Status / Priority / Size)
+gh project item-edit --project-id PVT_kwDOCKXjws4A7Y85 --id <item-id> \
+  --field-id <field-id> --single-select-option-id <option-id>
+
+# Set the numeric Estimate (story points)
+gh project item-edit --project-id PVT_kwDOCKXjws4A7Y85 --id <item-id> \
+  --field-id PVTF_lADOCKXjws4A7Y85zgvs_nw --number 5
+
+# Set a date field (Start date / End date)
+gh project item-edit --project-id PVT_kwDOCKXjws4A7Y85 --id <item-id> \
+  --field-id PVTF_lADOCKXjws4A7Y85zgvs_n4 --date 2026-06-23
+```
+
+Field and option IDs are unique per GitHub Project. For any other Tiferet project, resolve them with `gh project field-list <number> --owner <org> --format json` and record them here.
+
 ## Release Publishing
 
 **Tool availability:** **`gh` CLI only**.

--- a/docs/collab/project_fields.md
+++ b/docs/collab/project_fields.md
@@ -1,0 +1,106 @@
+# Project Fields — Tiferet Projects
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose
+
+This document defines the canonical GitHub Project field set used across all Tiferet-related projects (`greatstrength/tiferet`, `tiferet-*`, `Tiferet.*`). It complements the Status states and project assignment in [main.md](main.md) and the field/option IDs and example commands in [commands.md](commands.md). The goal is a single, consistent triage model — Priority, Size, story points, and dates — that an agent or human can apply identically on every project.
+
+## Field Set
+
+### Triage fields (set at triage / during the workflow)
+
+- **Status** — workflow state: Backlog → Ready → In progress → In review → Done (see [main.md](main.md)).
+- **Priority** — `P0`/`P1`/`P2`; sequence and criticality.
+- **Size** — `XS`–`XL`; fast t-shirt judgment.
+- **Estimate** — numeric story points on a Fibonacci scale; the additive rollup/velocity metric. Kept under GitHub's built-in **Estimate** field name (it stores the point value).
+- **Start date** / **End date** — actual cycle-time bounds.
+
+### Automatic / contextual (no policy required)
+
+Milestone, Labels, Repository, Linked pull requests, Assignees, Reviewers, Created, Updated, Closed, Parent issue, Sub-issues progress.
+
+### Deferred
+
+- **Iteration** — not used at this time. Agent-driven throughput is not bound to fixed, recurring human sprint capacity, and the **Milestone** already serves as the scope boundary while Priority + dependency order sequence the work. Keep the field defined (hidden) for future human-team adoption; if a cadence is ever required, treat the Milestone as the iteration rather than adding a parallel time-box.
+
+## Status Workflow
+
+Status tracks each issue through its lifecycle. Transitions are driven by branch, PR, and merge events and mirror the Per-Issue Workflow in [main.md](main.md):
+
+1. **Backlog** — issue created, not yet scheduled.
+2. **Ready** — triaged and ready to pick up. Assign **Priority**, **Size**, and **Estimate** (see below) before promoting to Ready.
+3. **In progress** — work has started / the feature branch is cut. Set the **Start date**.
+4. **In review** — the PR is opened (targeting `main`). If review comments arrive, move back to **In progress**, address them, then return to **In review**.
+5. **Done** — the PR is merged. Set the **End date** and **close the issue**.
+
+In short: starting an issue → **In progress**; PR opened → **In review**; PR merged → **Done** + issue closed. Triage (Backlog → Ready) is where the Priority/Size/Estimate fields below are assigned.
+
+## Priority
+
+Priority is read off the TRD **Prerequisites** table rather than guessed:
+
+- **P0** — critical path; the issue appears as a prerequisite for other issues (root/unblocker).
+- **P1** — required for the milestone, independently workable, blocks little.
+- **P2** — trailing or externally gated (tests, docs, companion-coupled work).
+
+For feature releases (as opposed to parity/tracking milestones), Priority may also fold in user/business value.
+
+## Size and Story Points
+
+**Size** is the quick human judgment; **Estimate** is the additive numeric value derived from Size on a Fibonacci scale:
+
+| Size | Estimate (points) | Typical TRD signature |
+|------|-------------------|------------------------|
+| XS | 1 | one file, trivial or no logic |
+| S | 2 | rename-only, ≤ 3 files |
+| M | 3 | small net-new unit, contained |
+| L | 5 | net-new behavior **or** broad multi-file change |
+| XL | 8 | complex net-new with edge cases, or high coupling |
+
+### Sizing rubric (read from the TRD)
+
+Score using signals already present in the TRD:
+
+- number of rows in **Components Affected** (files touched);
+- **new files / net-new behavior** vs. rename-only;
+- count of **Acceptance Criteria**;
+- cross-package risk or "land jointly with companion" coupling;
+- number of **Prerequisites**.
+
+Rename-only or few files → XS/S; net-new logic or a wide blast radius → L; coupling or high risk → bump one size.
+
+### Splitting rules
+
+- **XXL (≥ 13) — must split.** No single issue may exceed XL/8 points; break it into multiple TRDs/issues. This matches Agile guidance to decompose oversized stories and reinforces one-TRD-per-issue granularity.
+- **XL (8) — consider splitting.** Treat XL as a soft warning rather than a hard stop: it is a gray area, so split when a natural seam exists and the pieces stand on their own; otherwise proceed as a single issue.
+
+## Start / End Date
+
+- **Start date** — set when Status → In progress (feature branch cut).
+- **End date** — set when Status → Done (PR merged).
+
+Together these give per-issue and per-milestone cycle time; the automatic **Created**/**Closed** timestamps serve as an audit backup. Agents set these as part of the per-issue workflow in [main.md](main.md) — two field writes, at the In progress and Done transitions.
+
+## Cross-Project Standardization
+
+1. **Same field set everywhere.** Field names, types, option sets, semantics, and the Size→points map above are identical across all Tiferet projects.
+2. **IDs are per-project.** Field and option node IDs are unique to each GitHub Project, so automation must resolve them at runtime via `gh project field-list <number> --owner <org> --format json`. Known IDs are recorded in [commands.md](commands.md).
+3. **Bootstrapping a new project.** Create the same fields on a fresh project: single-selects for Status, Priority, and Size; a number field for Estimate; and two date fields (Start date, End date). Leave Iteration unused. Then record the resolved IDs in [commands.md](commands.md).
+
+## Worked Example — Milestone 1 (#28)
+
+Applied values for the Domain Infrastructure milestone (≈ 34 points total):
+
+| Issue | Priority | Size | Points |
+|-------|----------|------|--------|
+| #848 Domain Naming | P0 | S | 2 |
+| #849 Mapper Naming | P0 | L | 5 |
+| #850 Interfaces | P0 | M | 3 |
+| #851 Utils TOML | P1 | M | 3 |
+| #852 Request Validation | P1 | L | 5 |
+| #853 Logging Settings | P1 | M | 3 |
+| #854 Domain Cleanup | P2 | L | 5 |
+| #855 Tests Relocation | P2 | L | 5 |
+| #856 Docs | P2 | M | 3 |


### PR DESCRIPTION
## Summary

Propagates the GitHub Project **field strategy** and **status workflow** into the contribution docs and agent skills. Doc stream — no issue/milestone attached. Mirrors the changes already on `v2.0-proto`.

## Changes

- **New `docs/collab/project_fields.md`** — canonical, cross-project field spec:
  - Field tiers (triage / automatic / deferred; Iteration deferred, with rationale).
  - **Priority** (P0/P1/P2) read off the TRD Prerequisites table.
  - **Size → Estimate** Fibonacci points (XS 1, S 2, M 3, L 5, XL 8) plus a TRD-signal sizing rubric.
  - **Split rules:** XXL (≥ 13) must split; XL (8) consider splitting (gray area).
  - Start/End date usage and the **Status Workflow**: starting an issue → In progress; PR opened → In review; PR merged → Done + issue closed.
  - Cross-project standardization (same field set everywhere; per-project ID resolution; bootstrap).
- **`docs/collab/commands.md`** — new *Project Field Updates* section: project #2 node id, the Priority/Size/Estimate/Start/End field + option IDs, and `gh project item-edit` examples (single-select / number / date).
- **Skills** (`docs/collab/agents/skills/`): `tiferet-milestone-session` now covers field triage + Start/End date transitions and links `project_fields.md`; `tiferet-create-milestone` and `tiferet-author-trd` cross-reference the field strategy.

## Notes

- Already applied to the Milestone 1 issues (#848–#856): Priority/Size/Estimate set; milestone total ≈ 34 points.

[Warp conversation](https://app.warp.dev/conversation/5759c1cb-3dd3-457c-8647-7246d94a2236)

Co-Authored-By: Oz <oz-agent@warp.dev>
