### PR TITLE
Docs – Agent-Assisted PR/Code Review Process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,13 @@ Key points:
 - Keep PRs focused — one logical change per PR.
 - After submitting, provide the PR URL to the user.
 
+### Reviewing a Pull Request
+
+When a PR is meant to bring a branch toward parity with a prototype **source of truth**, an agent can review it by comparing each changed file against that reference and posting only the **actionable** discrepancies — line-specific items as inline comments, and structural or whole-file changes in the PR-level comment.
+
+See the full guide:
+**[docs/collab/code_review.md](docs/collab/code_review.md)**
+
 ### Collaboration Report
 
 Upon completion of a story or issue, a **Collaboration Report** is published as a comment on the originating GitHub issue. This report documents the implementation, deviations from the TRD, git state, and a log of key decisions made during development.
@@ -88,6 +95,7 @@ Warp/AI agents contributing to Tiferet follow the same conventions described abo
 - **`tiferet-author-trd`** — author a TRD in the standard structure ([tech_requirements.md](docs/collab/tech_requirements.md)).
 - **`tiferet-collab-report`** — generate a Collaboration Report once an issue is confirmed complete ([collab_report.md](docs/collab/collab_report.md)).
 - **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop ([main.md](docs/collab/main.md)).
+- **`tiferet-pr-code-review`** — review a PR by comparing its feature branch against a prototype source of truth and posting only actionable comments ([code_review.md](docs/collab/code_review.md)).
 
 A ready-to-apply **global agent rule** is preserved at [docs/collab/agent_rule.md](docs/collab/agent_rule.md) — copy it into your agent's global/user rules to apply these standards across every Tiferet repo.
 

--- a/docs/collab/agent_rule.md
+++ b/docs/collab/agent_rule.md
@@ -19,7 +19,7 @@ Applies to all Tiferet-family repositories (greatstrength/tiferet, and any tifer
 
 Source of truth (read when relevant): start at CONTRIBUTING.md, which indexes docs/collab/ (stream guides) and docs/core/ (code style). Inside the tiferet repo use those local paths; from any other repo use the GitHub URLs under https://github.com/greatstrength/tiferet/blob/main/.
 
-For these workflows, use the matching skill (each carries the detailed conventions): tiferet-create-milestone (GitHub milestones), tiferet-author-trd (TRDs), tiferet-collab-report (completion reports), tiferet-milestone-session (per-issue release loop).
+For these workflows, use the matching skill (each carries the detailed conventions): tiferet-create-milestone (GitHub milestones), tiferet-author-trd (TRDs), tiferet-collab-report (completion reports), tiferet-milestone-session (per-issue release loop), tiferet-pr-code-review (PR review against a source of truth).
 
 Always: tie work to a GitHub issue; write a TRD before non-trivial changes; follow the structured code style (artifact comments, RST docstrings, spacing); keep functional vs docs/config commits separate; add a Co-Authored-By line when an AI agent collaborates; never commit or merge unless asked.
 ```
@@ -32,5 +32,6 @@ The workflows named in the rule are packaged as agent skills, with canonical cop
 - `tiferet-author-trd`
 - `tiferet-collab-report`
 - `tiferet-milestone-session`
+- `tiferet-pr-code-review`
 
 See the **Working with AI Agents** section of [CONTRIBUTING.md](../../CONTRIBUTING.md) for the overview.

--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -7,6 +7,7 @@ Canonical, version-controlled copies of the reusable agent **skills** for Tifere
 - **`tiferet-author-trd`** — author a Technical Requirements Document.
 - **`tiferet-collab-report`** — generate a Collaboration Report when an issue is confirmed complete.
 - **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop.
+- **`tiferet-pr-code-review`** — review a PR by comparing its feature branch against a prototype source of truth and posting only actionable comments.
 
 Each is a directory with a `SKILL.md` (YAML frontmatter + instructions). The skills are thin wrappers that reference `docs/collab/` and `docs/core/` as the source of truth — they don't copy that content, so the docs stay authoritative.
 
@@ -31,7 +32,7 @@ cp -R docs/collab/agents/skills/tiferet-* .agents/skills/
 Other tools work the same way with their own folder names (`.claude/skills/`, `.warp/skills/`, `.codex/skills/`, etc.) — copy into whichever your agent uses.
 
 ## Verify
-Start an agent and ask "what skills do I have?", or invoke one directly such as `/tiferet-create-milestone`. The four `tiferet-*` skills should appear.
+Start an agent and ask "what skills do I have?", or invoke one directly such as `/tiferet-create-milestone`. The five `tiferet-*` skills should appear.
 
 ## Keep in sync
 These repo copies are canonical. When they change here, re-run the copy command above to refresh your active install. Pair the skills with the global rule template in [../../agent_rule.md](../../agent_rule.md).

--- a/docs/collab/agents/skills/tiferet-pr-code-review/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-pr-code-review/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: tiferet-pr-code-review
+description: Review a Tiferet pull request by comparing its feature branch against a prototype "source of truth" branch and posting only the actionable discrepancies back to the PR. Use this whenever the user asks an agent to review or compare a PR — especially "review PR #N", "compare this branch to v2.0-proto / the prototype / the source of truth", parity-verification requests, or "post code-review comments on the PR" — even if they don't say the word "review" outright. Covers the file-by-file comparison method, what counts as actionable, and where each comment goes (inline vs the global PR comment).
+---
+
+# Review a Tiferet PR Against the Source of Truth
+
+## When to use
+Use this when reviewing a Tiferet-family PR whose feature branch is meant to match or move toward a prototype **source of truth** branch (e.g., `v2.0-proto`). The agent does the exhaustive, file-by-file comparison and posts precise, well-placed comments; humans decide and merge.
+
+If there is no source-of-truth branch to compare against, say so and fall back to a standard diff-against-base review — the comparative method here does not apply.
+
+Canonical source of truth:
+https://github.com/greatstrength/tiferet/blob/main/docs/collab/code_review.md
+
+## Method
+1. **Establish inputs.** Get the PR's head and base branches and changed files (`gh pr view <n> --json number,headRefName,baseRefName,files`). Identify the source-of-truth branch and fetch it (`git fetch origin <branch>`).
+2. **Compare each changed file** against the source of truth: `git diff origin/<source-of-truth>..HEAD -- <path>`. Confirm the direction of every difference (`-` = source of truth, `+` = branch); read the file on both sides when the diff is ambiguous. Map relocated files to their counterparts.
+3. **Classify** each difference: **behind** (branch missing a reference change — actionable), **ahead** (branch more correct than the reference — keep it, flag the reference to reconcile), or **out of scope** (already acknowledged in the PR description — do not comment).
+4. **Place comments by granularity:**
+   - Line-specific issues → **inline review comments** on the exact file/line.
+   - Global/structural issues (adding or removing whole files, package exports, a missing/extra `__init__.py` / `conftest.py`) → the **global PR review body**.
+   - Inline comments must anchor to a line in the PR's diff vs base; if the target line is outside the diff, anchor to the nearest changed line and name the exact line, or move it to the body.
+5. **Post one consolidated review** via the reviews API with the PR head commit:
+   `gh api --method POST /repos/greatstrength/tiferet/pulls/<n>/reviews --input review.json`, where `review.json` has `commit_id`, `event: "COMMENT"`, a global `body`, and a `comments[]` array (`path`, `line`, `side`, `body`). See [commands.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/commands.md).
+
+## Actionable only
+Comment on naming inconsistencies from incomplete renames, docstring/description drift, test assertions or structure that change what's verified, duplicated/missing/shadowed tests, and changes to the importable surface. **Do not** comment on acknowledged out-of-scope differences, formatting that already matches the code style, or cases where the branch is correct and the reference is stale (note that once, in the body).
+
+## Guardrails
+- Actionable only — a noisy review is worse than a short one.
+- Never recommend reverting a branch that is more correct than the source of truth.
+- Verify behavior-dependent findings (imports, test resolution, identity) in the code before claiming them.
+- Include a `Co-Authored-By:` line in the review body when an AI agent authors the review.
+- A review only comments — never commit or merge unless explicitly asked.

--- a/docs/collab/code_review.md
+++ b/docs/collab/code_review.md
@@ -1,0 +1,92 @@
+# Code Review — Agent-Assisted PR Review
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose
+
+The Code Review process uses an AI agent to review an open pull request by comparing the contents of its feature branch against a prototype **"source of truth"** branch, then posting only the **actionable** discrepancies back to the PR as review comments. It complements — it does not replace — human review: the agent performs the mechanical, exhaustive file-by-file comparison and drafts precise, well-placed comments for a human to act on and merge.
+
+This process emerged from parity work, where a feature branch is meant to bring `main` (or another base) into line with a prototype branch (e.g., `v2.0-proto`). The agent's job is to find where the branch and the source of truth disagree **in ways that need action** — and to ignore the differences that don't.
+
+## When to Use
+
+Use this process when:
+
+- A PR claims to bring a branch toward parity with a prototype/source-of-truth branch, and you want to verify that claim file by file.
+- You want a thorough, line-anchored review of a PR against a known-good reference.
+- A human asks an agent to "review PR #N against `<prototype>`" or to "compare the branch to the source of truth and comment."
+
+If there is **no** prototype source of truth to compare against, say so explicitly and fall back to a standard diff-against-base review — the comparative method below does not apply.
+
+## Inputs
+
+Before starting, establish:
+
+- The **PR number** and its **head (feature) branch** and **base branch** (`gh pr view <n> --json number,headRefName,baseRefName,files`).
+- The **source-of-truth branch**, if one exists (e.g., `v2.0-proto`). Fetch it so the comparison uses the latest: `git fetch origin <source-of-truth>`.
+- The **files changed** in the PR — these scope the comparison.
+
+## Method
+
+### 1. Compare each changed file against the source of truth
+
+For every file the PR touches, diff the feature branch against the source of truth:
+
+```bash
+git diff origin/<source-of-truth>..HEAD -- <path>
+```
+
+Confirm the **direction** of every difference before drawing conclusions (`-` lines are the source of truth, `+` lines are the feature branch). When a diff is ambiguous, read the actual file on both sides — do not infer naming or intent from the diff alone. Account for files that moved (e.g., relocated tests): map each PR file to its counterpart on the source of truth even when the path differs.
+
+### 2. Classify every discrepancy
+
+Sort each difference into one of:
+
+- **Behind** — the branch is missing a change the source of truth has. Actionable: align the branch.
+- **Ahead** — the branch is *more* correct than the source of truth (e.g., a later naming decision). Do **not** revert it; instead flag the source of truth as the thing to reconcile.
+- **Out of scope** — a real difference that belongs to other work and is already acknowledged in the PR description. Do **not** comment on these; they are noise.
+
+Only **Behind** and **Ahead** items are actionable. Everything else is excluded.
+
+### 3. Place comments by granularity
+
+- **Line-specific** discrepancies (a wrong description, a stale docstring, an assertion style, a renamed symbol) → **inline review comments** anchored to the exact file and line.
+- **Global / structural** discrepancies (adding or removing an entire file, package-level export structure, a missing or extra `__init__.py` / `conftest.py`, anything not tied to a single line) → the **global PR review body**.
+
+Inline comments must anchor to a line that is part of the PR's diff against its base. If the relevant line was **not** changed by the PR (so it falls outside the diff), anchor to the nearest changed line and name the exact line in the comment text, or move the item to the global body.
+
+### 4. Post one consolidated review
+
+Submit a single review so the comments arrive together. Use the GitHub reviews API with the PR head commit and an array of inline comments plus the global body:
+
+```bash
+gh api --method POST /repos/greatstrength/tiferet/pulls/<n>/reviews --input review.json
+```
+
+`review.json` contains `commit_id` (the PR head OID), `event: "COMMENT"`, a `body` (the global/structural items), and a `comments[]` array where each entry has `path`, `line`, `side` (usually `"RIGHT"`), and `body`. See [commands.md](commands.md) for the surrounding `gh` operations.
+
+## What Counts as Actionable
+
+Comment on differences that change behavior, correctness, public API, naming consistency, or test integrity — for example:
+
+- Stale or inconsistent naming left behind by an incomplete rename.
+- Docstrings or field descriptions that disagree with the source of truth.
+- Test assertions or structure that diverge from the reference in a way that changes what is verified.
+- Duplicated, missing, or shadowed tests.
+- Export lists or package markers that change the importable surface.
+
+Do **not** comment on:
+
+- Differences the PR description already declares out of scope.
+- Pure formatting that already matches the project's [code style](../core/code_style.md).
+- Cases where the branch is correct and the difference is the source of truth being stale — except to note, once, that the source of truth should be reconciled.
+
+## Guardrails
+
+- **Actionable only.** A noisy review is worse than a short one. Exclude acknowledged, out-of-scope differences.
+- **Respect "ahead" branches.** Never recommend reverting a branch that is more correct than the source of truth; flag the reference instead.
+- **Verify before claiming.** When a finding hinges on behavior (imports, test resolution, identity), confirm it in the code rather than asserting it.
+- **Place comments correctly.** Line items inline; structural and whole-file items in the PR body.
+- **Attribution.** When an AI agent authors the review, include a `Co-Authored-By:` line in the review body.
+- **Never commit or merge** as part of a review unless explicitly asked — a review only comments.


### PR DESCRIPTION
## Summary
Documents the agent-assisted PR/code-review process and packages it as a reusable skill. The process: compare every changed file on a PR's feature branch against a prototype **source of truth** branch (e.g., `v2.0-proto`) and post only **actionable** discrepancies — line-specific items as inline review comments, and structural / whole-file changes in the PR-level comment.

This codifies the workflow first exercised on #867.

## Changes
- **`docs/collab/code_review.md`** (new) — the Code Review stream guide: inputs, the file-by-file comparison method, discrepancy classification (behind / ahead / out-of-scope), comment-placement rules, the consolidated `gh api .../reviews` posting step, what counts as actionable, and guardrails.
- **`docs/collab/agents/skills/tiferet-pr-code-review/SKILL.md`** (new) — companion skill, a thin wrapper that references the guide as the source of truth.
- Index updates:
  - `CONTRIBUTING.md` — new "Reviewing a Pull Request" subsection + skill in the "Working with AI Agents" list.
  - `docs/collab/agent_rule.md` — rule text + companion skills list.
  - `docs/collab/agents/skills/README.md` — skills list + count.

## Notes
- Doc stream change — no milestone, issue, or TRD required (per `docs/collab/doc.md`).
- Branch `docs-agent-pr-code-review` cut from `main`; targets `main`.

---
Oz conversation: https://app.warp.dev/conversation/f816e1e2-837f-4e47-84d5-05ae22e1ee61

Co-Authored-By: Oz <oz-agent@warp.dev>
