### PR TITLE
Interfaces parity: MiddlewareService contract and DIService registration rename (#850)

### DIFF
--- a/tests/interfaces/test_di.py
+++ b/tests/interfaces/test_di.py
@@ -5,9 +5,6 @@
 # ** core
 import inspect
 
-# ** infra
-import pytest
-
 # ** app
 from tiferet.interfaces.di import DIService
 from tiferet.mappers.di import ServiceRegistrationAggregate

--- a/tests/interfaces/test_di.py
+++ b/tests/interfaces/test_di.py
@@ -1,0 +1,157 @@
+"""Tiferet Interfaces DI Contract Tests"""
+
+# *** imports
+
+# ** core
+import inspect
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.interfaces.di import DIService
+from tiferet.mappers.di import ServiceRegistrationAggregate
+
+# *** tests
+
+# ** test: di_service_has_registration_exists
+def test_di_service_has_registration_exists():
+    '''
+    Test that DIService defines the registration_exists method with expected signature.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'registration_exists')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.registration_exists)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'id']
+
+# ** test: di_service_has_get_registration
+def test_di_service_has_get_registration():
+    '''
+    Test that DIService defines the get_registration method with registration_id and flag.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'get_registration')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.get_registration)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names include registration_id and flag.
+    assert params == ['self', 'registration_id', 'flag']
+
+    # Verify flag defaults to None.
+    assert sig.parameters['flag'].default is None
+
+    # Verify the return annotation is the ServiceRegistrationAggregate type.
+    assert sig.return_annotation is ServiceRegistrationAggregate
+
+# ** test: di_service_has_list_all
+def test_di_service_has_list_all():
+    '''
+    Test that DIService defines the list_all method.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'list_all')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.list_all)
+    params = list(sig.parameters.keys())
+
+    # Verify only the self parameter.
+    assert params == ['self']
+
+# ** test: di_service_has_save_registration
+def test_di_service_has_save_registration():
+    '''
+    Test that DIService defines the save_registration method with a registration parameter.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'save_registration')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.save_registration)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'registration']
+
+    # Verify the registration parameter is annotated with ServiceRegistrationAggregate.
+    assert sig.parameters['registration'].annotation is ServiceRegistrationAggregate
+
+# ** test: di_service_has_delete_registration
+def test_di_service_has_delete_registration():
+    '''
+    Test that DIService defines the delete_registration method with a registration_id parameter.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'delete_registration')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.delete_registration)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'registration_id']
+
+# ** test: di_service_has_save_constants
+def test_di_service_has_save_constants():
+    '''
+    Test that DIService defines the save_constants method with a constants parameter.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(DIService, 'save_constants')
+
+    # Inspect the signature.
+    sig = inspect.signature(DIService.save_constants)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'constants']
+
+    # Verify the constants parameter defaults to an empty dict.
+    assert sig.parameters['constants'].default == {}
+
+# ** test: di_service_methods_are_abstract
+def test_di_service_methods_are_abstract():
+    '''
+    Test that all DIService registration methods are marked as abstract.
+    '''
+
+    # Define the expected abstract methods.
+    expected_methods = [
+        'registration_exists', 'get_registration', 'list_all',
+        'save_registration', 'delete_registration', 'save_constants',
+    ]
+
+    # Verify each method is in the abstract methods set.
+    for method_name in expected_methods:
+        assert method_name in DIService.__abstractmethods__, \
+            f'{method_name} should be abstract'
+
+# ** test: di_service_drops_configuration_terminology
+def test_di_service_drops_configuration_terminology():
+    '''
+    Test that the legacy configuration-terminology methods were renamed away.
+    '''
+
+    # Define the legacy method names that must no longer exist.
+    legacy_methods = [
+        'configuration_exists', 'get_configuration',
+        'save_configuration', 'delete_configuration',
+    ]
+
+    # Verify none of the legacy method names remain on DIService.
+    for method_name in legacy_methods:
+        assert not hasattr(DIService, method_name), \
+            f'{method_name} should have been renamed to registration terminology'

--- a/tests/interfaces/test_middleware.py
+++ b/tests/interfaces/test_middleware.py
@@ -1,0 +1,105 @@
+"""Tiferet Interfaces Middleware Contract Tests"""
+
+# *** imports
+
+# ** core
+import inspect
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.interfaces.settings import Service
+from tiferet.interfaces.middleware import MiddlewareService
+
+# *** fixtures
+
+# ** fixture: passthrough_middleware
+@pytest.fixture
+def passthrough_middleware() -> MiddlewareService:
+    '''
+    A concrete synchronous middleware that records invocation and continues the chain.
+
+    :return: A concrete MiddlewareService subclass instance.
+    :rtype: MiddlewareService
+    '''
+
+    # Define a concrete middleware that wraps and continues the chain.
+    class PassthroughMiddleware(MiddlewareService):
+
+        def __init__(self):
+            self.calls = []
+
+        def __call__(self, event, kwargs, next_fn):
+            self.calls.append((event, kwargs))
+            return next_fn()
+
+    # Return an instance of the concrete middleware.
+    return PassthroughMiddleware()
+
+# *** tests
+
+# ** test: middleware_service_is_service
+def test_middleware_service_is_service():
+    '''
+    Test that MiddlewareService is a Service subclass.
+    '''
+
+    # Verify MiddlewareService derives from the Service base class.
+    assert issubclass(MiddlewareService, Service)
+
+# ** test: middleware_service_has_call
+def test_middleware_service_has_call():
+    '''
+    Test that MiddlewareService defines __call__ with the expected signature.
+    '''
+
+    # Verify the method exists.
+    assert hasattr(MiddlewareService, '__call__')
+
+    # Inspect the signature.
+    sig = inspect.signature(MiddlewareService.__call__)
+    params = list(sig.parameters.keys())
+
+    # Verify parameter names.
+    assert params == ['self', 'event', 'kwargs', 'next_fn']
+
+# ** test: middleware_service_call_is_abstract
+def test_middleware_service_call_is_abstract():
+    '''
+    Test that __call__ is marked as abstract.
+    '''
+
+    # Verify __call__ is in the abstract methods set.
+    assert '__call__' in MiddlewareService.__abstractmethods__
+
+# ** test: middleware_service_cannot_instantiate
+def test_middleware_service_cannot_instantiate():
+    '''
+    Test that MiddlewareService cannot be instantiated directly.
+    '''
+
+    # Verify direct instantiation raises a TypeError due to the abstract method.
+    with pytest.raises(TypeError):
+        MiddlewareService()
+
+# ** test: middleware_service_concrete_wraps_and_continues
+def test_middleware_service_concrete_wraps_and_continues(passthrough_middleware: MiddlewareService):
+    '''
+    Test that a concrete middleware invokes next_fn and returns its result.
+
+    :param passthrough_middleware: A concrete synchronous middleware instance.
+    :type passthrough_middleware: MiddlewareService
+    '''
+
+    # Arrange a sentinel event and kwargs plus a next_fn returning a known result.
+    event = object()
+    kwargs = {'a': 1}
+    next_fn = lambda: 'result'
+
+    # Execute the middleware.
+    result = passthrough_middleware(event, kwargs, next_fn)
+
+    # Verify the chain continued and the result propagated.
+    assert result == 'result'
+    assert passthrough_middleware.calls == [(event, kwargs)]

--- a/tiferet/interfaces/__init__.py
+++ b/tiferet/interfaces/__init__.py
@@ -2,6 +2,20 @@
 
 # *** exports
 
+__all__ = [
+    'Service',
+    'ConfigurationService',
+    'FileService',
+    'SqliteService',
+    'AppService',
+    'CliService',
+    'DIService',
+    'ErrorService',
+    'FeatureService',
+    'LoggingService',
+    'MiddlewareService',
+]
+
 # ** app
 from .settings import Service
 from .config import ConfigurationService
@@ -13,3 +27,4 @@ from .di import DIService
 from .error import ErrorService
 from .feature import FeatureService
 from .logging import LoggingService
+from .middleware import MiddlewareService

--- a/tiferet/interfaces/di.py
+++ b/tiferet/interfaces/di.py
@@ -12,7 +12,7 @@ from typing import (
 )
 
 # ** app
-from ..mappers.di import ServiceConfigurationAggregate
+from ..mappers.di import ServiceRegistrationAggregate
 from .settings import Service
 
 # *** interfaces
@@ -23,75 +23,75 @@ class DIService(Service):
     Service interface for managing service configurations and constants.
     '''
 
-    # * method: configuration_exists
+    # * method: registration_exists
     @abstractmethod
-    def configuration_exists(self, id: str) -> bool:
+    def registration_exists(self, id: str) -> bool:
         '''
-        Check if a service configuration exists by ID.
+        Check if a service registration exists by ID.
 
-        :param id: The service configuration identifier.
+        :param id: The service registration identifier.
         :type id: str
-        :return: True if the service configuration exists, otherwise False.
+        :return: True if the service registration exists, otherwise False.
         :rtype: bool
         '''
         # Not implemented.
-        raise NotImplementedError('configuration_exists method is required for DIService.')
+        raise NotImplementedError('registration_exists method is required for DIService.')
 
-    # * method: get_configuration
+    # * method: get_registration
     @abstractmethod
-    def get_configuration(self, configuration_id: str, flag: str = None) -> ServiceConfigurationAggregate:
+    def get_registration(self, registration_id: str, flag: str = None) -> ServiceRegistrationAggregate:
         '''
-        Retrieve a service configuration by ID, optionally filtered by flag.
+        Retrieve a service registration by ID, optionally filtered by flag.
 
-        :param configuration_id: The service configuration identifier.
-        :type configuration_id: str
-        :param flag: Optional flag to filter the configuration.
+        :param registration_id: The service registration identifier.
+        :type registration_id: str
+        :param flag: Optional flag to filter the registration.
         :type flag: str
-        :return: The service configuration aggregate.
-        :rtype: ServiceConfigurationAggregate
+        :return: The service registration aggregate.
+        :rtype: ServiceRegistrationAggregate
         '''
         # Not implemented.
-        raise NotImplementedError('get_configuration method is required for DIService.')
+        raise NotImplementedError('get_registration method is required for DIService.')
 
     # * method: list_all
     @abstractmethod
-    def list_all(self) -> Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]:
+    def list_all(self) -> Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]:
         '''
         List all service configurations and constants.
 
-        :return: A tuple containing a list of service configuration aggregates and a dictionary of constants.
-        :rtype: Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]
+        :return: A tuple containing a list of service registration aggregates and a dictionary of constants.
+        :rtype: Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]
         '''
         # Not implemented.
         raise NotImplementedError('list_all method is required for DIService.')
 
-    # * method: save_configuration
+    # * method: save_registration
     @abstractmethod
-    def save_configuration(self, configuration: ServiceConfigurationAggregate) -> None:
+    def save_registration(self, registration: ServiceRegistrationAggregate) -> None:
         '''
-        Save or update a service configuration.
+        Save or update a service registration.
 
-        :param configuration: The service configuration aggregate to save.
-        :type configuration: ServiceConfigurationAggregate
+        :param registration: The service registration aggregate to save.
+        :type registration: ServiceRegistrationAggregate
         :return: None
         :rtype: None
         '''
         # Not implemented.
-        raise NotImplementedError('save_configuration method is required for DIService.')
+        raise NotImplementedError('save_registration method is required for DIService.')
 
-    # * method: delete_configuration
+    # * method: delete_registration
     @abstractmethod
-    def delete_configuration(self, configuration_id: str) -> None:
+    def delete_registration(self, registration_id: str) -> None:
         '''
-        Delete a service configuration by ID. This operation should be idempotent.
+        Delete a service registration by ID. This operation should be idempotent.
 
-        :param configuration_id: The service configuration identifier.
-        :type configuration_id: str
+        :param registration_id: The service registration identifier.
+        :type registration_id: str
         :return: None
         :rtype: None
         '''
         # Not implemented.
-        raise NotImplementedError('delete_configuration method is required for DIService.')
+        raise NotImplementedError('delete_registration method is required for DIService.')
 
     # * method: save_constants
     @abstractmethod

--- a/tiferet/interfaces/di.py
+++ b/tiferet/interfaces/di.py
@@ -20,7 +20,7 @@ from .settings import Service
 # ** interface: di_service
 class DIService(Service):
     '''
-    Service interface for managing service configurations and constants.
+    Service interface for managing service registrations and constants.
     '''
 
     # * method: registration_exists
@@ -57,7 +57,7 @@ class DIService(Service):
     @abstractmethod
     def list_all(self) -> Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]:
         '''
-        List all service configurations and constants.
+        List all service registrations and constants.
 
         :return: A tuple containing a list of service registration aggregates and a dictionary of constants.
         :rtype: Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]

--- a/tiferet/interfaces/middleware.py
+++ b/tiferet/interfaces/middleware.py
@@ -1,0 +1,85 @@
+"""Tiferet Middleware Interface"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import Any, Callable, Dict
+
+# ** app
+from .settings import Service
+
+# *** interfaces
+
+# ** interface: middleware_service
+class MiddlewareService(Service):
+    '''
+    Abstract service interface for domain event middleware.
+
+    Middleware wraps domain event execution with cross-cutting concerns such
+    as audit logging, execution timing, distributed tracing, and retry logic.
+    Middleware instances are resolved from the DI container by ``service_id``
+    and composed into an ordered chain before the event executes.
+
+    **Protocol**
+
+    Each middleware receives:
+
+    - ``event`` — the instantiated ``DomainEvent`` (or ``AsyncDomainEvent``) instance.
+    - ``kwargs`` — the merged execution kwargs dict passed to ``execute``.
+    - ``next_fn`` — a zero-argument callable that invokes the next middleware in
+      the chain, or the event itself when no further middleware remains.
+      In synchronous execution paths ``next_fn`` is a plain callable.
+      In asynchronous execution paths ``next_fn`` is a coroutine function —
+      middleware intended for async contexts must be implemented as
+      ``async def __call__`` and must ``await next_fn()``.
+
+    **Ordering**
+
+    Middleware is composed outermost-first: the first entry in the list is the
+    outermost wrapper (first to run on entry, last to run on exit).  Feature-level
+    middleware wraps step-level middleware.
+
+    **Sync example**::
+
+        class TimingMiddleware(MiddlewareService):
+            def __call__(self, event, kwargs, next_fn):
+                start = time.perf_counter()
+                result = next_fn()
+                elapsed = time.perf_counter() - start
+                print(f"{event.__class__.__name__} took {elapsed:.4f}s")
+                return result
+
+    **Async example**::
+
+        class AsyncAuditMiddleware(MiddlewareService):
+            async def __call__(self, event, kwargs, next_fn):
+                print(f"Before: {event.__class__.__name__}")
+                result = await next_fn()
+                print(f"After: {event.__class__.__name__}")
+                return result
+    '''
+
+    # * method: __call__
+    @abstractmethod
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the middleware, calling ``next_fn()`` to continue the chain.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that invokes the remainder of
+            the chain.  In async execution contexts this is a coroutine function
+            and must be awaited.
+        :type next_fn: Callable[[], Any]
+        :return: The result of the event execution.
+        :rtype: Any
+        '''
+
+        # Not implemented.
+        raise NotImplementedError()


### PR DESCRIPTION
## Summary
Brings the service interfaces to `v2.0-proto` parity (Milestone #28, issue #850, P0).

- **MiddlewareService** (`tiferet/interfaces/middleware.py`, new): abstract callable `MiddlewareService(Service)` with an abstract `__call__(self, event, kwargs, next_fn)` describing the sync/async wrap-and-continue contract.
- **DIService** (`tiferet/interfaces/di.py`): methods renamed to registration terminology — `registration_exists`, `get_registration(registration_id, flag)`, `list_all`, `save_registration(registration)`, `delete_registration(registration_id)`, `save_constants` — typed against `ServiceRegistrationAggregate`.
- **Exports** (`tiferet/interfaces/__init__.py`): add `MiddlewareService` and an explicit `__all__`.
- **Tests**: new `tests/interfaces/` package with `test_di.py` (registration-method contract) and `test_middleware.py` (MiddlewareService contract, including a concrete sync wrap-and-continue case).

The three source files are byte-identical to their `v2.0-proto` counterparts.

## Acceptance criteria
- [x] `MiddlewareService` exists and is exported from `tiferet.interfaces`.
- [x] `DIService` uses registration-terminology names and `ServiceRegistrationAggregate` typing.
- [x] `from tiferet.interfaces import MiddlewareService` succeeds.
- [x] Affected interface tests relocated into `tests/interfaces/` and pass, including `MiddlewareService` coverage.
- [x] All methods `@abstractmethod`; structured code style / artifact comments followed.

## Testing
`python -m pytest tests` → 182 passed (includes 13 new interface tests).

## Notes
- Out of scope (per TRD): concrete middleware utilities, the DI repository implementation of the renamed methods, and event composition — all Milestone 2.
- The pre-existing guarded `import tiferet` warning about `ServiceConfiguration` is the intentional downstream breakage tracked by Milestone 2 and is unchanged by this PR.

Closes #850

---
[Warp conversation](https://app.warp.dev/conversation/3131e74c-95bc-4de3-a994-30212a60f517)

Co-Authored-By: Oz <oz-agent@warp.dev>
