### PR TITLE
Utils – TOML: TomlLoader and Packaging (#851)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.6",
     "pyyaml>=6.0.1",
-    "dependency-injector>=4.49.0"
+    "dependency-injector>=4.49.0",
+    "tomli>=2.0; python_version < '3.11'"
 ]
 
 [project.urls]
@@ -19,10 +20,14 @@ Homepage = "https://github.com/greatstrength/tiferet"
 Repository = "https://github.com/greatstrength/tiferet"
 Download = "https://github.com/greatstrength/tiferet"
 
+[project.scripts]
+tiferet = "tiferet.blueprints.tiferet_cli:main"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.3",
-    "pytest_env>=1.1.5"
+    "pytest_env>=1.1.5",
+    "pytest-asyncio>=0.23.0"
 ]
 
 [build-system]
@@ -48,3 +53,6 @@ include = [
 
 [tool.setuptools.dynamic]
 version = { attr = "tiferet.__version__" }
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "tests_int"]

--- a/tests/utils/test_toml.py
+++ b/tests/utils/test_toml.py
@@ -1,0 +1,208 @@
+"""Tiferet TomlLoader Utility Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from pathlib import Path
+
+# ** app
+from tiferet.utils.toml import TomlLoader
+from tiferet.assets.exceptions import TiferetError
+from tiferet.assets.constants import (
+    TOML_FILE_NOT_FOUND_ID,
+    TOML_FILE_LOAD_ERROR_ID,
+    INVALID_TOML_FILE_ID,
+)
+
+
+# *** fixtures
+
+# ** fixture: sample_toml_file
+@pytest.fixture
+def sample_toml_file(tmp_path) -> Path:
+    '''
+    Create a temporary TOML file with sample content.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: Path
+    :return: Path to the temporary TOML file.
+    :rtype: Path
+    '''
+
+    # Write sample TOML content.
+    file_path = tmp_path / 'config.toml'
+    file_path.write_text(
+        '[project]\nname = "tiferet"\nversion = "2.0.0"\n\n'
+        '[project.options]\ndebug = true\ncount = 42\n',
+        encoding='utf-8',
+    )
+    return file_path
+
+
+# ** fixture: invalid_toml_file
+@pytest.fixture
+def invalid_toml_file(tmp_path) -> Path:
+    '''
+    Create a temporary TOML file with invalid content.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: Path
+    :return: Path to the invalid TOML file.
+    :rtype: Path
+    '''
+
+    # Write invalid TOML content.
+    file_path = tmp_path / 'bad.toml'
+    file_path.write_bytes(b'[invalid\nkey = ???')
+    return file_path
+
+
+# *** tests
+
+# ** test: toml_loader_load_basic
+def test_toml_loader_load_basic(sample_toml_file: Path):
+    '''
+    Test loading a valid TOML file returns parsed data.
+
+    :param sample_toml_file: Path to the sample TOML file.
+    :type sample_toml_file: Path
+    '''
+
+    # Load the TOML file.
+    loader = TomlLoader(path=sample_toml_file)
+    data = loader.load()
+
+    # Assert parsed structure.
+    assert data['project']['name'] == 'tiferet'
+    assert data['project']['version'] == '2.0.0'
+    assert data['project']['options']['debug'] is True
+    assert data['project']['options']['count'] == 42
+
+
+# ** test: toml_loader_load_with_start_node
+def test_toml_loader_load_with_start_node(sample_toml_file: Path):
+    '''
+    Test loading with a start_node transformation.
+
+    :param sample_toml_file: Path to the sample TOML file.
+    :type sample_toml_file: Path
+    '''
+
+    # Load with a start_node that navigates to the project section.
+    loader = TomlLoader(path=sample_toml_file)
+    data = loader.load(start_node=lambda d: d.get('project'))
+
+    # Assert the start_node transformation was applied.
+    assert data['name'] == 'tiferet'
+    assert data['version'] == '2.0.0'
+
+
+# ** test: toml_loader_load_with_data_factory
+def test_toml_loader_load_with_data_factory(sample_toml_file: Path):
+    '''
+    Test loading with a data_factory transformation.
+
+    :param sample_toml_file: Path to the sample TOML file.
+    :type sample_toml_file: Path
+    '''
+
+    # Load with a data_factory that extracts a single value.
+    loader = TomlLoader(path=sample_toml_file)
+    result = loader.load(
+        start_node=lambda d: d.get('project'),
+        data_factory=lambda d: d.get('name'),
+    )
+
+    # Assert the factory result.
+    assert result == 'tiferet'
+
+
+# ** test: toml_loader_load_file_not_found
+def test_toml_loader_load_file_not_found(tmp_path: Path):
+    '''
+    Test that loading a nonexistent TOML file raises FILE_NOT_FOUND.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: Path
+    '''
+
+    # Attempt to load a nonexistent file.
+    loader = TomlLoader(path=tmp_path / 'missing.toml')
+    with pytest.raises(TiferetError) as exc_info:
+        loader.load()
+
+    # Assert the correct error code.
+    assert exc_info.value.error_code == 'FILE_NOT_FOUND'
+
+
+# ** test: toml_loader_load_invalid_toml
+def test_toml_loader_load_invalid_toml(invalid_toml_file: Path):
+    '''
+    Test that loading a malformed TOML file raises TOML_FILE_LOAD_ERROR.
+
+    :param invalid_toml_file: Path to the invalid TOML file.
+    :type invalid_toml_file: Path
+    '''
+
+    # Attempt to load the invalid file.
+    loader = TomlLoader(path=invalid_toml_file)
+    with pytest.raises(TiferetError) as exc_info:
+        loader.load()
+
+    # Assert the correct error code.
+    assert exc_info.value.error_code == TOML_FILE_LOAD_ERROR_ID
+
+
+# ** test: toml_loader_verify_toml_file_wrong_extension
+def test_toml_loader_verify_toml_file_wrong_extension(tmp_path: Path):
+    '''
+    Test that verify_toml_file raises INVALID_TOML_FILE for non-.toml files.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: Path
+    '''
+
+    # Create a file with the wrong extension.
+    file_path = tmp_path / 'config.yaml'
+    file_path.write_text('key: value', encoding='utf-8')
+
+    # Create a loader and verify.
+    loader = TomlLoader(path=file_path)
+    with pytest.raises(TiferetError) as exc_info:
+        TomlLoader.verify_toml_file(loader)
+
+    # Assert the correct error code.
+    assert exc_info.value.error_code == INVALID_TOML_FILE_ID
+
+
+# ** test: toml_loader_verify_toml_file_not_found
+def test_toml_loader_verify_toml_file_not_found(tmp_path: Path):
+    '''
+    Test that verify_toml_file raises TOML_FILE_NOT_FOUND for missing files.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: Path
+    '''
+
+    # Create a loader pointing to a non-existent .toml file.
+    loader = TomlLoader(path=tmp_path / 'missing.toml')
+    with pytest.raises(TiferetError) as exc_info:
+        TomlLoader.verify_toml_file(loader)
+
+    # Assert the correct error code.
+    assert exc_info.value.error_code == TOML_FILE_NOT_FOUND_ID
+
+
+# ** test: toml_loader_defaults_to_binary_mode
+def test_toml_loader_defaults_to_binary_mode():
+    '''
+    Test that TomlLoader defaults to binary read mode as required by tomllib.
+    '''
+
+    # Create a loader (file need not exist for attribute checks).
+    loader = TomlLoader(path='/tmp/test.toml')
+
+    # Assert binary read mode and no encoding.
+    assert loader.mode == 'rb'
+    assert loader.encoding is None

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -175,6 +175,10 @@ CSV_INVALID_WRITE_MODE_ID       = 'CSV_INVALID_WRITE_MODE'
 CSV_FIELDNAMES_REQUIRED_ID      = 'CSV_FIELDNAMES_REQUIRED'
 CSV_DICT_NO_HEADER_ID           = 'CSV_DICT_NO_HEADER'
 
+TOML_FILE_NOT_FOUND_ID          = 'TOML_FILE_NOT_FOUND'
+TOML_FILE_LOAD_ERROR_ID         = 'TOML_FILE_LOAD_ERROR'
+INVALID_TOML_FILE_ID            = 'INVALID_TOML_FILE'
+
 # ** constant: default_errors
 DEFAULT_ERRORS = {
 
@@ -863,6 +867,33 @@ DEFAULT_ERRORS = {
         'name': 'CSV Dict Reader Without Header',
         'message': [
             {'lang': 'en_US', 'text': 'Dict reader expects header row; file appears to lack one or was not read correctly.'}
+        ]
+    },
+
+    # * error: TOML_FILE_NOT_FOUND
+    TOML_FILE_NOT_FOUND_ID: {
+        'id': TOML_FILE_NOT_FOUND_ID,
+        'name': 'TOML File Not Found',
+        'message': [
+            {'lang': 'en_US', 'text': 'The specified TOML file could not be found at {path}.'}
+        ]
+    },
+
+    # * error: TOML_FILE_LOAD_ERROR
+    TOML_FILE_LOAD_ERROR_ID: {
+        'id': TOML_FILE_LOAD_ERROR_ID,
+        'name': 'TOML Load Failure',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to parse TOML file: {error}. Path: {path}.'}
+        ]
+    },
+
+    # * error: INVALID_TOML_FILE
+    INVALID_TOML_FILE_ID: {
+        'id': INVALID_TOML_FILE_ID,
+        'name': 'Invalid TOML File',
+        'message': [
+            {'lang': 'en_US', 'text': 'File is not a valid TOML file: {path}.'}
         ]
     },
 }

--- a/tiferet/utils/__init__.py
+++ b/tiferet/utils/__init__.py
@@ -6,5 +6,6 @@
 from .file import FileLoader, FileLoader as File
 from .json import JsonLoader, JsonLoader as Json
 from .yaml import YamlLoader, YamlLoader as Yaml
+from .toml import TomlLoader, TomlLoader as Toml
 from .csv import CsvLoader, CsvLoader as Csv, CsvDictLoader, CsvDictLoader as CsvDict
 from .sqlite import SqliteClient, SqliteClient as Sqlite

--- a/tiferet/utils/toml.py
+++ b/tiferet/utils/toml.py
@@ -1,0 +1,127 @@
+"""Tiferet Utils Toml"""
+
+# *** imports
+
+# ** core
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+# ** app
+from .file import FileLoader
+from ..events import RaiseError, a
+from ..events.settings import TiferetError
+
+# *** utils
+
+# ** util: toml_loader
+class TomlLoader(FileLoader):
+    '''
+    Utility for loading TOML files with structured error handling.
+    Extends FileLoader for stream lifecycle management.
+
+    TOML is a read-only format in this utility; writing is not supported
+    because the ``tomllib`` / ``tomli`` library only provides parsing.
+    '''
+
+    # * init
+    def __init__(self,
+            path: str | Path,
+            mode: str = 'rb',
+            **kwargs,
+        ):
+        '''
+        Initialize TomlLoader.
+
+        :param path: Path to the TOML file.
+        :type path: str | Path
+        :param mode: File open mode (defaults to 'rb' for binary read as required by tomllib).
+        :type mode: str
+        :param kwargs: Additional parameters passed to parent.
+        :type kwargs: dict
+        '''
+
+        # Initialize the parent FileLoader with binary mode (no encoding).
+        super().__init__(path=path, mode=mode, encoding=None, **kwargs)
+
+    # * method: verify_toml_file (static)
+    @staticmethod
+    def verify_toml_file(loader: 'TomlLoader', default_path: Optional[Path] = None):
+        '''
+        Verify the file has a TOML extension and exists (with optional fallback).
+
+        :param loader: TomlLoader instance to verify.
+        :type loader: TomlLoader
+        :param default_path: Optional fallback path if primary path is invalid.
+        :type default_path: Optional[Path]
+        '''
+
+        # Start with the loader's path.
+        path = loader.path
+
+        # Check if the path has a valid TOML extension; fall back or raise error.
+        if path.suffix.lower() != '.toml':
+            if default_path and default_path.suffix.lower() == '.toml':
+                path = default_path
+            else:
+                RaiseError.execute(
+                    error_code=a.const.INVALID_TOML_FILE_ID,
+                    message="File must have .toml extension",
+                    path=str(loader.path),
+                )
+
+        # Verify the resolved path exists.
+        if not path.exists():
+            RaiseError.execute(
+                error_code=a.const.TOML_FILE_NOT_FOUND_ID,
+                path=str(path),
+            )
+
+    # * method: load
+    def load(self,
+            start_node: Callable[[Any], Any] = lambda x: x,
+            data_factory: Callable[[Any], Any] = lambda x: x,
+            **kwargs,
+        ) -> Any:
+        '''
+        Load TOML content, apply optional transformations, and return result.
+
+        :param start_node: First transformation applied to raw data.
+        :type start_node: Callable[[Any], Any]
+        :param data_factory: Final factory applied to transformed data.
+        :type data_factory: Callable[[Any], Any]
+        :param kwargs: Additional keyword arguments (ignored).
+        :type kwargs: dict
+        :return: Parsed and transformed Python object.
+        :rtype: Any
+        '''
+
+        try:
+
+            # Open the file stream via context manager, parse TOML, and apply transformations.
+            with self:
+                data = tomllib.load(self.file)
+
+                # Apply the start_node transformation.
+                transformed = start_node(data)
+
+                # Apply the data_factory and return.
+                return data_factory(transformed)
+
+        except TiferetError:
+
+            # Re-raise structured errors from FileLoader (e.g., FILE_NOT_FOUND).
+            raise
+
+        except Exception as e:
+
+            # Wrap TOML parsing errors as structured TiferetError.
+            RaiseError.execute(
+                error_code=a.const.TOML_FILE_LOAD_ERROR_ID,
+                error=str(e),
+                path=str(self.path),
+            )


### PR DESCRIPTION
## Summary
Implements #851 — adds the read-only TOML loader utility and associated packaging updates, bringing `tiferet/utils` to `v2.0-proto` parity for TOML support.

- **New `TomlLoader`** (`tiferet/utils/toml.py`): a `FileLoader` subclass parsing via `tomllib` (with a `tomli` fallback for Python < 3.11). Provides `verify_toml_file` (extension + existence, optional fallback) and `load(start_node, data_factory)`; wraps parse failures as `TOML_FILE_LOAD_ERROR` and re-raises `FileLoader`'s structured errors.
- **Exports** `Toml`/`TomlLoader` from `tiferet/utils/__init__.py`.
- **Constants** (`tiferet/assets/constants.py`): adds `TOML_FILE_NOT_FOUND`, `TOML_FILE_LOAD_ERROR`, and `INVALID_TOML_FILE` with default error messages.
- **Packaging** (`pyproject.toml`): `tomli>=2.0; python_version < '3.11'`, the `pytest-asyncio` test extra, the `tiferet` `[project.scripts]` entry, and `[tool.pytest.ini_options]` `testpaths`.

Middleware utilities remain out of scope (tracked in Milestone 2), so the proto's `middleware` exports are intentionally omitted here.

## Acceptance criteria
- [x] `from tiferet.utils import Toml, TomlLoader` succeeds; `TomlLoader.load()` parses a `.toml` file.
- [x] Invalid extension and missing file raise the corresponding structured errors.
- [x] The three TOML constants exist with default error messages.
- [x] `pyproject.toml` includes the `tomli` marker, `pytest-asyncio`, the CLI script entry, and `testpaths`.
- [x] `tests/utils/test_toml.py` exists, covers the loader and error paths, and passes.

## Test plan
- `python -m pytest tests/utils` → 8 passed.
- `python -m pytest tests/` → 190 passed (no regressions).

Implements #851 (close after collab report per milestone workflow).

[Warp conversation](https://app.warp.dev/conversation/89598691-9851-47f8-9794-11d1caf8f365)

Co-Authored-By: Oz <oz-agent@warp.dev>