### PR TITLE
Domain – Request Validation: Request and RequestSpecification objects (#852)

### DIFF
--- a/tests/domain/test_feature.py
+++ b/tests/domain/test_feature.py
@@ -10,7 +10,10 @@ from tiferet.domain.feature import (
     Feature,
     FeatureStep,
     EventFeatureStep,
+    ParameterSpecification,
+    RequestSpecification,
 )
+from tiferet.assets import TiferetError
 
 # *** fixtures
 
@@ -202,3 +205,181 @@ def test_feature_get_step_valid_and_invalid_indices(feature: Feature) -> None:
 
     # Assert invalid type returns None.
     assert feature.get_step('invalid') is None
+
+# ** test: parameter_specification_get_type_mapping
+def test_parameter_specification_get_type_mapping() -> None:
+    '''
+    Test that ParameterSpecification.get_type maps declared type strings to Python types.
+    '''
+
+    # Assert each supported type string maps to its Python type.
+    assert ParameterSpecification(name='a', type='str').get_type() is str
+    assert ParameterSpecification(name='a', type='int').get_type() is int
+    assert ParameterSpecification(name='a', type='float').get_type() is float
+    assert ParameterSpecification(name='a', type='bool').get_type() is bool
+    assert ParameterSpecification(name='a', type='list').get_type() is list
+    assert ParameterSpecification(name='a', type='dict').get_type() is dict
+
+# ** test: parameter_specification_field_definition_required
+def test_parameter_specification_field_definition_required() -> None:
+    '''
+    Test that a required parameter produces a required field definition.
+    '''
+
+    # Build the field definition for a required parameter.
+    annotation, field = ParameterSpecification(name='a', type='int').field_definition()
+
+    # Assert the annotation and requiredness.
+    assert annotation is int
+    assert field.is_required()
+
+# ** test: parameter_specification_field_definition_optional_with_default
+def test_parameter_specification_field_definition_optional_with_default() -> None:
+    '''
+    Test that an optional parameter with a default is not required and carries the default.
+    '''
+
+    # Build the field definition for an optional parameter with a default.
+    spec = ParameterSpecification(name='b', type='float', required=False, default=1.0)
+    _annotation, field = spec.field_definition()
+
+    # Assert the field is optional with the configured default.
+    assert not field.is_required()
+    assert field.default == 1.0
+
+# ** test: request_specification_normalizes_shorthand
+def test_request_specification_normalizes_shorthand() -> None:
+    '''
+    Test that the shorthand keyed form expands to a required parameter.
+    '''
+
+    # Normalize a shorthand keyed mapping.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+
+    # Assert the expanded parameter is required.
+    assert len(spec.parameters) == 1
+    assert spec.parameters[0].name == 'a'
+    assert spec.parameters[0].type == 'int'
+    assert spec.parameters[0].required is True
+
+# ** test: request_specification_normalizes_expanded
+def test_request_specification_normalizes_expanded() -> None:
+    '''
+    Test that the expanded keyed form preserves constraints and defaults.
+    '''
+
+    # Normalize an expanded keyed mapping.
+    spec = RequestSpecification.model_validate(
+        {'b': {'type': 'float', 'required': False, 'default': 1.0, 'minimum': 0}}
+    )
+    param = spec.parameters[0]
+
+    # Assert the parameter constraints are preserved.
+    assert param.name == 'b'
+    assert param.type == 'float'
+    assert param.required is False
+    assert param.default == 1.0
+    assert param.minimum == 0.0
+
+# ** test: request_specification_validate_coerces_and_preserves_extra
+def test_request_specification_validate_coerces_and_preserves_extra() -> None:
+    '''
+    Test that validate coerces typed fields, applies defaults, and preserves extra keys.
+    '''
+
+    # Validate a payload against a schema with a defaulted optional field.
+    spec = RequestSpecification.model_validate(
+        {'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}}
+    )
+    result = spec.validate({'a': '5', 'extra': 'keep'})
+
+    # Assert coercion, default application, and extra-key preservation.
+    assert result['a'] == 5
+    assert isinstance(result['a'], int)
+    assert result['b'] == 1.0
+    assert result['extra'] == 'keep'
+
+# ** test: request_specification_validate_missing_required_raises
+def test_request_specification_validate_missing_required_raises() -> None:
+    '''
+    Test that missing required parameters raise a single REQUEST_VALIDATION_FAILED error.
+    '''
+
+    # Validate an empty payload against a required schema.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+    with pytest.raises(TiferetError) as exc_info:
+        spec.validate({}, feature_id='calc.add')
+
+    # Assert the structured validation error with one violation.
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert exc_info.value.kwargs.get('feature_id') == 'calc.add'
+    assert len(exc_info.value.kwargs.get('violations')) == 1
+
+# ** test: request_specification_validate_aggregates_multiple_errors
+def test_request_specification_validate_aggregates_multiple_errors() -> None:
+    '''
+    Test that multiple validation failures are aggregated into one error.
+    '''
+
+    # Validate a payload that fails two fields.
+    spec = RequestSpecification.model_validate({'a': 'int', 'b': 'int'})
+    with pytest.raises(TiferetError) as exc_info:
+        spec.validate({'a': 'x', 'b': 'y'}, feature_id='calc.add')
+
+    # Assert both violations are aggregated.
+    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert len(exc_info.value.kwargs.get('violations')) == 2
+
+# ** test: request_specification_validate_choices
+def test_request_specification_validate_choices() -> None:
+    '''
+    Test that choices restrict values via a Literal annotation.
+    '''
+
+    # Validate a payload constrained by choices.
+    spec = RequestSpecification.model_validate(
+        {'mode': {'type': 'str', 'choices': ['add', 'sub']}}
+    )
+
+    # Assert a valid choice passes and an invalid choice fails.
+    assert spec.validate({'mode': 'add'})['mode'] == 'add'
+    with pytest.raises(TiferetError):
+        spec.validate({'mode': 'bad'})
+
+# ** test: request_specification_is_satisfied_by
+def test_request_specification_is_satisfied_by() -> None:
+    '''
+    Test the convenience is_satisfied_by predicate.
+    '''
+
+    # Build a simple required schema.
+    spec = RequestSpecification.model_validate({'a': 'int'})
+
+    # Assert satisfied and unsatisfied payloads.
+    assert spec.is_satisfied_by({'a': 3}) is True
+    assert spec.is_satisfied_by({}) is False
+
+# ** test: feature_params_schema_defaults_to_none
+def test_feature_params_schema_defaults_to_none() -> None:
+    '''
+    Test that Feature.params_schema defaults to None.
+    '''
+
+    # Create a Feature without a params schema.
+    feature = Feature(id='calc.add', name='Add')
+
+    # Assert the schema defaults to None.
+    assert feature.params_schema is None
+
+# ** test: feature_params_schema_construction
+def test_feature_params_schema_construction() -> None:
+    '''
+    Test that Feature.params_schema is built from keyed config.
+    '''
+
+    # Create a Feature with a keyed params schema.
+    feature = Feature(id='calc.add', name='Add', params_schema={'a': 'int', 'b': 'int'})
+
+    # Assert the schema parsed into a RequestSpecification.
+    assert isinstance(feature.params_schema, RequestSpecification)
+    assert [p.name for p in feature.params_schema.parameters] == ['a', 'b']

--- a/tests/domain/test_request.py
+++ b/tests/domain/test_request.py
@@ -1,0 +1,85 @@
+"""Tests for Tiferet Domain Request"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.domain.request import Request
+
+# *** tests
+
+# ** test: request_defaults
+def test_request_defaults() -> None:
+    '''
+    Test that Request defaults headers/data to empty dicts and feature_id to None.
+    '''
+
+    # Create a Request with no arguments.
+    request = Request()
+
+    # Assert the defaults.
+    assert request.headers == {}
+    assert request.data == {}
+    assert request.feature_id is None
+
+# ** test: request_session_id_auto_derived
+def test_request_session_id_auto_derived() -> None:
+    '''
+    Test that a session_id is auto-generated when not supplied.
+    '''
+
+    # Create a Request without a session id.
+    request = Request()
+
+    # Assert a session id was generated.
+    assert isinstance(request.session_id, str)
+    assert request.session_id
+
+    # Assert two requests receive distinct session ids.
+    assert Request().session_id != request.session_id
+
+# ** test: request_session_id_preserved
+def test_request_session_id_preserved() -> None:
+    '''
+    Test that an explicit session_id is preserved.
+    '''
+
+    # Create a Request with an explicit session id.
+    request = Request(session_id='fixed-session')
+
+    # Assert the session id is preserved.
+    assert request.session_id == 'fixed-session'
+
+# ** test: request_construction_with_fields
+def test_request_construction_with_fields() -> None:
+    '''
+    Test that Request stores supplied fields.
+    '''
+
+    # Create a fully-specified Request.
+    request = Request(feature_id='calc.add', headers={'h': '1'}, data={'a': 1})
+
+    # Assert the fields are stored.
+    assert request.feature_id == 'calc.add'
+    assert request.headers == {'h': '1'}
+    assert request.data == {'a': 1}
+
+# ** test: request_model_dump_round_trip
+def test_request_model_dump_round_trip() -> None:
+    '''
+    Test that a Request round-trips through model_dump.
+    '''
+
+    # Create a Request and serialize it.
+    request = Request(feature_id='calc.add', data={'a': 1})
+    primitive = request.model_dump()
+
+    # Reload the Request from the serialized data.
+    reloaded = Request(**primitive)
+
+    # Assert the round-trip preserves the fields.
+    assert reloaded.feature_id == 'calc.add'
+    assert reloaded.data == {'a': 1}
+    assert reloaded.session_id == request.session_id

--- a/tests/mappers/test_feature.py
+++ b/tests/mappers/test_feature.py
@@ -464,3 +464,78 @@ class TestFeatureConfigObject(TransferObjectTestBase):
         assert yaml_obj.name == model.name
         assert yaml_obj.service_id == model.service_id
         assert yaml_obj.parameters == model.parameters
+
+
+# *** params_schema tests
+
+# ** test: feature_config_object_maps_params_schema
+def test_feature_config_object_maps_params_schema():
+    '''
+    Test that FeatureConfigObject maps a keyed params_schema into the aggregate.
+    '''
+
+    # Create a YAML object with a keyed params_schema and map it.
+    yaml_obj = FeatureConfigObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    ))
+    aggregate = yaml_obj.map()
+
+    # Verify the params_schema mapped onto the aggregate with constraints intact.
+    params = {p.name: p for p in aggregate.params_schema.parameters}
+    assert params['a'].type == 'int'
+    assert params['a'].required is True
+    assert params['b'].type == 'float'
+    assert params['b'].required is False
+    assert params['b'].default == 1.0
+
+# ** test: feature_config_object_serializes_params_schema_keyed
+def test_feature_config_object_serializes_params_schema_keyed():
+    '''
+    Test that params_schema serializes to the ergonomic keyed mapping.
+    '''
+
+    # Build an aggregate carrying a params_schema.
+    aggregate = FeatureConfigObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    )).map()
+
+    # Serialize the aggregate back to data form.
+    data = FeatureConfigObject.from_model(aggregate).to_primitive('to_data.yaml')
+
+    # Verify shorthand and expanded keyed forms.
+    assert data['params_schema']['a'] == 'int'
+    assert data['params_schema']['b']['type'] == 'float'
+    assert data['params_schema']['b']['default'] == 1.0
+    assert data['params_schema']['b']['required'] is False
+
+# ** test: feature_config_object_params_schema_round_trip
+def test_feature_config_object_params_schema_round_trip():
+    '''
+    Test that params_schema is preserved through a map/from_model round-trip.
+    '''
+
+    # Map then reverse-map the feature.
+    aggregate = FeatureConfigObject.model_validate(dict(
+        id='calc.add',
+        name='Add Number',
+        group_id='calc',
+        feature_key='add',
+        steps=[],
+        params_schema={'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}},
+    )).map()
+    aggregate2 = FeatureConfigObject.from_model(aggregate).map()
+
+    # Verify the params survive the round-trip.
+    params = {p.name: (p.type, p.required, p.default) for p in aggregate2.params_schema.parameters}
+    assert params['a'] == ('int', True, None)
+    assert params['b'] == ('float', False, 1.0)

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -52,6 +52,9 @@ REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
 # ** constant: parameter_not_found_id
 PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
 
+# ** constant: request_validation_failed_id
+REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
+
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
@@ -326,6 +329,15 @@ DEFAULT_ERRORS = {
         'name': 'Parameter Not Found',
         'message': [
             {'lang': 'en_US', 'text': 'Parameter {parameter} not found in request data.'}
+        ]
+    },
+
+    # * error: REQUEST_VALIDATION_FAILED
+    REQUEST_VALIDATION_FAILED_ID: {
+        'id': REQUEST_VALIDATION_FAILED_ID,
+        'name': 'Request Validation Failed',
+        'message': [
+            {'lang': 'en_US', 'text': 'Request validation failed for feature {feature_id}: {violations}.'}
         ]
     },
 

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -24,6 +24,11 @@ from .feature import (
     Feature,
     FeatureStep,
     EventFeatureStep,
+    ParameterSpecification,
+    RequestSpecification,
+)
+from .request import (
+    Request,
 )
 from .logging import (
     Formatter,
@@ -46,6 +51,9 @@ __all__ = [
     'Feature',
     'FeatureStep',
     'EventFeatureStep',
+    'ParameterSpecification',
+    'RequestSpecification',
+    'Request',
     'Formatter',
     'Handler',
     'Logger',

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -3,13 +3,15 @@
 # *** imports
 
 # ** core
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 # ** infra
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, ValidationError, create_model, model_validator
 
 # ** app
 from .settings import DomainObject
+from .. import assets as a
+from ..assets import TiferetError
 
 # *** models
 
@@ -55,6 +57,255 @@ class EventFeatureStep(FeatureStep):
         description='Optional boolean expression evaluated against request data. Step executes only when the expression resolves to True. When None, the step always executes.',
     )
 
+# ** model: parameter_specification
+class ParameterSpecification(DomainObject):
+    '''
+    A value object describing one expected request parameter, including its
+    declared type, requiredness, default, and validation constraints.
+    '''
+
+    # * attribute: name
+    name: str = Field(..., description='The name of the request parameter.')
+
+    # * attribute: type
+    type: Literal['str', 'int', 'float', 'bool', 'list', 'dict'] = Field(
+        default='str',
+        description='The declared type of the parameter.',
+    )
+
+    # * attribute: required
+    required: bool = Field(default=True, description='Whether the parameter is required.')
+
+    # * attribute: default
+    default: Any | None = Field(default=None, description='The default value applied when the parameter is absent.')
+
+    # * attribute: description
+    description: str | None = Field(default=None, description='A human-readable description of the parameter.')
+
+    # * attribute: minimum
+    minimum: float | None = Field(default=None, description='Inclusive lower bound for numeric values (maps to ge).')
+
+    # * attribute: maximum
+    maximum: float | None = Field(default=None, description='Inclusive upper bound for numeric values (maps to le).')
+
+    # * attribute: min_length
+    min_length: int | None = Field(default=None, description='Minimum length for string or list values.')
+
+    # * attribute: max_length
+    max_length: int | None = Field(default=None, description='Maximum length for string or list values.')
+
+    # * attribute: pattern
+    pattern: str | None = Field(default=None, description='Regex pattern the value must match.')
+
+    # * attribute: choices
+    choices: List[Any] | None = Field(default=None, description='Enumerated set of valid values.')
+
+    # * method: get_type
+    def get_type(self) -> type:
+        '''
+        Map the declared type string to a Python type.
+
+        :return: The corresponding Python type.
+        :rtype: type
+        '''
+
+        # Map the supported type strings to Python types.
+        type_map = {
+            'str': str,
+            'int': int,
+            'float': float,
+            'bool': bool,
+            'list': list,
+            'dict': dict,
+        }
+
+        # Return the mapped type, defaulting to str.
+        return type_map.get(self.type, str)
+
+    # * method: field_definition
+    def field_definition(self) -> Tuple[Any, Any]:
+        '''
+        Build the ``(annotation, default)`` pair consumed by
+        ``pydantic.create_model``, applying constraints via ``Field`` and using
+        ``Literal`` when ``choices`` is present.
+
+        :return: The annotation and field-default pair.
+        :rtype: Tuple[Any, Any]
+        '''
+
+        # Resolve the base annotation, preferring a Literal of the choices.
+        annotation = Literal[tuple(self.choices)] if self.choices else self.get_type()
+
+        # A parameter is effectively required only when flagged required with no default.
+        effective_required = self.required and self.default is None
+
+        # Optional parameters must also accept None.
+        if not effective_required:
+            annotation = Optional[annotation]
+
+        # Translate friendly constraint keys into pydantic Field keywords.
+        constraints: Dict[str, Any] = {}
+        if self.minimum is not None:
+            constraints['ge'] = self.minimum
+        if self.maximum is not None:
+            constraints['le'] = self.maximum
+        if self.min_length is not None:
+            constraints['min_length'] = self.min_length
+        if self.max_length is not None:
+            constraints['max_length'] = self.max_length
+        if self.pattern is not None:
+            constraints['pattern'] = self.pattern
+        if self.description is not None:
+            constraints['description'] = self.description
+
+        # Required fields use Ellipsis; optional fields use the configured default.
+        default = ... if effective_required else self.default
+
+        # Return the annotation/field pair for dynamic model construction.
+        return (annotation, Field(default, **constraints))
+
+# ** model: request_specification
+class RequestSpecification(DomainObject):
+    '''
+    A feature-level Specification object that dynamically reconstitutes the
+    request configuration as a Pydantic model to validate and coerce request
+    data, failing fast with a single aggregated error.
+    '''
+
+    # * attribute: parameters
+    parameters: List[ParameterSpecification] = Field(
+        default_factory=list,
+        description='The expected request parameters.',
+    )
+
+    # * method: normalize_parameters (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def normalize_parameters(cls, data: Any) -> Any:
+        '''
+        Normalize ergonomic config forms into the canonical ``parameters`` list.
+
+        Accepts the canonical ``{'parameters': [...]}`` form, the shorthand
+        keyed form ``{'a': 'int'}``, and the expanded keyed form
+        ``{'b': {'type': 'float', 'required': False}}``.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The canonicalized input data.
+        :rtype: Any
+        '''
+
+        # Only normalize dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+
+        # Treat a list-valued ``parameters`` key as already canonical. The keyed
+        # form only ever maps a name to a type string or a spec dict, so a list
+        # here unambiguously indicates the canonical ``{'parameters': [...]}``
+        # shape. This lets a feature declare a request parameter literally named
+        # ``parameters`` (e.g. service.add) without colliding with canonical form.
+        if isinstance(data.get('parameters'), list):
+            return data
+
+        # Expand each keyed entry into a parameter specification dict.
+        parameters: List[Dict[str, Any]] = []
+        for name, spec in data.items():
+            if isinstance(spec, str):
+                parameters.append({'name': name, 'type': spec, 'required': True})
+            elif isinstance(spec, dict):
+                parameters.append({'name': name, **spec})
+
+        # Return the canonical parameters mapping.
+        return {'parameters': parameters}
+
+    # * method: build_model
+    def build_model(self, model_name: str = 'RequestModel') -> type:
+        '''
+        Dynamically create a standalone Pydantic model from the parameter
+        specifications.
+
+        The model is a plain ``pydantic.BaseModel`` (not a ``DomainObject``) so
+        ``coerce_numbers_to_str`` does not corrupt numeric coercion.
+
+        :param model_name: The name for the generated model.
+        :type model_name: str
+        :return: The dynamically built Pydantic model class.
+        :rtype: type
+        '''
+
+        # Build the field definitions from each parameter specification.
+        field_definitions = {
+            param.name: param.field_definition()
+            for param in self.parameters
+        }
+
+        # Create a standalone model that ignores unspecified extra keys.
+        return create_model(
+            model_name,
+            __config__=ConfigDict(extra='ignore'),
+            **field_definitions,
+        )
+
+    # * method: validate
+    def validate(self, data: Dict[str, Any], feature_id: str = None) -> Dict[str, Any]:
+        '''
+        Validate and coerce ``data`` against the schema, returning the original
+        request data merged with coerced schema-covered fields and defaults.
+        Unspecified extra request keys are preserved.
+
+        :param data: The request data to validate.
+        :type data: Dict[str, Any]
+        :param feature_id: The feature id used for error context.
+        :type feature_id: str
+        :return: The merged, coerced request data.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Build the dynamic validation model.
+        model_cls = self.build_model()
+
+        # Validate and coerce the request data, aggregating all field errors.
+        try:
+            validated = model_cls(**(data or {}))
+
+        # Convert Pydantic validation errors into a single structured error.
+        except ValidationError as error:
+            violations = [
+                {
+                    'field': '.'.join(str(loc) for loc in err.get('loc', ())),
+                    'type': err.get('type'),
+                    'message': err.get('msg'),
+                }
+                for err in error.errors()
+            ]
+            raise TiferetError(
+                a.const.REQUEST_VALIDATION_FAILED_ID,
+                f'Request validation failed for feature {feature_id}: {violations}.',
+                feature_id=feature_id,
+                violations=violations,
+            )
+
+        # Merge coerced schema fields and defaults over the original data.
+        return {**(data or {}), **validated.model_dump()}
+
+    # * method: is_satisfied_by
+    def is_satisfied_by(self, data: Dict[str, Any]) -> bool:
+        '''
+        Report whether ``data`` satisfies the specification.
+
+        :param data: The request data to test.
+        :type data: Dict[str, Any]
+        :return: True when the data validates, otherwise False.
+        :rtype: bool
+        '''
+
+        # Attempt validation, treating a validation error as not satisfied.
+        try:
+            self.validate(data)
+            return True
+        except TiferetError:
+            return False
+
 # ** model: feature
 class Feature(DomainObject):
     '''
@@ -84,6 +335,12 @@ class Feature(DomainObject):
 
     # * attribute: log_params
     log_params: Dict[str, str] = Field(default_factory=dict, description='The parameters to log for the feature.')
+
+    # * attribute: params_schema
+    params_schema: RequestSpecification | None = Field(
+        default=None,
+        description='Optional feature-level request validation schema applied to request data before step execution.',
+    )
 
     # * method: derive_keys (validator)
     @model_validator(mode='before')

--- a/tiferet/domain/request.py
+++ b/tiferet/domain/request.py
@@ -1,0 +1,73 @@
+"""Tiferet Request Domain Models"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict
+from uuid import uuid4
+
+# ** infra
+from pydantic import Field, model_validator
+
+# ** app
+from .settings import DomainObject
+
+# *** models
+
+# ** model: request
+class Request(DomainObject):
+    '''
+    A request value object carrying the session, feature, headers, and data for
+    a single feature execution. Runtime output (``result``) is intentionally not
+    modeled here; it is owned by the operational request context.
+    '''
+
+    # * attribute: session_id
+    session_id: str = Field(
+        ...,
+        description='The unique session identifier for the request.',
+    )
+
+    # * attribute: feature_id
+    feature_id: str | None = Field(
+        default=None,
+        description='The identifier of the feature being executed.',
+    )
+
+    # * attribute: headers
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description='The request headers.',
+    )
+
+    # * attribute: data
+    data: Dict[str, Any] = Field(
+        default_factory=dict,
+        description='The request data payload.',
+    )
+
+    # * method: derive_session_id (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def derive_session_id(cls, data: Any) -> Any:
+        '''
+        Generate a ``uuid4`` ``session_id`` when one is not supplied, mirroring
+        the derivation validators on other domain objects.
+
+        :param data: The raw input data passed to the model.
+        :type data: Any
+        :return: The (possibly augmented) input data.
+        :rtype: Any
+        '''
+
+        # Only mutate dict-shaped inputs; pass other shapes through unchanged.
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        # Generate a session id when missing or None.
+        if not data.get('session_id'):
+            data['session_id'] = str(uuid4())
+
+        # Return the (possibly augmented) input data.
+        return data

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -6,7 +6,7 @@
 from typing import Any, ClassVar, Dict, List
 
 # ** infra
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_serializer
 
 # ** app
 from ..domain import (
@@ -333,6 +333,60 @@ class FeatureConfigObject(Feature, TransferObject):
         validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
         description='The step workflow for the feature.',
     )
+
+    # * method: serialize_params_schema
+    @field_serializer('params_schema')
+    def serialize_params_schema(self, value: Any, _info: Any) -> Any:
+        '''
+        Serialize ``params_schema`` into the ergonomic keyed mapping used in
+        configuration files, emitting shorthand ``name: type`` when a parameter
+        has no extra constraints and the expanded mapping otherwise.
+
+        :param value: The request specification to serialize.
+        :type value: Any
+        :param _info: The pydantic serialization info (unused).
+        :type _info: Any
+        :return: The keyed parameter mapping, or None when unset.
+        :rtype: Any
+        '''
+
+        # Emit nothing when no schema is configured.
+        if value is None:
+            return None
+
+        # Build a keyed mapping of parameter name to its specification.
+        result: Dict[str, Any] = {}
+        for param in value.parameters:
+
+            # Collect non-default constraint fields beyond name and type.
+            extras: Dict[str, Any] = {}
+            if param.default is not None:
+                extras['default'] = param.default
+            if not param.required:
+                extras['required'] = param.required
+            if param.description is not None:
+                extras['description'] = param.description
+            if param.minimum is not None:
+                extras['minimum'] = param.minimum
+            if param.maximum is not None:
+                extras['maximum'] = param.maximum
+            if param.min_length is not None:
+                extras['min_length'] = param.min_length
+            if param.max_length is not None:
+                extras['max_length'] = param.max_length
+            if param.pattern is not None:
+                extras['pattern'] = param.pattern
+            if param.choices is not None:
+                extras['choices'] = param.choices
+
+            # Use shorthand when only the type is meaningful, else the expanded form.
+            if not extras:
+                result[param.name] = param.type
+            else:
+                result[param.name] = {'type': param.type, **extras}
+
+        # Return the keyed parameter mapping.
+        return result
 
     # * method: map
     def map(self, **overrides) -> FeatureAggregate:


### PR DESCRIPTION
## Summary
Implements milestone #28 issue #852 — brings `main` to `v2.0-proto` parity for the **request-validation domain objects** and wires the feature-level request schema.

Closes #852.

## What changed
- **`tiferet/domain/request.py` (new)** — `Request` value object: `session_id` (auto-`uuid4` via a `model_validator(mode='before')`), `feature_id`, `headers`, `data`. Runtime `result` is intentionally not modeled (owned by the request context).
- **`tiferet/domain/feature.py`** — adds:
  - `ParameterSpecification` — describes one expected parameter (type, required, default, numeric/length/pattern/choices constraints) with `get_type()` and `field_definition()`.
  - `RequestSpecification` — feature-level specification with a `normalize_parameters` before-validator (accepts canonical / shorthand / expanded forms), `build_model()`, `validate(data, feature_id)` (fails fast with a single aggregated `REQUEST_VALIDATION_FAILED` error), and `is_satisfied_by(data)`.
  - `Feature.params_schema: RequestSpecification | None`.
- **`tiferet/domain/__init__.py`** — exports `Request`, `ParameterSpecification`, `RequestSpecification`.
- **`tiferet/mappers/feature.py`** — `FeatureConfigObject` round-trips `params_schema` via a `@field_serializer` that emits the ergonomic keyed mapping (shorthand `name: type` or expanded form); deserialization is handled by `RequestSpecification`'s normalizer.
- **`tiferet/assets/constants.py`** — adds `REQUEST_VALIDATION_FAILED_ID` + its `DEFAULT_ERRORS` entry.

## Notes / scope decisions
- **`REQUEST_VALIDATION_FAILED_ID` is included here on purpose.** The TRD lists it out of scope *only if* delivered by companion assets work; that constant is absent on `main` and `RequestSpecification.validate` requires it, so it is added here to keep the feature functional. The id/message match `v2.0-proto`.
- **Non-functional requirement honored:** the dynamically generated validation model is a plain `pydantic.BaseModel` (via `create_model(..., __config__=ConfigDict(extra='ignore'))`), so it does **not** inherit `DomainObject`'s `coerce_numbers_to_str` and numeric coercion stays correct.
- **Out-of-scope `v2.0-proto` deltas intentionally excluded** (they belong to later milestones): `EventFeatureStep.middleware`, `Feature.middleware`, `Feature.is_async`, the duplicate `_derive_keys` validator, and the `_ROLES` `to_data.yaml` → `to_data` rename (kept as `to_data.yaml` per #849). The ported mapper test was adapted to `to_primitive('to_data.yaml')` accordingly.

## Testing
- `tests/domain/test_request.py` (new) — `Request` defaults, session-id derivation/preservation, construction, round-trip.
- `tests/domain/test_feature.py` — adds `ParameterSpecification` / `RequestSpecification` / `Feature.params_schema` cases (coercion, defaults, extra-key preservation, single + aggregated validation errors, choices, `is_satisfied_by`).
- `tests/mappers/test_feature.py` — adds `params_schema` map / serialize-keyed / round-trip cases.
- `python -m pytest tests` → **210 passed**.

## Acceptance criteria
1. ✅ `Request`, `ParameterSpecification`, `RequestSpecification` exist and are exported.
2. ✅ `RequestSpecification.validate` coerces valid data and raises a single aggregated error for invalid data.
3. ✅ `Feature.params_schema` round-trips through the feature mapper.
4. ✅ `tests/domain/test_request.py` exists; affected domain + mapper tests ported and passing.

---
Conversation: https://app.warp.dev/conversation/694909b0-88a0-4de8-b03c-2b7becf783d6

Co-Authored-By: Oz <oz-agent@warp.dev>
