### PR TITLE
Domain – Logging: LoggingSettings value object and config mapper (#853)

### DIFF
--- a/tests/domain/test_logging.py
+++ b/tests/domain/test_logging.py
@@ -6,11 +6,12 @@
 import pytest
 
 # ** app
-from ..settings import DomainObject
-from ..logging import (
+from tiferet.domain.settings import DomainObject
+from tiferet.domain.logging import (
     Formatter,
     Handler,
     Logger,
+    LoggingSettings,
 )
 
 # *** fixtures
@@ -218,3 +219,68 @@ def test_logger_format_config_empty_handlers(logger_empty_handlers: Logger) -> N
     assert config['handlers'] == []
     assert config['propagate'] is False
     assert config['level'] == 'WARNING'
+
+# ** test: logging_settings_format_config_assembles_sections
+def test_logging_settings_format_config_assembles_sections(formatter, handler, logger_empty_handlers) -> None:
+    '''
+    Test that LoggingSettings.format_config() assembles formatters, handlers, and
+    the root entry (from the is_root logger) into a dictConfig dictionary.
+
+    :param formatter: The Formatter fixture.
+    :type formatter: Formatter
+    :param handler: The Handler fixture.
+    :type handler: Handler
+    :param logger_empty_handlers: The root Logger fixture.
+    :type logger_empty_handlers: Logger
+    '''
+
+    # Assemble the configuration from the bundled value object.
+    config = LoggingSettings(
+        formatters=[formatter],
+        handlers=[handler],
+        loggers=[logger_empty_handlers],
+    ).format_config()
+
+    # Assert top-level shape and section membership.
+    assert config['version'] == 1
+    assert config['disable_existing_loggers'] is False
+    assert config['formatters']['simple'] == formatter.format_config()
+    assert config['handlers']['console'] == handler.format_config()
+    assert config['root'] == logger_empty_handlers.format_config()
+
+    # Assert the root logger is excluded from the keyed loggers section.
+    assert 'root' not in config['loggers']
+
+# ** test: logging_settings_format_config_non_root_logger
+def test_logging_settings_format_config_non_root_logger(logger) -> None:
+    '''
+    Test that LoggingSettings.format_config() keys non-root loggers under loggers
+    and leaves the root entry None.
+
+    :param logger: The non-root Logger fixture.
+    :type logger: Logger
+    '''
+
+    # Assemble the configuration with a single non-root logger.
+    config = LoggingSettings(loggers=[logger]).format_config()
+
+    # Assert the non-root logger is keyed under loggers and root is None.
+    assert config['loggers']['app'] == logger.format_config()
+    assert config['root'] is None
+
+# ** test: logging_settings_format_config_defaults
+def test_logging_settings_format_config_defaults() -> None:
+    '''
+    Test that LoggingSettings defaults to empty sections, version 1, and a None root.
+    '''
+
+    # Assemble the configuration from an empty value object.
+    config = LoggingSettings().format_config()
+
+    # Assert empty sections and default scalars.
+    assert config['version'] == 1
+    assert config['disable_existing_loggers'] is False
+    assert config['formatters'] == {}
+    assert config['handlers'] == {}
+    assert config['loggers'] == {}
+    assert config['root'] is None

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -34,6 +34,7 @@ from .logging import (
     Formatter,
     Handler,
     Logger,
+    LoggingSettings,
 )
 
 # *** exports
@@ -57,4 +58,5 @@ __all__ = [
     'Formatter',
     'Handler',
     'Logger',
+    'LoggingSettings',
 ]

--- a/tiferet/domain/logging.py
+++ b/tiferet/domain/logging.py
@@ -216,10 +216,8 @@ class Logger(DomainObject):
 # ** model: logging_settings
 class LoggingSettings(DomainObject):
     '''
-    A runtime value object bundling formatter, handler, and logger
-    configurations and owning the ``logging.config.dictConfig`` assembly.
-    The bundle is logger-agnostic; the final ``getLogger`` call (and its
-    ``logger_id``) remains the responsibility of the logging context.
+    A value object representing the overall logging configuration, bundling
+    the formatter, handler, and logger configurations.
     '''
 
     # * attribute: formatters
@@ -264,11 +262,11 @@ class LoggingSettings(DomainObject):
 
         # Assemble the whole-system logging configuration, drawing the root
         # entry from the logger flagged is_root.
-        return dict(
-            version=self.version,
-            disable_existing_loggers=self.disable_existing_loggers,
-            formatters={formatter.id: formatter.format_config() for formatter in self.formatters},
-            handlers={handler.id: handler.format_config() for handler in self.handlers},
-            loggers={logger.id: logger.format_config() for logger in self.loggers if not logger.is_root},
-            root=next((logger.format_config() for logger in self.loggers if logger.is_root), None),
-        )
+        return {
+            'version': self.version,
+            'disable_existing_loggers': self.disable_existing_loggers,
+            'formatters': {formatter.id: formatter.format_config() for formatter in self.formatters},
+            'handlers': {handler.id: handler.format_config() for handler in self.handlers},
+            'loggers': {logger.id: logger.format_config() for logger in self.loggers if not logger.is_root},
+            'root': next((logger.format_config() for logger in self.loggers if logger.is_root), None),
+        }

--- a/tiferet/domain/logging.py
+++ b/tiferet/domain/logging.py
@@ -212,3 +212,63 @@ class Logger(DomainObject):
             'handlers': self.handlers,
             'propagate': self.propagate,
         }
+
+# ** model: logging_settings
+class LoggingSettings(DomainObject):
+    '''
+    A runtime value object bundling formatter, handler, and logger
+    configurations and owning the ``logging.config.dictConfig`` assembly.
+    The bundle is logger-agnostic; the final ``getLogger`` call (and its
+    ``logger_id``) remains the responsibility of the logging context.
+    '''
+
+    # * attribute: formatters
+    formatters: List[Formatter] = Field(
+        default_factory=list,
+        description='The formatter configurations.',
+    )
+
+    # * attribute: handlers
+    handlers: List[Handler] = Field(
+        default_factory=list,
+        description='The handler configurations.',
+    )
+
+    # * attribute: loggers
+    loggers: List[Logger] = Field(
+        default_factory=list,
+        description='The logger configurations.',
+    )
+
+    # * attribute: version
+    version: int = Field(
+        default=1,
+        description='The logging configuration schema version.',
+    )
+
+    # * attribute: disable_existing_loggers
+    disable_existing_loggers: bool = Field(
+        default=False,
+        description='Whether to disable existing loggers on configuration.',
+    )
+
+    # * method: format_config
+    def format_config(self) -> Dict[str, Any]:
+        '''
+        Assemble a dictionary suitable for ``logging.config.dictConfig`` from
+        the bundled formatter, handler, and logger configurations.
+
+        :return: The assembled logging configuration dictionary.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Assemble the whole-system logging configuration, drawing the root
+        # entry from the logger flagged is_root.
+        return dict(
+            version=self.version,
+            disable_existing_loggers=self.disable_existing_loggers,
+            formatters={formatter.id: formatter.format_config() for formatter in self.formatters},
+            handlers={handler.id: handler.format_config() for handler in self.handlers},
+            loggers={logger.id: logger.format_config() for logger in self.loggers if not logger.is_root},
+            root=next((logger.format_config() for logger in self.loggers if logger.is_root), None),
+        )

--- a/tiferet/mappers/logging.py
+++ b/tiferet/mappers/logging.py
@@ -230,7 +230,7 @@ class LoggingSettingsConfigObject(TransferObject):
     def from_data(cls, **data) -> 'LoggingSettingsConfigObject':
         '''
         Initialize a new LoggingSettingsConfigObject from a raw data dictionary,
-        injecting each section's keys as ``id`` on the contained YAML objects.
+        injecting each section's keys as ``id`` on the contained config objects.
 
         :param data: The raw data to construct the settings from.
         :type data: dict
@@ -238,7 +238,7 @@ class LoggingSettingsConfigObject(TransferObject):
         :rtype: LoggingSettingsConfigObject
         '''
 
-        # Construct each section's YAML objects, threading the dict key as id.
+        # Construct each section's config objects, threading the dict key as id.
         return cls.model_validate({
             'formatters': {
                 key: {**(formatter_data or {}), 'id': key}


### PR DESCRIPTION
## Summary
Implements milestone #28 issue #853 — brings `main` to `v2.0-proto` parity for the **logging-settings value object** and its config mapper.

Closes #853.

## What changed
- **`tiferet/domain/logging.py`** — adds the `LoggingSettings` runtime value object: bundles `formatters` / `handlers` / `loggers` (lists) plus `version` (default `1`) and `disable_existing_loggers` (default `False`). `format_config()` assembles a `logging.config.dictConfig` mapping, excluding the `is_root` logger from `loggers` and drawing the `root` entry from it (or `None`). The bundle is logger-agnostic — the final `getLogger` call stays the logging context's responsibility. Byte-identical to `v2.0-proto`.
- **`tiferet/domain/__init__.py`** — exports `LoggingSettings` (kept exports-last per `main` convention).
- **`tiferet/mappers/logging.py`** — aligns the `LoggingSettingsConfigObject.from_data` docstring/comment wording to "config objects" for `v2.0-proto` parity. (The config object itself already landed via #849.)

## Notes / scope decisions
- **`LoggingSettingsConfigObject` already exists on `main`** (added in #849, with tests byte-identical to `v2.0-proto`), so acceptance criterion 2 was already satisfied; this PR only aligns the leftover "YAML objects" → "config objects" wording within that class.
- **`_ROLES` `to_data.yaml` / `to_data.json` kept as-is** (not renamed to `to_data`) — that rename is intentionally out of scope per #849 and the milestone handoff.
- **Out of scope:** `LoggingContext.build_logger` consumption of `LoggingSettings` (companion contexts work, Milestone #29).

## Testing
- **`tests/domain/test_logging.py`** — relocated from `tiferet/domain/tests/test_logging.py` (ported from `v2.0-proto`) and now covers `LoggingSettings.format_config()`: section assembly + root extraction, non-root keying, and empty/default behavior.
- `python -m pytest tests/domain/test_logging.py tests/mappers/test_logging.py` → **37 passed**.
- `python -m pytest tests` → **219 passed** (210 baseline + 9 relocated domain logging tests).

## Acceptance criteria
1. ✅ `LoggingSettings` exists, is exported, and `format_config()` produces a valid dictConfig mapping.
2. ✅ `LoggingSettingsConfigObject` round-trips the bundle (present + tested via #849).
3. ✅ Affected logging tests ported into `tests/domain/` / `tests/mappers/`, cover `LoggingSettings`, and pass.

---
Conversation: https://app.warp.dev/conversation/d9c7fac9-5e40-4463-ac58-b46153d738b0

Co-Authored-By: Oz <oz-agent@warp.dev>
