### PR TITLE
Docs – Parity: Domain Infrastructure (#856)

### DIFF
--- a/docs/core/domain.md
+++ b/docs/core/domain.md
@@ -16,7 +16,7 @@ Domain objects serve a **dual role**:
 
 2. **Structural Foundation for the Mappers Layer**  
    - Aggregates extend domain objects with mutation logic (e.g., `ErrorAggregate(Error, Aggregate)`).
-   - TransferObjects extend domain objects with serialization roles (e.g., `ErrorYamlObject(Error, TransferObject)`).
+   - TransferObjects extend domain objects with serialization roles (e.g., `ErrorConfigObject(Error, TransferObject)`).
    - Define the field shape mirrored in YAML/JSON configuration files.
    - Enable reliable round-trip mapping between persistent configuration and runtime models.
 
@@ -26,22 +26,22 @@ This duality ensures a single source of truth for domain structure and behavior,
 
 - **Runtime Use** (`ErrorContext`):
   ```python
-  error = self.get_error_handler(error_code, include_defaults=True)
-  formatted = error.format_response(lang=lang, **exception.kwargs)
+  # The hub loads the Error; the context formats the response from it.
+  error_message = error.format_message(lang, **getattr(exception, 'kwargs', {}))
   ```
-  The `Error` domain object is retrieved via command and actively formats responses.
+  The `Error` domain object is retrieved via the hub's `load_error_domain` and used by `ErrorContext.format_response` to assemble the structured response.
 
-- **Mapper Layer Use** (`ErrorAggregate`, `ErrorYamlObject`):
+- **Mapper Layer Use** (`ErrorAggregate`, `ErrorConfigObject`):
   ```python
   class ErrorAggregate(Error, Aggregate):
       # Inherits fields/validation from Error
       # Adds mutation methods (rename, set_message, remove_message)
 
-  class ErrorYamlObject(Error, TransferObject):
+  class ErrorConfigObject(Error, TransferObject):
       # Inherits fields/validation from Error
       # Adds serialization roles and mapping logic
   ```
-  Configuration (`error.yml`) maps through `ErrorYamlObject` to `ErrorAggregate`, which converts to/from the runtime `Error`.
+  Configuration (`error.yml`) maps through `ErrorConfigObject` to `ErrorAggregate`, which converts to/from the runtime `Error`.
 
 ## The DomainObject Base Class
 
@@ -154,7 +154,7 @@ Tests validate instantiation, behavior, and edge cases using `pytest`.
 - `# *** tests`
 - `# ** test: <name>`
 
-**Example** – Error domain object tests cover constructor instantiation, `format_message`, `format_response`, and multilingual support.
+**Example** – Error domain object tests cover constructor instantiation, `format_message`, and multilingual support (structured response assembly is tested in `ErrorContext`).
 
 ## Package Layout
 
@@ -163,9 +163,9 @@ Domain objects are defined in `tiferet/domain/`:
 - `settings.py` – `DomainObject` base class (extends `pydantic.BaseModel` with `ConfigDict`).
 - `app.py` – `AppInterface`, `AppServiceDependency`.
 - `cli.py` – `CliCommand`, `CliArgument`.
-- `di.py` – `ServiceConfiguration`, `FlaggedDependency`.
+- `di.py` – `ServiceRegistration`, `FlaggedDependency`.
 - `error.py` – `Error`, `ErrorMessage`.
-- `feature.py` – `Feature`, `FeatureStep`, `FeatureEvent`.
+- `feature.py` – `Feature`, `FeatureStep`, `EventFeatureStep`.
 - `logging.py` – `Formatter`, `Handler`, `Logger`.
 - `__init__.py` – Public exports for all domain objects.
 

--- a/docs/core/interfaces.md
+++ b/docs/core/interfaces.md
@@ -6,17 +6,17 @@ This document focuses exclusively on **Services** as the vertical contracts.
 
 ## What is a Service?
 
-A **Service** in Tiferet is an abstract class derived from `tiferet.interfaces.settings.Service` (a minimal `ABC`) that defines the expected behavior for vertical concerns in the application. Services act as injectable interfaces that:
+A **Service** in Tiferet is an abstract class derived from `tiferet.interfaces.settings.Service` (a minimal `ABC`) that defines the expected behavior for vertical concerns in the application. Services act as the contracts that:
 
 - Abstract data access (CRUD operations, existence checks, listing)
 - Manage configuration persistence (loading/saving structured data from YAML/JSON/etc.)
 - Provide middleware and utility behavior (file handling, context management, validation, caching)
 - Coordinate domain logic while hiding infrastructure details
 
-**Commands** and **domain events** depend on injected Service instances to perform persistence, retrieval, or orchestration (e.g., `error_service.save(error)`, `configuration_service.load(...)`). Services encapsulate the infrastructure details, allowing commands and events to remain pure domain logic.
+**Commands** and **domain events** depend on Service instances to perform persistence, retrieval, or orchestration (e.g., `error_service.save(error)`, `configuration_service.load(...)`). Services encapsulate the infrastructure details, allowing commands and events to remain pure domain logic.
 
 ### Role in Runtime
-- **Commands** and **domain events** are the primary consumers of Services, receiving them via dependency injection (constructor).
+- **Commands** and **domain events** are the primary consumers of Services.
 - Commands and events use Services to delegate vertical concerns (data access, configuration, file I/O, etc.).
 - Concrete implementations (YAML-backed repositories, middleware classes) satisfy the Service interfaces while hiding implementation details.
 - **Factories** (e.g., `ConfigurationFileRepository`) resolve the correct concrete Service at runtime based on context (file type, etc.).
@@ -24,7 +24,7 @@ A **Service** in Tiferet is an abstract class derived from `tiferet.interfaces.s
 ### Key Characteristics of Services as Vertical Contracts
 - **Vertical abstraction**: They cross the domain ↔ infrastructure boundary, hiding how data is stored, files are managed, or middleware is applied.
 - **Unified interface**: All vertical concerns (previously handled by repositories, configuration loaders, middleware, utilities) converge under `Service`.
-- **Dependency injection**: Services are injected into commands and events via containers or initializers, making implementations swappable.
+- **Swappable implementations**: Consumers depend only on the Service contract, so concrete implementations can be substituted without changing domain logic.
 - **Extensibility**: New concerns (e.g., authentication, logging, rate limiting) can be added as new Service interfaces or layered inside existing ones.
 
 In the error domain, `ErrorService` is the vertical contract that all error-related commands depend on. In configuration handling, `ConfigurationService` abstracts YAML/JSON loading and saving, with concrete middleware implementations satisfying the interface.
@@ -156,7 +156,7 @@ class FileService(Service):
    - Use factories (e.g., `ConfigurationFileRepository.open_config()`) to resolve concrete implementations dynamically.
 
 3. **Use in Commands and Domain Events**
-   - Inject the Service via constructor (e.g., `error_service: ErrorService`).
+   - Declare the Service as a constructor dependency (e.g., `error_service: ErrorService`).
    - Depend only on the interface for all vertical operations.
 
 ## Migration from Contracts
@@ -188,12 +188,12 @@ New service interfaces should be created in `tiferet.interfaces` from the start.
 - Define methods with clear RST docstrings, type hints, and domain intent.
 - Use `@abstractmethod` to enforce implementation.
 - Keep services focused but composable (layer via inheritance or decoration).
-- Inject Services into commands and events — never hard-code concrete classes.
+- Depend on Service contracts in commands and events — never hard-code concrete classes.
 - Maintain one empty line between sections, comments, and code blocks.
 
 ## MiddlewareService
 
-`MiddlewareService` (`tiferet/interfaces/middleware.py`) is the abstract contract for domain event middleware. Middleware instances are resolved from the DI container by `service_id` and composed into an ordered chain that wraps event execution.
+`MiddlewareService` (`tiferet/interfaces/middleware.py`) is the abstract contract for domain event middleware — a cross-cutting concern that wraps the execution of a domain event. Middleware is composed into an ordered chain, where each one may run logic before and after delegating to the next, letting concerns such as validation, logging, or timing layer around an event without changing the event itself.
 
 ```python
 # *** interfaces
@@ -219,7 +219,7 @@ class MiddlewareService(Service):
         raise NotImplementedError()
 ```
 
-For async middleware, implement `async def __call__` and `await next_fn()`. The concrete class is exported from `tiferet.interfaces` as `MiddlewareService`.
+For async middleware, implement `async def __call__` and `await next_fn()`. The interface is exported from `tiferet.interfaces` as `MiddlewareService`.
 
 ## Conclusion
 

--- a/docs/core/interfaces.md
+++ b/docs/core/interfaces.md
@@ -191,6 +191,36 @@ New service interfaces should be created in `tiferet.interfaces` from the start.
 - Inject Services into commands and events — never hard-code concrete classes.
 - Maintain one empty line between sections, comments, and code blocks.
 
+## MiddlewareService
+
+`MiddlewareService` (`tiferet/interfaces/middleware.py`) is the abstract contract for domain event middleware. Middleware instances are resolved from the DI container by `service_id` and composed into an ordered chain that wraps event execution.
+
+```python
+# *** interfaces
+
+# ** interface: middleware_service
+class MiddlewareService(Service):
+    '''
+    Abstract service interface for domain event middleware.
+    '''
+
+    # * method: __call__
+    @abstractmethod
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any]) -> Any:
+        '''
+        Execute the middleware, calling next_fn() to continue the chain.
+
+        In async execution contexts next_fn is a coroutine function
+        and must be awaited.
+        '''
+        raise NotImplementedError()
+```
+
+For async middleware, implement `async def __call__` and `await next_fn()`. The concrete class is exported from `tiferet.interfaces` as `MiddlewareService`.
+
 ## Conclusion
 
 Services are the unified vertical interfaces in Tiferet, serving as the primary interface for middleware, data access, configuration management, and utilities. Commands and domain events depend exclusively on these Service interfaces, achieving high decoupling, testability, and extensibility. Concrete implementations satisfy the Service interfaces while hiding infrastructure details.

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -17,7 +17,7 @@ The mappers layer (`tiferet.mappers`) provides the bridge between persistent con
    - Extends `DomainObject` with a lenient `ConfigDict` (`extra='ignore'`, `validate_assignment=False`).
    - Manages role-based serialization via a `_ROLES` ClassVar mapping role names to `model_dump` kwargs.
    - Provides `to_primitive(role)`, `map(target)`, and `from_model` classmethod for mapping and transformation.
-   - Concrete transfer objects combine a domain object with `TransferObject` to add serialization roles (e.g., `ErrorYamlObject(Error, TransferObject)`).
+   - Concrete transfer objects combine a domain object with `TransferObject` to add serialization roles (e.g., `ErrorConfigObject(Error, TransferObject)`).
 
 Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`) with a clearer separation of mutation (Aggregate) and serialization (TransferObject) concerns.
 
@@ -30,9 +30,9 @@ Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`
       # Adds mutation methods (rename, set_message, remove_message)
   ```
 
-- **TransferObject Use** (`ErrorYamlObject`):
+- **TransferObject Use** (`ErrorConfigObject`):
   ```python
-  class ErrorYamlObject(Error, TransferObject):
+  class ErrorConfigObject(Error, TransferObject):
       # Inherits fields/validation from Error
       # Adds serialization roles and mapping logic
   ```
@@ -82,9 +82,9 @@ Key characteristics:
 Transfer objects use a `_ROLES` ClassVar to control which fields are serialized for different contexts. Each role maps to a dict of `model_dump` kwargs:
 
 ```python
-class ErrorYamlObject(Error, TransferObject):
+class ErrorConfigObject(Error, TransferObject):
     '''
-    A YAML data representation of an error object.
+    A configuration data representation of an error object.
     '''
 
     # * attribute: _ROLES
@@ -152,10 +152,10 @@ class FeatureAggregate(Feature, Aggregate):
 - Override `map()` to specify the target aggregate and handle nested mapping.
 - Override `from_model()` as a `@classmethod` to handle nested conversions.
 
-**Example** – `FeatureYamlObject`:
+**Example** – `FeatureConfigObject`:
 ```python
-# ** mapper: feature_yaml_object
-class FeatureYamlObject(Feature, TransferObject):
+# ** mapper: feature_config_object
+class FeatureConfigObject(Feature, TransferObject):
     '''
     YAML transfer object for the Feature domain object.
     '''
@@ -170,7 +170,7 @@ class FeatureYamlObject(Feature, TransferObject):
     }
 
     # * attribute: steps
-    steps: List[FeatureEventYamlObject] = Field(
+    steps: List[EventFeatureStepConfigObject] = Field(
         default_factory=list,
         validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
         description='The step workflow for the feature.',
@@ -187,12 +187,12 @@ class FeatureYamlObject(Feature, TransferObject):
 
     # * method: from_model
     @classmethod
-    def from_model(cls, feature: Feature, **overrides) -> 'FeatureYamlObject':
-        '''Creates a FeatureYamlObject from a Feature model.'''
+    def from_model(cls, feature: Feature, **overrides) -> 'FeatureConfigObject':
+        '''Creates a FeatureConfigObject from a Feature model.'''
         return super().from_model(
             feature,
             steps=[
-                FeatureEventYamlObject.from_model(step)
+                EventFeatureStepConfigObject.from_model(step)
                 for step in feature.steps
             ],
             **overrides,
@@ -299,7 +299,7 @@ import pytest
 
 # ** app
 from ..settings import TransferObject
-from ..<domain> import SomeAggregate, SomeYamlObject
+from ..<domain> import SomeAggregate, SomeConfigObject
 from .settings import AggregateTestBase, TransferObjectTestBase
 
 
@@ -354,11 +354,11 @@ class TestSomeAggregate(AggregateTestBase):
         assert aggregate.name == 'New Name'
 
 
-# ** class: TestSomeYamlObject
-class TestSomeYamlObject(TransferObjectTestBase):
-    '''Tests for SomeYamlObject.'''
+# ** class: TestSomeConfigObject
+class TestSomeConfigObject(TransferObjectTestBase):
+    '''Tests for SomeConfigObject.'''
 
-    transfer_cls = SomeYamlObject
+    transfer_cls = SomeConfigObject
     aggregate_cls = SomeAggregate
     sample_data = { ... }  # YAML-format
     aggregate_sample_data = AGGREGATE_SAMPLE_DATA
@@ -372,7 +372,7 @@ class TestSomeYamlObject(TransferObjectTestBase):
             **(data if data is not None else self.aggregate_sample_data)
         )
 
-    # *** child mapper: ChildYamlObject
+    # *** child mapper: ChildConfigObject
 
     # ** test: child_yaml_map_basic
     def test_child_yaml_map_basic(self):
@@ -405,10 +405,10 @@ FIELD_NORMALIZERS = {
 ```
 
 #### Child Mapper Tests
-When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyYamlObject` inside `AppInterfaceYamlObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
+When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyConfigObject` inside `AppInterfaceConfigObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
 
 #### Standalone Tests
-Small leaf-level mappers without mutation logic (e.g., `ErrorMessageYamlObject`) may use standalone test functions instead of the harness, placed after the class-based tests.
+Small leaf-level mappers without mutation logic (e.g., `ErrorMessageConfigObject`) may use standalone test functions instead of the harness, placed after the class-based tests.
 
 ### Migration Status
 
@@ -425,12 +425,12 @@ The following use the legacy standalone style and are candidates for migration:
 Mappers are defined in `tiferet/mappers/`:
 
 - `settings.py` — `Aggregate` and `TransferObject` base classes + constants.
-- `app.py` — `AppInterfaceAggregate`, `AppInterfaceYamlObject`.
-- `cli.py` — `CliArgumentAggregate`, `CliCommandAggregate`, `CliCommandYamlObject`.
-- `di.py` — `ServiceConfigurationAggregate`, `ServiceConfigurationYamlObject`.
-- `error.py` — `ErrorAggregate`, `ErrorYamlObject`, `ErrorMessageYamlObject`.
-- `feature.py` — `FeatureAggregate`, `FeatureYamlObject`, `FeatureEventAggregate`, `FeatureEventYamlObject`.
-- `logging.py` — `FormatterAggregate`, `HandlerAggregate`, `LoggerAggregate`, and their YamlObject counterparts.
+- `app.py` — `AppInterfaceAggregate`, `AppInterfaceConfigObject`.
+- `cli.py` — `CliArgumentAggregate`, `CliCommandAggregate`, `CliCommandConfigObject`.
+- `di.py` — `ServiceRegistrationAggregate`, `ServiceRegistrationConfigObject`.
+- `error.py` — `ErrorAggregate`, `ErrorConfigObject`, `ErrorMessageConfigObject`.
+- `feature.py` — `FeatureAggregate`, `FeatureConfigObject`, `EventFeatureStepAggregate`, `EventFeatureStepConfigObject`.
+- `logging.py` — `FormatterAggregate`, `HandlerAggregate`, `LoggerAggregate`, and their ConfigObject counterparts.
 - `__init__.py` — Public exports.
 
 Tests live in `tiferet/mappers/tests/`.

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -44,6 +44,18 @@ arg = CliArgument(name_or_flags=['--count'], type='int')
 assert arg.get_type() is int
 ```
 
+**`to_argparse_kwargs() -> Dict[str, Any]`**
+
+Builds the keyword arguments for `argparse.add_argument()` from the argument's fields. Trivial fields come from a pydantic `model_dump(exclude_none=True, ...)` and `description` is mapped to `help`. Value-consuming actions (the default, `store`, `append`) receive a resolved `type` callable (via `get_type()`) and retain `nargs`/`choices`, while flag and const actions (e.g. `store_true`) omit those keywords so parser construction stays valid. `name_or_flags` is excluded because it is passed positionally to `add_argument`.
+
+```python
+arg = CliArgument(name_or_flags=['a'], description='First operand.', type='int')
+arg.to_argparse_kwargs()  # {'help': 'First operand.', 'type': int}
+
+flag = CliArgument(name_or_flags=['--verbose'], description='Verbose.', action='store_true')
+flag.to_argparse_kwargs()  # {'action': 'store_true', 'help': 'Verbose.'}
+```
+
 ### CliCommand
 
 Represents a CLI command with a composite identifier.

--- a/docs/guides/domain/di.md
+++ b/docs/guides/domain/di.md
@@ -1,4 +1,4 @@
-# Domain – DI: ServiceConfiguration and FlaggedDependency
+# Domain – DI: ServiceRegistration and FlaggedDependency
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -7,15 +7,15 @@
 
 ## Overview
 
-The DI (Dependency Injection) domain defines the structural configuration for the Tiferet service container. Every injectable service entry is described by a `ServiceConfiguration` domain object, which holds a default implementation binding and zero or more `FlaggedDependency` overrides that are selected based on active runtime flags.
+The DI (Dependency Injection) domain defines the structural configuration for the Tiferet service container. Every injectable service entry is described by a `ServiceRegistration` domain object, which holds a default implementation binding and zero or more `FlaggedDependency` overrides that are selected based on active runtime flags.
 
 These domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing dependencies, setting default types, updating parameters) occur exclusively through Aggregates in the mappers layer.
 
 **Module:** `tiferet/domain/di.py`
 
-### Rename Note: container.py → di.py, ContainerAttribute → ServiceConfiguration
+### Rename Note: container.py → di.py, ContainerAttribute → ServiceRegistration
 
-In v1.x, dependency injection configuration was defined in `container.py` with the `ContainerAttribute` domain object. In v2.0, the module is renamed to `di.py` and the class to `ServiceConfiguration` to better reflect its role in the DI infrastructure. `FlaggedDependency` retains its original name. The field set and semantics are unchanged.
+In v1.x, dependency injection configuration was defined in `container.py` with the `ContainerAttribute` domain object. In v2.0, the module is renamed to `di.py` and the class to `ServiceRegistration` to better reflect its role in the DI infrastructure. `FlaggedDependency` retains its original name. The field set and semantics are unchanged.
 
 ## Domain Objects
 
@@ -32,14 +32,14 @@ Represents one flag-qualified implementation override for a service.
 
 No methods. Pure data structure.
 
-### ServiceConfiguration
+### ServiceRegistration
 
 Represents a single injectable service entry in the DI registry.
 
 | Attribute       | Type                                  | Required | Default | Description                                       |
 |-----------------|---------------------------------------|----------|---------|---------------------------------------------------|
-| `id`            | `str`                                 | Yes      | —       | The unique identifier for the service configuration. |
-| `name`          | `str \| None`                         | No       | `None`  | The name of the service configuration.             |
+| `id`            | `str`                                 | Yes      | —       | The unique identifier for the service registration. |
+| `name`          | `str \| None`                         | No       | `None`  | The name of the service registration.             |
 | `module_path`   | `str \| None`                         | No       | `None`  | The default module path for the dependency class.  |
 | `class_name`    | `str \| None`                         | No       | `None`  | The default class name for the dependency class.   |
 | `parameters`    | `Dict[str, str]`                      | No       | `{}`    | The default configuration parameters.              |
@@ -65,25 +65,25 @@ Flags flow into the DI container from multiple sources:
 
 1. **`AppInterface.flags`** — interface-level flags set in `app/configs/app.yml` (e.g., `['yaml']`, `['sqlite', 'yaml']`).
 2. **`Feature.flags`** — feature-level flag overrides defined in `feature.yml`.
-3. **`FeatureEvent.flags`** — command-level flag overrides within a feature workflow.
+3. **`EventFeatureStep.flags`** — step-level flag overrides within a feature workflow.
 
-At resolution time, `DIContext` merges these flag sources and calls `ServiceConfiguration.get_dependency(*merged_flags)` to select the correct concrete implementation for each service.
+At resolution time, `DIContext` merges these flag sources and calls `ServiceRegistration.get_dependency(*merged_flags)` to select the correct concrete implementation for each service.
 
 ## Runtime Role
 
 The DI domain objects participate in the service resolution flow:
 
-1. **`DIContext`** loads all `ServiceConfiguration` entries from the `services` section of the configuration file via `DIService`.
-2. **`build_service_provider()`** iterates each `ServiceConfiguration`, resolving concrete types:
+1. **`DIContext`** loads all `ServiceRegistration` entries from the `services` section of the configuration file via `DIService`.
+2. **`build_service_provider()`** iterates each `ServiceRegistration`, resolving concrete types:
    - If a matching `FlaggedDependency` is found via `get_dependency(*flags)`, its `module_path` and `class_name` are used.
-   - Otherwise, the default `module_path` and `class_name` on `ServiceConfiguration` are used.
+   - Otherwise, the default `module_path` and `class_name` on `ServiceRegistration` are used.
 3. **`get_configuration_type()`** calls `ImportDependency.execute()` to dynamically import the resolved class.
 4. The resolved types and their parameters are wired into the DI service provider.
 5. Domain events and contexts receive fully constructed service instances via constructor injection.
 
 ## Configuration Mapping
 
-Service configurations are defined in the `services` section of the configuration file (typically `config.yml`). Each top-level key maps to a `ServiceConfiguration`:
+Service configurations are defined in the `services` section of the configuration file (typically `config.yml`). Each top-level key maps to a `ServiceRegistration`:
 
 ```yaml
 services:
@@ -108,14 +108,14 @@ services:
 
 ## Domain Events
 
-The following domain events interact with `ServiceConfiguration` and `FlaggedDependency`:
+The following domain events interact with `ServiceRegistration` and `FlaggedDependency`:
 
 | Event                       | Description                                              |
 |-----------------------------|----------------------------------------------------------|
-| `ListAllSettings`           | Lists all `ServiceConfiguration` entries.                |
-| `AddServiceConfiguration`   | Creates and persists a new `ServiceConfiguration`.        |
-| `UpdateServiceConfiguration`| Modifies an existing `ServiceConfiguration` via aggregate.|
-| `DeleteServiceConfiguration`| Removes a `ServiceConfiguration` by ID.                   |
+| `ListAllSettings`           | Lists all `ServiceRegistration` entries.                |
+| `AddServiceConfiguration`   | Creates and persists a new `ServiceRegistration`.        |
+| `UpdateServiceConfiguration`| Modifies an existing `ServiceRegistration` via aggregate.|
+| `DeleteServiceConfiguration`| Removes a `ServiceRegistration` by ID.                   |
 
 These events depend on the `DIService` interface for persistence operations.
 
@@ -123,11 +123,11 @@ These events depend on the `DIService` interface for persistence operations.
 
 **`DIService`** (`tiferet/interfaces/di.py`) defines the abstract contract for DI configuration persistence:
 
-- `configuration_exists(id: str) -> bool`
-- `get_configuration(id: str) -> ServiceConfiguration`
-- `list_all() -> Tuple[List[ServiceConfiguration], Dict[str, str]]`
-- `save_configuration(service_configuration) -> None`
-- `delete_configuration(id: str) -> None`
+- `registration_exists(id: str) -> bool`
+- `get_registration(registration_id: str, flag: str = None) -> ServiceRegistration`
+- `list_all() -> Tuple[List[ServiceRegistration], Dict[str, str]]`
+- `save_registration(registration) -> None`
+- `delete_registration(registration_id: str) -> None`
 - `save_constants(constants: Dict[str, Any]) -> None`
 
 Concrete implementations (e.g., `DIYamlRepository`) satisfy this interface.
@@ -135,15 +135,15 @@ Concrete implementations (e.g., `DIYamlRepository`) satisfy this interface.
 ## Relationships to Other Domains
 
 - **App:** `AppInterface.flags` provides the primary set of runtime flags used during dependency resolution.
-- **Feature:** `Feature.flags` and `FeatureEvent.flags` can override or extend the active flag set for specific workflows.
-- **Error:** Error service implementations are resolved through the DI container, making `ServiceConfiguration` entries for `error_service` a common pattern.
+- **Feature:** `Feature.flags` and `EventFeatureStep.flags` can override or extend the active flag set for specific workflows.
+- **Error:** Error service implementations are resolved through the DI container, making `ServiceRegistration` entries for `error_service` a common pattern.
 
 ## Instantiation
 
 Both domain objects are instantiated directly via the Pydantic constructor:
 
 ```python
-from tiferet.domain import FlaggedDependency, ServiceConfiguration
+from tiferet.domain import FlaggedDependency, ServiceRegistration
 
 dep = FlaggedDependency(
     flag='sqlite',
@@ -152,7 +152,7 @@ dep = FlaggedDependency(
     parameters={'db_path': 'app/data/errors.db'},
 )
 
-config = ServiceConfiguration(
+config = ServiceRegistration(
     id='error_service',
     module_path='tiferet.repos.error',
     class_name='ErrorYamlRepository',

--- a/docs/guides/domain/error.md
+++ b/docs/guides/domain/error.md
@@ -63,14 +63,9 @@ assert error.error_code == 'INVALID_INPUT'
 
 Finds the first `ErrorMessage` matching the given `lang` and formats it. Returns `None` if no message matches the language.
 
-**`format_response(lang='en_US', **kwargs) -> dict`**
+**Response formatting (moved to `ErrorContext`)**
 
-Returns a structured error response dict with `error_code`, `name`, `message`, and any additional kwargs. Returns `None` if the language is not supported.
-
-```python
-response = error.format_response('en_US', value='abc')
-# {'error_code': 'invalid_input', 'name': 'Invalid Input', 'message': 'Value abc is invalid', 'value': 'abc'}
-```
+`Error` no longer defines `format_response`. Structured response assembly lives in `ErrorContext.format_response(error, exception, lang='en_US')`, which calls `Error.format_message` and adds `error_code`, `name`, and any exception kwargs. Keeping response shaping in the context layer lets interface-specific contexts (e.g. Flask, FastAPI) override it polymorphically, while `Error.format_message` and `ErrorMessage.format` remain on the domain objects.
 
 ## Error Formatting Flow
 
@@ -78,10 +73,9 @@ The error formatting flow in Tiferet follows this path:
 
 1. A domain event calls `self.verify(expression, error_code, ...)` or `self.raise_error(error_code, ...)`.
 2. A `TiferetError` is raised with the `error_code` and contextual kwargs.
-3. The application context catches the error and delegates to `ErrorContext.handle_error()`.
-4. `ErrorContext` retrieves the `Error` domain object via `ErrorService.get(error_code)`.
-5. `Error.format_response(lang, **kwargs)` produces the structured error response.
-6. The response is returned to the caller (API response, CLI output, etc.).
+3. `AppInterfaceContext.handle_error()` catches the error and loads the `Error` domain object via the hub's `load_error_domain` (backed by `GetError`/`ErrorService`).
+4. `ErrorContext.format_response(error, exception, lang)` produces the structured error response from the loaded `Error`.
+5. The response is wrapped in `TiferetAPIError` and returned to the caller (API response, CLI output, etc.).
 
 ## Built-In Defaults
 
@@ -145,7 +139,7 @@ Concrete implementations (e.g., `ErrorYamlRepository`) satisfy this interface.
 
 - **All Domains:** Every domain event uses `verify()` and `raise_error()` to raise `TiferetError`, which is resolved to an `Error` for formatting.
 - **App:** `ErrorContext` is loaded as part of the application interface bootstrap, receiving `ErrorService` via dependency injection.
-- **DI:** `ErrorService` is wired through the DI container (`ServiceConfiguration` entries in the `services` section of the configuration).
+- **DI:** `ErrorService` is wired through the DI container (`ServiceRegistration` entries in the `services` section of the configuration).
 
 ## Instantiation
 

--- a/docs/guides/domain/feature.md
+++ b/docs/guides/domain/feature.md
@@ -1,4 +1,4 @@
-# Domain – Feature: FeatureStep, FeatureEvent, and Feature
+# Domain – Feature: FeatureStep, EventFeatureStep, and Feature
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -7,13 +7,15 @@
 
 ## Overview
 
-The Feature domain defines the structural foundation for workflow orchestration in Tiferet. A `Feature` represents a complete workflow definition — a named, identifiable unit composed of ordered steps that execute domain events from the dependency injection container. Each step is described by a `FeatureEvent`, which carries container resolution metadata, flags, parameters, result routing, and error handling configuration.
+The Feature domain defines the structural foundation for workflow orchestration in Tiferet. A `Feature` represents a complete workflow definition — a named, identifiable unit composed of ordered steps that execute domain events from the dependency injection container. Each step is described by an `EventFeatureStep`, which carries container resolution metadata, flags, parameters, result routing, and error handling configuration.
 
 All domain objects in this module are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing steps, renaming, reordering) occur exclusively through Aggregates in the mappers layer.
 
 **Module:** `tiferet/domain/feature.py`
 
-> **Rename note (v2.0a2):** `FeatureCommand` has been renamed to `FeatureEvent` to align with the `Command` → `DomainEvent` transition. The polymorphic `FeatureStep` base class is new in v2.0a2.
+> **Rename note (v2.0a2):** `FeatureCommand` was renamed to `FeatureEvent` to align with the `Command` → `DomainEvent` transition. The polymorphic `FeatureStep` base class is new in v2.0a2.
+>
+> **Rename note:** the concrete step domain object `FeatureEvent` was renamed to `EventFeatureStep` (mappers `EventFeatureStepAggregate`/`EventFeatureStepConfigObject`), freeing the `FeatureEvent` name for a future per-module base domain event. The field set and semantics are unchanged.
 
 ## Domain Objects
 
@@ -28,20 +30,19 @@ Base class for steps in a feature workflow. Provides a `type` discriminator for 
 
 Currently the only supported `type` value is `'event'`, constrained via `Literal['event']`.
 
-### FeatureEvent
+### EventFeatureStep
 
 Concrete step type that extends `FeatureStep`. Represents the execution of a domain event resolved from the DI container.
 
 | Attribute        | Type                    | Required | Default | Description                                                        |
 |------------------|-------------------------|----------|---------|--------------------------------------------------------------------|
-| `service_id`     | `str \| None`           | No *(todo: required)* | `None` | The service configuration ID for the feature event.          |
-| `attribute_id`   | `str \| None`           | No *(obsolete)*       | `None` | The container attribute ID for the domain event. Replaced by `service_id`. |
+| `service_id`     | `str`                   | Yes      | —       | The service registration ID for the feature event.                |
 | `flags`          | `List[str]`             | No       | `[]`    | Feature flags that activate this event.                            |
 | `parameters`     | `Dict[str, str]`        | No       | `{}`    | Custom parameters for the event.                                   |
 | `return_to_data` | `bool`                  | No       | `False` | Whether to return the result to the feature data context (obsolete). |
-| `data_key`       | `str \| None`           | No       | `None`  | Data key to store the result in if `return_to_data` is True.       |
-|| `pass_on_error`  | `bool`                  | No       | `False` | Whether to continue the workflow if the event fails.               |
-|| `condition`      | `str \| None`           | No       | `None`  | Boolean expression evaluated against request data before execution. If `False`, the step is silently skipped. |
+| `data_key`       | `str \| None`           | No       | `None`  | Data key to store the result in.                                   |
+| `pass_on_error`  | `bool`                  | No       | `False` | Whether to continue the workflow if the event fails.               |
+| `condition`      | `str \| None`           | No       | `None`  | Boolean expression evaluated against request data before execution. If `False`, the step is silently skipped. |
 
 Inherits `type` (defaults to `'event'`) and `name` from `FeatureStep`.
 
@@ -68,7 +69,7 @@ Immutable value object representing a complete feature workflow definition.
 | `description`  | `str \| None`                   | No       | `None`  | The description of the feature.                      |
 | `group_id`     | `str`                           | Yes      | —       | The context group identifier for the feature.        |
 | `feature_key`  | `str`                           | Yes      | —       | The key of the feature.                              |
-| `steps`        | `List[FeatureEvent]`            | No       | `[]`    | The ordered step workflow for the feature.            |
+| `steps`        | `List[EventFeatureStep]`        | No       | `[]`    | The ordered step workflow for the feature.            |
 | `log_params`   | `Dict[str, str]`                | No       | `{}`    | Parameters to log for the feature.                   |
 
 #### Methods
@@ -90,7 +91,7 @@ The Feature domain objects participate in runtime workflow execution through the
 
 1. `FeatureContext.execute_feature(feature_id, data)` receives a feature ID from the application interface.
 2. The `Feature` is loaded from the `FeatureService` (backed by `feature.yml` configuration).
-3. `FeatureContext` iterates over `feature.steps`, resolving each `FeatureEvent.service_id` (with `attribute_id` fallback during migration) from the DI container.
+3. `FeatureContext` iterates over `feature.steps`, resolving each `EventFeatureStep.service_id` from the DI container.
 4. Each resolved domain event is executed with the merged request data and step parameters.
 5. If `data_key` is set, the result is stored back into the data context under that key for downstream steps.
 6. If `pass_on_error` is `True`, errors from that step are caught and the workflow continues.
@@ -118,18 +119,18 @@ features:
             b: '0.5'
 ```
 
-The `commands` key in YAML maps to `steps` (list of `FeatureEvent`) on the domain object. The `params` key maps to `parameters`.
+The `commands` key in YAML maps to `steps` (list of `EventFeatureStep`) on the domain object. The `params` key maps to `parameters`.
 
 ## Domain Events
 
-The following domain events interact with `Feature`, `FeatureStep`, and `FeatureEvent`:
+The following domain events interact with `Feature`, `FeatureStep`, and `EventFeatureStep`:
 
 | Event               | Description                                          |
 |---------------------|------------------------------------------------------|
 | `GetFeature`        | Retrieves a `Feature` by ID.                         |
 | `AddFeature`        | Creates and persists a new `Feature`.                |
-| `AddFeatureCommand` | Adds a `FeatureEvent` step to an existing `Feature`. |
-| `RenameFeature`     | Renames an existing `Feature` via aggregate.         |
+| `AddFeatureStep`    | Adds an `EventFeatureStep` step to an existing `Feature`. |
+| `UpdateFeature`     | Updates an existing `Feature`'s metadata via aggregate.   |
 
 These events depend on the `FeatureService` interface for persistence operations.
 
@@ -148,16 +149,16 @@ Concrete implementations (e.g., `FeatureYamlRepository`) satisfy this interface.
 ## Relationships to Other Domains
 
 - **App:** `FeatureContext` is loaded as part of the application interface bootstrap, receiving `FeatureService` and container resolution via dependency injection.
-- **DI:** `FeatureEvent.service_id` references a `ServiceConfiguration` entry in `di.yml`, which is resolved at runtime by the DI container. During migration, `attribute_id` is supported as a fallback.
+- **DI:** `EventFeatureStep.service_id` references a `ServiceRegistration` entry in the `services` section of the configuration, which is resolved at runtime by the DI container.
 - **Error:** Domain events use `verify()` and `raise_error()` to raise `TiferetError` when features are not found or parameters are invalid. These are resolved to `Error` domain objects for formatted responses.
 - **CLI:** CLI commands map to features via `group_key` and `key`, enabling command-line execution of feature workflows.
 
 ## Instantiation
 
 ```python
-from tiferet.domain import Feature, FeatureEvent
+from tiferet.domain import Feature, EventFeatureStep
 
-step = FeatureEvent(
+step = EventFeatureStep(
     name='Add a and b',
     service_id='add_number_event',
     parameters={'b': '0.5'},

--- a/docs/guides/domain/logging.md
+++ b/docs/guides/domain/logging.md
@@ -1,4 +1,4 @@
-# Domain – Logging: Formatter, Handler, and Logger
+# Domain – Logging: Formatter, Handler, Logger, and LoggingSettings
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -21,7 +21,7 @@ The Logging domain follows a three-model composition pattern:
 2. **Handler** defines where log messages are sent (console, file), at what level, and references a `Formatter` by ID.
 3. **Logger** defines a named logger with a level, a list of `Handler` IDs, and propagation behavior.
 
-At runtime, `LoggingContext` assembles these into a `dictConfig`-compatible dictionary by calling `format_config()` on each domain object and composing the results into the standard Python `logging.config.dictConfig` structure.
+At runtime, the `LoggingSettings` value object bundles the formatters, handlers, and loggers and owns the assembly: its `format_config()` calls `format_config()` on each bundled domain object and composes the results into the standard Python `logging.config.dictConfig` structure. `LoggingContext.build_logger` builds the `LoggingSettings` (applying the built-in defaults as the per-section fallback) and passes its assembled config to `create_logger`.
 
 ```
 Logger → [handler_id, ...] → Handler → formatter_id → Formatter
@@ -113,6 +113,31 @@ logger.format_config()
 # {'level': 'DEBUG', 'handlers': ['console'], 'propagate': True}
 ```
 
+### LoggingSettings
+
+Runtime value object that bundles the formatter, handler, and logger configurations and owns the whole-system `dictConfig` assembly. It is runtime-only — there is no Aggregate or TransferObject counterpart — and is intentionally logger-agnostic (the final `getLogger` call and its `logger_id` stay with `LoggingContext`).
+
+| Attribute | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `formatters` | `List[Formatter]` | No | `[]` | The formatter configurations. |
+| `handlers` | `List[Handler]` | No | `[]` | The handler configurations. |
+| `loggers` | `List[Logger]` | No | `[]` | The logger configurations. |
+| `version` | `int` | No | `1` | The dictConfig schema version. |
+| `disable_existing_loggers` | `bool` | No | `False` | Whether to disable existing loggers on configuration. |
+
+#### Methods
+
+**`format_config() -> Dict[str, Any]`**
+
+Assembles a `logging.config.dictConfig`-compatible dictionary, keying `formatters`/`handlers`/`loggers` by id and drawing the `root` entry from the logger flagged `is_root`:
+
+```python
+settings = LoggingSettings(formatters=[fmt], handlers=[hdlr], loggers=[root_logger])
+settings.format_config()
+# {'version': 1, 'disable_existing_loggers': False, 'formatters': {...},
+#  'handlers': {...}, 'loggers': {...}, 'root': {...}}
+```
+
 ## Built-In Defaults
 
 Tiferet provides built-in logging defaults in `assets/logging.py`. These define a standard console formatter, stream handler, and root logger that are used when no application-specific logging configuration is provided.
@@ -123,8 +148,8 @@ The Logging domain objects participate in runtime configuration through the foll
 
 1. `LoggingContext.build_logger()` is called during application interface initialization.
 2. `LoggingService` loads all `Formatter`, `Handler`, and `Logger` domain objects from `logging.yml`.
-3. `LoggingContext` calls `format_config()` on each domain object to produce `dictConfig`-compatible entries.
-4. The results are assembled into a complete `dictConfig` dictionary with `formatters`, `handlers`, and `loggers` sections.
+3. `LoggingContext.build_logger` wraps the loaded formatters, handlers, and loggers in a `LoggingSettings` value object (applying the built-in defaults as the per-section fallback).
+4. `LoggingSettings.format_config()` assembles a complete `dictConfig` dictionary with `formatters`, `handlers`, `loggers`, and `root` sections.
 5. `logging.config.dictConfig(config)` is called to configure the Python logging system.
 6. The configured logger is available for use throughout the application.
 


### PR DESCRIPTION
## Summary

Closes #856 — the final issue in Milestone #28 (Core DDD Parity I – Domain Infrastructure).

Brings `main`'s core/guide docs to `v2.0-proto` parity for the **Milestone 1** changes (domain, mappers, interfaces, TOML utility), while deliberately **not** adopting Milestone 2 changes (events/repos/contexts/blueprints/middleware utilities) that are not yet on `main`.

## Changes (8 docs)

- **`docs/core/domain.md`**, **`docs/core/mappers.md`** — `*YamlObject` → `*ConfigObject`, `ServiceConfiguration` → `ServiceRegistration`, `FeatureEvent` → `EventFeatureStep`; `Error.format_response` removal. **Kept the `to_data.yaml` `_ROLES` keys** (main retains `to_data.yaml`/`to_data.json`; the `to_data` rename is Milestone 2).
- **`docs/core/interfaces.md`** — added the `MiddlewareService` abstract-contract section (the DI registration methods were already at parity).
- **`docs/guides/domain/cli.md`** — documented `CliArgument.to_argparse_kwargs()` (added in #854).
- **`docs/guides/domain/error.md`** — `format_response` moved to `ErrorContext`; `ServiceConfiguration` → `ServiceRegistration`.
- **`docs/guides/domain/di.md`** — `ServiceRegistration` + `EventFeatureStep` renames and the `DIService` registration-method signatures (`registration_exists`/`get_registration`/`save_registration`/`delete_registration`).
- **`docs/guides/domain/feature.md`** — `EventFeatureStep` rename, required `service_id` (no `attribute_id`), accurate `AddFeatureStep`/`UpdateFeature` event table.
- **`docs/guides/domain/logging.md`** — documented the `LoggingSettings` value object and its `format_config()` assembly (added in #853).

`docs/core/utils.md` and `docs/guides/domain/app.md` are intentionally **unchanged** — their only `v2.0-proto` deltas are Milestone 2 repo/blueprint renames. The TOML loader is already documented (`docs/core/utils.md` + `docs/guides/utils/toml.md`, from #851).

## Scope discipline (intentional `main` vs `v2.0-proto` deltas)

Every change was verified against `main`'s actual code so docs reference symbols that exist on `main`:

- **Repo names kept** (`*YamlRepository`) and **DI params kept** (`*_yaml_file`) — repo renames to `*ConfigRepository` / `*_config` are Milestone 2 (#29). Adopting them would reference classes that don't exist on `main`.
- **`di.md` DI event class names kept** (`AddServiceConfiguration`, `UpdateServiceConfiguration`, `DeleteServiceConfiguration`) — `tiferet/events/di.py` still uses these on `main` (events are Milestone 2). Only the **domain-object references in their descriptions** were updated to `ServiceRegistration`. (By contrast, `feature.md` adopts `AddFeatureStep`/`UpdateFeature` because `tiferet/events/feature.py` already uses those names on `main`.)
- **Runtime-architecture wording kept** as `main`'s (`DIContext`/`build_service_provider`, "resolved from the DI container") — proto's `ServiceResolver`/`ServiceContainer`/`get_dependency`-handler/`AsyncFeatureContext` wording is Milestone 2 contexts work.
- **Excluded Milestone 2 fields** `EventFeatureStep.middleware` and `Feature.is_async` (absent on `main`).
- **`to_data.yaml` `_ROLES` keys kept** (the `to_data` role rename is Milestone 2).
- Dropped proto's `v2.0.0b9` version string in `error.md` (`main` is `2.0.0b3`); the `format_response` removal is stated without a misleading future version.

## Note / possible follow-up

The TRD overview mentions documenting "the request validation schema" (`Request`/`ParameterSpecification`/`RequestSpecification`/`Feature.params_schema`, from #852). These symbols are **not documented in `v2.0-proto`'s in-scope core/guide docs** (they appear only in proto's tutorial chapters 07–08, which are out of scope for this Docs TRD). To preserve parity and avoid pushing `main` ahead of proto, no new request-validation sections were added here — flagging as a candidate follow-up (ideally backported to proto's `core/domain.md`/`feature.md` first).

## Testing

Docs-only change — no code or tests affected. Verified the in-scope docs contain no `*YamlObject` and no obsolete `ServiceConfiguration`/`FeatureEvent` **domain** references, and no premature `*ConfigRepository`/`app_config`/`cli_config` contamination.

[Warp conversation](https://app.warp.dev/conversation/598abb48-956e-484e-b7a8-20b08a2520cc)

Co-Authored-By: Oz <oz-agent@warp.dev>
