### PR TITLE
Repos – Parity: ConfigurationRepository and Config Repository Renames (#858)

### DIFF
--- a/tests/mappers/test_cli.py
+++ b/tests/mappers/test_cli.py
@@ -269,14 +269,14 @@ class TestCliCommandConfigObject(TransferObjectTestBase):
     # ** test: to_primitive_excludes_id_and_inlines_args
     def test_to_primitive_excludes_id_and_inlines_args(self):
         '''
-        Test that to_primitive('to_data.yaml') excludes 'id' and includes 'args' with full argument dicts.
+        Test that to_primitive('to_data') excludes 'id' and includes 'args' with full argument dicts.
         '''
 
         # Create a YAML object and serialize to primitive.
         yaml_obj = CliCommandConfigObject.model_validate(dict(
             **self.sample_data,
         ))
-        primitive = yaml_obj.to_primitive('to_data.yaml')
+        primitive = yaml_obj.to_primitive('to_data')
 
         # Assert 'id' is excluded and 'args' is present with full dicts.
         assert isinstance(primitive, dict)

--- a/tests/mappers/test_di.py
+++ b/tests/mappers/test_di.py
@@ -378,8 +378,8 @@ class TestServiceRegistrationConfigObject(TransferObjectTestBase):
 
     # *** domain-specific tests
 
-    # ** test: to_primitive_to_data_yaml
-    def test_to_primitive_to_data_yaml(self):
+    # ** test: to_primitive_to_data
+    def test_to_primitive_to_data(self):
         '''
         Test that ServiceRegistrationConfigObject serializes correctly to YAML primitive format.
         '''
@@ -388,7 +388,7 @@ class TestServiceRegistrationConfigObject(TransferObjectTestBase):
         yaml_obj = ServiceRegistrationConfigObject.model_validate(self.sample_data)
 
         # Serialize to primitive format for YAML.
-        primitive = yaml_obj.to_primitive(role='to_data.yaml')
+        primitive = yaml_obj.to_primitive(role='to_data')
 
         # Verify id is excluded and the remaining structure is correct.
         assert isinstance(primitive, dict)
@@ -461,7 +461,7 @@ class TestServiceRegistrationConfigObject(TransferObjectTestBase):
         assert isinstance(data_object.dependencies['flag1'], FlaggedDependencyConfigObject)
 
         # When serializing to data, dependencies should still be emitted as 'deps'.
-        primitive = data_object.to_primitive(role='to_data.yaml')
+        primitive = data_object.to_primitive(role='to_data')
         assert 'flags' not in primitive
         assert 'deps' in primitive
         assert 'flag1' in primitive['deps']
@@ -561,17 +561,17 @@ class TestServiceRegistrationConfigObject(TransferObjectTestBase):
         assert yaml_obj.flag == model.flag
         assert yaml_obj.parameters == model.parameters
 
-    # ** test: flagged_dependency_yaml_roles_to_data_yaml_excludes_flag
-    def test_flagged_dependency_yaml_roles_to_data_yaml_excludes_flag(self):
+    # ** test: flagged_dependency_yaml_roles_to_data_excludes_flag
+    def test_flagged_dependency_yaml_roles_to_data_excludes_flag(self):
         '''
-        Test that to_data.yaml role excludes the flag field.
+        Test that to_data role excludes the flag field.
         '''
 
         # Create a YAML object.
         yaml_obj = FlaggedDependencyConfigObject.model_validate(self.flagged_dep_sample_data)
 
-        # Serialize with to_data.yaml role.
-        primitive = yaml_obj.to_primitive('to_data.yaml')
+        # Serialize with to_data role.
+        primitive = yaml_obj.to_primitive('to_data')
 
         # Flag should be excluded; other fields present.
         assert 'flag' not in primitive

--- a/tests/mappers/test_error.py
+++ b/tests/mappers/test_error.py
@@ -176,15 +176,15 @@ class TestErrorConfigObject(TransferObjectTestBase):
         assert yaml_obj.message[0].lang == 'en'
         assert yaml_obj.message[0].text == 'Test error message.'
 
-    # ** test: to_primitive_to_data_yaml
-    def test_to_primitive_to_data_yaml(self):
+    # ** test: to_primitive_to_data
+    def test_to_primitive_to_data(self):
         '''
-        Test that to_primitive('to_data.yaml') excludes id and serializes messages correctly.
+        Test that to_primitive('to_data') excludes id and serializes messages correctly.
         '''
 
         # Create a YAML object and serialize.
         yaml_obj = ErrorConfigObject.model_validate(self.sample_data)
-        primitive = yaml_obj.to_primitive('to_data.yaml')
+        primitive = yaml_obj.to_primitive('to_data')
 
         # Assert id is excluded.
         assert isinstance(primitive, dict)

--- a/tests/mappers/test_feature.py
+++ b/tests/mappers/test_feature.py
@@ -510,7 +510,7 @@ def test_feature_config_object_serializes_params_schema_keyed():
     )).map()
 
     # Serialize the aggregate back to data form.
-    data = FeatureConfigObject.from_model(aggregate).to_primitive('to_data.yaml')
+    data = FeatureConfigObject.from_model(aggregate).to_primitive('to_data')
 
     # Verify shorthand and expanded keyed forms.
     assert data['params_schema']['a'] == 'int'

--- a/tests/repos/__init__.py
+++ b/tests/repos/__init__.py
@@ -1,0 +1,1 @@
+"""Tiferet Repository Integration Tests"""

--- a/tests/repos/test_app.py
+++ b/tests/repos/test_app.py
@@ -9,8 +9,8 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import AppInterfaceYamlObject
-from ..app import AppYamlRepository
+from tiferet.mappers import AppInterfaceConfigObject
+from tiferet.repos.app import AppConfigRepository
 
 
 # *** constants
@@ -67,30 +67,30 @@ def app_config_file(tmp_path) -> str:
 
 # ** fixture: app_config_repo
 @pytest.fixture
-def app_config_repo(app_config_file: str) -> AppYamlRepository:
+def app_config_repo(app_config_file: str) -> AppConfigRepository:
     '''
     Fixture to create an instance of the App Configuration Repository.
 
     :param app_config_file: The app YAML configuration file path.
     :type app_config_file: str
-    :return: An instance of AppYamlRepository.
-    :rtype: AppYamlRepository
+    :return: An instance of AppConfigRepository.
+    :rtype: AppConfigRepository
     '''
 
-    # Create and return the AppYamlRepository instance.
-    return AppYamlRepository(app_config_file)
+    # Create and return the AppConfigRepository instance.
+    return AppConfigRepository(app_config_file)
 
 # *** tests
 
 # ** test_int: app_config_repo_exists
 def test_int_app_config_repo_exists(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the exists method of the AppYamlRepository.
+    Test the exists method of the AppConfigRepository.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # Check if the app interfaces exist.
@@ -100,13 +100,13 @@ def test_int_app_config_repo_exists(
 
 # ** test_int: app_config_repo_get
 def test_int_app_config_repo_get(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the get method of the AppYamlRepository.
+    Test the get method of the AppConfigRepository.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # Get app interfaces by id.
@@ -129,13 +129,13 @@ def test_int_app_config_repo_get(
 
 # ** test_int: app_config_repo_get_not_found
 def test_int_app_config_repo_get_not_found(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the get method of the AppYamlRepository for a non-existent app interface.
+    Test the get method of the AppConfigRepository for a non-existent app interface.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # Attempt to get a non-existent app interface.
@@ -146,13 +146,13 @@ def test_int_app_config_repo_get_not_found(
 
 # ** test_int: app_config_repo_list
 def test_int_app_config_repo_list(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the list method of the AppYamlRepository for all app interfaces.
+    Test the list method of the AppConfigRepository for all app interfaces.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # List all app interfaces.
@@ -167,20 +167,20 @@ def test_int_app_config_repo_list(
 
 # ** test_int: app_config_repo_save
 def test_int_app_config_repo_save(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the save method of the AppYamlRepository.
+    Test the save method of the AppConfigRepository.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # Create constant for new test app interface.
     new_app_id = 'new.app'
 
     # Create new app interface config data and map to an aggregate.
-    app = AppInterfaceYamlObject.model_validate(dict(
+    app = AppInterfaceConfigObject.model_validate(dict(
         id=new_app_id,
         name='New App',
         description='A new test app interface.',
@@ -205,13 +205,13 @@ def test_int_app_config_repo_save(
 
 # ** test_int: app_config_repo_delete
 def test_int_app_config_repo_delete(
-        app_config_repo: AppYamlRepository,
+        app_config_repo: AppConfigRepository,
     ) -> None:
     '''
-    Test the delete method of the AppYamlRepository.
+    Test the delete method of the AppConfigRepository.
 
     :param app_config_repo: The app configuration repository.
-    :type app_config_repo: AppYamlRepository
+    :type app_config_repo: AppConfigRepository
     '''
 
     # Delete an existing app interface.

--- a/tests/repos/test_cli.py
+++ b/tests/repos/test_cli.py
@@ -9,11 +9,11 @@ from typing import Dict, List
 import pytest, yaml
 
 # ** app
-from ...mappers import (
+from tiferet.mappers import (
     CliArgumentAggregate,
-    CliCommandYamlObject,
+    CliCommandConfigObject,
 )
-from ..cli import CliYamlRepository
+from tiferet.repos.cli import CliConfigRepository
 
 
 # *** constants
@@ -106,30 +106,30 @@ def cli_yaml_file(tmp_path) -> str:
 
 # ** fixture: cli_config_repo
 @pytest.fixture
-def cli_config_repo(cli_yaml_file: str) -> CliYamlRepository:
+def cli_config_repo(cli_yaml_file: str) -> CliConfigRepository:
     '''
     Fixture to create an instance of the CLI Configuration Repository.
 
     :param cli_yaml_file: The CLI YAML configuration file path.
     :type cli_yaml_file: str
-    :return: An instance of CliYamlRepository.
-    :rtype: CliYamlRepository
+    :return: An instance of CliConfigRepository.
+    :rtype: CliConfigRepository
     '''
 
-    # Create and return the CliYamlRepository instance.
-    return CliYamlRepository(cli_yaml_file)
+    # Create and return the CliConfigRepository instance.
+    return CliConfigRepository(cli_yaml_file)
 
 # *** tests
 
 # ** test_int: cli_config_repo_list
 def test_int_cli_config_repo_list(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the list method of the CliYamlRepository.
+    Test the list method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # List all CLI commands.
@@ -144,13 +144,13 @@ def test_int_cli_config_repo_list(
 
 # ** test_int: cli_config_repo_get
 def test_int_cli_config_repo_get(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the get method of the CliYamlRepository.
+    Test the get method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Get a CLI command by id.
@@ -173,13 +173,13 @@ def test_int_cli_config_repo_get(
 
 # ** test_int: cli_config_repo_get_not_found
 def test_int_cli_config_repo_get_not_found(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the get method of the CliYamlRepository for a non-existent command.
+    Test the get method of the CliConfigRepository for a non-existent command.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Attempt to get a non-existent CLI command.
@@ -190,13 +190,13 @@ def test_int_cli_config_repo_get_not_found(
 
 # ** test_int: cli_config_repo_get_parent_arguments
 def test_int_cli_config_repo_get_parent_arguments(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the get_parent_arguments method of the CliYamlRepository.
+    Test the get_parent_arguments method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Get all parent-level CLI arguments.
@@ -213,20 +213,20 @@ def test_int_cli_config_repo_get_parent_arguments(
 
 # ** test_int: cli_config_repo_save
 def test_int_cli_config_repo_save(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the save method of the CliYamlRepository.
+    Test the save method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Create constant for new test CLI command.
     new_cmd_id = 'calc.multiply'
 
     # Create new CLI command config data and map to an aggregate.
-    cmd = CliCommandYamlObject.model_validate(dict(
+    cmd = CliCommandConfigObject.model_validate(dict(
         id=new_cmd_id,
         name='Multiply Number Command',
         description='Multiplies two numbers.',
@@ -261,13 +261,13 @@ def test_int_cli_config_repo_save(
 
 # ** test_int: cli_config_repo_delete
 def test_int_cli_config_repo_delete(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the delete method of the CliYamlRepository.
+    Test the delete method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Delete an existing CLI command.
@@ -286,13 +286,13 @@ def test_int_cli_config_repo_delete(
 
 # ** test_int: cli_config_repo_delete_idempotent
 def test_int_cli_config_repo_delete_idempotent(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the delete method of the CliYamlRepository for idempotent behavior.
+    Test the delete method of the CliConfigRepository for idempotent behavior.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Delete a non-existent CLI command (should not raise).
@@ -304,13 +304,13 @@ def test_int_cli_config_repo_delete_idempotent(
 
 # ** test_int: cli_config_repo_save_parent_arguments
 def test_int_cli_config_repo_save_parent_arguments(
-        cli_config_repo: CliYamlRepository,
+        cli_config_repo: CliConfigRepository,
     ) -> None:
     '''
-    Test the save_parent_arguments method of the CliYamlRepository.
+    Test the save_parent_arguments method of the CliConfigRepository.
 
     :param cli_config_repo: The CLI configuration repository.
-    :type cli_config_repo: CliYamlRepository
+    :type cli_config_repo: CliConfigRepository
     '''
 
     # Create new parent arguments.

--- a/tests/repos/test_di.py
+++ b/tests/repos/test_di.py
@@ -36,7 +36,7 @@ DI_DATA: Dict[str, Dict] = {
                     'module_path': 'tiferet.repos.di',
                     'class_name': 'DIConfigRepository',
                     'params': {
-                        'di_yaml_file': 'app/configs/di.yml',
+                        'di_config': 'app/configs/di.yml',
                     },
                 },
             },

--- a/tests/repos/test_di.py
+++ b/tests/repos/test_di.py
@@ -9,8 +9,8 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import ServiceConfigurationYamlObject
-from ..di import DIYamlRepository
+from tiferet.mappers import ServiceRegistrationConfigObject
+from tiferet.repos.di import DIConfigRepository
 
 
 # *** constants
@@ -34,7 +34,7 @@ DI_DATA: Dict[str, Dict] = {
             'deps': {
                 'yaml': {
                     'module_path': 'tiferet.repos.di',
-                    'class_name': 'DIYamlRepository',
+                    'class_name': 'DIConfigRepository',
                     'params': {
                         'di_yaml_file': 'app/configs/di.yml',
                     },
@@ -76,51 +76,51 @@ def di_config_file(tmp_path) -> str:
 
 # ** fixture: di_config_repo
 @pytest.fixture
-def di_config_repo(di_config_file: str) -> DIYamlRepository:
+def di_config_repo(di_config_file: str) -> DIConfigRepository:
     '''
     Fixture to create an instance of the DI Configuration Repository.
 
     :param di_config_file: The DI YAML configuration file path.
     :type di_config_file: str
-    :return: An instance of DIYamlRepository.
-    :rtype: DIYamlRepository
+    :return: An instance of DIConfigRepository.
+    :rtype: DIConfigRepository
     '''
 
-    # Create and return the DIYamlRepository instance.
-    return DIYamlRepository(di_config_file)
+    # Create and return the DIConfigRepository instance.
+    return DIConfigRepository(di_config_file)
 
 # *** tests
 
-# ** test_int: di_config_repo_configuration_exists
-def test_int_di_config_repo_configuration_exists(
-        di_config_repo: DIYamlRepository,
+# ** test_int: di_config_repo_registration_exists
+def test_int_di_config_repo_registration_exists(
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the configuration_exists method of the DIYamlRepository.
+    Test the registration_exists method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Check if the service configurations exist.
-    assert di_config_repo.configuration_exists(DI_SERVICE_ID)
-    assert di_config_repo.configuration_exists(ANOTHER_SERVICE_ID)
-    assert not di_config_repo.configuration_exists('missing_service')
+    assert di_config_repo.registration_exists(DI_SERVICE_ID)
+    assert di_config_repo.registration_exists(ANOTHER_SERVICE_ID)
+    assert not di_config_repo.registration_exists('missing_service')
 
-# ** test_int: di_config_repo_get_configuration
-def test_int_di_config_repo_get_configuration(
-        di_config_repo: DIYamlRepository,
+# ** test_int: di_config_repo_get_registration
+def test_int_di_config_repo_get_registration(
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the get_configuration method of the DIYamlRepository.
+    Test the get_registration method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Get service configurations by id.
-    config = di_config_repo.get_configuration(DI_SERVICE_ID)
-    another_config = di_config_repo.get_configuration(ANOTHER_SERVICE_ID)
+    config = di_config_repo.get_registration(DI_SERVICE_ID)
+    another_config = di_config_repo.get_registration(ANOTHER_SERVICE_ID)
 
     # Check the first service configuration.
     assert config
@@ -139,32 +139,32 @@ def test_int_di_config_repo_get_configuration(
     assert another_config.module_path == 'tiferet.services.another'
     assert another_config.class_name == 'AnotherServiceImpl'
 
-# ** test_int: di_config_repo_get_configuration_not_found
-def test_int_di_config_repo_get_configuration_not_found(
-        di_config_repo: DIYamlRepository,
+# ** test_int: di_config_repo_get_registration_not_found
+def test_int_di_config_repo_get_registration_not_found(
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the get_configuration method of the DIYamlRepository for a non-existent configuration.
+    Test the get_registration method of the DIConfigRepository for a non-existent configuration.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Attempt to get a non-existent service configuration.
-    config = di_config_repo.get_configuration('missing_service')
+    config = di_config_repo.get_registration('missing_service')
 
     # Check that the configuration is None.
     assert not config
 
 # ** test_int: di_config_repo_list_all
 def test_int_di_config_repo_list_all(
-        di_config_repo: DIYamlRepository,
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the list_all method of the DIYamlRepository.
+    Test the list_all method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # List all service configurations and constants.
@@ -181,22 +181,22 @@ def test_int_di_config_repo_list_all(
     assert constants
     assert constants.get('sample_const') == 'sample_value'
 
-# ** test_int: di_config_repo_save_configuration
-def test_int_di_config_repo_save_configuration(
-        di_config_repo: DIYamlRepository,
+# ** test_int: di_config_repo_save_registration
+def test_int_di_config_repo_save_registration(
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the save_configuration method of the DIYamlRepository.
+    Test the save_registration method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Create constant for new service configuration.
     new_service_id = 'new_service'
 
     # Create new service configuration data and map to an aggregate.
-    config = ServiceConfigurationYamlObject.model_validate(dict(
+    config = ServiceRegistrationConfigObject.model_validate(dict(
         id=new_service_id,
         name='New Service',
         module_path='tiferet.services.new',
@@ -204,10 +204,10 @@ def test_int_di_config_repo_save_configuration(
     )).map()
 
     # Save the new service configuration.
-    di_config_repo.save_configuration(config)
+    di_config_repo.save_registration(config)
 
     # Reload the service configuration to verify it was saved.
-    new_config = di_config_repo.get_configuration(new_service_id)
+    new_config = di_config_repo.get_registration(new_service_id)
 
     # Check the new service configuration.
     assert new_config
@@ -216,38 +216,38 @@ def test_int_di_config_repo_save_configuration(
     assert new_config.module_path == 'tiferet.services.new'
     assert new_config.class_name == 'NewServiceImpl'
 
-# ** test_int: di_config_repo_delete_configuration
-def test_int_di_config_repo_delete_configuration(
-        di_config_repo: DIYamlRepository,
+# ** test_int: di_config_repo_delete_registration
+def test_int_di_config_repo_delete_registration(
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the delete_configuration method of the DIYamlRepository.
+    Test the delete_registration method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Delete an existing service configuration.
-    di_config_repo.delete_configuration(ANOTHER_SERVICE_ID)
+    di_config_repo.delete_registration(ANOTHER_SERVICE_ID)
 
     # Attempt to get the deleted service configuration.
-    deleted_config = di_config_repo.get_configuration(ANOTHER_SERVICE_ID)
+    deleted_config = di_config_repo.get_registration(ANOTHER_SERVICE_ID)
 
     # Check that the service configuration is None.
     assert not deleted_config
 
     # Ensure that deleting a non-existent service configuration is idempotent.
-    di_config_repo.delete_configuration('missing_service')
+    di_config_repo.delete_registration('missing_service')
 
 # ** test_int: di_config_repo_save_constants
 def test_int_di_config_repo_save_constants(
-        di_config_repo: DIYamlRepository,
+        di_config_repo: DIConfigRepository,
     ) -> None:
     '''
-    Test the save_constants method of the DIYamlRepository.
+    Test the save_constants method of the DIConfigRepository.
 
     :param di_config_repo: The DI configuration repository.
-    :type di_config_repo: DIYamlRepository
+    :type di_config_repo: DIConfigRepository
     '''
 
     # Save new constants.

--- a/tests/repos/test_error.py
+++ b/tests/repos/test_error.py
@@ -9,8 +9,8 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import ErrorYamlObject
-from ..error import ErrorYamlRepository
+from tiferet.mappers import ErrorConfigObject
+from tiferet.repos.error import ErrorConfigRepository
 
 
 # *** constants
@@ -77,30 +77,30 @@ def error_yaml_file(tmp_path) -> str:
 
 # ** fixture: error_config_repo
 @pytest.fixture
-def error_config_repo(error_yaml_file: str) -> ErrorYamlRepository:
+def error_config_repo(error_yaml_file: str) -> ErrorConfigRepository:
     '''
     Fixture to create an instance of the Error Configuration Repository.
 
     :param error_yaml_file: The error YAML configuration file path.
     :type error_yaml_file: str
-    :return: An instance of ErrorYamlRepository.
-    :rtype: ErrorYamlRepository
+    :return: An instance of ErrorConfigRepository.
+    :rtype: ErrorConfigRepository
     '''
 
-    # Create and return the ErrorYamlRepository instance.
-    return ErrorYamlRepository(error_yaml_file)
+    # Create and return the ErrorConfigRepository instance.
+    return ErrorConfigRepository(error_yaml_file)
 
 # *** tests
 
 # ** test_int: error_config_repo_exists
 def test_int_error_config_repo_exists(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the exists method of the ErrorYamlRepository.
+    Test the exists method of the ErrorConfigRepository.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # Check if the errors exist.
@@ -110,13 +110,13 @@ def test_int_error_config_repo_exists(
 
 # ** test_int: error_config_repo_get
 def test_int_error_config_repo_get(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the get method of the ErrorYamlRepository.
+    Test the get method of the ErrorConfigRepository.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # Get errors by id.
@@ -145,13 +145,13 @@ def test_int_error_config_repo_get(
 
 # ** test_int: error_config_repo_get_not_found
 def test_int_error_config_repo_get_not_found(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the get method of the ErrorYamlRepository for a non-existent error.
+    Test the get method of the ErrorConfigRepository for a non-existent error.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # Attempt to get a non-existent error.
@@ -162,13 +162,13 @@ def test_int_error_config_repo_get_not_found(
 
 # ** test_int: error_config_repo_list
 def test_int_error_config_repo_list(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the list method of the ErrorYamlRepository for all errors.
+    Test the list method of the ErrorConfigRepository for all errors.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # List all errors.
@@ -183,20 +183,20 @@ def test_int_error_config_repo_list(
 
 # ** test_int: error_config_repo_save
 def test_int_error_config_repo_save(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the save method of the ErrorYamlRepository.
+    Test the save method of the ErrorConfigRepository.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # Create constant for new test error.
     new_error_id = 'NEW_ERROR_CODE'
 
     # Create new error config data and map to an aggregate.
-    error = ErrorYamlObject.model_validate(dict(
+    error = ErrorConfigObject.model_validate(dict(
         id=new_error_id,
         name='New Error',
         message=[
@@ -229,13 +229,13 @@ def test_int_error_config_repo_save(
 
 # ** test_int: error_config_repo_delete
 def test_int_error_config_repo_delete(
-        error_config_repo: ErrorYamlRepository,
+        error_config_repo: ErrorConfigRepository,
     ) -> None:
     '''
-    Test the delete method of the ErrorYamlRepository.
+    Test the delete method of the ErrorConfigRepository.
 
     :param error_config_repo: The error configuration repository.
-    :type error_config_repo: ErrorYamlRepository
+    :type error_config_repo: ErrorConfigRepository
     '''
 
     # Delete an existing error.

--- a/tests/repos/test_feature.py
+++ b/tests/repos/test_feature.py
@@ -9,8 +9,8 @@ from typing import Dict
 import pytest, yaml
 
 # ** app
-from ...mappers import FeatureYamlObject
-from ..feature import FeatureYamlRepository
+from tiferet.mappers import FeatureConfigObject
+from tiferet.repos.feature import FeatureConfigRepository
 
 
 # *** constants
@@ -85,31 +85,31 @@ def feature_yaml_file(tmp_path) -> str:
 
 # ** fixture: feature_config_repo
 @pytest.fixture
-def feature_config_repo(feature_yaml_file: str) -> FeatureYamlRepository:
+def feature_config_repo(feature_yaml_file: str) -> FeatureConfigRepository:
     '''
     Fixture to create an instance of the Feature Configuration Repository.
 
     :param feature_yaml_file: The feature YAML configuration file path.
     :type feature_yaml_file: str
-    :return: An instance of FeatureYamlRepository.
-    :rtype: FeatureYamlRepository
+    :return: An instance of FeatureConfigRepository.
+    :rtype: FeatureConfigRepository
     '''
 
-    # Create and return the FeatureYamlRepository instance.
-    return FeatureYamlRepository(feature_yaml_file=feature_yaml_file)
+    # Create and return the FeatureConfigRepository instance.
+    return FeatureConfigRepository(feature_config=feature_yaml_file)
 
 
 # *** tests
 
 # ** test_int: feature_config_repo_exists
 def test_int_feature_config_repo_exists(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the exists method of the FeatureYamlRepository.
+    Test the exists method of the FeatureConfigRepository.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # Check if the features exist.
@@ -120,13 +120,13 @@ def test_int_feature_config_repo_exists(
 
 # ** test_int: feature_config_repo_get
 def test_int_feature_config_repo_get(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the get method of the FeatureYamlRepository.
+    Test the get method of the FeatureConfigRepository.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # Get features by id.
@@ -157,13 +157,13 @@ def test_int_feature_config_repo_get(
 
 # ** test_int: feature_config_repo_get_not_found
 def test_int_feature_config_repo_get_not_found(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the get method of the FeatureYamlRepository for a non-existent feature.
+    Test the get method of the FeatureConfigRepository for a non-existent feature.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # Attempt to get a non-existent feature.
@@ -174,13 +174,13 @@ def test_int_feature_config_repo_get_not_found(
 
 # ** test_int: feature_config_repo_list_all
 def test_int_feature_config_repo_list_all(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the list method of the FeatureYamlRepository for all features.
+    Test the list method of the FeatureConfigRepository for all features.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # List all features.
@@ -196,13 +196,13 @@ def test_int_feature_config_repo_list_all(
 
 # ** test_int: feature_config_repo_list_by_group
 def test_int_feature_config_repo_list_by_group(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the list method of the FeatureYamlRepository filtered by group.
+    Test the list method of the FeatureConfigRepository filtered by group.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # List features for a specific group.
@@ -223,20 +223,20 @@ def test_int_feature_config_repo_list_by_group(
 
 # ** test_int: feature_config_repo_save
 def test_int_feature_config_repo_save(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the save method of the FeatureYamlRepository.
+    Test the save method of the FeatureConfigRepository.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # Create constant for new test feature.
     new_feature_id = 'new_group.new_feature'
 
     # Create new feature config data and map to a model.
-    feature = FeatureYamlObject.model_validate(dict(
+    feature = FeatureConfigObject.model_validate(dict(
         id=new_feature_id,
         name='New Feature',
         description='A new test feature.',
@@ -259,13 +259,13 @@ def test_int_feature_config_repo_save(
 
 # ** test_int: feature_config_repo_delete
 def test_int_feature_config_repo_delete(
-        feature_config_repo: FeatureYamlRepository,
+        feature_config_repo: FeatureConfigRepository,
     ) -> None:
     '''
-    Test the delete method of the FeatureYamlRepository.
+    Test the delete method of the FeatureConfigRepository.
 
     :param feature_config_repo: The feature configuration repository.
-    :type feature_config_repo: FeatureYamlRepository
+    :type feature_config_repo: FeatureConfigRepository
     '''
 
     # Delete an existing feature.

--- a/tests/repos/test_logging.py
+++ b/tests/repos/test_logging.py
@@ -6,8 +6,8 @@
 import pytest, yaml
 
 # ** app
-from ...mappers import FormatterYamlObject, HandlerYamlObject, LoggerYamlObject
-from ..logging import LoggingYamlRepository
+from tiferet.mappers import FormatterConfigObject, HandlerConfigObject, LoggerConfigObject
+from tiferet.repos.logging import LoggingConfigRepository
 
 # *** constants
 
@@ -81,30 +81,30 @@ def logging_config_file(tmp_path) -> str:
 
 # ** fixture: logging_config_repo
 @pytest.fixture
-def logging_config_repo(logging_config_file: str) -> LoggingYamlRepository:
+def logging_config_repo(logging_config_file: str) -> LoggingConfigRepository:
     '''
     Fixture to create an instance of the Logging Configuration Repository.
 
     :param logging_config_file: The logging YAML configuration file path.
     :type logging_config_file: str
-    :return: An instance of LoggingYamlRepository.
-    :rtype: LoggingYamlRepository
+    :return: An instance of LoggingConfigRepository.
+    :rtype: LoggingConfigRepository
     '''
 
-    # Create and return the LoggingYamlRepository instance.
-    return LoggingYamlRepository(logging_config_file)
+    # Create and return the LoggingConfigRepository instance.
+    return LoggingConfigRepository(logging_config_file)
 
 # *** tests
 
 # ** test_int: logging_config_repo_list_all
 def test_int_logging_config_repo_list_all(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the list_all method of the LoggingYamlRepository.
+    Test the list_all method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # List all formatters, handlers, and loggers.
@@ -135,20 +135,20 @@ def test_int_logging_config_repo_list_all(
 
 # ** test_int: logging_config_repo_save_formatter
 def test_int_logging_config_repo_save_formatter(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the save_formatter method of the LoggingYamlRepository.
+    Test the save_formatter method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Create constant for new test formatter.
     NEW_FORMATTER_ID = 'new_test_formatter'
 
     # Create new formatter.
-    formatter = FormatterYamlObject.model_validate(dict(
+    formatter = FormatterConfigObject.model_validate(dict(
         id=NEW_FORMATTER_ID,
         name='New Test Formatter',
         description='A new test formatter',
@@ -173,20 +173,20 @@ def test_int_logging_config_repo_save_formatter(
 
 # ** test_int: logging_config_repo_save_handler
 def test_int_logging_config_repo_save_handler(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the save_handler method of the LoggingYamlRepository.
+    Test the save_handler method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Create constant for new test handler.
     NEW_HANDLER_ID = 'new_test_handler'
 
     # Create new handler.
-    handler = HandlerYamlObject.model_validate(dict(
+    handler = HandlerConfigObject.model_validate(dict(
         id=NEW_HANDLER_ID,
         name='New Test Handler',
         description='A new test handler',
@@ -215,20 +215,20 @@ def test_int_logging_config_repo_save_handler(
 
 # ** test_int: logging_config_repo_save_logger
 def test_int_logging_config_repo_save_logger(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the save_logger method of the LoggingYamlRepository.
+    Test the save_logger method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Create constant for new test logger.
     NEW_LOGGER_ID = 'new_test_logger'
 
     # Create new logger.
-    logger = LoggerYamlObject.model_validate(dict(
+    logger = LoggerConfigObject.model_validate(dict(
         id=NEW_LOGGER_ID,
         name='New Test Logger',
         description='A new test logger',
@@ -256,13 +256,13 @@ def test_int_logging_config_repo_save_logger(
 
 # ** test_int: logging_config_repo_delete_formatter
 def test_int_logging_config_repo_delete_formatter(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the delete_formatter method of the LoggingYamlRepository.
+    Test the delete_formatter method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Delete an existing formatter.
@@ -277,13 +277,13 @@ def test_int_logging_config_repo_delete_formatter(
 
 # ** test_int: logging_config_repo_delete_handler
 def test_int_logging_config_repo_delete_handler(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the delete_handler method of the LoggingYamlRepository.
+    Test the delete_handler method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Delete an existing handler.
@@ -298,13 +298,13 @@ def test_int_logging_config_repo_delete_handler(
 
 # ** test_int: logging_config_repo_delete_logger
 def test_int_logging_config_repo_delete_logger(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
-    Test the delete_logger method of the LoggingYamlRepository.
+    Test the delete_logger method of the LoggingConfigRepository.
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Delete an existing logger.
@@ -319,13 +319,13 @@ def test_int_logging_config_repo_delete_logger(
 
 # ** test_int: logging_config_repo_delete_idempotent
 def test_int_logging_config_repo_delete_idempotent(
-        logging_config_repo: LoggingYamlRepository,
+        logging_config_repo: LoggingConfigRepository,
     ):
     '''
     Test that delete methods are idempotent (no error on non-existent ID).
 
     :param logging_config_repo: The logging configuration repository.
-    :type logging_config_repo: LoggingYamlRepository
+    :type logging_config_repo: LoggingConfigRepository
     '''
 
     # Delete a non-existent formatter (should not raise error).
@@ -364,7 +364,7 @@ def test_int_logging_config_repo_empty_sections(tmp_path):
         yaml.safe_dump(empty_data, f)
 
     # Create repository instance.
-    repo = LoggingYamlRepository(str(file_path))
+    repo = LoggingConfigRepository(str(file_path))
 
     # List all (should return empty lists).
     formatters, handlers, loggers = repo.list_all()

--- a/tests/repos/test_settings.py
+++ b/tests/repos/test_settings.py
@@ -1,0 +1,156 @@
+"""Tiferet Configuration Repository Settings Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.repos.settings import ConfigurationRepository
+from tiferet.utils import YamlLoader, JsonLoader
+from tiferet.assets import TiferetError
+
+
+# *** fixtures
+
+# ** fixture: yaml_repo
+@pytest.fixture
+def yaml_repo(tmp_path) -> ConfigurationRepository:
+    '''
+    Provide a ConfigurationRepository backed by a temporary YAML file.
+
+    :param tmp_path: The pytest temporary directory.
+    :type tmp_path: pathlib.Path
+    :return: A YAML-backed configuration repository.
+    :rtype: ConfigurationRepository
+    '''
+
+    # Create an empty YAML configuration file.
+    file_path = tmp_path / 'config.yaml'
+    file_path.write_text('root: {}\n', encoding='utf-8')
+
+    # Return a repository pointed at the YAML file.
+    return ConfigurationRepository(str(file_path))
+
+# ** fixture: json_repo
+@pytest.fixture
+def json_repo(tmp_path) -> ConfigurationRepository:
+    '''
+    Provide a ConfigurationRepository backed by a temporary JSON file.
+
+    :param tmp_path: The pytest temporary directory.
+    :type tmp_path: pathlib.Path
+    :return: A JSON-backed configuration repository.
+    :rtype: ConfigurationRepository
+    '''
+
+    # Create an empty JSON configuration file.
+    file_path = tmp_path / 'config.json'
+    file_path.write_text('{"root": {}}\n', encoding='utf-8')
+
+    # Return a repository pointed at the JSON file.
+    return ConfigurationRepository(str(file_path))
+
+
+# *** tests
+
+# ** test_int: default_role_is_to_data
+def test_int_default_role_is_to_data(yaml_repo: ConfigurationRepository) -> None:
+    '''
+    Test that the configuration repository defaults to the format-agnostic 'to_data' role.
+
+    :param yaml_repo: The YAML-backed configuration repository.
+    :type yaml_repo: ConfigurationRepository
+    '''
+
+    # The default role should be 'to_data'.
+    assert yaml_repo.default_role == 'to_data'
+
+# ** test_int: get_loader_yaml
+def test_int_get_loader_yaml(yaml_repo: ConfigurationRepository) -> None:
+    '''
+    Test that a YAML configuration file resolves to a YamlLoader.
+
+    :param yaml_repo: The YAML-backed configuration repository.
+    :type yaml_repo: ConfigurationRepository
+    '''
+
+    # Resolve the loader for the YAML file.
+    loader = yaml_repo._get_loader()
+
+    # The loader should be a YamlLoader.
+    assert isinstance(loader, YamlLoader)
+
+# ** test_int: get_loader_json
+def test_int_get_loader_json(json_repo: ConfigurationRepository) -> None:
+    '''
+    Test that a JSON configuration file resolves to a JsonLoader.
+
+    :param json_repo: The JSON-backed configuration repository.
+    :type json_repo: ConfigurationRepository
+    '''
+
+    # Resolve the loader for the JSON file.
+    loader = json_repo._get_loader()
+
+    # The loader should be a JsonLoader.
+    assert isinstance(loader, JsonLoader)
+
+# ** test_int: load_save_round_trip_yaml
+def test_int_load_save_round_trip_yaml(yaml_repo: ConfigurationRepository) -> None:
+    '''
+    Test that data saved to a YAML configuration file is loaded back intact.
+
+    :param yaml_repo: The YAML-backed configuration repository.
+    :type yaml_repo: ConfigurationRepository
+    '''
+
+    # Persist a sample structure.
+    yaml_repo._save({'root': {'alpha': 1, 'beta': 'two'}})
+
+    # Load the full structure back.
+    data = yaml_repo._load()
+
+    # The round-tripped data should match what was saved.
+    assert data == {'root': {'alpha': 1, 'beta': 'two'}}
+
+    # The start_node selector should resolve nested data.
+    nested = yaml_repo._load(start_node=lambda d: d.get('root', {}))
+    assert nested == {'alpha': 1, 'beta': 'two'}
+
+# ** test_int: load_save_round_trip_json
+def test_int_load_save_round_trip_json(json_repo: ConfigurationRepository) -> None:
+    '''
+    Test that data saved to a JSON configuration file is loaded back intact.
+
+    :param json_repo: The JSON-backed configuration repository.
+    :type json_repo: ConfigurationRepository
+    '''
+
+    # Persist a sample structure.
+    json_repo._save({'root': {'alpha': 1, 'beta': 'two'}})
+
+    # Load the full structure back.
+    data = json_repo._load()
+
+    # The round-tripped data should match what was saved.
+    assert data == {'root': {'alpha': 1, 'beta': 'two'}}
+
+# ** test_int: unsupported_config_file_type
+def test_int_unsupported_config_file_type(tmp_path) -> None:
+    '''
+    Test that an unsupported configuration file extension raises UNSUPPORTED_CONFIG_FILE_TYPE.
+
+    :param tmp_path: The pytest temporary directory.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Create a repository pointed at an unsupported file type.
+    repo = ConfigurationRepository(str(tmp_path / 'config.txt'))
+
+    # Resolving a loader should raise a structured error.
+    with pytest.raises(TiferetError) as exc_info:
+        repo._get_loader()
+
+    # The error code should indicate an unsupported configuration file type.
+    assert exc_info.value.error_code == 'UNSUPPORTED_CONFIG_FILE_TYPE'

--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -254,7 +254,7 @@ class AppServiceDependencyConfigObject(AppServiceDependency, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'parameters', 'service_id'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'service_id'}},
+        'to_data': {'by_alias': True, 'exclude': {'service_id'}},
     }
 
     # * attribute: service_id
@@ -319,7 +319,7 @@ class AppInterfaceConfigObject(AppInterface, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'services', 'constants', 'module_path', 'class_name'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: module_path

--- a/tiferet/mappers/cli.py
+++ b/tiferet/mappers/cli.py
@@ -164,7 +164,7 @@ class CliCommandConfigObject(CliCommand, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'arguments'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: arguments

--- a/tiferet/mappers/di.py
+++ b/tiferet/mappers/di.py
@@ -52,7 +52,7 @@ class FlaggedDependencyConfigObject(FlaggedDependency, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'flag'}},
+        'to_data': {'by_alias': True, 'exclude': {'flag'}},
     }
 
     # * attribute: flag
@@ -225,7 +225,7 @@ class ServiceRegistrationConfigObject(ServiceRegistration, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'dependencies', 'parameters'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: dependencies

--- a/tiferet/mappers/error.py
+++ b/tiferet/mappers/error.py
@@ -86,7 +86,7 @@ class ErrorMessageConfigObject(ErrorMessage, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True},
+        'to_data': {'by_alias': True},
     }
 
     # * method: map
@@ -113,7 +113,7 @@ class ErrorConfigObject(Error, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'message'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: message

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -105,7 +105,7 @@ class EventFeatureStepConfigObject(EventFeatureStep, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'type'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'type'}},
+        'to_data': {'by_alias': True, 'exclude': {'type'}},
     }
 
     # * attribute: parameters
@@ -321,7 +321,7 @@ class FeatureConfigObject(Feature, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'steps'}},
-        'to_data.yaml': {
+        'to_data': {
             'by_alias': True,
             'exclude': {'feature_key', 'group_id', 'id'},
         },

--- a/tiferet/mappers/logging.py
+++ b/tiferet/mappers/logging.py
@@ -31,8 +31,7 @@ class FormatterConfigObject(Formatter, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
-        'to_data.json': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: id
@@ -89,8 +88,7 @@ class HandlerConfigObject(Handler, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
-        'to_data.json': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: id
@@ -147,8 +145,7 @@ class LoggerConfigObject(Logger, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
-        'to_data.json': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 
     # * attribute: id
@@ -197,8 +194,7 @@ class LoggingSettingsConfigObject(TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {},
-        'to_data.yaml': {'by_alias': True},
-        'to_data.json': {'by_alias': True},
+        'to_data': {'by_alias': True},
     }
 
     # * attribute: id

--- a/tiferet/repos/__init__.py
+++ b/tiferet/repos/__init__.py
@@ -1,3 +1,5 @@
 """Tiferet Repository Exports"""
 
 # *** exports
+
+__all__ = []

--- a/tiferet/repos/__init__.py
+++ b/tiferet/repos/__init__.py
@@ -1,1 +1,3 @@
 """Tiferet Repository Exports"""
+
+# *** exports

--- a/tiferet/repos/app.py
+++ b/tiferet/repos/app.py
@@ -1,4 +1,4 @@
-"""Tiferet App YAML Repository"""
+"""Tiferet App Configuration Repository"""
 
 # *** imports
 
@@ -9,42 +9,31 @@ from typing import List
 from ..interfaces import AppService
 from ..mappers import (
     AppInterfaceAggregate,
-    AppInterfaceYamlObject,
+    AppInterfaceConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: app_yaml_repository
-class AppYamlRepository(AppService):
+# ** repo: app_config_repository
+class AppConfigRepository(AppService, ConfigurationRepository):
     '''
-    The app YAML repository.
+    The app configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, app_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, app_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the app YAML repository.
+        Initialize the app configuration repository.
 
-        :param app_yaml_file: The YAML configuration file path.
-        :type app_yaml_file: str
+        :param app_config: The configuration file path.
+        :type app_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = app_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=app_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -58,10 +47,7 @@ class AppYamlRepository(AppService):
         '''
 
         # Load the interfaces mapping from the configuration file.
-        interfaces_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        interfaces_data = self._load(
             start_node=lambda data: data.get('interfaces', {})
         )
 
@@ -80,10 +66,7 @@ class AppYamlRepository(AppService):
         '''
 
         # Load the specific interface data from the configuration file.
-        interface_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        interface_data = self._load(
             start_node=lambda data: data.get('interfaces', {}).get(id)
         )
 
@@ -92,7 +75,7 @@ class AppYamlRepository(AppService):
             return None
 
         # Map the data to an AppInterfaceAggregate and return it.
-        return AppInterfaceYamlObject.model_validate(
+        return AppInterfaceConfigObject.model_validate(
             {**interface_data, 'id': id}
         ).map()
 
@@ -106,16 +89,13 @@ class AppYamlRepository(AppService):
         '''
 
         # Load all interfaces data from the configuration file.
-        interfaces_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        interfaces_data = self._load(
             start_node=lambda data: data.get('interfaces', {})
         )
 
         # Map each interface entry to an AppInterfaceAggregate.
         return [
-            AppInterfaceYamlObject.model_validate(
+            AppInterfaceConfigObject.model_validate(
                 {**interface_data, 'id': interface_id}
             ).map()
             for interface_id, interface_data in interfaces_data.items()
@@ -133,23 +113,16 @@ class AppYamlRepository(AppService):
         '''
 
         # Convert the app interface model to configuration data.
-        interface_data = AppInterfaceYamlObject.from_model(interface)
+        interface_data = AppInterfaceConfigObject.from_model(interface)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Update or insert the interface entry.
         full_data.setdefault('interfaces', {})[interface.id] = interface_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete
     def delete(self, id: str) -> None:
@@ -163,17 +136,10 @@ class AppYamlRepository(AppService):
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Remove the interface entry if it exists (idempotent).
         full_data.get('interfaces', {}).pop(id, None)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/cli.py
+++ b/tiferet/repos/cli.py
@@ -1,4 +1,4 @@
-"""Tiferet CLI YAML Repository"""
+"""Tiferet CLI Configuration Repository"""
 
 # *** imports
 
@@ -10,42 +10,31 @@ from ..interfaces import CliService
 from ..mappers import (
     CliArgumentAggregate,
     CliCommandAggregate,
-    CliCommandYamlObject,
+    CliCommandConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: cli_yaml_repository
-class CliYamlRepository(CliService):
+# ** repo: cli_config_repository
+class CliConfigRepository(CliService, ConfigurationRepository):
     '''
-    The CLI YAML repository.
+    The CLI configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, cli_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, cli_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the CLI YAML repository.
+        Initialize the CLI configuration repository.
 
-        :param cli_yaml_file: The YAML configuration file path.
-        :type cli_yaml_file: str
+        :param cli_config: The configuration file path.
+        :type cli_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = cli_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=cli_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -76,10 +65,7 @@ class CliYamlRepository(CliService):
         group_key, command_key = id.split('.', 1)
 
         # Load the specific command data from the configuration file.
-        cmd_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        cmd_data = self._load(
             start_node=lambda data: data.get('cli', {}).get('cmds', {}).get(group_key, {}).get(command_key)
         )
 
@@ -88,7 +74,7 @@ class CliYamlRepository(CliService):
             return None
 
         # Map the data to a CliCommandAggregate and return it.
-        return CliCommandYamlObject.model_validate(
+        return CliCommandConfigObject.model_validate(
             {**cmd_data, 'id': id}
         ).map()
 
@@ -102,10 +88,7 @@ class CliYamlRepository(CliService):
         '''
 
         # Load all command groups from the configuration file.
-        cmds_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        cmds_data = self._load(
             start_node=lambda data: data.get('cli', {}).get('cmds', {})
         )
 
@@ -113,7 +96,7 @@ class CliYamlRepository(CliService):
         result = []
         for group_key, commands in cmds_data.items():
             for command_key, command_data in commands.items():
-                cmd = CliCommandYamlObject.model_validate(
+                cmd = CliCommandConfigObject.model_validate(
                     {**command_data, 'id': f'{group_key}.{command_key}'}
                 ).map()
                 result.append(cmd)
@@ -133,26 +116,19 @@ class CliYamlRepository(CliService):
         '''
 
         # Convert the CLI command model to configuration data.
-        cmd_data = CliCommandYamlObject.from_model(command)
+        cmd_data = CliCommandConfigObject.from_model(command)
 
         # Split the composite ID into group_key and command_key.
         group_key, command_key = command.id.split('.', 1)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Update or insert the command entry under the appropriate group.
         full_data.setdefault('cli', {}).setdefault('cmds', {}).setdefault(group_key, {})[command_key] = cmd_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete
     def delete(self, id: str) -> None:
@@ -169,20 +145,13 @@ class CliYamlRepository(CliService):
         group_key, command_key = id.split('.', 1)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Remove the command entry if it exists (idempotent).
         full_data.get('cli', {}).get('cmds', {}).get(group_key, {}).pop(command_key, None)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: get_parent_arguments
     def get_parent_arguments(self) -> List[CliArgumentAggregate]:
@@ -194,10 +163,7 @@ class CliYamlRepository(CliService):
         '''
 
         # Load parent arguments from the configuration file.
-        parent_args_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        parent_args_data = self._load(
             start_node=lambda data: data.get('cli', {}).get('parent_args', []),
             data_factory=lambda args: [
                 CliArgumentAggregate(**arg)
@@ -220,10 +186,7 @@ class CliYamlRepository(CliService):
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Set the parent_args section to the serialized argument list.
         full_data.setdefault('cli', {})['parent_args'] = [
@@ -232,8 +195,4 @@ class CliYamlRepository(CliService):
         ]
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/di.py
+++ b/tiferet/repos/di.py
@@ -1,4 +1,4 @@
-"""Tiferet DI YAML Repository"""
+"""Tiferet DI Configuration Repository"""
 
 # *** imports
 
@@ -8,195 +8,161 @@ from typing import Any, Dict, List, Tuple
 # ** app
 from ..interfaces import DIService
 from ..mappers import (
-    ServiceConfigurationAggregate,
-    ServiceConfigurationYamlObject,
+    ServiceRegistrationAggregate,
+    ServiceRegistrationConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: di_yaml_repository
-class DIYamlRepository(DIService):
+# ** repo: di_config_repository
+class DIConfigRepository(DIService, ConfigurationRepository):
     '''
-    The DI YAML repository.
+    The DI configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, di_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, di_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the DI YAML repository.
+        Initialize the DI configuration repository.
 
-        :param di_yaml_file: The YAML configuration file path.
-        :type di_yaml_file: str
+        :param di_config: The configuration file path.
+        :type di_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = di_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=di_config, encoding=encoding)
 
-    # * method: configuration_exists
-    def configuration_exists(self, id: str) -> bool:
+    # * method: registration_exists
+    def registration_exists(self, id: str) -> bool:
         '''
-        Check if a service configuration exists by ID.
+        Check if a service registration exists by ID.
 
-        :param id: The service configuration identifier.
+        :param id: The service registration identifier.
         :type id: str
-        :return: True if the service configuration exists, otherwise False.
+        :return: True if the service registration exists, otherwise False.
         :rtype: bool
         '''
 
         # Load the services mapping from the configuration file.
-        services_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        services_data = self._load(
             start_node=lambda data: data.get('services', {})
         )
 
-        # Return whether the configuration id exists in the mapping.
+        # Return whether the registration id exists in the mapping.
         return id in services_data
 
-    # * method: get_configuration
-    def get_configuration(self, configuration_id: str, flag: str = None) -> ServiceConfigurationAggregate | None:
+    # * method: get_registration
+    def get_registration(self, registration_id: str, flag: str = None) -> ServiceRegistrationAggregate | None:
         '''
-        Retrieve a service configuration by ID, optionally filtered by flag.
+        Retrieve a service registration by ID, optionally filtered by flag.
 
-        :param configuration_id: The service configuration identifier.
-        :type configuration_id: str
-        :param flag: Optional flag to filter the configuration.
+        :param registration_id: The service registration identifier.
+        :type registration_id: str
+        :param flag: Optional flag to filter the registration.
         :type flag: str
-        :return: The service configuration aggregate or None if not found.
-        :rtype: ServiceConfigurationAggregate | None
+        :return: The service registration aggregate or None if not found.
+        :rtype: ServiceRegistrationAggregate | None
         '''
 
-        # Load the specific service configuration data from the configuration file.
-        config_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
-            start_node=lambda data: data.get('services', {}).get(configuration_id)
+        # Load the specific service registration data from the configuration file.
+        registration_data = self._load(
+            start_node=lambda data: data.get('services', {}).get(registration_id)
         )
 
         # If no data is found, return None.
-        if not config_data:
+        if not registration_data:
             return None
 
-        # Map the data to a ServiceConfigurationAggregate.
-        configuration = ServiceConfigurationYamlObject.model_validate(
-            {**config_data, 'id': configuration_id}
+        # Map the data to a ServiceRegistrationAggregate.
+        registration = ServiceRegistrationConfigObject.model_validate(
+            {**registration_data, 'id': registration_id}
         ).map()
 
-        # If a flag is provided, filter the configuration by flag.
+        # If a flag is provided, filter the registration by flag.
         if flag:
-            dependency = configuration.get_dependency(flag)
+            dependency = registration.get_dependency(flag)
             if dependency:
-                configuration.module_path = dependency.module_path
-                configuration.class_name = dependency.class_name
+                registration.module_path = dependency.module_path
+                registration.class_name = dependency.class_name
                 if dependency.parameters:
-                    merged = dict(configuration.parameters or {})
+                    merged = dict(registration.parameters or {})
                     merged.update(dependency.parameters)
-                    configuration.parameters = merged
+                    registration.parameters = merged
 
-        # Return the configuration.
-        return configuration
+        # Return the registration.
+        return registration
 
     # * method: list_all
-    def list_all(self) -> Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]:
+    def list_all(self) -> Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]:
         '''
-        List all service configurations and constants.
+        List all service registrations and constants.
 
-        :return: A tuple containing a list of service configuration aggregates and a dictionary of constants.
-        :rtype: Tuple[List[ServiceConfigurationAggregate], Dict[str, str]]
+        :return: A tuple containing a list of service registration aggregates and a dictionary of constants.
+        :rtype: Tuple[List[ServiceRegistrationAggregate], Dict[str, str]]
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
-        # Map each service entry to a ServiceConfigurationAggregate.
-        configurations = [
-            ServiceConfigurationYamlObject.model_validate(
-                {**config_data, 'id': config_id}
+        # Map each service entry to a ServiceRegistrationAggregate.
+        registrations = [
+            ServiceRegistrationConfigObject.model_validate(
+                {**registration_data, 'id': registration_id}
             ).map()
-            for config_id, config_data in full_data.get('services', {}).items()
+            for registration_id, registration_data in full_data.get('services', {}).items()
         ]
 
         # Get the constants dictionary.
         constants = full_data.get('const', {})
 
-        # Return the configurations and constants.
-        return configurations, constants
+        # Return the registrations and constants.
+        return registrations, constants
 
-    # * method: save_configuration
-    def save_configuration(self, configuration: ServiceConfigurationAggregate) -> None:
+    # * method: save_registration
+    def save_registration(self, registration: ServiceRegistrationAggregate) -> None:
         '''
-        Save or update a service configuration.
+        Save or update a service registration.
 
-        :param configuration: The service configuration aggregate to save.
-        :type configuration: ServiceConfigurationAggregate
+        :param registration: The service registration aggregate to save.
+        :type registration: ServiceRegistrationAggregate
         :return: None
         :rtype: None
         '''
 
-        # Convert the service configuration model to configuration data.
-        config_data = ServiceConfigurationYamlObject.from_model(configuration)
+        # Convert the service registration model to configuration data.
+        registration_data = ServiceRegistrationConfigObject.from_model(registration)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
-        # Update or insert the service configuration entry.
-        full_data.setdefault('services', {})[configuration.id] = config_data.to_primitive(self.default_role)
+        # Update or insert the service registration entry.
+        full_data.setdefault('services', {})[registration.id] = registration_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
-    # * method: delete_configuration
-    def delete_configuration(self, configuration_id: str) -> None:
+    # * method: delete_registration
+    def delete_registration(self, registration_id: str) -> None:
         '''
-        Delete a service configuration by ID. This operation is idempotent.
+        Delete a service registration by ID. This operation is idempotent.
 
-        :param configuration_id: The service configuration identifier.
-        :type configuration_id: str
+        :param registration_id: The service registration identifier.
+        :type registration_id: str
         :return: None
         :rtype: None
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
-        # Remove the service configuration entry if it exists (idempotent).
-        full_data.get('services', {}).pop(configuration_id, None)
+        # Remove the service registration entry if it exists (idempotent).
+        full_data.get('services', {}).pop(registration_id, None)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: save_constants
     def save_constants(self, constants: Dict[str, Any] = {}) -> None:
@@ -210,10 +176,7 @@ class DIYamlRepository(DIService):
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Merge existing constants with new ones.
         existing_constants = full_data.get('const', {})
@@ -223,8 +186,4 @@ class DIYamlRepository(DIService):
         full_data['const'] = {k: v for k, v in existing_constants.items() if v is not None}
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/error.py
+++ b/tiferet/repos/error.py
@@ -1,4 +1,4 @@
-"""Tiferet Error YAML Repository"""
+"""Tiferet Error Configuration Repository"""
 
 # *** imports
 
@@ -9,42 +9,31 @@ from typing import List
 from ..interfaces import ErrorService
 from ..mappers import (
     ErrorAggregate,
-    ErrorYamlObject,
+    ErrorConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: error_yaml_repository
-class ErrorYamlRepository(ErrorService):
+# ** repo: error_config_repository
+class ErrorConfigRepository(ErrorService, ConfigurationRepository):
     '''
-    The error YAML repository.
+    The error configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, error_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the error YAML repository.
+        Initialize the error configuration repository.
 
-        :param error_yaml_file: The YAML configuration file path.
-        :type error_yaml_file: str
+        :param error_config: The configuration file path.
+        :type error_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = error_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -58,10 +47,7 @@ class ErrorYamlRepository(ErrorService):
         '''
 
         # Load the errors mapping from the configuration file.
-        errors_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        errors_data = self._load(
             start_node=lambda data: data.get('errors', {})
         )
 
@@ -80,10 +66,7 @@ class ErrorYamlRepository(ErrorService):
         '''
 
         # Load the specific error data from the configuration file.
-        error_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        error_data = self._load(
             start_node=lambda data: data.get('errors', {}).get(id)
         )
 
@@ -92,7 +75,7 @@ class ErrorYamlRepository(ErrorService):
             return None
 
         # Map the data to an ErrorAggregate and return it.
-        return ErrorYamlObject.model_validate(
+        return ErrorConfigObject.model_validate(
             {**error_data, 'id': id}
         ).map()
 
@@ -106,16 +89,13 @@ class ErrorYamlRepository(ErrorService):
         '''
 
         # Load all errors data from the configuration file.
-        errors_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        errors_data = self._load(
             start_node=lambda data: data.get('errors', {})
         )
 
         # Map each error entry to an ErrorAggregate.
         return [
-            ErrorYamlObject.model_validate(
+            ErrorConfigObject.model_validate(
                 {**error_data, 'id': error_id}
             ).map()
             for error_id, error_data in errors_data.items()
@@ -133,23 +113,16 @@ class ErrorYamlRepository(ErrorService):
         '''
 
         # Convert the error model to configuration data.
-        error_data = ErrorYamlObject.from_model(error)
+        error_data = ErrorConfigObject.from_model(error)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Update or insert the error entry.
         full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete
     def delete(self, id: str) -> None:
@@ -163,17 +136,10 @@ class ErrorYamlRepository(ErrorService):
         '''
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Remove the error entry if it exists (idempotent).
         full_data.get('errors', {}).pop(id, None)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/feature.py
+++ b/tiferet/repos/feature.py
@@ -1,4 +1,4 @@
-"""Tiferet Feature YAML Repository"""
+"""Tiferet Feature Configuration Repository"""
 
 # *** imports
 
@@ -9,42 +9,31 @@ from typing import Any, Dict, List
 from ..interfaces import FeatureService
 from ..mappers import (
     FeatureAggregate,
-    FeatureYamlObject,
+    FeatureConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: feature_yaml_repository
-class FeatureYamlRepository(FeatureService):
+# ** repo: feature_config_repository
+class FeatureConfigRepository(FeatureService, ConfigurationRepository):
     '''
-    The feature YAML repository.
+    The feature configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, feature_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, feature_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the feature YAML repository.
+        Initialize the feature configuration repository.
 
-        :param feature_yaml_file: The YAML configuration file path.
-        :type feature_yaml_file: str
+        :param feature_config: The configuration file path.
+        :type feature_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = feature_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=feature_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -61,10 +50,7 @@ class FeatureYamlRepository(FeatureService):
         group_id, feature_key = id.split('.', 1)
 
         # Load the group-specific feature data from the configuration file.
-        group_data: Dict[str, Any] = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        group_data: Dict[str, Any] = self._load(
             start_node=lambda data: data.get('features', {}).get(group_id, None)
         )
 
@@ -90,10 +76,7 @@ class FeatureYamlRepository(FeatureService):
         group_id, feature_key = id.split('.', 1)
 
         # Load the group-specific feature data from the configuration file.
-        group_data: Dict[str, Any] = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        group_data: Dict[str, Any] = self._load(
             start_node=lambda data: data.get('features', {}).get(group_id, None)
         )
 
@@ -109,7 +92,7 @@ class FeatureYamlRepository(FeatureService):
             return None
 
         # Map the feature data to a FeatureAggregate and return it.
-        return FeatureYamlObject.model_validate(
+        return FeatureConfigObject.model_validate(
             {**feature_data, 'id': f'{group_id}.{feature_key}'}
         ).map()
 
@@ -125,21 +108,18 @@ class FeatureYamlRepository(FeatureService):
         '''
 
         # Load all groups and feature definitions from the configuration file.
-        groups_data: Dict[str, Dict[str, Any]] = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        groups_data: Dict[str, Dict[str, Any]] = self._load(
             start_node=lambda data: data.get('features', {})
         )
 
-        # Initialize the list of FeatureYamlObject objects.
-        features: List[FeatureYamlObject] = []
+        # Initialize the list of FeatureConfigObject objects.
+        features: List[FeatureConfigObject] = []
 
         # If a specific group is requested, limit to that group.
         if group_id:
             group_features = groups_data.get(group_id, {})
             for feature_key, feature_data in group_features.items():
-                features.append(FeatureYamlObject.model_validate(
+                features.append(FeatureConfigObject.model_validate(
                     {**feature_data, 'id': f'{group_id}.{feature_key}'}
                 ))
 
@@ -147,11 +127,11 @@ class FeatureYamlRepository(FeatureService):
         else:
             for group, group_features in groups_data.items():
                 for feature_key, feature_data in group_features.items():
-                    features.append(FeatureYamlObject.model_validate(
+                    features.append(FeatureConfigObject.model_validate(
                         {**feature_data, 'id': f'{group}.{feature_key}'}
                     ))
 
-        # Map all FeatureYamlObject instances to FeatureAggregates and return them.
+        # Map all FeatureConfigObject instances to FeatureAggregates and return them.
         return [feature.map() for feature in features]
 
     # * method: save
@@ -165,27 +145,20 @@ class FeatureYamlRepository(FeatureService):
         :rtype: None
         '''
 
-        # Convert the feature model to a FeatureYamlObject.
-        feature_data = FeatureYamlObject.from_model(feature)
+        # Convert the feature model to a FeatureConfigObject.
+        feature_data = FeatureConfigObject.from_model(feature)
 
         # Split the feature id for nested update.
         group_id, feature_key = feature.id.split('.', 1)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Update or insert the feature entry using nested setdefault.
         full_data.setdefault('features', {}).setdefault(group_id, {})[feature_key] = feature_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete
     def delete(self, id: str) -> None:
@@ -199,10 +172,7 @@ class FeatureYamlRepository(FeatureService):
         '''
 
         # Load all features data from the configuration file.
-        features_data: Dict[str, Dict[str, Any]] = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        features_data: Dict[str, Dict[str, Any]] = self._load(
             start_node=lambda data: data.get('features', {})
         )
 
@@ -222,17 +192,10 @@ class FeatureYamlRepository(FeatureService):
             features_data[group_id] = group_data
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
+        full_data = self._load()
 
         # Update the features section.
         full_data['features'] = features_data
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/logging.py
+++ b/tiferet/repos/logging.py
@@ -30,7 +30,7 @@ class LoggingConfigRepository(LoggingService, ConfigurationRepository):
     '''
 
     # * init
-    def __init__(self, logging_config: str, encoding: str = 'utf-8'):
+    def __init__(self, logging_config: str, encoding: str = 'utf-8') -> None:
         '''
         Initialize the logging configuration repository.
 

--- a/tiferet/repos/logging.py
+++ b/tiferet/repos/logging.py
@@ -1,4 +1,4 @@
-"""Tiferet Logging YAML Repository"""
+"""Tiferet Logging Configuration Repository"""
 
 # *** imports
 
@@ -11,48 +11,37 @@ from typing import (
 # ** app
 from ..interfaces import LoggingService
 from ..mappers import (
-    LoggingSettingsYamlObject,
+    LoggingSettingsConfigObject,
     FormatterAggregate,
-    FormatterYamlObject,
+    FormatterConfigObject,
     HandlerAggregate,
-    HandlerYamlObject,
+    HandlerConfigObject,
     LoggerAggregate,
-    LoggerYamlObject,
+    LoggerConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: logging_yaml_repository
-class LoggingYamlRepository(LoggingService):
+# ** repo: logging_config_repository
+class LoggingConfigRepository(LoggingService, ConfigurationRepository):
     '''
-    YAML-backed repository for logging configurations (formatters, handlers, loggers).
+    Configuration-backed repository for logging configurations (formatters, handlers, loggers).
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: default_role
-    default_role: str
-
-    # * attribute: encoding
-    encoding: str
 
     # * init
-    def __init__(self, logging_yaml_file: str, encoding: str = 'utf-8'):
+    def __init__(self, logging_config: str, encoding: str = 'utf-8'):
         '''
-        Initialize the logging YAML repository.
+        Initialize the logging configuration repository.
 
-        :param logging_yaml_file: Path to YAML logging config file
-        :type logging_yaml_file: str
-        :param encoding: File encoding (default 'utf-8')
+        :param logging_config: The configuration file path.
+        :type logging_config: str
+        :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = logging_yaml_file
-        self.default_role = 'to_data.yaml'
-        self.encoding = encoding
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=logging_config, encoding=encoding)
 
     # * method: list_all
     def list_all(self) -> Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]:
@@ -63,12 +52,9 @@ class LoggingYamlRepository(LoggingService):
         :rtype: Tuple[List[FormatterAggregate], List[HandlerAggregate], List[LoggerAggregate]]
         '''
 
-        # Load the logging settings data from the yaml configuration file.
-        data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load(
-            data_factory=lambda d: LoggingSettingsYamlObject.from_data(**d),
+        # Load the logging settings data from the configuration file.
+        data = self._load(
+            data_factory=lambda d: LoggingSettingsConfigObject.from_data(**d),
             start_node=lambda d: d.get('logging', {})
         )
 
@@ -89,23 +75,16 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create formatter data object from the model.
-        formatter_data = FormatterYamlObject.from_model(formatter)
+        formatter_data = FormatterConfigObject.from_model(formatter)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the formatter entry.
         full_data.setdefault('logging', {}).setdefault('formatters', {})[formatter.id] = formatter_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: save_handler
     def save_handler(self, handler: HandlerAggregate):
@@ -117,23 +96,16 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create handler data object from the model.
-        handler_data = HandlerYamlObject.from_model(handler)
+        handler_data = HandlerConfigObject.from_model(handler)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the handler entry.
         full_data.setdefault('logging', {}).setdefault('handlers', {})[handler.id] = handler_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: save_logger
     def save_logger(self, logger: LoggerAggregate):
@@ -145,23 +117,16 @@ class LoggingYamlRepository(LoggingService):
         '''
 
         # Create logger data object from the model.
-        logger_data = LoggerYamlObject.from_model(logger)
+        logger_data = LoggerConfigObject.from_model(logger)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the logger entry.
         full_data.setdefault('logging', {}).setdefault('loggers', {})[logger.id] = logger_data.to_primitive(self.default_role)
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete_formatter
     def delete_formatter(self, formatter_id: str):
@@ -172,11 +137,8 @@ class LoggingYamlRepository(LoggingService):
         :type formatter_id: str
         '''
 
-        # Load all formatters data from the yaml file.
-        formatter_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load(
+        # Load all formatters data from the configuration file.
+        formatter_data = self._load(
             start_node=lambda d: d.get('logging', {}).get('formatters', {})
         )
 
@@ -184,20 +146,13 @@ class LoggingYamlRepository(LoggingService):
         formatter_data.pop(formatter_id, None)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the formatters section.
         full_data.setdefault('logging', {})['formatters'] = formatter_data
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete_handler
     def delete_handler(self, handler_id: str):
@@ -208,11 +163,8 @@ class LoggingYamlRepository(LoggingService):
         :type handler_id: str
         '''
 
-        # Load all handlers data from the yaml file.
-        handler_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load(
+        # Load all handlers data from the configuration file.
+        handler_data = self._load(
             start_node=lambda d: d.get('logging', {}).get('handlers', {})
         )
 
@@ -220,20 +172,13 @@ class LoggingYamlRepository(LoggingService):
         handler_data.pop(handler_id, None)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the handlers section.
         full_data.setdefault('logging', {})['handlers'] = handler_data
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)
 
     # * method: delete_logger
     def delete_logger(self, logger_id: str):
@@ -244,11 +189,8 @@ class LoggingYamlRepository(LoggingService):
         :type logger_id: str
         '''
 
-        # Load all loggers data from the yaml file.
-        logger_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load(
+        # Load all loggers data from the configuration file.
+        logger_data = self._load(
             start_node=lambda d: d.get('logging', {}).get('loggers', {})
         )
 
@@ -256,17 +198,10 @@ class LoggingYamlRepository(LoggingService):
         logger_data.pop(logger_id, None)
 
         # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding
-        ).load()
+        full_data = self._load()
 
         # Update the loggers section.
         full_data.setdefault('logging', {})['loggers'] = logger_data
 
         # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding
-        ).save(data=full_data)
+        self._save(full_data)

--- a/tiferet/repos/settings.py
+++ b/tiferet/repos/settings.py
@@ -1,0 +1,115 @@
+"""Tiferet Configuration Repository Settings"""
+
+# *** imports
+
+# ** core
+from pathlib import Path
+from typing import Any, Callable
+
+# ** app
+from ..utils import YamlLoader, JsonLoader
+from ..events import RaiseError, a
+
+# *** classes
+
+# ** class: configuration_repository
+class ConfigurationRepository(object):
+    '''
+    A format-agnostic base for configuration repositories.
+
+    Dispatches load and save operations to a format-specific loader (YAML or
+    JSON) based on the configuration file extension, and exposes a single
+    ``default_role`` for transfer-object serialization regardless of the
+    underlying file format.
+    '''
+
+    # * attribute: config_file
+    config_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, config_file: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the configuration repository.
+
+        :param config_file: The configuration file path (.yaml/.yml or .json).
+        :type config_file: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Set the configuration repository attributes.
+        self.config_file = config_file
+        self.encoding = encoding
+        self.default_role = 'to_data'
+
+    # * method: _get_loader
+    def _get_loader(self, mode: str = 'r') -> Any:
+        '''
+        Resolve a format-specific configuration loader by file extension.
+
+        :param mode: The file open mode (typically 'r' or 'w').
+        :type mode: str
+        :return: A loader appropriate for the configuration file's format.
+        :rtype: Any
+        '''
+
+        # Determine the configuration file extension.
+        ext = Path(self.config_file).suffix.lower()
+
+        # Dispatch to the YAML loader for YAML extensions.
+        if ext in ('.yaml', '.yml'):
+            return YamlLoader(self.config_file, mode=mode, encoding=self.encoding)
+
+        # Dispatch to the JSON loader for the JSON extension.
+        if ext == '.json':
+            return JsonLoader(self.config_file, mode=mode, encoding=self.encoding)
+
+        # Raise a structured error for any unsupported file type.
+        RaiseError.execute(
+            error_code=a.const.UNSUPPORTED_CONFIG_FILE_TYPE_ID,
+            file_extension=ext,
+        )
+
+    # * method: _load
+    def _load(self,
+            start_node: Callable[[Any], Any] = lambda x: x,
+            data_factory: Callable[[Any], Any] = lambda x: x,
+        ) -> Any:
+        '''
+        Load configuration data via the format-specific loader.
+
+        :param start_node: Callable to select the starting node of the loaded data.
+        :type start_node: Callable[[Any], Any]
+        :param data_factory: Callable to transform the loaded data.
+        :type data_factory: Callable[[Any], Any]
+        :return: The loaded and transformed configuration data.
+        :rtype: Any
+        '''
+
+        # Delegate to the resolved loader's load method.
+        return self._get_loader().load(
+            start_node=start_node,
+            data_factory=data_factory,
+        )
+
+    # * method: _save
+    def _save(self, data: Any) -> None:
+        '''
+        Persist configuration data via the format-specific loader.
+
+        :param data: The configuration data to persist.
+        :type data: Any
+        :return: None
+        :rtype: None
+        '''
+
+        # Delegate to the resolved write-mode loader's save method.
+        self._get_loader(mode='w').save(data=data)

--- a/tiferet/repos/settings.py
+++ b/tiferet/repos/settings.py
@@ -13,7 +13,7 @@ from ..events import RaiseError, a
 # *** classes
 
 # ** class: configuration_repository
-class ConfigurationRepository(object):
+class ConfigurationRepository:
     '''
     A format-agnostic base for configuration repositories.
 
@@ -41,8 +41,6 @@ class ConfigurationRepository(object):
         :type config_file: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
-        :return: None
-        :rtype: None
         '''
 
         # Set the configuration repository attributes.


### PR DESCRIPTION
## Summary
Brings `tiferet/repos/` to v2.0-proto parity with the already-migrated domain, mapper, and interface layers, and adds a format-agnostic `ConfigurationRepository` base. Resolves the repo-layer import failures against the migrated `tiferet/mappers` package and restores `DIService` conformance on `main`.

Closes #858. Part of Milestone 29 (Core DDD Parity II – Events and Repos).

## Changes
**Add** — `tiferet/repos/settings.py`: `ConfigurationRepository` with extension-dispatched `_get_loader`/`_load`/`_save` (`.yaml`/`.yml` → `YamlLoader`, `.json` → `JsonLoader`, else `UNSUPPORTED_CONFIG_FILE_TYPE`) and `default_role = 'to_data'`.

**Update** — the six config repos to `*ConfigRepository` on the new base: `<domain>_config` params, `*ConfigObject` mappers, persistence via the inherited `_load`/`_save`; removed each local `default_role` and the direct `Yaml` import. `di.py` adopts the registration terminology (`registration_exists`/`get_registration`/`save_registration`/`delete_registration`) and the corrected `# ** repo: di_config_repository` label; `logging.py` retains `from_data` in its load path. `repos/__init__.py` gains the `# *** exports` header.

**Tests** — relocated the six affected repo integration tests to `tests/repos/` (via `git mv`, updated to the new artifacts) and added `tests/repos/test_settings.py` for the base (loader dispatch, load/save round-trip, unsupported-type path).

## Prerequisite (mapper `_ROLES`)
Per TRD §7, the base's `default_role = 'to_data'` requires the mapper `_ROLES` rename `'to_data.yaml'`/`'to_data.json'` → `'to_data'`, which was still pending on `main`. It is committed separately (first commit) and includes the affected `tests/mappers` updates, so AC#7's `save → load` round-trip passes standalone.

## Out of scope (owned elsewhere; remains mid-migration)
- `tiferet/assets/blueprints.py` still references `*YamlRepository` / `*_yaml_file` (bootstrap/assets companion work); full `build_app` wiring lands with that.
- `tiferet/events/di.py` and `tiferet/contexts/di.py` retired-name references (DI Events #862 / contexts work).

## Testing
`pytest tests/repos tests/mappers` → **215 passed**. All `tiferet.repos.*` modules import; all repos are concrete (service interfaces satisfied).

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/6Da3vmNqNTNT5ffxAFK17l
- Conversation: https://app.warp.dev/conversation/6064547c-1b18-440d-b872-daa88a7e174f

Co-Authored-By: Oz <oz-agent@warp.dev>