### PR TITLE
Utils – Middleware: LoggingMiddleware and TimingMiddleware (#860)

### DIFF
--- a/tests/utils/test_middleware.py
+++ b/tests/utils/test_middleware.py
@@ -2,8 +2,11 @@
 
 # *** imports
 
-# ** infra
+# ** core
 import logging
+import re
+
+# ** infra
 import pytest
 
 # ** app
@@ -52,6 +55,9 @@ def test_middleware_conformance():
     assert isinstance(timing_mw, MiddlewareService)
 
     # Assert the default logger_id resolves a logger named 'root'.
+    # NOTE: logging.getLogger('root') returns a named logger called 'root' — a child of
+    # the true process root logger (logging.getLogger() with no name), not the root
+    # logger itself; records still propagate to the root handlers.
     assert logging_mw.logger.name == 'root'
     assert timing_mw.logger.name == 'root'
 
@@ -69,6 +75,31 @@ def test_middleware_resolves_named_logger():
     # Assert the resolved loggers carry the requested name.
     assert logging_mw.logger.name == 'tiferet.test'
     assert timing_mw.logger.name == 'tiferet.test'
+
+
+# ** test: middleware_forwards_nonempty_kwargs
+def test_middleware_forwards_nonempty_kwargs(sample_event: object):
+    '''
+    Test that both utilities return the chain result unchanged and leave a non-empty kwargs dict intact.
+
+    :param sample_event: The stub event instance.
+    :type sample_event: object
+    '''
+
+    # Build both utilities and a next_fn returning a sentinel result.
+    logging_mw = LoggingMiddleware()
+    timing_mw = TimingMiddleware()
+    next_fn = lambda: 'result'
+
+    # Provide a non-empty kwargs dict that the middleware must forward without inspecting or mutating.
+    kwargs = {'a': 1}
+
+    # Assert both utilities return the chain result unchanged.
+    assert logging_mw(sample_event, kwargs, next_fn) == 'result'
+    assert timing_mw(sample_event, kwargs, next_fn) == 'result'
+
+    # Assert the kwargs dict was neither consumed nor mutated.
+    assert kwargs == {'a': 1}
 
 
 # ** test: logging_middleware_success
@@ -167,7 +198,7 @@ def test_timing_middleware_success(sample_event: object, caplog):
         if r.levelno == logging.DEBUG and 'SampleEvent' in r.getMessage()
     ]
     assert len(timing_records) == 1
-    assert 'completed in' in timing_records[0].getMessage()
+    assert re.search(r'completed in \d+\.\d{2}ms', timing_records[0].getMessage())
 
 
 # ** test: timing_middleware_failure
@@ -200,4 +231,4 @@ def test_timing_middleware_failure(sample_event: object, caplog):
         if r.levelno == logging.DEBUG and 'SampleEvent' in r.getMessage()
     ]
     assert len(timing_records) == 1
-    assert 'raised after' in timing_records[0].getMessage()
+    assert re.search(r'raised after \d+\.\d{2}ms', timing_records[0].getMessage())

--- a/tests/utils/test_middleware.py
+++ b/tests/utils/test_middleware.py
@@ -1,0 +1,203 @@
+"""Tiferet Middleware Utility Tests"""
+
+# *** imports
+
+# ** infra
+import logging
+import pytest
+
+# ** app
+from tiferet.utils.middleware import LoggingMiddleware, TimingMiddleware
+from tiferet.interfaces.middleware import MiddlewareService
+
+
+# *** fixtures
+
+# ** fixture: sample_event
+@pytest.fixture
+def sample_event() -> object:
+    '''
+    Provide a stub domain event whose class name is observable in log records.
+
+    :return: A stub event instance with class name ``SampleEvent``.
+    :rtype: object
+    '''
+
+    # Define a minimal stand-in event class.
+    class SampleEvent:
+        pass
+
+    # Return an instance of the stub event.
+    return SampleEvent()
+
+
+# *** tests
+
+# ** test: middleware_conformance
+def test_middleware_conformance():
+    '''
+    Test that both utilities conform to MiddlewareService and resolve the default logger.
+    '''
+
+    # Assert class-level conformance to the MiddlewareService contract.
+    assert issubclass(LoggingMiddleware, MiddlewareService)
+    assert issubclass(TimingMiddleware, MiddlewareService)
+
+    # Instantiate both utilities with the default logger_id.
+    logging_mw = LoggingMiddleware()
+    timing_mw = TimingMiddleware()
+
+    # Assert instance-level conformance to the MiddlewareService contract.
+    assert isinstance(logging_mw, MiddlewareService)
+    assert isinstance(timing_mw, MiddlewareService)
+
+    # Assert the default logger_id resolves a logger named 'root'.
+    assert logging_mw.logger.name == 'root'
+    assert timing_mw.logger.name == 'root'
+
+
+# ** test: middleware_resolves_named_logger
+def test_middleware_resolves_named_logger():
+    '''
+    Test that a custom logger_id resolves a logger whose name matches.
+    '''
+
+    # Instantiate both utilities with a custom logger_id.
+    logging_mw = LoggingMiddleware(logger_id='tiferet.test')
+    timing_mw = TimingMiddleware(logger_id='tiferet.test')
+
+    # Assert the resolved loggers carry the requested name.
+    assert logging_mw.logger.name == 'tiferet.test'
+    assert timing_mw.logger.name == 'tiferet.test'
+
+
+# ** test: logging_middleware_success
+def test_logging_middleware_success(sample_event: object, caplog):
+    '''
+    Test that LoggingMiddleware returns the chain result unchanged and logs DEBUG records.
+
+    :param sample_event: The stub event instance.
+    :type sample_event: object
+    :param caplog: Pytest log-capture fixture.
+    :type caplog: pytest.LogCaptureFixture
+    '''
+
+    # Capture DEBUG-level records.
+    caplog.set_level(logging.DEBUG)
+
+    # Build the middleware and a next_fn returning a sentinel result.
+    middleware = LoggingMiddleware()
+    next_fn = lambda: 'result'
+
+    # Execute the middleware around the chain.
+    result = middleware(sample_event, {}, next_fn)
+
+    # Assert the chain result is returned unchanged.
+    assert result == 'result'
+
+    # Assert DEBUG records were emitted before and after execution.
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+    assert 'Executing SampleEvent' in debug_messages
+    assert 'Completed SampleEvent' in debug_messages
+
+
+# ** test: logging_middleware_failure
+def test_logging_middleware_failure(sample_event: object, caplog):
+    '''
+    Test that LoggingMiddleware logs an ERROR record with traceback and re-raises.
+
+    :param sample_event: The stub event instance.
+    :type sample_event: object
+    :param caplog: Pytest log-capture fixture.
+    :type caplog: pytest.LogCaptureFixture
+    '''
+
+    # Capture DEBUG-level records.
+    caplog.set_level(logging.DEBUG)
+
+    # Build the middleware and a next_fn that raises.
+    middleware = LoggingMiddleware()
+
+    def next_fn():
+        raise ValueError('boom')
+
+    # Execute and assert the original exception propagates unaltered.
+    with pytest.raises(ValueError, match='boom'):
+        middleware(sample_event, {}, next_fn)
+
+    # Assert a single ERROR record with traceback was emitted.
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    assert error_records[0].exc_info is not None
+    assert 'Failed SampleEvent' in error_records[0].getMessage()
+
+    # Assert the pre-execution DEBUG record fired but not the completion record.
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+    assert 'Executing SampleEvent' in debug_messages
+    assert 'Completed SampleEvent' not in debug_messages
+
+
+# ** test: timing_middleware_success
+def test_timing_middleware_success(sample_event: object, caplog):
+    '''
+    Test that TimingMiddleware returns the chain result and logs one elapsed-time DEBUG record.
+
+    :param sample_event: The stub event instance.
+    :type sample_event: object
+    :param caplog: Pytest log-capture fixture.
+    :type caplog: pytest.LogCaptureFixture
+    '''
+
+    # Capture DEBUG-level records.
+    caplog.set_level(logging.DEBUG)
+
+    # Build the middleware and a next_fn returning a sentinel result.
+    middleware = TimingMiddleware()
+    next_fn = lambda: 'result'
+
+    # Execute the middleware around the chain.
+    result = middleware(sample_event, {}, next_fn)
+
+    # Assert the chain result is returned unchanged.
+    assert result == 'result'
+
+    # Assert a single DEBUG elapsed-time record reported the completion.
+    timing_records = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and 'SampleEvent' in r.getMessage()
+    ]
+    assert len(timing_records) == 1
+    assert 'completed in' in timing_records[0].getMessage()
+
+
+# ** test: timing_middleware_failure
+def test_timing_middleware_failure(sample_event: object, caplog):
+    '''
+    Test that TimingMiddleware logs an elapsed-time DEBUG record and re-raises on failure.
+
+    :param sample_event: The stub event instance.
+    :type sample_event: object
+    :param caplog: Pytest log-capture fixture.
+    :type caplog: pytest.LogCaptureFixture
+    '''
+
+    # Capture DEBUG-level records.
+    caplog.set_level(logging.DEBUG)
+
+    # Build the middleware and a next_fn that raises.
+    middleware = TimingMiddleware()
+
+    def next_fn():
+        raise ValueError('boom')
+
+    # Execute and assert the original exception propagates unaltered.
+    with pytest.raises(ValueError, match='boom'):
+        middleware(sample_event, {}, next_fn)
+
+    # Assert a single DEBUG elapsed-time record reported the failure.
+    timing_records = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and 'SampleEvent' in r.getMessage()
+    ]
+    assert len(timing_records) == 1
+    assert 'raised after' in timing_records[0].getMessage()

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -34,6 +34,9 @@ IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
 # ** constant: feature_command_loading_failed_id
 FEATURE_COMMAND_LOADING_FAILED_ID = 'FEATURE_COMMAND_LOADING_FAILED'
 
+# ** constant: middleware_loading_failed_id
+MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
+
 # ** constant: app_repository_import_failed_id
 APP_REPOSITORY_IMPORT_FAILED_ID = 'APP_REPOSITORY_IMPORT_FAILED'
 
@@ -275,6 +278,15 @@ DEFAULT_ERRORS = {
         'name': 'Feature Command Loading Failed',
         'message': [
             {'lang': 'en_US', 'text': 'Failed to load feature command attribute: {attribute_id}. Error: {exception}.'}
+        ]
+    },
+
+    # * error: MIDDLEWARE_LOADING_FAILED
+    MIDDLEWARE_LOADING_FAILED_ID: {
+        'id': MIDDLEWARE_LOADING_FAILED_ID,
+        'name': 'Middleware Loading Failed',
+        'message': [
+            {'lang': 'en_US', 'text': 'Failed to load middleware: {service_id}. Error: {exception}.'}
         ]
     },
 

--- a/tiferet/utils/__init__.py
+++ b/tiferet/utils/__init__.py
@@ -2,6 +2,25 @@
 
 # *** exports
 
+__all__ = [
+    'FileLoader',
+    'File',
+    'JsonLoader',
+    'Json',
+    'YamlLoader',
+    'Yaml',
+    'TomlLoader',
+    'Toml',
+    'CsvLoader',
+    'Csv',
+    'CsvDictLoader',
+    'CsvDict',
+    'SqliteClient',
+    'Sqlite',
+    'LoggingMiddleware',
+    'TimingMiddleware',
+]
+
 # ** app
 from .file import FileLoader, FileLoader as File
 from .json import JsonLoader, JsonLoader as Json
@@ -9,3 +28,4 @@ from .yaml import YamlLoader, YamlLoader as Yaml
 from .toml import TomlLoader, TomlLoader as Toml
 from .csv import CsvLoader, CsvLoader as Csv, CsvDictLoader, CsvDictLoader as CsvDict
 from .sqlite import SqliteClient, SqliteClient as Sqlite
+from .middleware import LoggingMiddleware, TimingMiddleware

--- a/tiferet/utils/middleware.py
+++ b/tiferet/utils/middleware.py
@@ -1,0 +1,147 @@
+"""Tiferet Utils Middleware"""
+
+# *** imports
+
+# ** core
+import logging
+import time
+from typing import Any, Callable, Dict
+
+# ** app
+from ..interfaces.middleware import MiddlewareService
+
+# *** utils
+
+# ** util: logging_middleware
+class LoggingMiddleware(MiddlewareService):
+    '''
+    Infrastructure middleware that logs domain event execution.
+
+    Emits a DEBUG record before and after the wrapped execution and an ERROR
+    record (with traceback) when the chain raises.  The middleware observes
+    execution without altering control flow: the result of ``next_fn`` is
+    returned unchanged and any exception is re-raised unaltered.  It contains
+    no domain logic and raises no ``TiferetError``.
+    '''
+
+    # * attribute: logger
+    logger: logging.Logger
+
+    # * init
+    def __init__(self, logger_id: str = 'root'):
+        '''
+        Initialize the LoggingMiddleware.
+
+        :param logger_id: The name of the stdlib logger to resolve.
+        :type logger_id: str
+        '''
+
+        # Resolve the named stdlib logger by logger_id.
+        self.logger = logging.getLogger(logger_id)
+
+    # * method: __call__
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any],
+        ) -> Any:
+        '''
+        Log execution around the wrapped chain, then return its result.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that invokes the remainder of the chain.
+        :type next_fn: Callable[[], Any]
+        :return: The unchanged result of the chain execution.
+        :rtype: Any
+        '''
+
+        # Resolve the event class name for the log records.
+        name = event.__class__.__name__
+
+        # Log a DEBUG record before execution.
+        self.logger.debug('Executing %s', name)
+
+        # Execute the chain; on failure log an ERROR record with traceback and re-raise.
+        try:
+            result = next_fn()
+        except Exception as exc:
+            self.logger.error('Failed %s: %s', name, exc, exc_info=True)
+            raise
+
+        # Log a DEBUG record after successful execution.
+        self.logger.debug('Completed %s', name)
+
+        # Return the chain result unchanged.
+        return result
+
+
+# ** util: timing_middleware
+class TimingMiddleware(MiddlewareService):
+    '''
+    Infrastructure middleware that times domain event execution.
+
+    Measures elapsed wall-clock time with ``time.perf_counter`` and emits a
+    single DEBUG record reporting the duration in milliseconds on both the
+    success and exception paths.  The middleware observes execution without
+    altering control flow: the result of ``next_fn`` is returned unchanged and
+    any exception is re-raised unaltered.  It contains no domain logic and
+    raises no ``TiferetError``.
+    '''
+
+    # * attribute: logger
+    logger: logging.Logger
+
+    # * init
+    def __init__(self, logger_id: str = 'root'):
+        '''
+        Initialize the TimingMiddleware.
+
+        :param logger_id: The name of the stdlib logger to resolve.
+        :type logger_id: str
+        '''
+
+        # Resolve the named stdlib logger by logger_id.
+        self.logger = logging.getLogger(logger_id)
+
+    # * method: __call__
+    def __call__(self,
+            event: Any,
+            kwargs: Dict[str, Any],
+            next_fn: Callable[[], Any],
+        ) -> Any:
+        '''
+        Time the wrapped chain, logging elapsed milliseconds, then return its result.
+
+        :param event: The instantiated domain event instance.
+        :type event: Any
+        :param kwargs: The merged execution keyword arguments.
+        :type kwargs: Dict[str, Any]
+        :param next_fn: Zero-argument callable that invokes the remainder of the chain.
+        :type next_fn: Callable[[], Any]
+        :return: The unchanged result of the chain execution.
+        :rtype: Any
+        '''
+
+        # Resolve the event class name for the log records.
+        name = event.__class__.__name__
+
+        # Capture the start time using a high-resolution performance counter.
+        start = time.perf_counter()
+
+        # Execute the chain; on failure log elapsed time and re-raise.
+        try:
+            result = next_fn()
+        except Exception:
+            elapsed = (time.perf_counter() - start) * 1000
+            self.logger.debug('%s raised after %.2fms', name, elapsed)
+            raise
+
+        # Compute elapsed time and log a single DEBUG record on success.
+        elapsed = (time.perf_counter() - start) * 1000
+        self.logger.debug('%s completed in %.2fms', name, elapsed)
+
+        # Return the chain result unchanged.
+        return result


### PR DESCRIPTION
## Summary
Adds the two concrete middleware utilities that satisfy the `MiddlewareService` contract — `LoggingMiddleware` and `TimingMiddleware` — in a new `tiferet/utils/middleware.py`, exports them from the utils package, and adds the `MIDDLEWARE_LOADING_FAILED_ID` assets artifacts referenced by the runtime middleware-resolution path. Purely additive (TRD #860): no renames, no removals.

Closes #860.

## Changes
**`tiferet/utils/middleware.py`** (new)
- `LoggingMiddleware(MiddlewareService)`: resolves `logging.getLogger(logger_id)` (default `'root'`); `__call__` logs a `DEBUG` record before and after success, logs an `ERROR` record with `exc_info=True` on exception, and always re-raises; returns `next_fn()` unchanged.
- `TimingMiddleware(MiddlewareService)`: resolves `logging.getLogger(logger_id)` (default `'root'`); `__call__` measures elapsed time via `time.perf_counter` and emits a single `DEBUG` elapsed-millisecond record on both the success (`'%s completed in %.2fms'`) and exception (`'%s raised after %.2fms'`) paths, always re-raising.
- Infrastructure-only: no domain logic, no `TiferetError`; depends only on `MiddlewareService`, `logging`, and `time`.

**`tiferet/utils/__init__.py`**
- Declare `__all__` (existing loader names/aliases + `LoggingMiddleware`, `TimingMiddleware`); add `from .middleware import LoggingMiddleware, TimingMiddleware`.

**`tiferet/assets/constants.py`**
- Add `MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'` (adjacent to `FEATURE_COMMAND_LOADING_FAILED_ID`) and its `DEFAULT_ERRORS` entry (`name` `'Middleware Loading Failed'`, `en_US` `'Failed to load middleware: {service_id}. Error: {exception}.'`).

**Tests**
- New `tests/utils/test_middleware.py` covering conformance, success, and failure paths for both utilities (via `caplog`, a stub `event`, and a controllable `next_fn`).

## Acceptance criteria
- [x] `middleware.py` defines `LoggingMiddleware` and `TimingMiddleware`, both `MiddlewareService` subclasses resolving `logging.getLogger(logger_id)` (default `'root'`).
- [x] `LoggingMiddleware.__call__`: `DEBUG` before/after success, `ERROR` with `exc_info` on exception, re-raises; success result unchanged.
- [x] `TimingMiddleware.__call__`: `time.perf_counter`, single `DEBUG` elapsed-ms record on success and exception paths, re-raises.
- [x] Neither suppresses exceptions; neither raises `TiferetError` or imports domain/event modules.
- [x] Both import from `tiferet.utils`; `__init__.py` declares `__all__` with both names alongside the existing loader exports.
- [x] `MIDDLEWARE_LOADING_FAILED_ID` exists with a matching `DEFAULT_ERRORS` entry (`name` + `en_US`).
- [x] `tests/utils/test_middleware.py` covers success/failure/conformance and passes under `pytest`.

## Testing
- `pytest tests/utils/test_middleware.py` → 6 passed
- `pytest tests/utils tests/events` → 132 passed

## Scope notes
- The event composition path (`handle`/`handle_async` middleware, #859) and the context-level middleware resolution that raises `MIDDLEWARE_LOADING_FAILED_ID` (#862/#863) are downstream consumers, out of scope here; each utility is verified in isolation via a stub `next_fn`.
- The pre-existing `ServiceConfiguration` import warning is unrelated carry-over debt (handoff §4, owned by #862).

## Agent collaboration
Oz conversation (for the collaboration report): https://app.warp.dev/conversation/6790a595-790b-4ee6-a9be-bd94259e5c61

Co-Authored-By: Oz <oz-agent@warp.dev>
