### PR TITLE
Events – Feature/App/CLI: Base Events and Fallback Removal (#864)

### DIFF
--- a/tests/events/test_app.py
+++ b/tests/events/test_app.py
@@ -7,7 +7,8 @@ import pytest
 from unittest import mock
 
 # ** app
-from ..app import (
+from tiferet.events.app import (
+    AppEvent,
     GetAppInterface,
     AddAppInterface,
     ListAppInterfaces,
@@ -17,14 +18,14 @@ from ..app import (
     RemoveServiceDependency,
     RemoveAppInterface,
 )
-from ..settings import TiferetError, DomainEvent, a
-from ...domain import (
+from tiferet.events.settings import TiferetError, DomainEvent, a
+from tiferet.domain import (
     AppInterface,
     AppServiceDependency,
 )
-from ...interfaces import AppService
-from ...mappers import AppInterfaceAggregate
-from .settings import DomainEventTestBase, ServiceEventTestBase
+from tiferet.interfaces import AppService
+from tiferet.mappers import AppInterfaceAggregate
+from tiferet.testing import DomainEventTestBase, ServiceEventTestBase
 
 # *** fixtures
 
@@ -56,6 +57,54 @@ def app_interface():
     )
 
 # *** tests
+
+# ** class: TestAppEvent
+class TestAppEvent:
+    '''
+    Tests for the AppEvent base event shared by all app events.
+    '''
+
+    # * method: test_base_extends_domain_event
+    def test_base_extends_domain_event(self):
+        '''
+        Test that AppEvent extends DomainEvent.
+        '''
+
+        # Assert the base event extends DomainEvent.
+        assert issubclass(AppEvent, DomainEvent)
+
+    # * method: test_concrete_events_extend_base
+    def test_concrete_events_extend_base(self):
+        '''
+        Test that every concrete app event extends AppEvent.
+        '''
+
+        # Assert each concrete event extends the module base.
+        for event_cls in (
+            AddAppInterface,
+            GetAppInterface,
+            UpdateAppInterface,
+            SetAppConstants,
+            ListAppInterfaces,
+            SetServiceDependency,
+            RemoveServiceDependency,
+            RemoveAppInterface,
+        ):
+            assert issubclass(event_cls, AppEvent)
+
+    # * method: test_service_injection
+    def test_service_injection(self):
+        '''
+        Test that constructing an app event wires the shared service attribute.
+        '''
+
+        # Create a mock app service.
+        service = mock.Mock(spec=AppService)
+
+        # Assert the base and a concrete event both expose the injected service.
+        assert AppEvent(app_service=service).app_service is service
+        assert GetAppInterface(app_service=service).app_service is service
+
 
 # ** test: TestAddAppInterface
 class TestAddAppInterface(DomainEventTestBase):
@@ -163,6 +212,28 @@ class TestAddAppInterface(DomainEventTestBase):
         # Assert the interface is saved.
         mock_dependencies['app_service'].save.assert_called_once_with(interface)
 
+    # * method: test_none_arguments_coerced
+    def test_none_arguments_coerced(self, mock_dependencies):
+        '''
+        Test that None logger_id, flags, services, and constants are coerced to defaults.
+        '''
+
+        # Execute with the optional arguments explicitly set to None (as argparse may pass).
+        interface = self.handle(
+            mock_dependencies,
+            logger_id=None,
+            flags=None,
+            services=None,
+            constants=None,
+        )
+
+        # Assert the defaults are applied.
+        assert interface.logger_id == 'default'
+        assert interface.flags == ['default']
+        assert interface.services == []
+        assert interface.constants == {}
+        mock_dependencies['app_service'].save.assert_called_once_with(interface)
+
 
 # ** test: TestGetAppInterface
 class TestGetAppInterface(ServiceEventTestBase):
@@ -206,75 +277,10 @@ class TestGetAppInterface(ServiceEventTestBase):
         # Assert that the returned interface matches the expected app interface.
         assert result == app_interface
 
-    # * method: test_merges_missing_default_services_only
-    def test_merges_missing_default_services_only(self, mock_dependencies, app_interface):
+    # * method: test_returns_domain_object_without_rewrap
+    def test_returns_domain_object_without_rewrap(self, mock_dependencies):
         '''
-        Test that default services are merged only when service_id is missing.
-        '''
-
-        # Configure the service mock to return the app interface.
-        mock_dependencies['app_service'].get.return_value = app_interface
-
-        # Create default services with one duplicate and one missing service_id.
-        default_services = [
-            AppServiceDependency(
-                service_id='test_service',
-                module_path='ignored.module',
-                class_name='IgnoredClass',
-                parameters={'ignored': 'value'},
-            ),
-            AppServiceDependency(
-                service_id='new_service',
-                module_path='new.module',
-                class_name='NewClass',
-                parameters={'new': 'value'},
-            ),
-        ]
-
-        # Execute the event with default services.
-        result = self.handle(
-            mock_dependencies,
-            default_services=default_services,
-        )
-
-        # Assert the existing dependency remains and only the missing dependency is added.
-        assert result.get_service('test_service').module_path == 'test_module_path'
-        assert result.get_service('new_service').module_path == 'new.module'
-        assert len(result.services) == 2
-
-    # * method: test_merges_missing_default_constants_only
-    def test_merges_missing_default_constants_only(self, mock_dependencies, app_interface):
-        '''
-        Test that default constants are merged without overwriting existing values.
-        '''
-
-        # Configure the service mock to return the app interface.
-        mock_dependencies['app_service'].get.return_value = app_interface
-
-        # Seed interface constants with an existing key that should be preserved.
-        app_interface.constants = {
-            'di_yaml_file': 'custom.yml',
-            'custom_key': 'custom_value',
-        }
-
-        # Execute the event with default constants.
-        result = self.handle(
-            mock_dependencies,
-            default_constants={
-                'di_yaml_file': 'config.yml',
-                'feature_yaml_file': 'config.yml',
-            },
-        )
-
-        # Assert existing keys are preserved and missing keys are added.
-        assert result.constants['di_yaml_file'] == 'custom.yml'
-        assert result.constants['feature_yaml_file'] == 'config.yml'
-        assert result.constants['custom_key'] == 'custom_value'
-
-    # * method: test_converts_to_aggregate_and_merges_services_and_constants
-    def test_converts_to_aggregate_and_merges_services_and_constants(self, mock_dependencies):
-        '''
-        Test aggregate conversion before applying default services and constants.
+        Test that a plain AppInterface from the repository is returned as-is.
         '''
 
         # Configure the service mock to return a plain AppInterface domain object.
@@ -283,42 +289,15 @@ class TestGetAppInterface(ServiceEventTestBase):
             name='Test Interface',
             module_path='tiferet.contexts.app',
             class_name='AppContext',
-            services=[
-                AppServiceDependency(
-                    service_id='existing_service',
-                    module_path='existing.module',
-                    class_name='ExistingClass',
-                    parameters={},
-                ),
-            ],
-            constants={'di_yaml_file': 'custom.yml'},
         )
         mock_dependencies['app_service'].get.return_value = domain_interface
 
-        # Execute the event with both defaults provided.
-        result = self.handle(
-            mock_dependencies,
-            interface_id='test.interface',
-            default_services=[
-                AppServiceDependency(
-                    service_id='new_service',
-                    module_path='new.module',
-                    class_name='NewClass',
-                    parameters={'key': 'value'},
-                ),
-            ],
-            default_constants={
-                'di_yaml_file': 'config.yml',
-                'feature_yaml_file': 'config.yml',
-            },
-        )
+        # Execute via the harness handle helper.
+        result = self.handle(mock_dependencies, interface_id='test.interface')
 
-        # Assert conversion to aggregate and correct merge behavior.
-        assert isinstance(result, AppInterfaceAggregate)
-        assert result.get_service('existing_service') is not None
-        assert result.get_service('new_service') is not None
-        assert result.constants['di_yaml_file'] == 'custom.yml'
-        assert result.constants['feature_yaml_file'] == 'config.yml'
+        # Assert the stored interface is returned unchanged (no aggregate re-wrap).
+        assert result is domain_interface
+        mock_dependencies['app_service'].get.assert_called_once_with('test.interface')
 
 
 # ** test: TestListAppInterfaces

--- a/tests/events/test_app.py
+++ b/tests/events/test_app.py
@@ -18,7 +18,7 @@ from tiferet.events.app import (
     RemoveServiceDependency,
     RemoveAppInterface,
 )
-from tiferet.events.settings import TiferetError, DomainEvent, a
+from tiferet.events.settings import DomainEvent, TiferetError, a
 from tiferet.domain import (
     AppInterface,
     AppServiceDependency,

--- a/tests/events/test_cli.py
+++ b/tests/events/test_cli.py
@@ -7,17 +7,18 @@ import pytest
 from unittest import mock
 
 # ** app
-from ..cli import (
+from tiferet.events.cli import (
+    CliEvent,
     AddCliCommand,
     AddCliArgument,
     ListCliCommands,
     GetParentArguments,
 )
-from ..settings import DomainEvent, a
-from ...domain import CliCommand, CliArgument
-from ...interfaces import CliService
-from ...mappers import CliCommandAggregate
-from .settings import DomainEventTestBase, ServiceEventTestBase
+from tiferet.events.settings import DomainEvent, TiferetError, a
+from tiferet.domain import CliCommand, CliArgument
+from tiferet.interfaces import CliService
+from tiferet.mappers import CliCommandAggregate
+from tiferet.testing import DomainEventTestBase, ServiceEventTestBase
 
 # *** fixtures
 
@@ -42,6 +43,50 @@ def cli_command():
     )
 
 # *** tests
+
+# ** class: TestCliEvent
+class TestCliEvent:
+    '''
+    Tests for the CliEvent base event shared by all CLI events.
+    '''
+
+    # * method: test_base_extends_domain_event
+    def test_base_extends_domain_event(self):
+        '''
+        Test that CliEvent extends DomainEvent.
+        '''
+
+        # Assert the base event extends DomainEvent.
+        assert issubclass(CliEvent, DomainEvent)
+
+    # * method: test_concrete_events_extend_base
+    def test_concrete_events_extend_base(self):
+        '''
+        Test that every concrete CLI event extends CliEvent.
+        '''
+
+        # Assert each concrete event extends the module base.
+        for event_cls in (
+            ListCliCommands,
+            GetParentArguments,
+            AddCliCommand,
+            AddCliArgument,
+        ):
+            assert issubclass(event_cls, CliEvent)
+
+    # * method: test_service_injection
+    def test_service_injection(self):
+        '''
+        Test that constructing a CLI event wires the shared service attribute.
+        '''
+
+        # Create a mock CLI service.
+        service = mock.Mock(spec=CliService)
+
+        # Assert the base and a concrete event both expose the injected service.
+        assert CliEvent(cli_service=service).cli_service is service
+        assert AddCliCommand(cli_service=service).cli_service is service
+
 
 # ** test: TestAddCliCommand
 class TestAddCliCommand(DomainEventTestBase):
@@ -145,6 +190,20 @@ class TestAddCliCommand(DomainEventTestBase):
 
         # Assert the correct error code.
         assert exc_info.value.error_code == a.const.CLI_COMMAND_ALREADY_EXISTS_ID
+
+    # * method: test_none_arguments_coerced
+    def test_none_arguments_coerced(self, mock_dependencies):
+        '''
+        Test that None arguments are coerced to an empty list.
+        '''
+
+        # Execute with arguments explicitly set to None (as argparse may pass).
+        result = self.handle(mock_dependencies, arguments=None)
+
+        # Assert the command was created with an empty argument list.
+        assert isinstance(result, CliCommand)
+        assert result.arguments == []
+        mock_dependencies['cli_service'].save.assert_called_once_with(result)
 
 
 # ** test: TestAddCliArgument

--- a/tests/events/test_cli.py
+++ b/tests/events/test_cli.py
@@ -185,7 +185,7 @@ class TestAddCliCommand(DomainEventTestBase):
         mock_dependencies['cli_service'].exists.return_value = True
 
         # Execute and expect a CLI_COMMAND_ALREADY_EXISTS error.
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies)
 
         # Assert the correct error code.

--- a/tests/events/test_feature.py
+++ b/tests/events/test_feature.py
@@ -10,7 +10,8 @@ import pytest
 from unittest import mock
 
 # ** app
-from ..feature import (
+from tiferet.events.feature import (
+    FeatureEvent,
     AddFeature,
     GetFeature,
     ListFeatures,
@@ -21,11 +22,11 @@ from ..feature import (
     RemoveFeatureStep,
     ReorderFeatureStep,
 )
-from ..settings import DomainEvent, TiferetError, a
-from ...domain import Feature
-from ...interfaces import FeatureService
-from ...mappers import FeatureAggregate
-from .settings import DomainEventTestBase, ServiceEventTestBase
+from tiferet.events.settings import DomainEvent, TiferetError, a
+from tiferet.domain import Feature
+from tiferet.interfaces import FeatureService
+from tiferet.mappers import FeatureAggregate
+from tiferet.testing import DomainEventTestBase, ServiceEventTestBase
 
 # *** fixtures
 
@@ -50,6 +51,55 @@ def sample_feature() -> Feature:
 
 
 # *** tests
+
+# ** class: TestFeatureEvent
+class TestFeatureEvent:
+    '''
+    Tests for the FeatureEvent base event shared by all feature events.
+    '''
+
+    # * method: test_base_extends_domain_event
+    def test_base_extends_domain_event(self):
+        '''
+        Test that FeatureEvent extends DomainEvent.
+        '''
+
+        # Assert the base event extends DomainEvent.
+        assert issubclass(FeatureEvent, DomainEvent)
+
+    # * method: test_concrete_events_extend_base
+    def test_concrete_events_extend_base(self):
+        '''
+        Test that every concrete feature event extends FeatureEvent.
+        '''
+
+        # Assert each concrete event extends the module base.
+        for event_cls in (
+            AddFeature,
+            GetFeature,
+            ListFeatures,
+            RemoveFeature,
+            UpdateFeature,
+            AddFeatureStep,
+            UpdateFeatureStep,
+            RemoveFeatureStep,
+            ReorderFeatureStep,
+        ):
+            assert issubclass(event_cls, FeatureEvent)
+
+    # * method: test_service_injection
+    def test_service_injection(self):
+        '''
+        Test that constructing a feature event wires the shared service attribute.
+        '''
+
+        # Create a mock feature service.
+        service = mock.Mock(spec=FeatureService)
+
+        # Assert the base and a concrete event both expose the injected service.
+        assert FeatureEvent(feature_service=service).feature_service is service
+        assert AddFeature(feature_service=service).feature_service is service
+
 
 # ** test: TestAddFeature
 class TestAddFeature(DomainEventTestBase):
@@ -156,6 +206,24 @@ class TestAddFeature(DomainEventTestBase):
         mock_dependencies['feature_service'].exists.assert_called_once()
         mock_dependencies['feature_service'].save.assert_not_called()
 
+    # * method: test_contextual_kwargs_not_forwarded
+    def test_contextual_kwargs_not_forwarded(self, mock_dependencies):
+        '''
+        Test that contextual pipeline kwargs are not forwarded into FeatureAggregate.
+
+        FeatureAggregate forbids unknown fields, so a clean creation confirms
+        the extra kwargs are dropped rather than forwarded.
+        '''
+
+        # Execute with extra contextual kwargs that are not Feature fields.
+        result = self.handle(mock_dependencies, request=object(), logger=object())
+
+        # Assert the feature was created without error and ignored the extra kwargs.
+        assert isinstance(result, Feature)
+        assert result.name == 'New Feature'
+        assert not hasattr(result, 'request')
+        mock_dependencies['feature_service'].save.assert_called_once_with(result)
+
 
 # ** test: TestGetFeature
 class TestGetFeature(ServiceEventTestBase):
@@ -205,6 +273,44 @@ class TestGetFeature(ServiceEventTestBase):
         # Assert the feature is returned.
         assert result is sample_feature
         mock_dependencies['feature_service'].get.assert_called_once_with('group.sample_feature')
+
+    # * method: test_fallback_to_default_index
+    def test_fallback_to_default_index(self, mock_dependencies, sample_feature):
+        '''
+        Test that a repository miss falls back to a matching default_feature_index entry.
+        '''
+
+        # Configure the service to miss so the fallback index is consulted.
+        mock_dependencies['feature_service'].get.return_value = None
+
+        # Execute with a default index containing the requested feature.
+        result = self.handle(
+            mock_dependencies,
+            default_feature_index={'group.sample_feature': sample_feature},
+        )
+
+        # Assert the default feature is returned.
+        assert result is sample_feature
+        mock_dependencies['feature_service'].get.assert_called_once_with('group.sample_feature')
+
+    # * method: test_miss_with_nonmatching_index
+    def test_miss_with_nonmatching_index(self, mock_dependencies):
+        '''
+        Test that a repository miss with no matching default raises FEATURE_NOT_FOUND.
+        '''
+
+        # Configure the service to miss.
+        mock_dependencies['feature_service'].get.return_value = None
+
+        # Execute with a default index that does not contain the requested feature.
+        with pytest.raises(TiferetError) as exc_info:
+            self.handle(
+                mock_dependencies,
+                default_feature_index={'other.feature': mock.Mock()},
+            )
+
+        # Assert the correct error code.
+        assert exc_info.value.error_code == a.const.FEATURE_NOT_FOUND_ID
 
 
 # ** test: TestListFeatures

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -5,16 +5,16 @@ from typing import List, Dict, Any
 
 # ** app
 from .settings import DomainEvent, a
-from ..domain import AppInterface, AppServiceDependency
+from ..domain import AppInterface
 from ..interfaces import AppService
 from ..mappers import AppInterfaceAggregate
 
 # *** events
 
-# ** event: add_app_interface
-class AddAppInterface(DomainEvent):
+# ** event: app_event
+class AppEvent(DomainEvent):
     '''
-    A domain event to add a new application interface configuration via the AppService.
+    Base event providing the shared AppService dependency for app domain events.
     '''
 
     # * attribute: app_service
@@ -23,13 +23,20 @@ class AddAppInterface(DomainEvent):
     # * init
     def __init__(self, app_service: AppService):
         '''
-        Initialize the AddAppInterface event.
+        Initialize the app event with its shared service dependency.
 
-        :param app_service: The application service used to persist app interfaces.
+        :param app_service: The app service shared across app events.
         :type app_service: AppService
         '''
 
+        # Set the app service dependency.
         self.app_service = app_service
+
+# ** event: add_app_interface
+class AddAppInterface(AppEvent):
+    '''
+    A domain event to add a new application interface configuration via the AppService.
+    '''
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'name', 'module_path', 'class_name'])
@@ -75,6 +82,12 @@ class AddAppInterface(DomainEvent):
         :rtype: AppInterface
         '''
 
+        # Coerce optional arguments that argparse may pass as None to their defaults.
+        logger_id = logger_id or 'default'
+        flags = flags or ['default']
+        services = services or []
+        constants = constants or {}
+
         # Collect the app interface data.
         app_interface_data = {
             'id': id,
@@ -98,46 +111,19 @@ class AddAppInterface(DomainEvent):
         return interface
 
 # ** event: get_app_interface
-class GetAppInterface(DomainEvent):
+class GetAppInterface(AppEvent):
     '''
     A domain event to retrieve an app interface using the ``AppService`` abstraction.
     '''
 
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the GetAppInterface event.
-
-        :param app_service: The app service used to retrieve interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
-
     # * method: execute
     @DomainEvent.parameters_required(['interface_id'])
-    def execute(
-            self,
-            interface_id: str,
-            default_services: List[AppServiceDependency] | None = None,
-            default_constants: Dict[str, str] | None = None,
-            **kwargs,
-        ) -> AppInterface:
+    def execute(self, interface_id: str, **kwargs) -> AppInterface:
         '''
         Execute the event to load the application interface.
 
         :param interface_id: The ID of the application interface to load.
         :type interface_id: str
-        :param default_services: A list of AppServiceDependency objects to merge
-            into the interface for any service_id not already present.
-        :type default_services: List[AppServiceDependency] | None
-        :param default_constants: A mapping of default constants to merge into the
-            interface for any key not already present.
-        :type default_constants: Dict[str, str] | None
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The loaded application interface.
@@ -156,64 +142,14 @@ class GetAppInterface(DomainEvent):
                 interface_id=interface_id,
             )
 
-        # Ensure the interface is mutable before applying service/constant merges.
-        if not isinstance(interface, AppInterfaceAggregate):
-            interface = AppInterfaceAggregate(**interface.model_dump())
-
-        # Merge default services into the interface for any service_id not already present.
-        if default_services:
-
-            # Build a set of existing service_ids for lookup.
-            existing_ids = {dep.service_id for dep in interface.services}
-
-            # Add any default service whose service_id is not already present.
-            for dep in default_services:
-                if dep.service_id not in existing_ids:
-                    interface.add_service(
-                        service_id=dep.service_id,
-                        module_path=dep.module_path,
-                        class_name=dep.class_name,
-                        parameters=dep.parameters,
-                    )
-                    existing_ids.add(dep.service_id)
-
-        # Merge default constants only for keys that do not already exist.
-        if default_constants:
-
-            # Create a set of missing constants that are not already defined.
-            missing_constants = {
-                key: value
-                for key, value in default_constants.items()
-                if key not in interface.constants
-            }
-
-            # Apply only missing constants, preserving user-defined constants.
-            if missing_constants:
-                interface.set_constants(missing_constants)
-
         # Return the loaded application interface.
         return interface
 
 # ** event: update_app_interface
-class UpdateAppInterface(DomainEvent):
+class UpdateAppInterface(AppEvent):
     '''
     A domain event to update scalar attributes of an existing app interface.
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the UpdateAppInterface command.
-
-        :param app_service: The app service used to manage app interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'attribute'])
@@ -254,25 +190,10 @@ class UpdateAppInterface(DomainEvent):
         return id
 
 # ** event: set_app_constants
-class SetAppConstants(DomainEvent):
+class SetAppConstants(AppEvent):
     '''
     A domain event to set or clear constants on an app interface.
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the SetAppConstants command.
-
-        :param app_service: The app service used to manage app interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])
@@ -316,25 +237,10 @@ class SetAppConstants(DomainEvent):
         return id
 
 # ** event: list_app_interfaces
-class ListAppInterfaces(DomainEvent):
+class ListAppInterfaces(AppEvent):
     '''
     A domain event to list all configured app interfaces.
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the ListAppInterfaces command.
-
-        :param app_service: The app service to use.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     def execute(self, **kwargs) -> List[AppInterface]:
@@ -350,27 +256,11 @@ class ListAppInterfaces(DomainEvent):
         # Delegate to the app service to retrieve all interfaces.
         return self.app_service.list()
 
-
 # ** event: set_service_dependency
-class SetServiceDependency(DomainEvent):
+class SetServiceDependency(AppEvent):
     '''
     A domain event to set or update a service dependency on an app interface.
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the SetServiceDependency command.
-
-        :param app_service: The app service used to manage app interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'service_id', 'module_path', 'class_name'])
@@ -428,25 +318,10 @@ class SetServiceDependency(DomainEvent):
         return id
 
 # ** event: remove_service_dependency
-class RemoveServiceDependency(DomainEvent):
+class RemoveServiceDependency(AppEvent):
     '''
     A domain event to remove a service dependency from an app interface (idempotent).
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the RemoveServiceDependency command.
-
-        :param app_service: The app service used to manage app interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'service_id'])
@@ -485,25 +360,10 @@ class RemoveServiceDependency(DomainEvent):
         return id
 
 # ** event: remove_app_interface
-class RemoveAppInterface(DomainEvent):
+class RemoveAppInterface(AppEvent):
     '''
     A domain event to remove an entire app interface configuration by ID (idempotent).
     '''
-
-    # * attribute: app_service
-    app_service: AppService
-
-    # * init
-    def __init__(self, app_service: AppService) -> None:
-        '''
-        Initialize the RemoveAppInterface command.
-
-        :param app_service: The app service used to manage app interfaces.
-        :type app_service: AppService
-        '''
-
-        # Set the app service dependency.
-        self.app_service = app_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])

--- a/tiferet/events/cli.py
+++ b/tiferet/events/cli.py
@@ -13,10 +13,10 @@ from ..mappers import CliCommandAggregate
 
 # *** events
 
-# ** event: list_cli_commands
-class ListCliCommands(DomainEvent):
+# ** event: cli_event
+class CliEvent(DomainEvent):
     '''
-    A domain event to list all CLI commands.
+    Base event providing the shared CliService dependency for CLI domain events.
     '''
 
     # * attribute: cli_service
@@ -25,14 +25,20 @@ class ListCliCommands(DomainEvent):
     # * init
     def __init__(self, cli_service: CliService):
         '''
-        Initialize the ListCliCommands event.
+        Initialize the CLI event with its shared service dependency.
 
-        :param cli_service: The CLI service.
+        :param cli_service: The CLI service shared across CLI events.
         :type cli_service: CliService
         '''
 
         # Set the CLI service dependency.
         self.cli_service = cli_service
+
+# ** event: list_cli_commands
+class ListCliCommands(CliEvent):
+    '''
+    A domain event to list all CLI commands.
+    '''
 
     # * method: execute
     def execute(self, **kwargs) -> List[CliCommand]:
@@ -48,27 +54,11 @@ class ListCliCommands(DomainEvent):
         # Delegate to the CLI service.
         return self.cli_service.list()
 
-
 # ** event: get_parent_arguments
-class GetParentArguments(DomainEvent):
+class GetParentArguments(CliEvent):
     '''
     A domain event to retrieve parent-level CLI arguments.
     '''
-
-    # * attribute: cli_service
-    cli_service: CliService
-
-    # * init
-    def __init__(self, cli_service: CliService):
-        '''
-        Initialize the GetParentArguments event.
-
-        :param cli_service: The CLI service.
-        :type cli_service: CliService
-        '''
-
-        # Set the CLI service dependency.
-        self.cli_service = cli_service
 
     # * method: execute
     def execute(self, **kwargs) -> List:
@@ -85,25 +75,10 @@ class GetParentArguments(DomainEvent):
         return self.cli_service.get_parent_arguments()
 
 # ** event: add_cli_command
-class AddCliCommand(DomainEvent):
+class AddCliCommand(CliEvent):
     '''
     A domain event to add a new CLI command.
     '''
-
-    # * attribute: cli_service
-    cli_service: CliService
-
-    # * init
-    def __init__(self, cli_service: CliService):
-        '''
-        Initialize the AddCliCommand event.
-
-        :param cli_service: The CLI service.
-        :type cli_service: CliService
-        '''
-
-        # Set the CLI service dependency.
-        self.cli_service = cli_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])
@@ -143,6 +118,9 @@ class AddCliCommand(DomainEvent):
             id=id,
         )
 
+        # Coerce arguments that argparse may pass as None to an empty list.
+        arguments = arguments or []
+
         # Create CLI command aggregate.
         command = CliCommandAggregate(
             id=id,
@@ -157,27 +135,11 @@ class AddCliCommand(DomainEvent):
         self.cli_service.save(command)
         return command
 
-
 # ** event: add_cli_argument
-class AddCliArgument(DomainEvent):
+class AddCliArgument(CliEvent):
     '''
     A domain event to add an argument to an existing CLI command.
     '''
-
-    # * attribute: cli_service
-    cli_service: CliService
-
-    # * init
-    def __init__(self, cli_service: CliService):
-        '''
-        Initialize the AddCliArgument event.
-
-        :param cli_service: The CLI service.
-        :type cli_service: CliService
-        '''
-
-        # Set the CLI service dependency.
-        self.cli_service = cli_service
 
     # * method: execute
     @DomainEvent.parameters_required(['command_id'])

--- a/tiferet/events/feature.py
+++ b/tiferet/events/feature.py
@@ -3,7 +3,7 @@
 # *** imports
 
 # ** core
-from typing import List, Any
+from typing import Any, Dict, List
 
 # ** app
 from ..domain import Feature
@@ -13,10 +13,10 @@ from .settings import DomainEvent, a
 
 # *** events
 
-# ** event: add_feature
-class AddFeature(DomainEvent):
+# ** event: feature_event
+class FeatureEvent(DomainEvent):
     '''
-    Event to add a new feature configuration.
+    Base event providing the shared FeatureService dependency for feature domain events.
     '''
 
     # * attribute: feature_service
@@ -25,14 +25,20 @@ class AddFeature(DomainEvent):
     # * init
     def __init__(self, feature_service: FeatureService):
         '''
-        Initialize the AddFeature event.
+        Initialize the feature event with its shared service dependency.
 
-        :param feature_service: The feature service to use for managing feature configurations.
+        :param feature_service: The feature service shared across feature events.
         :type feature_service: FeatureService
         '''
 
         # Set the feature service dependency.
         self.feature_service = feature_service
+
+# ** event: add_feature
+class AddFeature(FeatureEvent):
+    '''
+    Event to add a new feature configuration.
+    '''
 
     # * method: execute
     @DomainEvent.parameters_required(['name', 'group_id'])
@@ -70,7 +76,8 @@ class AddFeature(DomainEvent):
         :rtype: Feature
         '''
 
-        # Create feature using the aggregate factory.
+        # Create feature using the aggregate factory. Contextual pipeline kwargs
+        # are intentionally not forwarded because FeatureAggregate forbids unknown fields.
         feature = FeatureAggregate(
             name=name,
             group_id=group_id,
@@ -79,7 +86,6 @@ class AddFeature(DomainEvent):
             description=description,
             steps=steps or [],
             log_params=log_params or {},
-            **kwargs,
         )
 
         # Check for duplicate feature identifier.
@@ -97,42 +103,31 @@ class AddFeature(DomainEvent):
         return feature
 
 # ** event: get_feature
-class GetFeature(DomainEvent):
+class GetFeature(FeatureEvent):
     '''
     Event to retrieve a feature by its identifier.
     '''
 
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService):
-        '''
-        Initialize the GetFeature event.
-
-        :param feature_service: The feature service to use for retrieving features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
-
     # * method: execute
     @DomainEvent.parameters_required(['id'])
-    def execute(self, id: str, **kwargs) -> Feature:
+    def execute(self, id: str, default_feature_index: Dict[str, Feature] = {}, **kwargs) -> Feature:
         '''
         Retrieve a feature by ID.
 
         :param id: The feature identifier.
         :type id: str
+        :param default_feature_index: Optional mapping of feature ID to a default Feature,
+            consulted when the repository lookup misses.
+        :type default_feature_index: Dict[str, Feature]
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The retrieved feature.
         :rtype: Feature
         '''
 
-        # Retrieve the feature from the feature service.
-        feature = self.feature_service.get(id)
+        # Retrieve the feature from the feature service, falling back to the
+        # supplied default feature index when the repository lookup misses.
+        feature = self.feature_service.get(id) or (default_feature_index or {}).get(id)
 
         # Verify that the feature exists; raise FEATURE_NOT_FOUND if it does not.
         self.verify(
@@ -145,25 +140,10 @@ class GetFeature(DomainEvent):
         return feature
 
 # ** event: list_features
-class ListFeatures(DomainEvent):
+class ListFeatures(FeatureEvent):
     '''
     Event to list feature configurations.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService):
-        '''
-        Initialize the ListFeatures event.
-
-        :param feature_service: The feature service to use for listing features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     def execute(self, group_id: str | None = None, **kwargs) -> List[Feature]:
@@ -182,7 +162,7 @@ class ListFeatures(DomainEvent):
         return self.feature_service.list(group_id=group_id)
 
 # ** event: remove_feature
-class RemoveFeature(DomainEvent):
+class RemoveFeature(FeatureEvent):
     '''
     Event to remove an entire feature configuration by ID (idempotent).
 
@@ -190,21 +170,6 @@ class RemoveFeature(DomainEvent):
     ``FeatureService.delete`` implementation, which is expected to behave
     idempotently when the feature does not exist.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService):
-        '''
-        Initialize the RemoveFeature event.
-
-        :param feature_service: The feature service to use.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])
@@ -228,29 +193,13 @@ class RemoveFeature(DomainEvent):
         return id
 
 # ** event: update_feature
-class UpdateFeature(DomainEvent):
+class UpdateFeature(FeatureEvent):
     '''
     Event to update basic metadata of an existing feature.
 
     Supports updating the ``name`` or ``description`` attributes using the
     Feature model helpers.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService) -> None:
-        '''
-        Initialize the UpdateFeature event.
-
-        :param feature_service: The feature service used to retrieve and
-            persist features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'attribute'])
@@ -316,25 +265,10 @@ class UpdateFeature(DomainEvent):
         return feature
 
 # ** event: add_feature_step
-class AddFeatureStep(DomainEvent):
+class AddFeatureStep(FeatureEvent):
     '''
     Event to add a step to an existing feature.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService):
-        '''
-        Initialize the AddFeatureStep event.
-
-        :param feature_service: The feature service to use.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'name', 'service_id'])
@@ -398,30 +332,14 @@ class AddFeatureStep(DomainEvent):
         return id
 
 # ** event: update_feature_step
-class UpdateFeatureStep(DomainEvent):
+class UpdateFeatureStep(FeatureEvent):
     '''
     Event to update an existing feature step within a feature workflow.
 
-    This event supports updating the following attributes on a
-    ``FeatureEvent`` instance: ``name``, ``service_id``, ``data_key``,
+    This event supports updating the following attributes on an
+    ``EventFeatureStep`` instance: ``name``, ``service_id``, ``data_key``,
     ``pass_on_error``, and ``parameters``.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService) -> None:
-        '''
-        Initialize the UpdateFeatureStep event.
-
-        :param feature_service: The feature service used to retrieve and
-            persist features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'position', 'attribute'])
@@ -516,7 +434,7 @@ class UpdateFeatureStep(DomainEvent):
             position=position,
         )
 
-        # Apply the attribute update using the FeatureEvent helper.
+        # Apply the attribute update using the EventFeatureStep helper.
         step.set_attribute(attribute, value)
 
         # Persist the updated feature.
@@ -526,29 +444,13 @@ class UpdateFeatureStep(DomainEvent):
         return id
 
 # ** event: remove_feature_step
-class RemoveFeatureStep(DomainEvent):
+class RemoveFeatureStep(FeatureEvent):
     '''
     Event to remove a step from an existing feature by position.
 
     This event is idempotent: invalid positions result in silent success
     with no mutation to the feature's step list.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService) -> None:
-        '''
-        Initialize the RemoveFeatureStep event.
-
-        :param feature_service: The feature service to use for retrieving and
-            persisting features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'position'])
@@ -594,7 +496,7 @@ class RemoveFeatureStep(DomainEvent):
         return id
 
 # ** event: reorder_feature_step
-class ReorderFeatureStep(DomainEvent):
+class ReorderFeatureStep(FeatureEvent):
     '''
     Event to reorder an existing feature step within a feature workflow.
 
@@ -602,22 +504,6 @@ class ReorderFeatureStep(DomainEvent):
     which clamps the target position and behaves idempotently for invalid
     start positions.
     '''
-
-    # * attribute: feature_service
-    feature_service: FeatureService
-
-    # * init
-    def __init__(self, feature_service: FeatureService) -> None:
-        '''
-        Initialize the ReorderFeatureStep event.
-
-        :param feature_service: The feature service used to retrieve and
-            persist features.
-        :type feature_service: FeatureService
-        '''
-
-        # Set the feature service dependency.
-        self.feature_service = feature_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'start_position', 'end_position'])


### PR DESCRIPTION
## Summary
Implements TRD #864 — per-module base events for the feature, app, and CLI event modules, plus the event/repository fallback-boundary shift.

### Functional (`tiferet/events/`)
- **Base events**: add `FeatureEvent`, `AppEvent`, `CliEvent` (shared service attribute + `__init__`); reparent all 21 concrete events and remove their redundant per-event attribute/`__init__`.
- **`GetAppInterface`**: remove `default_services`/`default_constants` params and merge logic — repository-only lookup raising `APP_INTERFACE_NOT_FOUND`; drop the now-unused `AppServiceDependency` import.
- **`GetFeature`**: add execute-time `default_feature_index: Dict[str, Feature]` fallback consulted on a repository miss.
- **`AddFeature`**: no longer forwards contextual `**kwargs` into `FeatureAggregate` (which forbids unknown fields).
- **`AddAppInterface` / `AddCliCommand`**: coerce `None` argparse values to their defaults.
- **`UpdateFeatureStep`**: docstring/comment terminology → `EventFeatureStep`.

### Tests (`tests/events/`)
- Relocate `test_feature.py`, `test_app.py`, `test_cli.py` via `git mv`; switch to the `tiferet.testing` harness with absolute imports.
- Add base-event coverage, `GetFeature` fallback coverage, `GetAppInterface` repository-only coverage (removing the obsolete default-merge tests), and coercion / no-kwargs-forwarding coverage.

## Validation
- `pytest tests/events` → **273 passed, 8 skipped**
- `pytest tests/` → **673 passed, 8 skipped** (no regressions)

## Joint-landing note (TRD §6)
The `GetAppInterface` fallback removal and `GetFeature.default_feature_index` must land jointly with the companion contexts/blueprint work that moves the default-merge to the context layer. `tiferet/blueprints/{main,cli}.py` still pass `default_services`/`default_constants`; these now pass harmlessly through `**kwargs` (no `TypeError`), but the merge will not take effect until that companion lands.

## Scope
No interface/mapper/domain/repo/constant signatures changed; `tiferet/events/__init__.py` exports are untouched; no new error constants.

Resolves #864.

Conversation: https://app.warp.dev/conversation/dc9ff6a7-b3f7-4485-a590-633e88130633

Co-Authored-By: Oz <oz-agent@warp.dev>