### PR TITLE
Events – DI: Service Registration Events and merge_settings (#862)

### DIFF
--- a/tests/events/test_di.py
+++ b/tests/events/test_di.py
@@ -822,6 +822,24 @@ class TestSetServiceConstants(DomainEventTestBase):
         assert result == {'existing': 'old'}
         mock_dependencies['di_service'].save_constants.assert_called_once_with({'existing': 'old'})
 
+    # * method: test_omitted_is_noop
+    def test_omitted_is_noop(self, mock_dependencies):
+        '''
+        Test that omitting the constants argument preserves existing
+        constants (the sentinel default is a no-op on omit, distinct from
+        an explicit None which clears all).
+        '''
+
+        # Execute without passing the constants argument at all.
+        result = DomainEvent.handle(
+            SetServiceConstants,
+            dependencies=mock_dependencies,
+        )
+
+        # Assert existing constants are returned and persisted unchanged.
+        assert result == {'existing': 'old'}
+        mock_dependencies['di_service'].save_constants.assert_called_once_with({'existing': 'old'})
+
 
 # ** test: TestListAllSettings
 class TestListAllSettings(DomainEventTestBase):

--- a/tests/events/test_di.py
+++ b/tests/events/test_di.py
@@ -2,31 +2,29 @@
 
 # *** imports
 
-# ** core
-from typing import Tuple, Dict, Any, List
-
 # ** infra
 import pytest
 from unittest import mock
 
 # ** app
-from ..di import (
-    AddServiceConfiguration,
-    SetDefaultServiceConfiguration,
+from tiferet.events.di import (
+    DIEvent,
+    AddServiceRegistration,
+    SetDefaultServiceRegistration,
     SetServiceDependency,
     RemoveServiceDependency,
-    RemoveServiceConfiguration,
+    RemoveServiceRegistration,
     SetServiceConstants,
     ListAllSettings,
 )
-from ..settings import DomainEvent, TiferetError, a
-from ...domain.di import ServiceConfiguration, FlaggedDependency
-from ...mappers.di import (
-    ServiceConfigurationAggregate,
+from tiferet.events.settings import DomainEvent, TiferetError, a
+from tiferet.domain.di import ServiceRegistration, FlaggedDependency
+from tiferet.mappers.di import (
+    ServiceRegistrationAggregate,
     FlaggedDependencyAggregate,
 )
-from ...interfaces.di import DIService
-from .settings import DomainEventTestBase, ServiceEventTestBase
+from tiferet.interfaces.di import DIService
+from tiferet.testing import DomainEventTestBase, ServiceEventTestBase
 
 # *** fixtures
 
@@ -51,20 +49,20 @@ def flagged_dependency_for_di() -> FlaggedDependency:
         },
     )
 
-# ** fixture: service_configuration_aggregate
+# ** fixture: service_registration_aggregate
 @pytest.fixture
-def service_configuration_aggregate(flagged_dependency_for_di) -> ServiceConfigurationAggregate:
+def service_registration_aggregate(flagged_dependency_for_di) -> ServiceRegistrationAggregate:
     '''
-    A service configuration aggregate for DI event tests.
+    A service registration aggregate for DI event tests.
 
     :param flagged_dependency_for_di: The flagged dependency fixture.
     :type flagged_dependency_for_di: FlaggedDependency
-    :return: A ServiceConfigurationAggregate instance.
-    :rtype: ServiceConfigurationAggregate
+    :return: A ServiceRegistrationAggregate instance.
+    :rtype: ServiceRegistrationAggregate
     '''
 
-    # Create a service configuration aggregate with a default type and one dependency.
-    return ServiceConfigurationAggregate(
+    # Create a service registration aggregate with a default type and one dependency.
+    return ServiceRegistrationAggregate(
         id='svc_test',
         module_path='tiferet.repos.example',
         class_name='ExampleRepository',
@@ -74,14 +72,61 @@ def service_configuration_aggregate(flagged_dependency_for_di) -> ServiceConfigu
 
 # *** tests
 
-# ** test: TestAddServiceConfiguration
-class TestAddServiceConfiguration(DomainEventTestBase):
+# ** class: TestDIEvent
+class TestDIEvent:
     '''
-    Tests for AddServiceConfiguration using the domain event test harness.
+    Tests for the DIEvent base event shared by all DI events.
+    '''
+
+    # * method: test_base_extends_domain_event
+    def test_base_extends_domain_event(self):
+        '''
+        Test that DIEvent extends DomainEvent.
+        '''
+
+        # Assert the base event extends DomainEvent.
+        assert issubclass(DIEvent, DomainEvent)
+
+    # * method: test_concrete_events_extend_base
+    def test_concrete_events_extend_base(self):
+        '''
+        Test that every concrete DI event extends DIEvent.
+        '''
+
+        # Assert each concrete event extends the module base.
+        for event_cls in (
+            AddServiceRegistration,
+            SetDefaultServiceRegistration,
+            SetServiceDependency,
+            RemoveServiceDependency,
+            RemoveServiceRegistration,
+            SetServiceConstants,
+            ListAllSettings,
+        ):
+            assert issubclass(event_cls, DIEvent)
+
+    # * method: test_service_injection
+    def test_service_injection(self):
+        '''
+        Test that constructing a DI event wires the shared service attribute.
+        '''
+
+        # Create a mock DI service.
+        service = mock.Mock(spec=DIService)
+
+        # Assert the base and a concrete event both expose the injected service.
+        assert DIEvent(di_service=service).di_service is service
+        assert AddServiceRegistration(di_service=service).di_service is service
+
+
+# ** test: TestAddServiceRegistration
+class TestAddServiceRegistration(DomainEventTestBase):
+    '''
+    Tests for AddServiceRegistration using the domain event test harness.
     '''
 
     # * attribute: event_cls
-    event_cls = AddServiceConfiguration
+    event_cls = AddServiceRegistration
 
     # * attribute: dependencies
     dependencies = {'di_service': DIService}
@@ -102,25 +147,25 @@ class TestAddServiceConfiguration(DomainEventTestBase):
     @pytest.fixture
     def mock_dependencies(self) -> dict:
         '''
-        Override to pre-configure configuration_exists to return False.
+        Override to pre-configure registration_exists to return False.
         '''
 
         # Create the mock DI service.
         service = mock.Mock(spec=DIService)
-        service.configuration_exists.return_value = False
+        service.registration_exists.return_value = False
         return {'di_service': service}
 
     # * method: test_default_type_only
     def test_default_type_only(self, mock_dependencies):
         '''
-        Test adding a configuration with only a default type.
+        Test adding a registration with only a default type.
         '''
 
         # Execute via the harness handle helper.
         result = self.handle(mock_dependencies)
 
-        # Assert the result is a ServiceConfiguration instance.
-        assert isinstance(result, ServiceConfiguration)
+        # Assert the result is a ServiceRegistration instance.
+        assert isinstance(result, ServiceRegistration)
         assert result.id == 'svc_new'
         assert result.module_path == 'tiferet.repos.example'
         assert result.class_name == 'ExampleRepository'
@@ -128,13 +173,13 @@ class TestAddServiceConfiguration(DomainEventTestBase):
         assert result.dependencies == []
 
         # Assert the service was called to check existence and save.
-        mock_dependencies['di_service'].configuration_exists.assert_called_once_with('svc_new')
-        mock_dependencies['di_service'].save_configuration.assert_called_once_with(result)
+        mock_dependencies['di_service'].registration_exists.assert_called_once_with('svc_new')
+        mock_dependencies['di_service'].save_registration.assert_called_once_with(result)
 
     # * method: test_dependencies_only
     def test_dependencies_only(self, mock_dependencies):
         '''
-        Test adding a configuration with only flagged dependencies.
+        Test adding a registration with only flagged dependencies.
         '''
 
         # Execute via the harness with flagged_dependencies and no default type.
@@ -153,8 +198,8 @@ class TestAddServiceConfiguration(DomainEventTestBase):
             ],
         )
 
-        # Assert the configuration was created with dependencies.
-        assert isinstance(result, ServiceConfiguration)
+        # Assert the registration was created with dependencies.
+        assert isinstance(result, ServiceRegistration)
         assert result.id == 'svc_new'
         assert result.module_path is None
         assert result.class_name is None
@@ -168,7 +213,7 @@ class TestAddServiceConfiguration(DomainEventTestBase):
     # * method: test_default_and_dependencies
     def test_default_and_dependencies(self, mock_dependencies):
         '''
-        Test adding a configuration with both a default type and dependencies.
+        Test adding a registration with both a default type and dependencies.
         '''
 
         # Execute via the harness with both default type and flagged_dependencies.
@@ -193,22 +238,22 @@ class TestAddServiceConfiguration(DomainEventTestBase):
     # * method: test_duplicate_id
     def test_duplicate_id(self, mock_dependencies):
         '''
-        Test that adding a configuration with an existing ID raises an error.
+        Test that adding a registration with an existing ID raises an error.
         '''
 
         # Configure the service to report the ID already exists.
-        mock_dependencies['di_service'].configuration_exists.return_value = True
+        mock_dependencies['di_service'].registration_exists.return_value = True
 
-        # Execute and expect a CONFIGURATION_ALREADY_EXISTS error.
+        # Execute and expect a SERVICE_REGISTRATION_ALREADY_EXISTS error.
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies)
 
-        assert exc_info.value.error_code == a.const.CONFIGURATION_ALREADY_EXISTS_ID
+        assert exc_info.value.error_code == a.const.SERVICE_REGISTRATION_ALREADY_EXISTS_ID
 
     # * method: test_no_type_source
     def test_no_type_source(self, mock_dependencies):
         '''
-        Test that adding a configuration with no default type and no dependencies fails.
+        Test that adding a registration with no default type and no dependencies fails.
         '''
 
         # Execute with neither default type nor flagged dependencies.
@@ -220,17 +265,17 @@ class TestAddServiceConfiguration(DomainEventTestBase):
                 flagged_dependencies=[],
             )
 
-        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_REGISTRATION_ID
 
 
-# ** test: TestSetDefaultServiceConfiguration
-class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
+# ** test: TestSetDefaultServiceRegistration
+class TestSetDefaultServiceRegistration(ServiceEventTestBase):
     '''
-    Tests for SetDefaultServiceConfiguration using the domain event test harness.
+    Tests for SetDefaultServiceRegistration using the domain event test harness.
     '''
 
     # * attribute: event_cls
-    event_cls = SetDefaultServiceConfiguration
+    event_cls = SetDefaultServiceRegistration
 
     # * attribute: dependencies
     dependencies = {'di_service': DIService}
@@ -247,7 +292,7 @@ class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
     )
 
     # * attribute: not_found_error_code
-    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+    not_found_error_code = a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
     # * attribute: not_found_kwargs
     not_found_kwargs = dict(
@@ -258,18 +303,18 @@ class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
 
     # * fixture: mock_dependencies
     @pytest.fixture
-    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+    def mock_dependencies(self, service_registration_aggregate) -> dict:
         '''
-        Override to pre-configure get_configuration to return the fixture.
+        Override to pre-configure get_registration to return the fixture.
         '''
 
         # Create the mock DI service.
         service = mock.Mock(spec=DIService)
-        service.get_configuration.return_value = service_configuration_aggregate
+        service.get_registration.return_value = service_registration_aggregate
         return {'di_service': service}
 
     # * method: test_full_update
-    def test_full_update(self, mock_dependencies, service_configuration_aggregate):
+    def test_full_update(self, mock_dependencies, service_registration_aggregate):
         '''
         Test updating both default type and parameters.
         '''
@@ -277,17 +322,17 @@ class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
         # Execute via the harness handle helper.
         result = self.handle(mock_dependencies)
 
-        # Assert the configuration was updated.
-        assert result is service_configuration_aggregate
+        # Assert the registration was updated.
+        assert result is service_registration_aggregate
         assert result.module_path == 'new.module'
         assert result.class_name == 'NewClass'
         assert result.parameters == {'param': 'value'}
 
         # Assert the service was called to save.
-        mock_dependencies['di_service'].save_configuration.assert_called_once_with(result)
+        mock_dependencies['di_service'].save_registration.assert_called_once_with(result)
 
     # * method: test_parameters_only
-    def test_parameters_only(self, mock_dependencies, service_configuration_aggregate):
+    def test_parameters_only(self, mock_dependencies, service_registration_aggregate):
         '''
         Test updating only parameters when module_path and class_name are not provided.
         '''
@@ -307,7 +352,7 @@ class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
         assert result.parameters == {'param_1': 'updated'}
 
     # * method: test_clear_parameters
-    def test_clear_parameters(self, mock_dependencies, service_configuration_aggregate):
+    def test_clear_parameters(self, mock_dependencies, service_registration_aggregate):
         '''
         Test clearing parameters when parameters is None.
         '''
@@ -339,23 +384,23 @@ class TestSetDefaultServiceConfiguration(ServiceEventTestBase):
                 parameters={'param': 'value'},
             )
 
-        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_REGISTRATION_ID
 
     # * method: test_not_found
     def test_not_found(self, mock_dependencies):
         '''
-        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        Test that the event raises SERVICE_REGISTRATION_NOT_FOUND when
         the DI service returns None.
         '''
 
         # Configure the service mock to return None.
-        mock_dependencies['di_service'].get_configuration.return_value = None
+        mock_dependencies['di_service'].get_registration.return_value = None
 
         # Execute and expect the not-found error.
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, **self.not_found_kwargs)
 
-        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+        assert exc_info.value.error_code == a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
 
 # ** test: TestSetServiceDependency
@@ -386,7 +431,7 @@ class TestSetServiceDependency(ServiceEventTestBase):
     required_params = ['flag']
 
     # * attribute: not_found_error_code
-    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+    not_found_error_code = a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
     # * attribute: not_found_kwargs
     not_found_kwargs = dict(
@@ -398,41 +443,41 @@ class TestSetServiceDependency(ServiceEventTestBase):
 
     # * fixture: mock_dependencies
     @pytest.fixture
-    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+    def mock_dependencies(self, service_registration_aggregate) -> dict:
         '''
-        Override to pre-configure get_configuration to return the fixture.
+        Override to pre-configure get_registration to return the fixture.
         '''
 
         # Create the mock DI service.
         service = mock.Mock(spec=DIService)
-        service.get_configuration.return_value = service_configuration_aggregate
+        service.get_registration.return_value = service_registration_aggregate
         return {'di_service': service}
 
     # * method: test_add_new
-    def test_add_new(self, mock_dependencies, service_configuration_aggregate):
+    def test_add_new(self, mock_dependencies, service_registration_aggregate):
         '''
         Test adding a new flagged dependency when the flag does not yet exist.
         '''
 
         # Remove existing dependencies to test adding a fresh one.
-        service_configuration_aggregate.dependencies = []
+        service_registration_aggregate.dependencies = []
 
         # Execute via the harness handle helper.
         result = self.handle(mock_dependencies)
 
         # Assert the dependency was added.
         assert result == 'svc_test'
-        dep = service_configuration_aggregate.get_dependency('alpha')
+        dep = service_registration_aggregate.get_dependency('alpha')
         assert dep is not None
         assert dep.module_path == 'tiferet.repos.example'
         assert dep.class_name == 'ExampleAlpha'
         assert dep.parameters == {'param': 'value'}
 
         # Assert save was called.
-        mock_dependencies['di_service'].save_configuration.assert_called_once()
+        mock_dependencies['di_service'].save_registration.assert_called_once()
 
     # * method: test_update_existing
-    def test_update_existing(self, mock_dependencies, service_configuration_aggregate):
+    def test_update_existing(self, mock_dependencies, service_registration_aggregate):
         '''
         Test updating an existing flagged dependency.
         '''
@@ -448,7 +493,7 @@ class TestSetServiceDependency(ServiceEventTestBase):
 
         # Assert the dependency was updated.
         assert result == 'svc_test'
-        dep = service_configuration_aggregate.get_dependency('test_alpha')
+        dep = service_registration_aggregate.get_dependency('test_alpha')
         assert dep.module_path == 'tiferet.repos.updated'
         assert dep.class_name == 'UpdatedAlpha'
         # Parameters should be cleaned (None removed) and merged.
@@ -477,18 +522,18 @@ class TestSetServiceDependency(ServiceEventTestBase):
     # * method: test_not_found
     def test_not_found(self, mock_dependencies):
         '''
-        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        Test that the event raises SERVICE_REGISTRATION_NOT_FOUND when
         the DI service returns None.
         '''
 
         # Configure the service mock to return None.
-        mock_dependencies['di_service'].get_configuration.return_value = None
+        mock_dependencies['di_service'].get_registration.return_value = None
 
         # Execute and expect the not-found error.
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, **self.not_found_kwargs)
 
-        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+        assert exc_info.value.error_code == a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
 
 # ** test: TestRemoveServiceDependency
@@ -516,7 +561,7 @@ class TestRemoveServiceDependency(ServiceEventTestBase):
     required_params = ['flag']
 
     # * attribute: not_found_error_code
-    not_found_error_code = a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+    not_found_error_code = a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
     # * attribute: not_found_kwargs
     not_found_kwargs = dict(
@@ -526,18 +571,18 @@ class TestRemoveServiceDependency(ServiceEventTestBase):
 
     # * fixture: mock_dependencies
     @pytest.fixture
-    def mock_dependencies(self, service_configuration_aggregate) -> dict:
+    def mock_dependencies(self, service_registration_aggregate) -> dict:
         '''
-        Override to pre-configure get_configuration to return the fixture.
+        Override to pre-configure get_registration to return the fixture.
         '''
 
         # Create the mock DI service.
         service = mock.Mock(spec=DIService)
-        service.get_configuration.return_value = service_configuration_aggregate
+        service.get_registration.return_value = service_registration_aggregate
         return {'di_service': service}
 
     # * method: test_success_with_remaining_default
-    def test_success_with_remaining_default(self, mock_dependencies, service_configuration_aggregate):
+    def test_success_with_remaining_default(self, mock_dependencies, service_registration_aggregate):
         '''
         Test removing a dependency while a default type remains configured.
         '''
@@ -547,15 +592,15 @@ class TestRemoveServiceDependency(ServiceEventTestBase):
 
         # Assert the dependency was removed but default type remains.
         assert result == 'svc_test'
-        assert service_configuration_aggregate.get_dependency('test_alpha') is None
-        assert service_configuration_aggregate.module_path == 'tiferet.repos.example'
-        assert service_configuration_aggregate.class_name == 'ExampleRepository'
+        assert service_registration_aggregate.get_dependency('test_alpha') is None
+        assert service_registration_aggregate.module_path == 'tiferet.repos.example'
+        assert service_registration_aggregate.class_name == 'ExampleRepository'
 
         # Assert save was called.
-        mock_dependencies['di_service'].save_configuration.assert_called_once()
+        mock_dependencies['di_service'].save_registration.assert_called_once()
 
     # * method: test_nonexistent_flag
-    def test_nonexistent_flag(self, mock_dependencies, service_configuration_aggregate):
+    def test_nonexistent_flag(self, mock_dependencies, service_registration_aggregate):
         '''
         Test removing a non-existent flag is idempotent when type sources remain.
         '''
@@ -565,54 +610,54 @@ class TestRemoveServiceDependency(ServiceEventTestBase):
 
         # Dependencies and default type remain unchanged.
         assert result == 'svc_test'
-        assert service_configuration_aggregate.get_dependency('test_alpha') is not None
-        assert service_configuration_aggregate.module_path == 'tiferet.repos.example'
+        assert service_registration_aggregate.get_dependency('test_alpha') is not None
+        assert service_registration_aggregate.module_path == 'tiferet.repos.example'
 
     # * method: test_invalid_after_removal
     def test_invalid_after_removal(self, mock_dependencies, flagged_dependency_for_di):
         '''
-        Test that removing the last type source raises INVALID_SERVICE_CONFIGURATION.
+        Test that removing the last type source raises INVALID_SERVICE_REGISTRATION.
         '''
 
-        # Create a configuration with only a dependency and no default type.
-        config = ServiceConfigurationAggregate(
+        # Create a registration with only a dependency and no default type.
+        config = ServiceRegistrationAggregate(
             id='svc_only_deps',
             dependencies=[flagged_dependency_for_di],
             parameters={},
         )
-        mock_dependencies['di_service'].get_configuration.return_value = config
+        mock_dependencies['di_service'].get_registration.return_value = config
 
-        # Execute and expect INVALID_SERVICE_CONFIGURATION.
+        # Execute and expect INVALID_SERVICE_REGISTRATION.
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, id='svc_only_deps', flag='test_alpha')
 
-        assert exc_info.value.error_code == a.const.INVALID_SERVICE_CONFIGURATION_ID
+        assert exc_info.value.error_code == a.const.INVALID_SERVICE_REGISTRATION_ID
 
     # * method: test_not_found
     def test_not_found(self, mock_dependencies):
         '''
-        Test that the event raises SERVICE_CONFIGURATION_NOT_FOUND when
+        Test that the event raises SERVICE_REGISTRATION_NOT_FOUND when
         the DI service returns None.
         '''
 
         # Configure the service mock to return None.
-        mock_dependencies['di_service'].get_configuration.return_value = None
+        mock_dependencies['di_service'].get_registration.return_value = None
 
         # Execute and expect the not-found error.
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, **self.not_found_kwargs)
 
-        assert exc_info.value.error_code == a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID
+        assert exc_info.value.error_code == a.const.SERVICE_REGISTRATION_NOT_FOUND_ID
 
 
-# ** test: TestRemoveServiceConfiguration
-class TestRemoveServiceConfiguration(DomainEventTestBase):
+# ** test: TestRemoveServiceRegistration
+class TestRemoveServiceRegistration(DomainEventTestBase):
     '''
-    Tests for RemoveServiceConfiguration using the domain event test harness.
+    Tests for RemoveServiceRegistration using the domain event test harness.
     '''
 
     # * attribute: event_cls
-    event_cls = RemoveServiceConfiguration
+    event_cls = RemoveServiceRegistration
 
     # * attribute: dependencies
     dependencies = {'di_service': DIService}
@@ -626,7 +671,7 @@ class TestRemoveServiceConfiguration(DomainEventTestBase):
     # * method: test_existing
     def test_existing(self, mock_dependencies):
         '''
-        Test removing an existing service configuration.
+        Test removing an existing service registration.
         '''
 
         # Execute via the harness handle helper.
@@ -634,12 +679,12 @@ class TestRemoveServiceConfiguration(DomainEventTestBase):
 
         # Assert the result is the deleted ID.
         assert result == 'svc_to_delete'
-        mock_dependencies['di_service'].delete_configuration.assert_called_once_with('svc_to_delete')
+        mock_dependencies['di_service'].delete_registration.assert_called_once_with('svc_to_delete')
 
     # * method: test_nonexistent_is_idempotent
     def test_nonexistent_is_idempotent(self, mock_dependencies):
         '''
-        Test that removing a non-existent configuration is idempotent.
+        Test that removing a non-existent registration is idempotent.
         '''
 
         # Execute with a non-existent ID.
@@ -647,7 +692,7 @@ class TestRemoveServiceConfiguration(DomainEventTestBase):
 
         # Assert the result is the ID and delete was called.
         assert result == 'missing_id'
-        mock_dependencies['di_service'].delete_configuration.assert_called_once_with('missing_id')
+        mock_dependencies['di_service'].delete_registration.assert_called_once_with('missing_id')
 
 
 # ** test: TestSetServiceConstants
@@ -794,13 +839,13 @@ class TestListAllSettings(DomainEventTestBase):
     sample_kwargs = dict()
 
     # * method: test_calls_list_all
-    def test_calls_list_all(self, mock_dependencies, service_configuration_aggregate):
+    def test_calls_list_all(self, mock_dependencies, service_registration_aggregate):
         '''
         Test that ListAllSettings delegates to the DI service list_all method.
         '''
 
-        # Configure the service to return a configuration and constants.
-        expected = ([service_configuration_aggregate], {'constant_1': 'value'})
+        # Configure the service to return a registration and constants.
+        expected = ([service_registration_aggregate], {'constant_1': 'value'})
         mock_dependencies['di_service'].list_all.return_value = expected
 
         # Execute via the harness handle helper.

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -121,20 +121,20 @@ CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
 # ** constant: cli_command_already_exists_id
 CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
 
-# ** constant: invalid_service_configuration_id
-INVALID_SERVICE_CONFIGURATION_ID = 'INVALID_SERVICE_CONFIGURATION'
+# ** constant: invalid_service_registration_id
+INVALID_SERVICE_REGISTRATION_ID = 'INVALID_SERVICE_REGISTRATION'
 
 # ** constant: attribute_already_exists_id
 ATTRIBUTE_ALREADY_EXISTS_ID = 'ATTRIBUTE_ALREADY_EXISTS'
 
-# ** constant: service_configuration_not_found_id
-SERVICE_CONFIGURATION_NOT_FOUND_ID = 'SERVICE_CONFIGURATION_NOT_FOUND'
+# ** constant: service_registration_not_found_id
+SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
 # ** constant: invalid_flagged_dependency_id
 INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
 
-# ** constant: configuration_already_exists_id
-CONFIGURATION_ALREADY_EXISTS_ID = 'CONFIGURATION_ALREADY_EXISTS'
+# ** constant: service_registration_already_exists_id
+SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
 
 # ** constant: invalid_dependency_error_id
 INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
@@ -522,15 +522,15 @@ DEFAULT_ERRORS = {
         ]
     },
 
-    # * error: INVALID_SERVICE_CONFIGURATION
-    INVALID_SERVICE_CONFIGURATION_ID: {
-        'id': INVALID_SERVICE_CONFIGURATION_ID,
-        'name': 'Invalid Service Configuration',
+    # * error: INVALID_SERVICE_REGISTRATION
+    INVALID_SERVICE_REGISTRATION_ID: {
+        'id': INVALID_SERVICE_REGISTRATION_ID,
+        'name': 'Invalid Service Registration',
         'message': [
             {
                 'lang': 'en_US',
                 'text': (
-                    'A container attribute must define either a default type '
+                    'A service registration must define either a default type '
                     '(module_path/class_name) or at least one flagged dependency.'
                 ),
             }
@@ -549,14 +549,14 @@ DEFAULT_ERRORS = {
         ],
     },
 
-    # * error: SERVICE_CONFIGURATION_NOT_FOUND
-    SERVICE_CONFIGURATION_NOT_FOUND_ID: {
-        'id': SERVICE_CONFIGURATION_NOT_FOUND_ID,
-        'name': 'Service Configuration Not Found',
+    # * error: SERVICE_REGISTRATION_NOT_FOUND
+    SERVICE_REGISTRATION_NOT_FOUND_ID: {
+        'id': SERVICE_REGISTRATION_NOT_FOUND_ID,
+        'name': 'Service Registration Not Found',
         'message': [
             {
                 'lang': 'en_US',
-                'text': 'Container attribute with ID {id} not found.',
+                'text': 'Service registration with ID {id} not found.',
             }
         ],
     },
@@ -573,14 +573,14 @@ DEFAULT_ERRORS = {
         ],
     },
 
-    # * error: CONFIGURATION_ALREADY_EXISTS
-    CONFIGURATION_ALREADY_EXISTS_ID: {
-        'id': CONFIGURATION_ALREADY_EXISTS_ID,
-        'name': 'Configuration Already Exists',
+    # * error: SERVICE_REGISTRATION_ALREADY_EXISTS
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: {
+        'id': SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+        'name': 'Service Registration Already Exists',
         'message': [
             {
                 'lang': 'en_US',
-                'text': 'A service configuration with ID {id} already exists.',
+                'text': 'A service registration with ID {id} already exists.',
             }
         ],
     },

--- a/tiferet/events/di.py
+++ b/tiferet/events/di.py
@@ -7,16 +7,16 @@ from typing import Tuple, List, Dict, Any, Optional
 
 # ** app
 from .settings import DomainEvent, a
-from ..domain.di import ServiceConfiguration
+from ..domain.di import ServiceRegistration
 from ..interfaces.di import DIService
-from ..mappers.di import ServiceConfigurationAggregate
+from ..mappers.di import ServiceRegistrationAggregate
 
 # *** events
 
-# ** event: add_service_configuration
-class AddServiceConfiguration(DomainEvent):
+# ** event: di_event
+class DIEvent(DomainEvent):
     '''
-    A domain event to add a new service configuration.
+    Base event providing the shared DIService dependency for DI domain events.
     '''
 
     # * attribute: di_service
@@ -25,14 +25,20 @@ class AddServiceConfiguration(DomainEvent):
     # * init
     def __init__(self, di_service: DIService):
         '''
-        Initialize the AddServiceConfiguration event.
+        Initialize the DI event with its shared service dependency.
 
-        :param di_service: The DI service.
+        :param di_service: The DI service shared across DI events.
         :type di_service: DIService
         '''
 
-        # Set the event attributes.
+        # Set the DI service dependency.
         self.di_service = di_service
+
+# ** event: add_service_registration
+class AddServiceRegistration(DIEvent):
+    '''
+    A domain event to add a new service registration.
+    '''
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])
@@ -44,9 +50,9 @@ class AddServiceConfiguration(DomainEvent):
         parameters: Optional[Dict[str, Any]] = {},
         flagged_dependencies: Optional[List[Dict[str, Any]]] = [],
         **kwargs,
-    ) -> ServiceConfiguration:
+    ) -> ServiceRegistration:
         '''
-        Add a new service configuration.
+        Add a new service registration.
 
         :param id: Required unique identifier.
         :type id: str
@@ -54,18 +60,22 @@ class AddServiceConfiguration(DomainEvent):
         :type module_path: str | None
         :param class_name: Optional default class name.
         :type class_name: str | None
-        :param parameters: Optional configuration parameters (default {}).
+        :param parameters: Optional registration parameters (default {}).
         :type parameters: Dict[str, Any] | None
         :param flagged_dependencies: Optional list of flagged dependencies (default []).
         :type flagged_dependencies: List[Dict[str, Any]] | None
-        :return: Created ServiceConfiguration model.
-        :rtype: ServiceConfiguration
+        :return: Created ServiceRegistration model.
+        :rtype: ServiceRegistration
         '''
 
-        # Check for existing configuration id.
+        # Coerce optional collection arguments to their empty defaults.
+        parameters = parameters or {}
+        flagged_dependencies = flagged_dependencies or []
+
+        # Check for an existing registration id.
         self.verify(
-            not self.di_service.configuration_exists(id),
-            a.const.CONFIGURATION_ALREADY_EXISTS_ID,
+            not self.di_service.registration_exists(id),
+            a.const.SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
             id=id,
         )
 
@@ -74,11 +84,11 @@ class AddServiceConfiguration(DomainEvent):
         has_deps = bool(flagged_dependencies)
         self.verify(
             has_default or has_deps,
-            a.const.INVALID_SERVICE_CONFIGURATION_ID,
+            a.const.INVALID_SERVICE_REGISTRATION_ID,
         )
 
-        # Create service configuration aggregate from dependency dicts.
-        configuration = ServiceConfigurationAggregate(
+        # Create the service registration aggregate from dependency dicts.
+        registration = ServiceRegistrationAggregate(
             id=id,
             module_path=module_path,
             class_name=class_name,
@@ -86,31 +96,16 @@ class AddServiceConfiguration(DomainEvent):
             dependencies=flagged_dependencies,
         )
 
-        # Save the new configuration and return it.
-        self.di_service.save_configuration(configuration)
-        return configuration
+        # Save the new registration and return it.
+        self.di_service.save_registration(registration)
+        return registration
 
-# ** event: set_default_service_configuration
-class SetDefaultServiceConfiguration(DomainEvent):
+# ** event: set_default_service_registration
+class SetDefaultServiceRegistration(DIEvent):
     '''
-    A domain event to set or update the default service configuration for an
-    existing service configuration.
+    A domain event to set or update the default service registration for an
+    existing service registration.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the SetDefaultServiceConfiguration event.
-
-        :param di_service: The DI service.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
     def execute(
@@ -120,31 +115,31 @@ class SetDefaultServiceConfiguration(DomainEvent):
         class_name: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ) -> ServiceConfiguration:
+    ) -> ServiceRegistration:
         '''
         Set or update the default module/class and parameters for an
-        existing service configuration.
+        existing service registration.
 
-        :param id: The unique service configuration identifier.
+        :param id: The unique service registration identifier.
         :type id: str
         :param module_path: Optional default module path.
         :type module_path: str | None
         :param class_name: Optional default class name.
         :type class_name: str | None
-        :param parameters: Optional configuration parameters. When None,
+        :param parameters: Optional registration parameters. When None,
             existing parameters are cleared.
         :type parameters: Dict[str, Any] | None
-        :return: The updated service configuration.
-        :rtype: ServiceConfiguration
+        :return: The updated service registration.
+        :rtype: ServiceRegistration
         '''
 
-        # Retrieve the existing configuration.
-        configuration = self.di_service.get_configuration(id)
+        # Retrieve the existing registration.
+        registration = self.di_service.get_registration(id)
 
-        # Verify that the configuration exists.
+        # Verify that the registration exists.
         self.verify(
-            configuration is not None,
-            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            registration is not None,
+            a.const.SERVICE_REGISTRATION_NOT_FOUND_ID,
             id=id,
         )
 
@@ -153,11 +148,11 @@ class SetDefaultServiceConfiguration(DomainEvent):
         if module_path is not None or class_name is not None:
             self.verify(
                 module_path is not None and class_name is not None,
-                a.const.INVALID_SERVICE_CONFIGURATION_ID,
+                a.const.INVALID_SERVICE_REGISTRATION_ID,
             )
 
             # Update both type and parameters via the model helper.
-            configuration.set_default_type(
+            registration.set_default_type(
                 module_path,
                 class_name,
                 parameters,
@@ -166,37 +161,22 @@ class SetDefaultServiceConfiguration(DomainEvent):
             # Only parameters are being updated (or cleared). Keep the
             # existing module_path and class_name but delegate parameter
             # handling/cleanup to the model helper.
-            configuration.set_default_type(
-                configuration.module_path,
-                configuration.class_name,
+            registration.set_default_type(
+                registration.module_path,
+                registration.class_name,
                 parameters,
             )
 
-        # Persist the updated configuration and return it.
-        self.di_service.save_configuration(configuration)
-        return configuration
+        # Persist the updated registration and return it.
+        self.di_service.save_registration(registration)
+        return registration
 
 # ** event: set_service_dependency
-class SetServiceDependency(DomainEvent):
+class SetServiceDependency(DIEvent):
     '''
     A domain event to set or update a flagged dependency on an existing
-    service configuration.
+    service registration.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the SetServiceDependency event.
-
-        :param di_service: The DI service.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
     @DomainEvent.parameters_required(['flag'])
@@ -211,9 +191,9 @@ class SetServiceDependency(DomainEvent):
     ) -> str:
         '''
         Set or update a flagged dependency for the given service
-        configuration.
+        registration.
 
-        :param id: The service configuration identifier.
+        :param id: The service registration identifier.
         :type id: str
         :param flag: The flag that identifies the dependency.
         :type flag: str
@@ -223,9 +203,12 @@ class SetServiceDependency(DomainEvent):
         :type class_name: str
         :param parameters: Parameters for the dependency.
         :type parameters: Dict[str, Any]
-        :return: The service configuration id.
+        :return: The service registration id.
         :rtype: str
         '''
+
+        # Coerce optional parameters to an empty dict.
+        parameters = parameters or {}
 
         # Ensure module_path and class_name are both provided for a valid
         # flagged dependency.
@@ -234,52 +217,36 @@ class SetServiceDependency(DomainEvent):
             a.const.INVALID_FLAGGED_DEPENDENCY_ID,
         )
 
-        # Retrieve the existing configuration.
-        configuration = self.di_service.get_configuration(id)
+        # Retrieve the existing registration.
+        registration = self.di_service.get_registration(id)
 
-        # Verify that the configuration exists.
+        # Verify that the registration exists.
         self.verify(
-            configuration is not None,
-            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            registration is not None,
+            a.const.SERVICE_REGISTRATION_NOT_FOUND_ID,
             id=id,
         )
 
         # Delegate to the model to set/update the flagged dependency.
-        configuration.set_dependency(
+        registration.set_dependency(
             flag=flag,
             module_path=module_path,
             class_name=class_name,
             parameters=parameters,
         )
 
-        # Persist the updated configuration.
-        self.di_service.save_configuration(configuration)
+        # Persist the updated registration.
+        self.di_service.save_registration(registration)
 
         # Return the id for convenience/confirmation.
         return id
 
-
 # ** event: remove_service_dependency
-class RemoveServiceDependency(DomainEvent):
+class RemoveServiceDependency(DIEvent):
     '''
     A domain event to remove a flagged dependency from an existing service
-    configuration.
+    registration.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the RemoveServiceDependency event.
-
-        :param di_service: The DI service.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
     @DomainEvent.parameters_required(['flag'])
@@ -290,105 +257,74 @@ class RemoveServiceDependency(DomainEvent):
         **kwargs,
     ) -> str:
         '''
-        Remove a flagged dependency from the given service configuration.
+        Remove a flagged dependency from the given service registration.
 
-        :param id: The service configuration identifier.
+        :param id: The service registration identifier.
         :type id: str
         :param flag: The flag that identifies the dependency to remove.
         :type flag: str
-        :return: The service configuration id.
+        :return: The service registration id.
         :rtype: str
         '''
 
-        # Retrieve the existing configuration.
-        configuration = self.di_service.get_configuration(id)
+        # Retrieve the existing registration.
+        registration = self.di_service.get_registration(id)
 
-        # Verify that the configuration exists.
+        # Verify that the registration exists.
         self.verify(
-            configuration is not None,
-            a.const.SERVICE_CONFIGURATION_NOT_FOUND_ID,
+            registration is not None,
+            a.const.SERVICE_REGISTRATION_NOT_FOUND_ID,
             id=id,
         )
 
         # Remove the dependency by flag (idempotent at the model level).
-        configuration.remove_dependency(flag)
+        registration.remove_dependency(flag)
 
         # Post-removal validation: ensure a remaining type source.
-        has_default = bool(configuration.module_path and configuration.class_name)
-        has_deps = bool(configuration.dependencies)
+        has_default = bool(registration.module_path and registration.class_name)
+        has_deps = bool(registration.dependencies)
         self.verify(
             has_default or has_deps,
-            a.const.INVALID_SERVICE_CONFIGURATION_ID,
+            a.const.INVALID_SERVICE_REGISTRATION_ID,
         )
 
-        # Persist the updated configuration.
-        self.di_service.save_configuration(configuration)
+        # Persist the updated registration.
+        self.di_service.save_registration(registration)
 
         # Return the id for convenience/confirmation.
         return id
 
-# ** event: remove_service_configuration
-class RemoveServiceConfiguration(DomainEvent):
+# ** event: remove_service_registration
+class RemoveServiceRegistration(DIEvent):
     '''
-    A domain event to remove a service configuration by ID.
+    A domain event to remove a service registration by ID.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the RemoveServiceConfiguration event.
-
-        :param di_service: The DI service.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id'])
     def execute(self, id: str, **kwargs) -> str:
         '''
-        Remove a service configuration.
+        Remove a service registration.
 
-        :param id: The unique identifier of the configuration to remove.
+        :param id: The unique identifier of the registration to remove.
         :type id: str
         :param kwargs: Additional context.
         :type kwargs: dict
-        :return: The removed configuration ID.
+        :return: The removed registration ID.
         :rtype: str
         '''
 
         # Delete (idempotent; underlying service handles non-existent IDs).
-        self.di_service.delete_configuration(id)
+        self.di_service.delete_registration(id)
 
         # Return id for confirmation.
         return id
 
-
 # ** event: set_service_constants
-class SetServiceConstants(DomainEvent):
+class SetServiceConstants(DIEvent):
     '''
     A domain event to set or clear service-level constants.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the SetServiceConstants event.
-
-        :param di_service: The DI service to use.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
     def execute(
@@ -430,36 +366,22 @@ class SetServiceConstants(DomainEvent):
         # Return the updated constants dictionary.
         return updated
 
-
 # ** event: list_all_settings
-class ListAllSettings(DomainEvent):
+class ListAllSettings(DIEvent):
     '''
-    A domain event to list all service configurations and constants.
+    A domain event to list all service registrations and constants.
     '''
-
-    # * attribute: di_service
-    di_service: DIService
-
-    # * init
-    def __init__(self, di_service: DIService):
-        '''
-        Initialize the ListAllSettings event.
-
-        :param di_service: The DI service.
-        :type di_service: DIService
-        '''
-
-        # Set the event attributes.
-        self.di_service = di_service
 
     # * method: execute
-    def execute(self) -> Tuple[List[ServiceConfiguration], Dict[str, Any]]:
+    def execute(self, **kwargs) -> Tuple[List[ServiceRegistration], Dict[str, Any]]:
         '''
         Execute the list all settings event.
 
-        :return: The list of all service configurations and constants.
-        :rtype: Tuple[List[ServiceConfiguration], Dict[str, Any]]
+        :param kwargs: Additional context.
+        :type kwargs: dict
+        :return: The list of all service registrations and constants.
+        :rtype: Tuple[List[ServiceRegistration], Dict[str, Any]]
         '''
 
-        # Return the list of all service configurations from the DI service.
+        # Return the list of all service registrations from the DI service.
         return self.di_service.list_all()

--- a/tiferet/events/di.py
+++ b/tiferet/events/di.py
@@ -11,6 +11,13 @@ from ..domain.di import ServiceRegistration
 from ..interfaces.di import DIService
 from ..mappers.di import ServiceRegistrationAggregate
 
+# *** constants
+
+# ** constant: omitted
+# Sentinel used to distinguish an omitted ``constants`` argument from an
+# explicit ``None`` (which clears all constants) in SetServiceConstants.
+_OMITTED: Any = object()
+
 # *** events
 
 # ** event: di_event
@@ -47,8 +54,8 @@ class AddServiceRegistration(DIEvent):
         id: str,
         module_path: Optional[str] = None,
         class_name: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = {},
-        flagged_dependencies: Optional[List[Dict[str, Any]]] = [],
+        parameters: Optional[Dict[str, Any]] = None,
+        flagged_dependencies: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> ServiceRegistration:
         '''
@@ -60,9 +67,9 @@ class AddServiceRegistration(DIEvent):
         :type module_path: str | None
         :param class_name: Optional default class name.
         :type class_name: str | None
-        :param parameters: Optional registration parameters (default {}).
+        :param parameters: Optional registration parameters.
         :type parameters: Dict[str, Any] | None
-        :param flagged_dependencies: Optional list of flagged dependencies (default []).
+        :param flagged_dependencies: Optional list of flagged dependencies.
         :type flagged_dependencies: List[Dict[str, Any]] | None
         :return: Created ServiceRegistration model.
         :rtype: ServiceRegistration
@@ -186,7 +193,7 @@ class SetServiceDependency(DIEvent):
         flag: str,
         module_path: str,
         class_name: str,
-        parameters: Dict[str, Any] = {},
+        parameters: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> str:
         '''
@@ -201,8 +208,8 @@ class SetServiceDependency(DIEvent):
         :type module_path: str
         :param class_name: The class name for the dependency.
         :type class_name: str
-        :param parameters: Parameters for the dependency.
-        :type parameters: Dict[str, Any]
+        :param parameters: Optional parameters for the dependency.
+        :type parameters: Dict[str, Any] | None
         :return: The service registration id.
         :rtype: str
         '''
@@ -329,20 +336,26 @@ class SetServiceConstants(DIEvent):
     # * method: execute
     def execute(
         self,
-        constants: Optional[Dict[str, Any]] = {},
+        constants: Optional[Dict[str, Any]] = _OMITTED,
         **kwargs,
     ) -> Dict[str, Any]:
         '''
         Set service constants.
 
         :param constants: New constants dictionary, or None to clear all.
-            Keys with None value are removed using pop-style semantics.
+            Keys with a None value are removed using pop-style semantics.
+            When omitted, existing constants are left unchanged.
         :type constants: Dict[str, Any] | None
         :param kwargs: Additional context.
         :type kwargs: dict
         :return: The updated constants dictionary.
         :rtype: Dict[str, Any]
         '''
+
+        # Treat an omitted argument as an empty update, preserving the prior
+        # no-op-on-omit behavior without relying on a mutable default.
+        if constants is _OMITTED:
+            constants = {}
 
         # Retrieve current constants from the DI service.
         _, current_constants = self.di_service.list_all()


### PR DESCRIPTION
## Summary
Brings `tiferet/events/di.py` to service-registration parity (Milestone #29, Core DDD Parity II — Events and Repos) and repairs the currently import-broken module.

- Add the `DIEvent` base event (shared `di_service` attribute + `__init__`); reparent all seven concrete DI events to it and drop their per-event attribute/`__init__`.
- Rename the configuration events to registration events: `AddServiceRegistration`, `SetDefaultServiceRegistration`, `RemoveServiceRegistration`. `SetServiceDependency`, `RemoveServiceDependency`, `SetServiceConstants`, and `ListAllSettings` keep their names (the string-wired `ListAllSettings` entry point is preserved).
- Switch imports to `ServiceRegistration`/`ServiceRegistrationAggregate`, update `DIService` call sites to `registration_exists`/`get_registration`/`save_registration`/`delete_registration`, update return types and the local variable, and adopt argument coercions (`parameters or {}`, `flagged_dependencies or []`) plus `ListAllSettings.execute(self, **kwargs)`. `merge_settings` is intentionally **not** introduced (DI runtime, out of scope).
- Rename the DI error constants to `INVALID_SERVICE_REGISTRATION`, `SERVICE_REGISTRATION_NOT_FOUND`, and `SERVICE_REGISTRATION_ALREADY_EXISTS`, each with a single matching `DEFAULT_ERRORS` entry; `INVALID_FLAGGED_DEPENDENCY` is unchanged.
- Relocate the DI events test to `tests/events/test_di.py` on the `tiferet.testing` harness and add `DIEvent` base coverage.

## Testing
- `pytest tests/events/test_di.py` → 34 passed, 3 skipped
- `pytest tests/` → 707 passed, 11 skipped (no regressions; +34/+3 from the relocated suite)

## Notes
The pre-existing `cannot import name 'ServiceConfiguration' from 'tiferet.domain'` warning originates from `tiferet/contexts/di.py` (companion contexts work) and is out of scope for this TRD.

## Links
- Issue: #862
- Milestone: #29 — Core DDD Parity II – Events and Repos
- Warp conversation: https://app.warp.dev/conversation/10631847-a840-4dcc-926f-d40f2d7893d1
