### PR TITLE
Docs – Parity: Events and Repos

### DIFF
--- a/docs/core/assets.md
+++ b/docs/core/assets.md
@@ -1,0 +1,192 @@
+# Assets in Tiferet
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+
+## Overview
+
+The assets package (`tiferet/assets/`) is the framework's foundational, dependency-light layer. It holds the primitive building blocks shared across every other layer — the structured exception types, error-code and default-configuration constants, bootstrap wiring definitions, and the package's public exports.
+
+Because it sits at the bottom of the dependency graph, assets modules import only the standard library and third-party primitives. They never import from `domain`, `events`, `mappers`, `interfaces`, `repos`, `contexts`, or `blueprints` — those layers depend on assets, not the other way around.
+
+Assets modules are deliberately simple. Only five artifact kinds appear in the layer:
+
+- **imports**
+- **constants**
+- **functions**
+- **classes** (standalone)
+- **exports**
+
+There are no domain objects, aggregates, services, events, or contexts here. That simplicity is the point: keeping assets primitive lets every other layer depend on it without introducing dependency cycles.
+
+## The Assets Layer's Role
+
+- **Exceptions** — `TiferetError` and `TiferetAPIError` (`exceptions.py`) are the structured error types raised throughout the framework.
+- **Constants** — error-code identifiers and the `DEFAULT_ERRORS` catalog (`constants.py`), bootstrap wiring defaults (`blueprints.py`), and default logging configuration (`logging.py`).
+- **Exports** — `__init__.py` re-exports the commonly used symbols and exposes the `constants` and `blueprints` modules under the short aliases `const` and `bps`.
+
+## Structured Code Design
+
+Assets modules follow the standard Tiferet artifact comment hierarchy (see [code_style.md](code_style.md)). Because the layer is primitive, only these top-level sections appear:
+
+- `# *** imports` — with `# ** core` / `# ** infra` / `# ** app` groupings.
+- `# *** constants` — module-level constants, each under `# ** constant: <snake_case_name>`.
+- `# *** functions` — module-level functions, each under `# ** function: <snake_case_name>`.
+- `# *** classes` — standalone classes, each under `# ** class: <snake_case_name>`.
+- `# *** exports` — public re-exports (only in `__init__.py`).
+
+**Spacing rules** match the rest of the framework: one empty line between a top-level comment and the first mid-level comment, one empty line between mid-level entries, and one empty line after docstrings and between code snippets.
+
+### Domain-appropriate specializations
+
+Two modules use specialized labels that are variants of the kinds above, chosen for readability:
+
+- **`# *** exceptions` / `# ** exception: <name>`** (`exceptions.py`) — a specialization of standalone **classes** for exception types.
+- **`# *** configs` / `# ** config: <name>`** (`logging.py`) — a specialization of **constants** for default configuration data structures.
+
+Both remain, fundamentally, standalone classes and constants; the specialized labels simply describe intent.
+
+## Artifact Kinds
+
+### Imports
+
+```python
+# *** imports
+
+# ** core
+from typing import Dict, Any
+import json
+```
+
+### Constants
+
+Constants are `SCREAMING_SNAKE_CASE` module-level values. Large related groups may share a descriptive `# ** constants: <group>` comment, and entries nested inside a data structure are annotated in place (e.g., `# * error: <NAME>` within `DEFAULT_ERRORS`):
+
+```python
+# *** constants
+
+# ** constant: error_not_found_id
+ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
+
+# ** constant: default_errors
+DEFAULT_ERRORS = {
+
+    # * error: ERROR_NOT_FOUND
+    ERROR_NOT_FOUND_ID: {
+        'id': ERROR_NOT_FOUND_ID,
+        'name': 'Error Not Found',
+        'message': [
+            {'lang': 'en_US', 'text': 'Error not found: {id}.'}
+        ],
+    },
+}
+```
+
+### Functions
+
+Assets functions are small, stateless helpers with no framework dependencies:
+
+```python
+# *** functions
+
+# ** function: is_blank
+def is_blank(value: str) -> bool:
+    '''
+    Return True when a string is empty or whitespace-only.
+
+    :param value: The string to inspect.
+    :type value: str
+    :return: True if the value is None or blank, otherwise False.
+    :rtype: bool
+    '''
+
+    # Treat None and whitespace-only strings as blank.
+    return value is None or not value.strip()
+```
+
+### Classes (standalone)
+
+Standalone classes carry no injected dependencies and extend only stdlib or other assets primitives. Exception types use the `# *** exceptions` / `# ** exception:` specialization:
+
+```python
+# *** exceptions
+
+# ** exception: tiferet_error
+class TiferetError(Exception):
+    '''
+    The base exception for all Tiferet-related errors.
+    '''
+
+    # * attribute: error_code
+    error_code: str
+
+    # * init
+    def __init__(self, error_code: str, message: str = None, **kwargs):
+        '''
+        Initialize the TiferetError with an error code, message, and arguments.
+        '''
+
+        # Set the error code and additional arguments.
+        self.error_code = error_code
+        self.kwargs = kwargs
+
+        # Initialize the base exception with serialized error data.
+        super().__init__(
+            json.dumps({'error_code': error_code, 'message': message, **kwargs})
+        )
+```
+
+### Exports
+
+Only `__init__.py` carries an `# *** exports` section. It re-exports the public surface and exposes module aliases where consumers use them heavily:
+
+```python
+# *** exports
+
+# ** app
+from .exceptions import TiferetError, TiferetAPIError
+from .constants import (
+    ERROR_NOT_FOUND_ID,
+    DEFAULT_ERRORS,
+)
+from . import constants as const
+from . import blueprints as bps
+```
+
+## Creating and Extending Assets Modules
+
+1. Start the module with a docstring, then an `# *** imports` section limited to the standard library and third-party primitives.
+2. Add content under exactly one primary artifact kind per concern — `# *** constants`, `# *** functions`, or `# *** classes` (or the `# *** exceptions` / `# *** configs` specializations).
+3. Do not introduce domain, service, event, mapper, or context artifacts here; if a concern needs one, it belongs in the corresponding layer.
+4. Surface any new public symbols from `__init__.py` under `# *** exports`.
+
+### Best Practices
+
+- Keep the layer dependency-light: never import from another Tiferet layer.
+- Restrict modules to the five artifact kinds (imports, constants, functions, standalone classes, exports).
+- Use `SCREAMING_SNAKE_CASE` values with `# ** constant: <snake_case>` labels; group large related blocks under `# ** constants: <group>`.
+- Reserve `# *** exceptions` for exception classes and `# *** configs` for default configuration data — both are specializations of the class/constant kinds.
+- Write RST docstrings on functions and classes, and keep code snippets separated by single blank lines.
+
+## Package Layout
+
+```
+tiferet/assets/
+├── __init__.py      — Public exports; exposes `const` and `bps` module aliases
+├── constants.py     — Error-code constants and the DEFAULT_ERRORS catalog
+├── exceptions.py    — TiferetError and TiferetAPIError
+├── blueprints.py    — Bootstrap default constants and service wiring
+└── logging.py       — Default logging formatters, handlers, and loggers
+```
+
+## Conclusion
+
+The assets layer is the simple, stable foundation of the Tiferet framework: a dependency-light collection of imports, constants, functions, standalone classes, and exports. Constraining it to these primitive artifact kinds keeps the dependency graph acyclic and the framework's shared building blocks easy to locate and reason about.
+
+Explore `tiferet/assets/` for the error catalog, exception types, and bootstrap defaults.
+
+## Related Documentation
+
+- [code_style.md](code_style.md) — General structured code style and artifact comments
+- [docs/guides/domain/error.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/error.md) — Error handling that consumes `TiferetError` and `DEFAULT_ERRORS`
+- [docs/core/blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md) — Bootstrap orchestration that consumes the `blueprints` defaults

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -329,6 +329,7 @@ These practices ensure Tiferet code remains consistent, maintainable, and AI-fri
 
 The Tiferet framework maintains a suite of focused documentation in `docs/core/` to guide consistent implementation across different component types. These documents complement the main **Structured Code Style** guidelines and provide domain-specific conventions.
 
+- **[assets.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md)** – Assets layer conventions (imports, constants, functions, standalone classes, exports).
 - **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain object conventions (dual role, factory methods, read-only design).
 - **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event conventions (dependency injection, validation, test harness).
 - **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -68,6 +68,63 @@ Key characteristics:
 - **`handle(EventClass, dependencies, **kwargs)`** is the standard invocation pattern in tests and contexts.
 - **`@parameters_required`** provides declarative, aggregated parameter validation.
 
+## Per-Module Base Events
+
+Each event module that shares a single injected service defines a **base event** that owns that service's dependency injection. Concrete events extend the base event and drop the `# * attribute` / `# * init` boilerplate, declaring only their `execute` method.
+
+```python
+# tiferet/events/error.py
+
+# *** events
+
+# ** event: error_event
+class ErrorEvent(DomainEvent):
+    '''
+    Base event providing the shared ErrorService dependency for error domain events.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the error event with its shared service dependency.
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+# ** event: get_error
+class GetError(ErrorEvent):
+    '''
+    Event to retrieve an Error domain object by its ID.
+    '''
+
+    # * method: execute
+    def execute(self, id: str, **kwargs) -> Error:
+        '''
+        Retrieve an Error by its ID.
+        '''
+
+        # Retrieve the error via the inherited service.
+        return self.error_service.get(id)
+```
+
+The framework defines seven base events, one per single-service event module:
+
+- `ErrorEvent` (`error_service`) — `tiferet/events/error.py`
+- `FeatureEvent` (`feature_service`) — `tiferet/events/feature.py`
+- `AppEvent` (`app_service`) — `tiferet/events/app.py`
+- `CliEvent` (`cli_service`) — `tiferet/events/cli.py`
+- `DIEvent` (`di_service`) — `tiferet/events/di.py`
+- `LoggingEvent` (`logging_service`) — `tiferet/events/logging.py`
+- `SqliteEvent` (`sqlite_service`) — `tiferet/events/sqlite.py`
+
+The static utility events (`ParseParameter`, `ImportDependency`, `RaiseError` in `tiferet/events/static.py`) take no injected service and therefore use no base event.
+
+> **Naming note:** The `FeatureEvent` base event reuses the name freed by the `FeatureEvent` → `EventFeatureStep` domain-object rename. The former `FeatureEvent` domain object (a feature workflow step) is now `EventFeatureStep`; the name `FeatureEvent` now denotes the feature module's base event.
+
 ## Structured Code Design
 
 Domain events follow the standard Tiferet artifact comment structure:
@@ -86,65 +143,54 @@ Domain events follow the standard Tiferet artifact comment structure:
 ## Creating Domain Events
 
 ### 1. Define the Event Class
-- Extend `DomainEvent`.
-- Declare dependencies under `# * attribute`.
-- Implement `__init__` and `execute`.
+- Extend the module's base event (e.g., `ErrorEvent`) to inherit the shared service, or `DomainEvent` directly for events with no shared service.
+- Implement `execute`; the base event supplies the `# * attribute` dependency and `# * init` (see [Per-Module Base Events](#per-module-base-events)).
 - Use `@DomainEvent.parameters_required` for declarative parameter validation.
 
-**Example** – `AddError`:
+**Example** – `AddError` (extends the `ErrorEvent` base event):
 ```python
 # *** imports
 
-# ** core
-from typing import List, Dict, Any
-
 # ** app
-from tiferet.events import DomainEvent, a
-from tiferet.contracts import ErrorService
-from tiferet.domain.error import Error
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..mappers import ErrorAggregate
 
 # *** events
 
 # ** event: add_error
-class AddError(DomainEvent):
+class AddError(ErrorEvent):
     '''
     Event to add a new Error domain object to the repository.
+
+    Extends the ErrorEvent base event (see "Per-Module Base Events"),
+    which injects the shared error_service; only execute is defined here.
     '''
-
-    # * attribute: error_service
-    error_service: ErrorService
-
-    # * init
-    def __init__(self, error_service: ErrorService):
-        '''
-        Initialize the AddError event.
-        '''
-        self.error_service = error_service
 
     # * method: execute
     @DomainEvent.parameters_required(['id', 'name', 'message'])
-    def execute(self, **kwargs) -> Error:
+    def execute(self, id: str, name: str, message: str, **kwargs) -> Error:
         '''
         Add a new Error.
         '''
 
-        # Unpack parameters.
-        id = kwargs['id']
-        name = kwargs['name']
-        message = kwargs['message']
-
-        # Check existence.
+        # Check existence via the inherited service.
         self.verify(
             not self.error_service.exists(id),
             a.const.ERROR_ALREADY_EXISTS_ID,
             message=f'An error with ID {id} already exists.',
-            id=id
+            id=id,
         )
 
-        # Create and save.
-        new_error = Error.new(id=id, name=name, message=message)
+        # Create and save the error aggregate.
+        new_error = ErrorAggregate(
+            id=id,
+            name=name,
+            message=[{'lang': 'en_US', 'text': message}],
+        )
         self.error_service.save(new_error)
 
+        # Return the new error.
         return new_error
 ```
 
@@ -307,6 +353,51 @@ def test_add_error_success(mock_error_service):
 - Verify service calls and return values.
 - Use `DomainEvent.handle` for consistent instantiation and execution.
 - Override `mock_dependencies` when tests need a pre-configured aggregate.
+
+## Middleware Support
+
+`DomainEvent.handle()` and `DomainEvent.handle_async()` accept an optional `middleware` list that wraps event execution with cross-cutting concerns (logging, timing, tracing, retries) without modifying the event itself.
+
+Each middleware is a callable following the `(event, kwargs, next_fn)` convention:
+- `event` — the instantiated domain event.
+- `kwargs` — the merged execution keyword arguments.
+- `next_fn` — a zero-argument callable that invokes the remainder of the chain (the next middleware, or the event's `execute` when none remain).
+
+Middleware is composed **outermost-first**: the first entry in the list is the outermost wrapper (first to run on entry, last to run on exit).
+
+**Sync example** — compose the chain programmatically via `handle`:
+```python
+result = DomainEvent.handle(
+    GetError,
+    dependencies={'error_service': error_service},
+    middleware=[LoggingMiddleware('root'), TimingMiddleware('root')],
+    id='ERR_001',
+)
+```
+
+A synchronous middleware calls `next_fn()` directly and returns its result:
+```python
+class LoggingMiddleware(MiddlewareService):
+
+    # * method: __call__
+    def __call__(self, event, kwargs, next_fn):
+        result = next_fn()
+        return result
+```
+
+**Async example** — `handle_async` composes the same chain for `AsyncDomainEvent` subclasses; async middleware must `await next_fn()`:
+```python
+class AsyncAuditMiddleware(MiddlewareService):
+
+    # * method: __call__
+    async def __call__(self, event, kwargs, next_fn):
+        result = await next_fn()
+        return result
+```
+
+**Configuration-driven middleware.** Beyond programmatic use, middleware can be declared in `config.yml` and resolved from the DI container by `FeatureContext` during `execute_feature` / `execute_feature_async`. Feature-level middleware wraps every step in the feature; step-level middleware applies to a single command.
+
+For built-in middleware, the `MiddlewareService` interface, ordering, `config.yml` registration, and testing, see the [Middleware guide](../guides/middleware.md).
 
 ## Package Layout
 

--- a/docs/core/repos.md
+++ b/docs/core/repos.md
@@ -5,24 +5,61 @@
 
 ## Overview
 
-Repositories are the concrete data-access layer in the Tiferet framework. Every repository implements a Service interface from `tiferet/interfaces/` and encapsulates the interaction between a data utility (e.g., `Yaml`) and the domain's transfer objects and aggregates.
+Repositories are the concrete data-access layer in the Tiferet framework. Every repository implements a Service interface from `tiferet/interfaces/` and inherits the shared `ConfigurationRepository` base, which handles format-specific file I/O and TransferObject serialization for the domain's aggregates.
 
-Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service configuration (`container.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. Consuming code depends only on the abstract Service interface, never on a concrete repository class.
+Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service registration (`config.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. Consuming code depends only on the abstract Service interface, never on a concrete repository class.
 
 ### Role in Runtime
 - **Service implementations**: Repositories are the concrete classes that satisfy the Service interfaces injected into domain events and contexts.
-- **Data-utility wiring**: Each repository composes a data utility (e.g., `Yaml`) with the domain's transfer objects to perform reads and writes against configuration files.
+- **Configuration-backed persistence**: Each repository inherits `ConfigurationRepository`, which dispatches reads and writes to a format-specific loader based on the configuration file extension.
 - **DI resolution**: Repositories are instantiated by the dependency injection container at runtime, not by direct import.
 
 ### Example: Error Domain
 
 ```python
-class ErrorYamlRepository(ErrorService):
+class ErrorConfigRepository(ErrorService, ConfigurationRepository):
     # Implements ErrorService interface
-    # Uses Yaml utility for file I/O
-    # Uses ErrorYamlObject for serialization
+    # Inherits ConfigurationRepository for format-dispatched file I/O
+    # Uses ErrorConfigObject for serialization
     # Returns ErrorAggregate instances
 ```
+
+## The ConfigurationRepository Base
+
+All concrete repositories inherit the shared `ConfigurationRepository` base (`tiferet/repos/settings.py`), which makes persistence format-agnostic. The base dispatches to a format-specific loader by the configuration file extension:
+
+- `.yaml` / `.yml` → `YamlLoader`
+- `.json` → `JsonLoader`
+- any other extension → raises `UNSUPPORTED_CONFIG_FILE_TYPE`
+
+It supplies three inherited attributes — `config_file`, `encoding`, and `default_role` (fixed to `'to_data'`) — and the inherited `_load` / `_save` helpers that concrete repositories call instead of instantiating a loader directly:
+
+```python
+# tiferet/repos/settings.py
+
+# ** class: configuration_repository
+class ConfigurationRepository:
+    '''
+    A format-agnostic base for configuration repositories.
+    '''
+
+    # * attribute: config_file
+    config_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: default_role
+    default_role: str
+
+    # * init
+    def __init__(self, config_file: str, encoding: str = 'utf-8') -> None:
+        self.config_file = config_file
+        self.encoding = encoding
+        self.default_role = 'to_data'
+```
+
+Concrete repositories accept a domain-prefixed `<domain>_config` parameter and forward it to the base as `config_file`.
 
 ## Structured Code Design
 
@@ -41,7 +78,7 @@ Repository classes follow the standard Tiferet artifact comment structure:
 
 **Example** — `tiferet/repos/error.py`:
 ```python
-"""Tiferet Error YAML Repository"""
+"""Tiferet Error Configuration Repository"""
 
 # *** imports
 
@@ -52,42 +89,31 @@ from typing import List
 from ..interfaces import ErrorService
 from ..mappers import (
     ErrorAggregate,
-    ErrorYamlObject,
+    ErrorConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: error_yaml_repository
-class ErrorYamlRepository(ErrorService):
+# ** repo: error_config_repository
+class ErrorConfigRepository(ErrorService, ConfigurationRepository):
     '''
-    The error YAML repository.
+    The error configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, error_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the error YAML repository.
+        Initialize the error configuration repository.
 
-        :param error_yaml_file: The YAML configuration file path.
-        :type error_yaml_file: str
+        :param error_config: The configuration file path.
+        :type error_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = error_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -100,11 +126,8 @@ class ErrorYamlRepository(ErrorService):
         :rtype: bool
         '''
 
-        # Load the errors mapping from the configuration file.
-        errors_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        # Load the errors mapping via the inherited loader.
+        errors_data = self._load(
             start_node=lambda data: data.get('errors', {})
         )
 
@@ -112,22 +135,20 @@ class ErrorYamlRepository(ErrorService):
         return id in errors_data
 ```
 
-## The Three-Attribute Foundation
+## The Inherited Configuration Foundation
 
-Every YAML-backed repository shares three instance attributes:
+Every repository inherits three instance attributes from `ConfigurationRepository`:
 
-- **`yaml_file`** (`str`) — Path to the YAML configuration file.
+- **`config_file`** (`str`) — Path to the configuration file (`.yaml`/`.yml` or `.json`).
 - **`encoding`** (`str`) — File encoding, defaulting to `'utf-8'`.
-- **`default_role`** (`str`) — The TransferObject serialization role used for writes, typically `'to_data.yaml'`.
+- **`default_role`** (`str`) — The TransferObject serialization role used for writes, fixed to `'to_data'`.
 
-The constructor parameter follows the convention `<domain>_yaml_file` (e.g., `error_yaml_file`, `feature_yaml_file`, `cli_yaml_file`). This domain-prefixed naming enables clean DI wiring in `container.yml`.
+The constructor parameter follows the convention `<domain>_config` (e.g., `error_config`, `feature_config`, `cli_config`) and is forwarded to the base as `config_file`. This domain-prefixed naming enables clean DI wiring in `config.yml`.
 
 ```python
 # * init
-def __init__(self, error_yaml_file: str, encoding: str = 'utf-8') -> None:
-    self.yaml_file = error_yaml_file
-    self.encoding = encoding
-    self.default_role = 'to_data.yaml'
+def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
+    ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
 ```
 
 ## Import Organization
@@ -144,40 +165,40 @@ from typing import List
 from ..interfaces import ErrorService           # Service interface
 from ..mappers import (                          # Transfer objects and aggregates
     ErrorAggregate,
-    ErrorYamlObject,
+    ErrorConfigObject,
 )
-from ..utils import Yaml                         # Data utility
+from .settings import ConfigurationRepository    # Shared configuration base
 ```
 
 The `# ** app` section imports three categories:
 1. The **Service interface** being implemented.
 2. The **transfer objects and aggregates** used for mapping (concrete classes only; no base-class imports needed).
-3. The **data utility** used for file I/O.
+3. The **`ConfigurationRepository` base** that supplies format-dispatched file I/O.
 
-No `# ** infra` section is needed — repositories do not import third-party libraries directly; all external interaction flows through Tiferet utilities.
+No `# ** infra` section is needed — repositories do not import third-party libraries directly; all external interaction flows through the inherited base and Tiferet utilities.
 
 ## Method Patterns
 
 ### Reading: `exists`, `get`, `list`
 
-All read methods compose a `Yaml` utility instance with a `start_node` lambda to navigate the YAML structure:
+All read methods call the inherited `_load` helper with a `start_node` lambda to navigate the configuration structure:
 
 ```python
 # Load a section.
-errors_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+errors_data = self._load(
     start_node=lambda data: data.get('errors', {})
 )
 
 # Load a single entry by ID.
-error_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+error_data = self._load(
     start_node=lambda data: data.get('errors', {}).get(id)
 )
 ```
 
-Mapping from raw YAML data to domain aggregates uses `model_validate` on the concrete TransferObject class with the YAML dictionary key injected as the `id`:
+Mapping from raw configuration data to domain aggregates uses `model_validate` on the concrete TransferObject class with the dictionary key injected as the `id`:
 
 ```python
-return ErrorYamlObject.model_validate(
+return ErrorConfigObject.model_validate(
     {**error_data, 'id': id}
 ).map()
 ```
@@ -191,16 +212,16 @@ Save methods follow a three-step sequence:
 
 ```python
 # Convert the error model to configuration data.
-error_data = ErrorYamlObject.from_model(error)
+error_data = ErrorConfigObject.from_model(error)
 
 # Load the full configuration file.
-full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+full_data = self._load()
 
 # Update or insert the error entry.
 full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
 
 # Persist the updated configuration file.
-Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+self._save(full_data)
 ```
 
 ### Deleting: `delete`
@@ -209,40 +230,40 @@ Delete operations are always **idempotent** — deleting a non-existent entry mu
 
 ```python
 # Load the full configuration file.
-full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+full_data = self._load()
 
 # Remove the entry if it exists (idempotent).
 full_data.get('errors', {}).pop(id, None)
 
 # Persist the updated configuration file.
-Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+self._save(full_data)
 ```
 
 ## Naming Convention
 
-Repository classes follow the pattern `<Domain>YamlRepository`:
+Repository classes follow the pattern `<Domain>ConfigRepository`:
 
-- `AppYamlRepository` implements `AppService`
-- `CliYamlRepository` implements `CliService`
-- `DIYamlRepository` implements `DIService`
-- `ErrorYamlRepository` implements `ErrorService`
-- `FeatureYamlRepository` implements `FeatureService`
-- `LoggingYamlRepository` implements `LoggingService`
+- `AppConfigRepository` implements `AppService`
+- `CliConfigRepository` implements `CliService`
+- `DIConfigRepository` implements `DIService`
+- `ErrorConfigRepository` implements `ErrorService`
+- `FeatureConfigRepository` implements `FeatureService`
+- `LoggingConfigRepository` implements `LoggingService`
 
-The `Yaml` suffix identifies the backing utility. Other utility-backed implementations (e.g., JSON, SQLite) would follow the same interface with a different suffix (e.g., `ErrorJsonRepository`, `ErrorSqliteRepository`).
+The `Config` suffix identifies the shared `ConfigurationRepository` base, which resolves the backing loader (`YamlLoader` or `JsonLoader`) from the configuration file extension at runtime.
 
 ## Creating and Extending Repositories
 
 ### 1. Define the Repository
 
 - Place under `# *** repos` and `# ** repo: <name>` in a domain-specific module.
-- Extend the corresponding Service interface from `tiferet/interfaces/`.
-- Set the three-attribute foundation in `__init__`.
+- Extend the corresponding Service interface from `tiferet/interfaces/` together with `ConfigurationRepository`.
+- Forward the `<domain>_config` path to the `ConfigurationRepository` base in `__init__`.
 - Implement each Service method using the read/write patterns described above.
 
-**Example** — `CalculatorYamlRepository`:
+**Example** — `CalculatorConfigRepository`:
 ```python
-"""Tiferet Calculator YAML Repository"""
+"""Tiferet Calculator Configuration Repository"""
 
 # *** imports
 
@@ -253,42 +274,31 @@ from typing import List
 from ..interfaces.calculator import CalculatorService
 from ..mappers.calculator import (
     CalculatorResultAggregate,
-    CalculatorResultYamlObject,
+    CalculatorResultConfigObject,
 )
-from ..utils import Yaml
+from .settings import ConfigurationRepository
 
 # *** repos
 
-# ** repo: calculator_yaml_repository
-class CalculatorYamlRepository(CalculatorService):
+# ** repo: calculator_config_repository
+class CalculatorConfigRepository(CalculatorService, ConfigurationRepository):
     '''
-    The calculator YAML repository.
+    The calculator configuration repository.
     '''
-
-    # * attribute: yaml_file
-    yaml_file: str
-
-    # * attribute: encoding
-    encoding: str
-
-    # * attribute: default_role
-    default_role: str
 
     # * init
-    def __init__(self, calculator_yaml_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, calculator_config: str, encoding: str = 'utf-8') -> None:
         '''
-        Initialize the calculator YAML repository.
+        Initialize the calculator configuration repository.
 
-        :param calculator_yaml_file: The YAML configuration file path.
-        :type calculator_yaml_file: str
+        :param calculator_config: The configuration file path.
+        :type calculator_config: str
         :param encoding: The file encoding (default is 'utf-8').
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = calculator_yaml_file
-        self.encoding = encoding
-        self.default_role = 'to_data.yaml'
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=calculator_config, encoding=encoding)
 
     # * method: exists
     def exists(self, id: str) -> bool:
@@ -301,11 +311,8 @@ class CalculatorYamlRepository(CalculatorService):
         :rtype: bool
         '''
 
-        # Load the results mapping from the configuration file.
-        results_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
+        # Load the results mapping via the inherited loader.
+        results_data = self._load(
             start_node=lambda data: data.get('results', {})
         )
 
@@ -315,54 +322,53 @@ class CalculatorYamlRepository(CalculatorService):
 
 ### 2. Register via DI
 
-Add the repository to the DI configuration file (`container.yml` or equivalent) with `module_path` and `class_name`. No `__init__.py` export is needed:
+Add the repository to the DI configuration file (`config.yml` or equivalent) with `module_path` and `class_name`. No `__init__.py` export is needed:
 
 ```yaml
 services:
   calculator_service:
     module_path: tiferet.repos.calculator
-    class_name: CalculatorYamlRepository
+    class_name: CalculatorConfigRepository
     params:
-      calculator_yaml_file: app/configs/calculator.yml
+      calculator_config: app/configs/calculator.yml
 ```
 
 ### 3. Write Tests
 
-Create tests in `tiferet/repos/tests/test_<domain>.py` using `tmp_path` fixtures with real temporary YAML files.
+Create tests in `tests/repos/test_<domain>.py` using `tmp_path` fixtures with real temporary configuration files.
 
 ### Best Practices
 - Use artifact comments consistently (`# *** repos`, `# ** repo:`, `# *`).
-- Follow the three-attribute foundation for all YAML-backed repos.
-- Use `YamlObject.model_validate({**data, 'id': id}).map()` for reads.
-- Use `YamlObject.from_model(aggregate)` classmethod for writes, then `to_primitive(self.default_role)` to serialize.
+- Extend `ConfigurationRepository` and forward `<domain>_config` to the base for all repos.
+- Use `ConfigObject.model_validate({**data, 'id': id}).map()` for reads.
+- Use `ConfigObject.from_model(aggregate)` classmethod for writes, then `to_primitive(self.default_role)` to serialize.
 - Make delete operations idempotent.
-- Use `setdefault` for safe section updates on save.
-- Use `start_node` lambdas for all read operations.
+- Use `self._load()` with `start_node` lambdas for reads, and `self._save()` for writes.
 - Include RST docstrings with `:param`, `:type`, `:return`, `:rtype`.
 
 ## Testing Repositories
 
-Repository tests are **integration tests** that operate against real temporary YAML files, not mocks. This is because the repository's value lies in the specific interaction between the utility and the transfer objects.
+Repository tests are **integration tests** that operate against real temporary configuration files, not mocks. This is because the repository's value lies in the specific interaction between the loader and the transfer objects.
 
 **Structure:**
 - `# *** constants` — sample data dictionaries.
-- `# *** fixtures` / `# ** fixture: <name>` — `tmp_path`-based YAML file and repository instance.
+- `# *** fixtures` / `# ** fixture: <name>` — `tmp_path`-based configuration file and repository instance.
 - `# *** tests` / `# ** test_int: <name>` — integration test cases.
 
 **Example** — Error repository test fixture:
 ```python
-# ** fixture: error_yaml_file
+# ** fixture: error_config
 @pytest.fixture
-def error_yaml_file(tmp_path) -> str:
+def error_config(tmp_path) -> str:
     file_path = tmp_path / 'test_error.yaml'
-    with open(file_path, 'w', encoding='utf-8') as yaml_file:
-        yaml.safe_dump(ERROR_DATA, yaml_file)
+    with open(file_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(ERROR_DATA, f)
     return str(file_path)
 
 # ** fixture: error_config_repo
 @pytest.fixture
-def error_config_repo(error_yaml_file: str) -> ErrorYamlRepository:
-    return ErrorYamlRepository(error_yaml_file)
+def error_config_repo(error_config: str) -> ErrorConfigRepository:
+    return ErrorConfigRepository(error_config)
 ```
 
 Standard test cases cover:
@@ -377,22 +383,22 @@ Standard test cases cover:
 Repositories are defined in `tiferet/repos/`:
 
 - `__init__.py` — Empty exports (repositories are never exported).
-- `app.py` — `AppYamlRepository`.
-- `cli.py` — `CliYamlRepository`.
-- `container.py` — `ContainerYamlRepository` (legacy).
-- `di.py` — `DIYamlRepository`.
-- `error.py` — `ErrorYamlRepository`.
-- `feature.py` — `FeatureYamlRepository`.
-- `logging.py` — `LoggingYamlRepository`.
+- `settings.py` — `ConfigurationRepository` (shared format-dispatch base).
+- `app.py` — `AppConfigRepository`.
+- `cli.py` — `CliConfigRepository`.
+- `di.py` — `DIConfigRepository`.
+- `error.py` — `ErrorConfigRepository`.
+- `feature.py` — `FeatureConfigRepository`.
+- `logging.py` — `LoggingConfigRepository`.
 
-Tests live in `tiferet/repos/tests/`.
+Tests live in `tests/repos/`.
 
 ## Migration from Proxies and Schematics
 
 Repositories are the v2.0 successor to Proxies (`tiferet/proxies/`). Key changes:
 
-- **Package rename**: `tiferet/proxies/yaml/<domain>.py` → `tiferet/repos/<domain>.py`. The nested middleware-specific directory structure is flattened because the utility suffix in the class name (`YamlRepository`) already identifies the backing technology.
-- **Base class**: Proxies extended `YamlConfigurationProxy` (a middleware base class). Repositories extend the Service interface directly and compose the `Yaml` utility internally.
+- **Package rename**: `tiferet/proxies/yaml/<domain>.py` → `tiferet/repos/<domain>.py`. The nested middleware-specific directory structure is flattened; the shared `ConfigurationRepository` base resolves the backing loader from the configuration file extension.
+- **Base class**: Proxies extended `YamlConfigurationProxy` (a middleware base class). Repositories extend the Service interface together with the `ConfigurationRepository` base, which dispatches to `YamlLoader` or `JsonLoader` internally.
 - **Artifact comments**: `# *** proxies` / `# ** proxy:` → `# *** repos` / `# ** repo:`.
 - **Data mapping**: Proxies used `DataObject.from_data()` and `DataObject.map()`. Repositories use `model_validate()` for reads and `from_model()` classmethod + `to_primitive(role)` for writes.
 - **Contract alignment**: Proxies implemented `Repository` contracts. Repositories implement `Service` interfaces — the unified v2.0 contract type.

--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -32,7 +32,7 @@ In both cases, the pattern is identical: a utility provides a concrete, reusable
 
 ### Role in Runtime
 
-- **Repositories and proxies** are the primary consumers of physical infrastructure utilities (e.g., `FeatureYamlRepository` uses `YamlLoader`).
+- **Repositories and proxies** are the primary consumers of physical infrastructure utilities (e.g., `FeatureConfigRepository` uses `YamlLoader`).
 - **Domain events** consume utilities indirectly through injected Services, keeping domain logic decoupled from infrastructure.
 - **Contexts** may use utilities directly for low-level operations when a full repository is unnecessary.
 - **Application code** (scripts, CLI handlers) may use utilities directly for quick operations outside the DDD layer.

--- a/docs/guides/events/app.md
+++ b/docs/guides/events/app.md
@@ -74,15 +74,9 @@ result = DomainEvent.handle(
 
 ### GetAppInterface
 
-Retrieves an `AppInterface` by ID. Optionally merges default services into the result for any `service_id` not already present on the interface.
+Retrieves an `AppInterface` by ID from the app service. It is a repository-only read — it returns the stored interface unchanged and does not merge any defaults.
 
 **Required:** `interface_id`
-
-**Optional parameters:**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `default_services` | `List[AppServiceDependency]` | `[]` | Default service dependencies to merge if their `service_id` is missing |
 
 **Returns:** The loaded `AppInterface` instance.
 
@@ -91,14 +85,13 @@ Retrieves an `AppInterface` by ID. Optionally merges default services into the r
 **Behavior:**
 1. Retrieves the interface via `app_service.get(interface_id)`.
 2. Raises a structured error if `None`.
-3. If `default_services` is provided, iterates them and adds any whose `service_id` is not already present on the interface.
+3. Returns the loaded interface.
 
 ```python
 interface = DomainEvent.handle(
     GetAppInterface,
     dependencies={'app_service': app_service},
     interface_id='my_app',
-    default_services=[default_error_repo, default_feature_repo],
 )
 ```
 
@@ -267,7 +260,12 @@ Both `RemoveServiceDependency` and `RemoveAppInterface` are idempotent — they 
 
 ### Default Service Merging
 
-`GetAppInterface` supports a `default_services` list that is merged into the loaded interface. This is used by `AppManagerContext` to inject framework-level defaults (error repository, feature repository, etc.) that the user doesn't need to declare explicitly.
+Bootstrap default merging is no longer a concern of `GetAppInterface`; the event is a plain repository read. Framework-level defaults (error repository, feature repository, etc.) are applied outside the event by two dedicated helpers:
+
+- **`AppInterface.apply_defaults(default_services, default_constants)`** (`tiferet/domain/app.py`) — a non-mutating domain helper that returns a new interface with default services added for any missing `service_id` and default constants added for any missing key (existing values win).
+- **`resolve_default_interface(interface_id, default_interfaces)`** (`tiferet/contexts/app.py`) — the context bootstrap helper that resolves an interface and applies its defaults during startup.
+
+Neither helper re-wraps `AppInterfaceAggregate`.
 
 ## Related Documentation
 

--- a/docs/guides/events/di.md
+++ b/docs/guides/events/di.md
@@ -1,4 +1,4 @@
-# Events – DI Service Configuration Management
+# Events – DI Service Registration Management
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -7,33 +7,33 @@
 
 ## Overview
 
-The DI event module provides the full CRUD surface for `ServiceConfiguration` objects — the dependency injection blueprints that define how services are resolved and wired at runtime. Every event in this module depends on an injected `DIService` and operates on `ServiceConfiguration` domain objects through the `ServiceConfigurationAggregate` mapper.
+The DI event module provides the full CRUD surface for `ServiceRegistration` objects — the dependency injection blueprints that define how services are resolved and wired at runtime. Every event in this module depends on an injected `DIService` and operates on `ServiceRegistration` domain objects through the `ServiceRegistrationAggregate` mapper.
 
-These events are the forward-compatible successors to the container events in `tiferet/events/container.py`, using DI-specific terminology (`ServiceConfiguration`, `DIService`, `configuration_exists`, etc.) instead of container-centric naming (`ContainerAttribute`, `ContainerService`, `attribute_exists`).
+These events are the forward-compatible successors to the container events in `tiferet/events/container.py`, using DI-specific terminology (`ServiceRegistration`, `DIService`, `registration_exists`, etc.) instead of container-centric naming (`ContainerAttribute`, `ContainerService`, `attribute_exists`).
 
 ## Events at a Glance
 
 | Event | Operation | Required Parameters | Returns |
 |---|---|---|---|
-| `AddServiceConfiguration` | Create | `id` | `ServiceConfiguration` |
-| `SetDefaultServiceConfiguration` | Update (default type) | *(none — `id` is positional)* | `ServiceConfiguration` |
+| `AddServiceRegistration` | Create | `id` | `ServiceRegistration` |
+| `SetDefaultServiceRegistration` | Update (default type) | *(none — `id` is positional)* | `ServiceRegistration` |
 | `SetServiceDependency` | Update (flagged dep) | `flag` | `str` (ID) |
 | `RemoveServiceDependency` | Delete (flagged dep) | `flag` | `str` (ID) |
-| `RemoveServiceConfiguration` | Delete | `id` | `str` (ID) |
+| `RemoveServiceRegistration` | Delete | `id` | `str` (ID) |
 | `SetServiceConstants` | Update (constants) | *(none)* | `Dict[str, Any]` |
-| `ListAllSettings` | Read (all) | *(none)* | `Tuple[List[ServiceConfiguration], Dict]` |
+| `ListAllSettings` | Read (all) | *(none)* | `Tuple[List[ServiceRegistration], Dict]` |
 
 ## Dependency
 
 All events inject a single dependency:
 
-- **`di_service: DIService`** — the service interface for persisting and retrieving `ServiceConfiguration` objects and constants.
+- **`di_service: DIService`** — the service interface for persisting and retrieving `ServiceRegistration` objects and constants.
 
 ## Event Details
 
-### AddServiceConfiguration
+### AddServiceRegistration
 
-Creates a new `ServiceConfiguration` and persists it via `DIService.save_configuration()`. A configuration must define at least one type source: either a default type (`module_path` + `class_name`) or one or more flagged dependencies.
+Creates a new `ServiceRegistration` and persists it via `DIService.save_registration()`. A registration must define at least one type source: either a default type (`module_path` + `class_name`) or one or more flagged dependencies.
 
 **Required:** `id`
 
@@ -43,35 +43,35 @@ Creates a new `ServiceConfiguration` and persists it via `DIService.save_configu
 |---|---|---|---|
 | `module_path` | `str \| None` | `None` | Default module path for the service class |
 | `class_name` | `str \| None` | `None` | Default class name for the service class |
-| `parameters` | `Dict[str, Any]` | `{}` | Default configuration parameters |
-|| `flagged_dependencies` | `List[Dict[str, Any]]` | `[]` | List of flagged dependency dicts (each with `flag`, `module_path`, `class_name`, optional `parameters`) |
+| `parameters` | `Dict[str, Any]` | `{}` | Default registration parameters |
+| `flagged_dependencies` | `List[Dict[str, Any]]` | `[]` | List of flagged dependency dicts (each with `flag`, `module_path`, `class_name`, optional `parameters`) |
 
-**Returns:** The created `ServiceConfiguration` instance.
+**Returns:** The created `ServiceRegistration` instance.
 
 **Errors:**
-- `CONFIGURATION_ALREADY_EXISTS` if a configuration with the given ID already exists.
-- `INVALID_SERVICE_CONFIGURATION` if neither a default type nor dependencies are provided.
+- `SERVICE_REGISTRATION_ALREADY_EXISTS` if a registration with the given ID already exists.
+- `INVALID_SERVICE_REGISTRATION` if neither a default type nor dependencies are provided.
 
 **Behavior:**
-1. Verifies the ID does not already exist via `di_service.configuration_exists(id)`.
+1. Verifies the ID does not already exist via `di_service.registration_exists(id)`.
 2. Validates that at least one type source is provided.
-3. Creates a `ServiceConfigurationAggregate` via its `new()` factory.
-4. Saves via `di_service.save_configuration(configuration)`.
+3. Creates a `ServiceRegistrationAggregate` via its constructor.
+4. Saves via `di_service.save_registration(registration)`.
 
 ```python
 result = DomainEvent.handle(
-    AddServiceConfiguration,
+    AddServiceRegistration,
     dependencies={'di_service': di_service},
     id='error_repo',
     module_path='myapp.repos.error',
-    class_name='ErrorYamlRepository',
-    parameters={'error_yaml_file': 'app/configs/error.yml'},
+    class_name='ErrorConfigRepository',
+    parameters={'error_config': 'app/configs/error.yml'},
 )
 ```
 
-### SetDefaultServiceConfiguration
+### SetDefaultServiceRegistration
 
-Sets or updates the default module/class and parameters for an existing service configuration.
+Sets or updates the default module/class and parameters for an existing service registration.
 
 **Required:** `id` (positional)
 
@@ -83,11 +83,11 @@ Sets or updates the default module/class and parameters for an existing service 
 | `class_name` | `str \| None` | `None` | New default class name |
 | `parameters` | `Dict[str, Any] \| None` | `None` | New parameters. `None` clears all parameters. |
 
-**Returns:** The updated `ServiceConfiguration` instance.
+**Returns:** The updated `ServiceRegistration` instance.
 
 **Errors:**
-- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
-- `INVALID_SERVICE_CONFIGURATION` if only one of `module_path` or `class_name` is provided (both must be provided for an atomic type update).
+- `SERVICE_REGISTRATION_NOT_FOUND` if the registration does not exist.
+- `INVALID_SERVICE_REGISTRATION` if only one of `module_path` or `class_name` is provided (both must be provided for an atomic type update).
 
 **Behavior:**
 - If both `module_path` and `class_name` are provided, updates the default type and parameters.
@@ -96,18 +96,18 @@ Sets or updates the default module/class and parameters for an existing service 
 
 ```python
 DomainEvent.handle(
-    SetDefaultServiceConfiguration,
+    SetDefaultServiceRegistration,
     dependencies={'di_service': di_service},
     id='error_repo',
-    module_path='myapp.repos.error_v2',
-    class_name='ErrorJsonRepository',
-    parameters={'error_json_file': 'app/configs/error.json'},
+    module_path='myapp.repos.error',
+    class_name='ErrorConfigRepository',
+    parameters={'error_config': 'app/configs/error.json'},
 )
 ```
 
 ### SetServiceDependency
 
-Adds or updates a flagged dependency on an existing service configuration. Uses PUT semantics — if the flag already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
+Adds or updates a flagged dependency on an existing service registration. Uses PUT semantics — if the flag already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
 
 **Required:** `flag`
 
@@ -115,16 +115,16 @@ Adds or updates a flagged dependency on an existing service configuration. Uses 
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `id` | `str` | — | The service configuration identifier |
+| `id` | `str` | — | The service registration identifier |
 | `module_path` | `str` | — | The module path for the dependency |
 | `class_name` | `str` | — | The class name for the dependency |
 | `parameters` | `Dict[str, Any]` | `{}` | Parameters for the dependency. Keys with `None` values are pruned during merge. |
 
-**Returns:** `str` — the service configuration ID.
+**Returns:** `str` — the service registration ID.
 
 **Errors:**
 - `INVALID_FLAGGED_DEPENDENCY` if either `module_path` or `class_name` is empty.
-- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
+- `SERVICE_REGISTRATION_NOT_FOUND` if the registration does not exist.
 
 ```python
 DomainEvent.handle(
@@ -133,14 +133,14 @@ DomainEvent.handle(
     id='error_repo',
     flag='json',
     module_path='myapp.repos.error',
-    class_name='ErrorJsonRepository',
-    parameters={'error_json_file': 'app/configs/error.json'},
+    class_name='ErrorConfigRepository',
+    parameters={'error_config': 'app/configs/error.json'},
 )
 ```
 
 ### RemoveServiceDependency
 
-Removes a flagged dependency from an existing service configuration by flag. The removal is **idempotent** at the model level — removing a non-existent flag does not raise an error. However, post-removal validation ensures at least one type source remains.
+Removes a flagged dependency from an existing service registration by flag. The removal is **idempotent** at the model level — removing a non-existent flag does not raise an error. However, post-removal validation ensures at least one type source remains.
 
 **Required:** `flag`
 
@@ -148,13 +148,13 @@ Removes a flagged dependency from an existing service configuration by flag. The
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `id` | `str` | — | The service configuration identifier |
+| `id` | `str` | — | The service registration identifier |
 
-**Returns:** `str` — the service configuration ID.
+**Returns:** `str` — the service registration ID.
 
 **Errors:**
-- `SERVICE_CONFIGURATION_NOT_FOUND` if the configuration does not exist.
-- `INVALID_SERVICE_CONFIGURATION` if removing the dependency would leave no type source (no default type and no remaining dependencies).
+- `SERVICE_REGISTRATION_NOT_FOUND` if the registration does not exist.
+- `INVALID_SERVICE_REGISTRATION` if removing the dependency would leave no type source (no default type and no remaining dependencies).
 
 ```python
 DomainEvent.handle(
@@ -165,17 +165,17 @@ DomainEvent.handle(
 )
 ```
 
-### RemoveServiceConfiguration
+### RemoveServiceRegistration
 
-Deletes an entire service configuration by ID. The operation is **idempotent** — the underlying service handles non-existent IDs gracefully.
+Deletes an entire service registration by ID. The operation is **idempotent** — the underlying service handles non-existent IDs gracefully.
 
 **Required:** `id`
 
-**Returns:** `str` — the removed configuration ID.
+**Returns:** `str` — the removed registration ID.
 
 ```python
 DomainEvent.handle(
-    RemoveServiceConfiguration,
+    RemoveServiceRegistration,
     dependencies={'di_service': di_service},
     id='error_repo',
 )
@@ -183,7 +183,7 @@ DomainEvent.handle(
 
 ### SetServiceConstants
 
-Sets, merges, or clears service-level constants. Constants are global key-value pairs stored alongside service configurations.
+Sets, merges, or clears service-level constants. Constants are global key-value pairs stored alongside service registrations.
 
 **Optional parameters:**
 
@@ -217,12 +217,12 @@ DomainEvent.handle(
 
 ### ListAllSettings
 
-Lists all service configurations and constants. No required parameters.
+Lists all service registrations and constants. No required parameters.
 
-**Returns:** `Tuple[List[ServiceConfiguration], Dict[str, Any]]` — the list of configurations and the constants dictionary.
+**Returns:** `Tuple[List[ServiceRegistration], Dict[str, Any]]` — the list of registrations and the constants dictionary.
 
 ```python
-configurations, constants = DomainEvent.handle(
+registrations, constants = DomainEvent.handle(
     ListAllSettings,
     dependencies={'di_service': di_service},
 )
@@ -232,20 +232,20 @@ configurations, constants = DomainEvent.handle(
 
 ### Retrieve → Verify → Mutate → Save
 
-Most mutation events (`SetDefaultServiceConfiguration`, `SetServiceDependency`, `RemoveServiceDependency`) follow a four-step pattern:
+Most mutation events (`SetDefaultServiceRegistration`, `SetServiceDependency`, `RemoveServiceDependency`) follow a four-step pattern:
 
-1. **Retrieve** the configuration via `di_service.get_configuration(id)`.
+1. **Retrieve** the registration via `di_service.get_registration(id)`.
 2. **Verify** it exists using `self.verify()`.
 3. **Mutate** the aggregate via its domain methods (`set_default_type`, `set_dependency`, `remove_dependency`).
-4. **Save** the updated aggregate via `di_service.save_configuration(configuration)`.
+4. **Save** the updated aggregate via `di_service.save_registration(registration)`.
 
 ### Type Source Invariant
 
-A service configuration must always have at least one type source — either a default type (`module_path` + `class_name`) or at least one flagged dependency. This invariant is enforced during creation (`AddServiceConfiguration`) and after dependency removal (`RemoveServiceDependency`).
+A service registration must always have at least one type source — either a default type (`module_path` + `class_name`) or at least one flagged dependency. This invariant is enforced during creation (`AddServiceRegistration`) and after dependency removal (`RemoveServiceDependency`).
 
 ### Idempotent Deletes
 
-Both `RemoveServiceDependency` (at the model level) and `RemoveServiceConfiguration` are idempotent — they succeed silently if the target does not exist.
+Both `RemoveServiceDependency` (at the model level) and `RemoveServiceRegistration` are idempotent — they succeed silently if the target does not exist.
 
 ### Container vs DI Events
 
@@ -254,12 +254,12 @@ The DI events mirror the container events but use forward-compatible DI terminol
 | Container (legacy) | DI (forward) |
 |---|---|
 | `ContainerService` | `DIService` |
-| `ContainerAttribute` | `ServiceConfiguration` |
-| `attribute_exists()` | `configuration_exists()` |
-| `get_attribute()` | `get_configuration()` |
-| `save_attribute()` | `save_configuration()` |
-| `delete_attribute()` | `delete_configuration()` |
-| `ATTRIBUTE_ALREADY_EXISTS` | `CONFIGURATION_ALREADY_EXISTS` |
+| `ContainerAttribute` | `ServiceRegistration` |
+| `attribute_exists()` | `registration_exists()` |
+| `get_attribute()` | `get_registration()` |
+| `save_attribute()` | `save_registration()` |
+| `delete_attribute()` | `delete_registration()` |
+| `ATTRIBUTE_ALREADY_EXISTS` | `SERVICE_REGISTRATION_ALREADY_EXISTS` |
 
 ## Related Documentation
 

--- a/docs/guides/events/feature.md
+++ b/docs/guides/events/feature.md
@@ -7,9 +7,9 @@
 
 ## Overview
 
-The feature event module provides the full CRUD surface for `Feature` domain objects — the configuration-driven workflow definitions that power Tiferet's feature execution engine. Every event in this module depends on an injected `FeatureService` and operates on `Feature` domain objects through the `FeatureAggregate` mapper.
+The feature event module provides the full CRUD surface for `Feature` domain objects — the configuration-driven workflow definitions that power Tiferet's feature execution engine. Every event in this module extends the shared `FeatureEvent` base event (which holds the injected `FeatureService`) and operates on `Feature` domain objects through the `FeatureAggregate` mapper.
 
-Features are composed of ordered **steps** (`FeatureEvent` instances), each referencing a `service_id` that maps to a service configuration in the dependency injection container.
+Features are composed of ordered **steps** (`EventFeatureStep` instances), each referencing a `service_id` that maps to a service registration in the dependency injection container.
 
 ## Events at a Glance
 
@@ -25,11 +25,13 @@ Features are composed of ordered **steps** (`FeatureEvent` instances), each refe
 | `RemoveFeatureStep` | Remove step | `id`, `position` | `str` (ID) |
 | `ReorderFeatureStep` | Reorder step | `id`, `start_position`, `end_position` | `str` (ID) |
 
-## Dependency
+## Base Event and Dependency
 
-All events inject a single dependency:
+All events extend the shared `FeatureEvent` base event, which declares the single injected dependency and its constructor. Concrete events (`AddFeature`, `GetFeature`, etc.) define only their `execute` method:
 
-- **`feature_service: FeatureService`** — the service interface for persisting and retrieving `Feature` objects.
+- **`FeatureEvent(DomainEvent)`** — declares **`feature_service: FeatureService`** (the service interface for persisting and retrieving `Feature` objects) and the `__init__` that injects it.
+
+> **Naming note:** The `FeatureEvent` base event reuses the name freed by the `FeatureEvent` → `EventFeatureStep` domain-object rename. A feature workflow step is now the `EventFeatureStep` domain object; `FeatureEvent` now denotes this module's base event.
 
 ## Event Details
 
@@ -158,7 +160,7 @@ DomainEvent.handle(
 
 ### AddFeatureStep
 
-Adds a step to an existing feature's workflow. Steps reference a `service_id` that maps to a service configuration in the DI container.
+Adds a step to an existing feature's workflow. Steps reference a `service_id` that maps to a service registration in the DI container.
 
 **Required:** `id`, `name`, `service_id`
 
@@ -271,3 +273,8 @@ DomainEvent.handle(
 - **Parameter renames:** `commands` → `steps` in `AddFeature.execute()`.
 - **Artifact comments:** Updated from `# *** commands` / `# ** command:` to `# *** events` / `# ** event:`.
 - **Unused imports removed:** `Aggregate` and `FeatureEventAggregate` no longer imported.
+
+### Core DDD Parity II Changes
+
+- **Base event introduced:** `FeatureEvent(DomainEvent)` now holds the shared `feature_service` and its constructor; concrete events keep only `execute`.
+- **Domain-object rename:** the former `FeatureEvent` domain object (a feature workflow step) is renamed to `EventFeatureStep`, with mappers `EventFeatureStepAggregate` and `EventFeatureStepConfigObject`. This frees the `FeatureEvent` name for the base event above.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,0 +1,289 @@
+# Middleware – Cross-Cutting Concerns for Domain Events
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Module:** `tiferet/utils/middleware.py`  
+**Version:** 2.0.0
+
+## Overview
+
+Middleware wraps domain event execution with cross-cutting concerns — logging, timing, tracing, retries, auditing — without modifying the event itself. A middleware is a callable that receives the event, its execution kwargs, and a `next_fn` callable that invokes the remainder of the chain.
+
+Middleware is applied through the `DomainEvent.handle()` and `DomainEvent.handle_async()` static methods, both of which accept an optional `middleware` list. When no middleware is supplied, execution is unchanged; when middleware is supplied, the entries are composed into an ordered chain around the event's `execute` method.
+
+See the [Middleware Support](../core/events.md#middleware-support) section of the events core doc for the base-class mechanics.
+
+## Built-in Middleware
+
+Two infrastructure middleware ship in `tiferet.utils.middleware`. Each is a `MiddlewareService` subclass that takes a single `logger_id: str` parameter (default `'root'`) and resolves the matching stdlib logger via `logging.getLogger(logger_id)`. They rely on `LoggingContext` having configured Python logging at application startup; on their own they emit records to whichever logger `logger_id` names.
+
+- **`LoggingMiddleware`** — emits a `DEBUG` record before execution and after success, and an `ERROR` record (with traceback via `exc_info=True`) when the chain raises. The exception is always re-raised.
+- **`TimingMiddleware`** — measures elapsed wall-clock time with `time.perf_counter` and emits a single `DEBUG` record reporting the duration in milliseconds on both the success and exception paths. The exception is always re-raised.
+
+```python
+from tiferet.events import DomainEvent
+from tiferet.utils.middleware import LoggingMiddleware, TimingMiddleware
+
+result = DomainEvent.handle(
+    GetError,
+    dependencies={'error_service': error_service},
+    middleware=[LoggingMiddleware('root'), TimingMiddleware('root')],
+    id='ERR_001',
+)
+```
+
+Both are infrastructure-only: they contain no domain logic and never raise a `TiferetError` of their own.
+
+## The MiddlewareService Interface
+
+Custom middleware extends `MiddlewareService` from `tiferet.interfaces.middleware` and implements a single `__call__` method:
+
+```python
+# *** imports
+
+# ** app
+from tiferet.interfaces.middleware import MiddlewareService
+
+# *** utils
+
+# ** util: audit_middleware
+class AuditMiddleware(MiddlewareService):
+    '''
+    Records an audit trail around domain event execution.
+    '''
+
+    # * method: __call__
+    def __call__(self, event, kwargs, next_fn):
+        '''
+        Invoke the chain, recording the event class name.
+        '''
+
+        # Execute the remainder of the chain and return its result.
+        return next_fn()
+```
+
+`__call__` receives three arguments:
+
+| Argument | Type | Description |
+|---|---|---|
+| `event` | `DomainEvent` | The instantiated domain event (or `AsyncDomainEvent`) instance. |
+| `kwargs` | `Dict[str, Any]` | The merged execution keyword arguments passed to `execute`. |
+| `next_fn` | `Callable[[], Any]` | Zero-argument callable that invokes the next middleware in the chain, or the event's `execute` when none remain. In asynchronous paths it is a coroutine function and must be awaited. |
+
+## Sync vs Async
+
+### Synchronous middleware
+
+Synchronous middleware is used with `DomainEvent.handle()`. It calls `next_fn()` directly and returns (or transforms) its result:
+
+```python
+class TimingMiddleware(MiddlewareService):
+
+    # * method: __call__
+    def __call__(self, event, kwargs, next_fn):
+        start = time.perf_counter()
+        try:
+            result = next_fn()
+        except Exception:
+            elapsed = (time.perf_counter() - start) * 1000
+            self.logger.debug('%s raised after %.2fms', event.__class__.__name__, elapsed)
+            raise
+        elapsed = (time.perf_counter() - start) * 1000
+        self.logger.debug('%s completed in %.2fms', event.__class__.__name__, elapsed)
+        return result
+```
+
+### Asynchronous middleware
+
+Asynchronous middleware is used with `DomainEvent.handle_async()` and `AsyncDomainEvent` subclasses. It must be implemented as `async def __call__` and must `await next_fn()`:
+
+```python
+class AsyncAuditMiddleware(MiddlewareService):
+
+    # * method: __call__
+    async def __call__(self, event, kwargs, next_fn):
+        result = await next_fn()
+        return result
+```
+
+`handle_async` awaits any coroutine returned by a middleware, so async and sync middleware compose alike within an async chain. A synchronous middleware may call `next_fn()` in an async chain, but it will receive a coroutine it cannot inspect directly — prefer `async def __call__` for async contexts.
+
+## Ordering
+
+Middleware is composed **outermost-first**: the first entry in the list is the outermost wrapper. It runs first on the way in and last on the way out.
+
+```python
+middleware=[LoggingMiddleware('root'), TimingMiddleware('root')]
+```
+
+For the list above, execution flows:
+
+```
+LoggingMiddleware → TimingMiddleware → event.execute → TimingMiddleware → LoggingMiddleware
+```
+
+When middleware is resolved from configuration, feature-level middleware is composed outside step-level middleware, so feature-level middleware wraps every step.
+
+## Registering Middleware in config.yml
+
+Middleware can also be declared in `config.yml` and resolved from the DI container by `FeatureContext` during `execute_feature` / `execute_feature_async`. First register the middleware as a service, pointing `module_path` at `tiferet.utils.middleware` (or your own module):
+
+```yaml
+services:
+  logging_middleware:
+    module_path: tiferet.utils.middleware
+    class_name: LoggingMiddleware
+    parameters:
+      logger_id: root
+  timing_middleware:
+    module_path: tiferet.utils.middleware
+    class_name: TimingMiddleware
+    parameters:
+      logger_id: root
+```
+
+### Feature-level
+
+Feature-level middleware wraps **every step** in the feature:
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Numbers
+      middleware:
+        - logging_middleware
+      commands:
+        - service_id: add_number_event
+```
+
+### Step-level
+
+Step-level middleware applies to a **single command** only:
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Numbers
+      commands:
+        - service_id: add_number_event
+          middleware:
+            - timing_middleware
+```
+
+### Both levels combined
+
+Feature-level and step-level middleware compose together, feature-level outermost:
+
+```yaml
+features:
+  calc:
+    add:
+      name: Add Numbers
+      middleware:
+        - logging_middleware
+      commands:
+        - service_id: add_number_event
+          middleware:
+            - timing_middleware
+```
+
+Each named entry is resolved from the `services` registration and composed into the chain before the step executes.
+
+## Using Middleware Directly via handle()
+
+Outside feature execution, compose middleware programmatically by passing the `middleware` list to `handle()` or `handle_async()`:
+
+```python
+# Synchronous
+result = DomainEvent.handle(
+    GetError,
+    dependencies={'error_service': error_service},
+    middleware=[LoggingMiddleware('root')],
+    id='ERR_001',
+)
+
+# Asynchronous
+result = await DomainEvent.handle_async(
+    GetErrorAsync,
+    dependencies={'error_service': error_service},
+    middleware=[AsyncAuditMiddleware()],
+    id='ERR_001',
+)
+```
+
+## Error Handling in Middleware
+
+Middleware **observes and re-raises**; it must not suppress exceptions. Both built-in middleware log on the exception path and then re-raise the original exception unchanged, so error propagation and structured `TiferetError` handling continue to work exactly as they would without middleware:
+
+```python
+try:
+    result = next_fn()
+except Exception:
+    # Observe (log, time, trace) ...
+    raise
+```
+
+Middleware should not convert, swallow, or replace exceptions raised by the event; doing so would hide domain errors from callers and contexts.
+
+## Testing Middleware
+
+Middleware is straightforward to unit test with a stub `event` and a controllable `next_fn`. Assert against captured log records for the built-in middleware, and against `next_fn` invocation for custom middleware:
+
+```python
+# *** imports
+
+# ** infra
+import logging
+import pytest
+from unittest import mock
+
+# ** app
+from tiferet.utils.middleware import LoggingMiddleware
+
+# *** tests
+
+# ** test: logging_middleware_success
+def test_logging_middleware_success(caplog):
+    '''
+    LoggingMiddleware logs around a successful call and returns its result.
+    '''
+
+    # Arrange a stub event and a next_fn returning a sentinel.
+    event = mock.Mock()
+    event.__class__.__name__ = 'GetError'
+    next_fn = mock.Mock(return_value='ok')
+
+    # Act with DEBUG capture on the resolved logger.
+    with caplog.at_level(logging.DEBUG):
+        result = LoggingMiddleware('root')(event, {}, next_fn)
+
+    # Assert the chain result is returned unchanged and next_fn ran once.
+    assert result == 'ok'
+    next_fn.assert_called_once_with()
+
+# ** test: logging_middleware_reraises
+def test_logging_middleware_reraises(caplog):
+    '''
+    LoggingMiddleware logs an ERROR and re-raises the original exception.
+    '''
+
+    # Arrange a next_fn that raises.
+    event = mock.Mock()
+    event.__class__.__name__ = 'GetError'
+    next_fn = mock.Mock(side_effect=ValueError('boom'))
+
+    # Act / assert the exception propagates unchanged.
+    with pytest.raises(ValueError):
+        LoggingMiddleware('root')(event, {}, next_fn)
+```
+
+For async middleware, drive `__call__` with `asyncio.run` (or an async test) and an `async def` `next_fn`.
+
+## Related Documentation
+
+- [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns, `handle` / `handle_async`, and the Middleware Support section
+- [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service interface conventions (`MiddlewareService`)
+- [docs/core/utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md) — Utility and infrastructure conventions
+- [docs/guides/domain/logging.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/logging.md) — Logging configuration consumed by the built-in middleware

--- a/docs/guides/repos.md
+++ b/docs/guides/repos.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Repositories are the concrete data-access layer in Tiferet. Each repository implements a Service interface and encapsulates the interaction between a data utility (e.g., `Yaml`) and the domain's transfer objects and aggregates. Repositories are highly situational — their functionality is shaped by the specific structural requirements of the configuration format they manage.
+Repositories are the concrete data-access layer in Tiferet. Each repository implements a Service interface and inherits the shared `ConfigurationRepository` base, which handles format-specific file I/O for the domain's transfer objects and aggregates. Repositories are highly situational — their functionality is shaped by the specific structural requirements of the configuration format they manage.
 
 This guide covers the cross-cutting strategies and design decisions that apply to all repository modules, rather than any single domain.
 
@@ -15,62 +15,61 @@ This guide covers the cross-cutting strategies and design decisions that apply t
 
 Every repository implements a Service interface from `tiferet/interfaces/`. The interface defines the abstract CRUD operations; the repository provides the concrete data-utility wiring.
 
-| Repository | Implements | Utility |
+| Repository | Implements | Base |
 |---|---|---|
-| `AppYamlRepository` | `AppService` | `Yaml` |
-| `CliYamlRepository` | `CliService` | `Yaml` |
-| `DIYamlRepository` | `DIService` | `Yaml` |
-| `DIYamlRepository` | `DIService` | `Yaml` |
-| `ErrorYamlRepository` | `ErrorService` | `Yaml` |
-| `FeatureYamlRepository` | `FeatureService` | `Yaml` |
-| `LoggingYamlRepository` | `LoggingService` | `Yaml` |
+| `AppConfigRepository` | `AppService` | `ConfigurationRepository` |
+| `CliConfigRepository` | `CliService` | `ConfigurationRepository` |
+| `DIConfigRepository` | `DIService` | `ConfigurationRepository` |
+| `ErrorConfigRepository` | `ErrorService` | `ConfigurationRepository` |
+| `FeatureConfigRepository` | `FeatureService` | `ConfigurationRepository` |
+| `LoggingConfigRepository` | `LoggingService` | `ConfigurationRepository` |
 
-The naming convention is `<Domain>YamlRepository`. Other utility-backed implementations (e.g., JSON, SQLite) would follow the same interface with a different suffix.
+The naming convention is `<Domain>ConfigRepository`. All repositories inherit `ConfigurationRepository`, which resolves the backing loader (`YamlLoader` or `JsonLoader`) from the configuration file extension at runtime.
 
 ## No Package Exports
 
-Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service configuration (`container.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. This keeps the dependency graph clean — consuming code depends only on the abstract Service interface, never on a concrete repository.
+Repositories are **never exported** from `tiferet/repos/__init__.py`. They are resolved at runtime through the DI service registration (`config.yml` or equivalent), which specifies the `module_path` and `class_name` for each concrete implementation. This keeps the dependency graph clean — consuming code depends only on the abstract Service interface, never on a concrete repository.
 
-## Three-Attribute Foundation
+## Inherited Configuration Foundation
 
-Every repository shares three instance attributes set during construction:
+Every repository inherits three instance attributes from the `ConfigurationRepository` base:
 
 ```python
-# * attribute: yaml_file
-yaml_file: str
-
-# * attribute: default_role
-default_role: str
+# * attribute: config_file
+config_file: str
 
 # * attribute: encoding
 encoding: str
+
+# * attribute: default_role
+default_role: str
 ```
 
-- **`yaml_file`** — path to the YAML configuration file.
-- **`default_role`** — the TransferObject serialization role used for writes (typically `'to_data.yaml'`).
+- **`config_file`** — path to the configuration file (`.yaml`/`.yml` or `.json`).
 - **`encoding`** — file encoding (default `'utf-8'`).
+- **`default_role`** — the TransferObject serialization role used for writes (`'to_data'`).
 
-The constructor parameter follows the convention `<domain>_yaml_file` (e.g., `error_yaml_file`, `feature_yaml_file`).
+The constructor parameter follows the convention `<domain>_config` (e.g., `error_config`, `feature_config`) and is forwarded to the base as `config_file`.
 
 ## Reading Patterns
 
 ### Start-node navigation
 
-The `Yaml` utility's `start_node` callback navigates into the YAML structure before returning data to the caller. This isolates the repository from the top-level file layout.
+The inherited `_load` helper's `start_node` callback navigates into the configuration structure before returning data to the caller. This isolates the repository from the top-level file layout.
 
 ```python
 # Single entry by ID.
-error_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+error_data = self._load(
     start_node=lambda data: data.get('errors').get(id)
 )
 
 # Entire section.
-interfaces_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+interfaces_data = self._load(
     start_node=lambda data: data.get('interfaces', {})
 )
 ```
 
-Repositories use `start_node` for all read operations. The lambda receives the full parsed YAML dict and returns the relevant subsection.
+Repositories use `start_node` for all read operations. The lambda receives the full parsed configuration dict and returns the relevant subsection.
 
 ### Data-factory callback
 
@@ -78,26 +77,26 @@ For complex loading that needs to construct multiple transfer objects in a singl
 
 ```python
 def data_factory(data):
-    attrs = [
-        ServiceConfigurationYamlObject.model_validate({**attr_data, 'id': id})
-        for id, attr_data in data.get('services', {}).items()
+    registrations = [
+        ServiceRegistrationConfigObject.model_validate({**reg_data, 'id': id})
+        for id, reg_data in data.get('services', {}).items()
     ] if data.get('services') else []
     consts = data.get('const', {}) if data.get('const') else {}
-    return attrs, consts
+    return registrations, consts
 
-services_data, consts = Yaml(self.yaml_file, encoding=self.encoding).load(
+registrations_data, consts = self._load(
     data_factory=data_factory
 )
 ```
 
-Use `data_factory` when the YAML file contains **multiple sibling sections** that must be returned together (e.g., `attrs` + `const`, or `formatters` + `handlers` + `loggers`).
+Use `data_factory` when the configuration file contains **multiple sibling sections** that must be returned together (e.g., `services` + `const`, or `formatters` + `handlers` + `loggers`).
 
-### ID derivation from YAML keys
+### ID derivation from configuration keys
 
-YAML configuration files store entries as dictionaries keyed by identifier. The ID is not stored inside the value — it is derived from the key and injected during mapping:
+Configuration files store entries as dictionaries keyed by identifier. The ID is not stored inside the value — it is derived from the key and injected during mapping:
 
 ```python
-return ErrorYamlObject.model_validate(
+return ErrorConfigObject.model_validate(
     {**error_data, 'id': id}   # Key becomes the domain object's ID.
 ).map()
 ```
@@ -116,14 +115,14 @@ Every save method follows the same three-step sequence:
 
 ```python
 # Serialize.
-error_data = ErrorYamlObject.from_model(error)
+error_data = ErrorConfigObject.from_model(error)
 
 # Load full file.
-full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+full_data = self._load()
 
 # Update and persist.
 full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
-Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+self._save(full_data)
 ```
 
 The `setdefault` call ensures the section exists even on a fresh file.
@@ -134,7 +133,7 @@ Deletes are always **idempotent** — deleting a non-existent entry is a no-op:
 
 ```python
 # Load the section.
-errors_data = Yaml(self.yaml_file, encoding=self.encoding).load(
+errors_data = self._load(
     start_node=lambda data: data.get('errors', {})
 )
 
@@ -142,9 +141,9 @@ errors_data = Yaml(self.yaml_file, encoding=self.encoding).load(
 errors_data.pop(id, None)
 
 # Load full, update, persist.
-full_data = Yaml(self.yaml_file, encoding=self.encoding).load()
+full_data = self._load()
 full_data['errors'] = errors_data
-Yaml(self.yaml_file, mode='w', encoding=self.encoding).save(data=full_data)
+self._save(full_data)
 ```
 
 ## Grouped YAML Structures
@@ -193,19 +192,19 @@ Some YAML files contain **multiple parallel sections** that represent different 
 The repository's `list_all` returns a tuple of section results:
 
 ```python
-def list_all(self) -> Tuple[List[ServiceConfiguration], Dict[str, str]]:
-    # data_factory returns (services_list, constants_dict)
+def list_all(self) -> Tuple[List[ServiceRegistration], Dict[str, str]]:
+    # data_factory returns (registrations_list, constants_dict)
 ```
 
 Each section is parsed independently within the `data_factory`.
 
 ### Composite transfer object (logging)
 
-The logging repository uses `LoggingSettingsYamlObject` — a transfer object that composes `FormatterYamlObject`, `HandlerYamlObject`, and `LoggerYamlObject` into a single object representing the entire file:
+The logging repository uses `LoggingSettingsConfigObject` — a transfer object that composes `FormatterConfigObject`, `HandlerConfigObject`, and `LoggerConfigObject` into a single object representing the entire file:
 
 ```python
-data = Yaml(self.yaml_file, encoding=self.encoding).load(
-    data_factory=lambda d: LoggingSettingsYamlObject.hydrate(**d),
+data = self._load(
+    data_factory=lambda d: LoggingSettingsConfigObject.hydrate(**d),
     start_node=lambda d: d.get('logging', {})
 )
 return (
@@ -223,7 +222,7 @@ Repository tests use `pytest` with temporary YAML files created via `tmp_path`:
 
 ```python
 @pytest.fixture
-def yaml_file(tmp_path) -> str:
+def config_file(tmp_path) -> str:
     file_path = tmp_path / 'test_config.yaml'
     with open(file_path, 'w', encoding='utf-8') as f:
         yaml.dump(SAMPLE_DATA, f)
@@ -245,11 +244,11 @@ Tests operate against real temporary files, not mocks, because the repository's 
 
 1. **Define the Service interface** in `tiferet/interfaces/<domain>.py` with abstract CRUD methods.
 2. **Implement the repository** in `tiferet/repos/<domain>.py`:
-   - Extend the Service interface.
-   - Set the three-attribute foundation in `__init__`.
+   - Extend the Service interface together with `ConfigurationRepository`.
+   - Forward the `<domain>_config` path to the `ConfigurationRepository` base in `__init__`.
    - Implement each method using the read/write patterns above.
-3. **Write tests** in `tiferet/repos/tests/test_<domain>.py` with sample YAML data and `tmp_path` fixtures.
-4. **Register via DI** — add the repository to the container/DI configuration file with `module_path` and `class_name`. No `__init__.py` export needed.
+3. **Write tests** in `tests/repos/test_<domain>.py` with sample configuration data and `tmp_path` fixtures.
+4. **Register via DI** — add the repository to the DI configuration file with `module_path` and `class_name`. No `__init__.py` export needed.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
Documentation finalizer for Milestone 29 (Core DDD Parity II). Brings the events and repos docs — plus a new middleware guide — in line with the current ubiquitous language, and adds a previously-missing Assets code-style doc. Documentation-only; no production or test code changes.

Implements issue #866.

## Updated (issue #866 scope)
- `docs/core/events.md` — new **Per-Module Base Events** and **Middleware Support** sections; `AddError` example aligned to the base-event pattern.
- `docs/core/repos.md`, `docs/guides/repos.md` — migrated to `ConfigurationRepository` / `*ConfigRepository` / `config_file` / `*ConfigObject` / `default_role = to_data`; documented the shared base (extension dispatch, `UNSUPPORTED_CONFIG_FILE_TYPE`).
- `docs/core/utils.md` — Role-in-Runtime reference `FeatureYamlRepository` → `FeatureConfigRepository`.
- `docs/guides/events/di.md` — service configuration → service registration rename (title, events, `DIService` methods, error codes, prose/migration table).
- `docs/guides/events/app.md` — `GetAppInterface` documented as a repository-only read; `default_services` table/merge removed; default-merging note points to `AppInterface.apply_defaults` and `resolve_default_interface`.
- `docs/guides/events/feature.md` — `FeatureEvent` base event + `FeatureEvent` → `EventFeatureStep` rename; Changes subsection.

## Added
- `docs/guides/middleware.md` — new middleware usage guide (built-ins, `MiddlewareService`, sync/async, ordering, `config.yml` registration, `handle()` use, error handling, testing).
- `docs/core/assets.md` — new Assets code-style doc (imports, constants, functions, standalone classes, exports; plus the `exceptions`/`configs` specializations), linked from `docs/core/code_style.md`.

## Validity notes
- Verified against shipped code: the seven base events, `GetAppInterface` repo-only read, `AppInterface.apply_defaults`, `ConfigurationRepository`, DI `registration_*` / `SERVICE_REGISTRATION_*`, and the middleware utilities/interface.
- Two references describe **companion work not yet in `main`** (per the milestone handoff), documented as target behavior per the TRD/ACs: `resolve_default_interface` (`tiferet/contexts/app.py`) and `FeatureContext` config-driven middleware resolution.
- The `error.md` / `logging.md` / `sqlite.md` / `cli.md` event guides are intentionally unchanged; the base-event pattern is documented centrally in `events.md`.

[Warp conversation](https://app.warp.dev/conversation/df0c4322-da23-41df-a122-361828749cce)
