### PR TITLE
Docs/Core – Align all 12 guides to v2.0.0 and fix naming drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
-# AGENTS.md — Tiferet Framework (v2.0.0b3)
+# AGENTS.md — Tiferet Framework (v2.0.0)
 
 ## Project Overview
 
-**Tiferet** is a Python framework for Domain-Driven Design (DDD). It provides a layered architecture for building applications with domain events, service interfaces, configuration-driven feature workflows, and dependency injection. The framework uses YAML-based configuration files and Pydantic v2 for model validation.
+**Tiferet** is a Python framework for Domain-Driven Design (DDD). It provides a layered architecture for building applications with domain events, service interfaces, configuration-driven feature workflows, and dependency injection. The framework uses YAML or JSON configuration files and Pydantic v2 for model validation.
 
 - **Repository:** https://github.com/greatstrength/tiferet
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `2.0.0b3`
+- **Version:** `2.0.0`
 
 ## Architecture
 
@@ -19,13 +19,13 @@ The v2.0 codebase is a clean, single-layer architecture. All legacy packages hav
 tiferet/
 ├── assets/               # Constants, exceptions (TiferetError), shared config
 ├── blueprints/           # build_app, build_cli and top-level runtime orchestration
-├── contexts/             # Runtime orchestration (AppInterfaceContext, DIContext, Feature, Error, Logging)
-├── di/                   # App-level DI: ServiceProvider, DynamicServiceProvider
+├── contexts/             # Runtime orchestration: BaseContext registry + AppSessionContext hub (Feature, Error, Logging) + CliContext
+├── di/                   # DI: core.py ABCs + dependency_injector.py impls (DIAppServiceContainer, DIDynamicServiceResolver) + legacy settings.py
 ├── domain/               # DomainObject base class and domain modules
 ├── events/               # DomainEvent base class and domain event modules
 ├── interfaces/           # Service ABC and domain service interfaces
 ├── mappers/              # Aggregate + TransferObject base classes and domain mappers
-├── repos/                # YAML-backed Service implementations
+├── repos/                # Configuration-backed Service implementations (YAML/JSON)
 ├── utils/                # Infrastructure utilities (file I/O, database, computational processes)
 └── tests_int/            # Integration tests
 ```
@@ -36,18 +36,20 @@ A working calculator application is provided in `examples/basic_calculator/`.
 
 **Key Concepts**:
 
-- **DomainObject** (`domain/settings.py`): Base domain model class extending `pydantic.BaseModel`. Instantiate via direct Pydantic constructors (e.g., `Feature(id='calc.add', ...)`). Use `model_construct()` to skip validation. Domain objects are read-only; mutation goes through Aggregates.
-- **DomainEvent** (`events/settings.py`): Base class for domain operations. Receives dependencies via constructor injection. Entry point is `execute(**kwargs)`. Use `@DomainEvent.parameters_required([...])` for declarative input validation. Use `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` for invocation in tests.
+- **DomainObject** (`domain/core.py`): Base domain model class extending `pydantic.BaseModel`. Instantiate via direct Pydantic constructors (e.g., `Feature(id='calc.add', ...)`). Use `model_construct()` to skip validation. Domain objects are read-only; mutation goes through Aggregates.
+- **DomainEvent** (`events/settings.py`): Base class for domain operations. Receives dependencies via constructor injection. Entry point is `execute(**kwargs)`. Use `@DomainEvent.parameters_required([...])` for declarative input validation. Use `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` for invocation in tests. Each single-service event module defines a per-module base event (e.g., `ErrorEvent`, `FeatureEvent`) that holds the shared service injection; concrete events extend the base and define only `execute`.
 - **Service** (`interfaces/settings.py`): Abstract base class (`ABC`) for all service contracts. All vertical concerns (data access, config, utilities) are unified under Service.
+- **MiddlewareService** (`interfaces/middleware.py`): Abstract callable that wraps domain event execution. Implement `__call__(self, event, kwargs, next_fn)` for sync middleware or `async def __call__` for async. Resolved from the DI container by `service_id` and composed into an ordered chain by `FeatureContext`.
 - **Aggregate** (`mappers/settings.py`): Mutable extension of domain objects. Instantiate via direct constructors. Provides `set_attribute()` for validated mutation with `validate_assignment=True`.
 - **TransferObject** (`mappers/settings.py`): Serialization layer with role-based field control via `_ROLES` ClassVar. Methods: `to_primitive(role)`, `map(target)`, `@classmethod from_model()`. Uses lenient config (`extra='ignore'`).
+- **BaseContext** (`contexts/settings.py`): Base class for all contexts, with a `ContextMeta` metaclass registry keyed by `domain_type`. `BaseContext.for_domain(DomainType)` resolves the registered context class; `BaseContext.from_domain(domain_obj, **kwargs)` constructs a context and binds the domain object as `ctx.domain`. The base holds no cache; contexts that need a `CacheContext` (e.g., `AppSessionContext`, `FeatureContext`) wire it themselves. The `AppSessionContext` hub binds the loaded `AppSession` and builds its sub-contexts on demand.
 
 ### Runtime Flow
 
-1. `App(interface_id)` (alias for `build_app`) resolves the interface and returns an `AppInterfaceContext`.
-2. The blueprint loads the app service (typically `AppYamlRepository`), resolves the interface via `GetAppInterface`, and wires the DI container.
-3. `AppInterfaceContext.run(feature_id, data={})` parses the request, executes the feature, and returns the response.
-4. `FeatureContext.execute_feature()` loads the feature config, resolves services from `DIContext`, and executes them sequentially.
+1. `App(interface_id)` (alias for `core.build_app`) resolves the app session and returns an `AppSessionContext`.
+2. `core.build_app` builds the shared cache (`build_cache`), composes the app service and resolves the session via the `GetAppSession` event (`get_app_session`), then constructs the context via `build_app_session_context`: it builds the app service container by merging cache defaults with the session's own constants/services (`build_app_service_container`), composes a `ServiceResolver` (`build_service_resolver`), resolves the hub's event collaborators from the app container, and constructs the `AppSessionContext` via `BaseContext.from_domain(app_session, get_dependency=resolver.get_dependency, ...)` — the context graph itself is not DI-resolved. No `apply_defaults` is called on the core path.
+3. `AppSessionContext.run(feature_id, data={})` builds a logger, parses the request, loads the `Feature` domain object, executes it, and returns the response.
+4. The hub builds its sub-contexts (`FeatureContext`, `ErrorContext`, `LoggingContext`) on demand; `FeatureContext.execute_feature(feature, request)` resolves each step's service via the injected `get_dependency` handler (from `ServiceResolver`) and executes it sequentially. When the loaded `Feature` has `is_async` set, the hub instead selects `AsyncFeatureContext` (a `FeatureContext` subclass) and drives `execute_feature_async` to completion via a `_run_coroutine` helper, keeping `run()` synchronous.
 5. Each step is a `DomainEvent` subclass that receives injected services and performs domain logic.
 6. Results flow back through `RequestContext` and `handle_response()`.
 
@@ -55,35 +57,38 @@ A working calculator application is provided in `examples/basic_calculator/`.
 
 Blueprints (`tiferet/blueprints/`) are module-level functions that orchestrate application bootstrapping and execution. They replace the previous class-based `AppBuilder`/`CliBuilder` pattern from v2.0.0b2.
 
-- `build_app(interface_id, ...)` is defined in `tiferet/blueprints/main.py` and exported as `App` from `tiferet/__init__.py`. It resolves the interface definition, builds the DI container, and returns a fully wired `AppInterfaceContext`.
-- `build_cli(interface_id, ...)` is defined in `tiferet/blueprints/cli.py` and exported as `CLI` from `tiferet/__init__.py`. It extends the app blueprint with argparse-based CLI parsing.
+- `build_app(interface_id, ...)` is defined in `tiferet/blueprints/core.py` and exported as `App` from `tiferet/__init__.py`. It chains `build_cache()` → `get_app_session(id, cache, ...)` → `build_app_session_context(session, cache)` → `INVALID_APP_SESSION_TYPE` validation, returning a fully wired `AppSessionContext`. (The former `blueprints/main.py` was retired in the Chapter M cleanup.)
+- `build_cli(interface_id, ...)` is defined in `tiferet/blueprints/cli.py` and exported as `CLI` from `tiferet/__init__.py`. It is a thin entrypoint that calls `core.build_app(...)` (the interface must point at `CliContext`) and delegates `argv` parsing and feature dispatch to `CliContext.run_cli`.
+- `build_tiferet_app` / `build_tiferet_cli` (`tiferet/blueprints/tiferet_app.py` / `tiferet_cli.py`, exported as `TiferetApp` / `TiferetCLI`) bootstrap the built-in `tiferet_app` / `tiferet_cli` sessions that are not in the consumer config; they resolve through the shared module-private `_resolve_bootstrap_session` in `tiferet_cli.py` (default-session fallback + `apply_defaults`).
 
-**Key blueprint functions in `main.py`:**
-- `create_service_provider(provider_type, type_map, **constants)` — Creates and configures a `ServiceProvider` instance.
-- `load_app_service(module_path, class_name, **parameters)` — Imports and constructs the application service.
-- `load_default_services()` — Loads default app service dependencies from `assets.blueprints`.
-- `resolve_interface(interface_id, ...)` — Loads the app service and resolves the interface definition via `GetAppInterface`.
-- `realize_interface(app_interface, interface_id, service_provider)` — Builds and validates the concrete `AppInterfaceContext`.
-- `build_app(interface_id, ...)` — Resolves and realizes the interface in a single call.
+**Core composition functions in `core.py` (`# *** blueprints`):**
+- `build_cache()` — builds the shared cache pre-seeded with default errors, app services, and constants.
+- `create_app_service(...)` — composes the app service via a single-use dynamic container.
+- `get_app_session(interface_id, cache, ...)` — resolves the app session via the `GetAppSession` event (raises `APP_SESSION_NOT_FOUND` when absent; no core fallback). The `cache` parameter is a build-ordering seam (`# ++ todo:` — default sessions are not yet cache-seeded).
+- `build_app_service_container(cache, app_instance)` — builds the singleton app service container by merging cache defaults with the session's own constants/services **before** building (session wins), so overrides reach default services the session does not redeclare.
+- `build_service_resolver(app_container)` — composes the feature-level `ServiceResolver`, caching the app container under the `app` flag.
+- `build_app_session_context(app_session, cache)` — imports the declared context class, resolves its collaborators from the app container, wires the four hub handlers, and constructs via `BaseContext.from_domain`.
+- `build_app(interface_id, ...)` — the single-call entry point chaining the above.
 
-**CLI blueprint functions in `cli.py`:**
-- `get_commands(service_provider)` — Resolves and groups `CliCommand` objects by `group_key`.
-- `get_parent_arguments(service_provider)` — Resolves parent-level CLI arguments.
-- `build_parser(cli_commands, parent_arguments)` — Composes the root `argparse.ArgumentParser`.
-- `parse_argv(parser, argv)` — Parses CLI arguments; exits 2 on failure.
-- `derive_feature_request(parsed)` — Derives `feature_id` and `headers` from parsed arguments.
-- `build_app(interface_id, argv, ...)` — Full CLI build: resolve interface, build parser, parse argv, dispatch feature. Exits 1 on `TiferetAPIError`.
+**Relocated legacy feature-DI bootstrap (module-private in `tiferet/blueprints/tiferet_cli.py`):** `_wire_services`, `_resolve_ctor_kwargs`, `_build_wiring_constants`, `_resolve_collaborators`, `_load_app_instance`, and the shared `_resolve_bootstrap_session`. Retained only for `build_tiferet_cli`, which still composes the resolver via the `CreateServiceResolver` bootstrap event; the standard app/CLI path uses the core compose path instead.
 
-CLI interfaces resolve to the default `AppInterfaceContext`; `CliContext` has been retired.
+**CLI blueprint function in `cli.py`:**
+- `build_app(interface_id, argv, ...)` — Thin CLI entrypoint: calls `core.build_app(...)` (a `CliContext`) and delegates to `cli_context.run_cli(argv)`. Exported as `build_cli` / `CLI`.
+
+CLI parsing is owned by `CliContext` (`tiferet/contexts/cli.py`): the side-effect-free module-level helpers `group_commands_by_key`, `build_parser`, and `derive_feature_request`, plus the `get_commands` / `parse_cli_request` / `run_cli` methods. Per-argument argparse translation lives on `CliArgument.to_argparse_kwargs()`. Consumer CLI interfaces opt in by pointing their config at `tiferet.contexts.cli` / `CliContext`.
 
 ### Dependency Injection
 
-Tiferet uses a two-layer DI architecture:
+As of v2.0.0b10, DI is provided by two classes in `tiferet/di/settings.py` (the previous `ServiceProvider` ABC, `DynamicServiceProvider`, `DependenciesServiceProvider` alias, and the feature-level `DIContext` have all been removed):
 
-- **App-level DI** (`tiferet/di/`) — `ServiceProvider` ABC and `DynamicServiceProvider` concrete implementation backed by `dependency-injector`'s `DynamicContainer`. The `create_service_provider` blueprint function assembles the full interface dependency graph via `AppInterface.get_service_type_mapping()` and resolves `AppInterfaceContext` via `service_provider.get_service('app_context')`.
-- **Feature-level DI** (`tiferet/contexts/di.py` — `DIContext`) — Builds and caches a `DynamicServiceProvider` per flag set from `ServiceConfiguration` objects loaded by `DIYamlRepository`. `FeatureContext` calls `DIContext.get_dependency(service_id, *flags)` to resolve each feature step.
+- **`ServiceContainer`** — the low-level engine, backed by `dependency-injector`'s `DynamicContainer`. Registers class types as `Factory` providers and scalars/callables as `Object` providers, and resolves instances via `get_service`. `build_factory(service_type)` wires each constructor parameter to a sibling provider via the shared `injectable_parameter_names` helper.
+- **`ServiceResolver`** — the application's single public provider. It takes a `DIService` and a `parse_parameter` callable as direct dependencies, reads service registrations and constants (merging bootstrap defaults via `merge_settings`), assembles a per-flag type map and constant set, and builds and caches a `ServiceContainer` per flag set. Its bound `get_dependency(registration_id, *flags)` method is injected into `AppSessionContext` and forwarded to each `FeatureContext` to resolve feature-step events and middleware.
 
-`DynamicServiceProvider.build_factory(service_type)` is a public method that builds a `Factory` provider with constructor kwargs wired to sibling providers. It inspects the constructor signature to identify injectable parameters and maps them to registered sibling providers.
+The DI layer is **event-free and asset-free** (it imports only stdlib, `dependency-injector`, `..domain`, and `..interfaces.di`); it assumes best-case inputs, raises raw exceptions for callers with event access to convert, and receives parameter parsing as the injected `parse_parameter` callable. `tiferet/di/settings.py` also exposes pure `# *** functions` — `injectable_parameter_names`, `normalize_flags`, `create_cache_key`, and `merge_settings` — exported from `tiferet/di/__init__.py`.
+
+Interface wiring is declarative: `wire_services` instantiates the interface's events and repositories into a name-to-value registry (no app-level container), and `load_app_instance` composes the `ServiceResolver` via the `CreateServiceResolver` bootstrap event (`tiferet/events/blueprint.py`) and injects `resolver.get_dependency`.
+
+A DI refactor (see Migration Notes) introduces an abstract, domain-only contract in `tiferet/di/core.py` (the `ServiceContainer` and `ServiceResolver` ABCs, plus `injectable_parameter_names` / `normalize_flags`) and concrete `dependency_injector`-backed implementations in `tiferet/di/dependency_injector.py` (`DIDynamicServiceContainer`, the Singleton `DIAppServiceContainer`, and the per-flag `DIDynamicServiceResolver`). These coexist with the legacy `tiferet/di/settings.py` classes above, which `build_app` still wires.
 
 ## Structured Code Style
 
@@ -91,7 +96,7 @@ All code follows a strict artifact comment hierarchy. **This is mandatory.**
 
 ### Comment Levels
 
-- `# *** <section>` — Top-level: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `repos`, `constants`, `classes`, `blueprints`
+- `# *** <section>` — Top-level: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `repos`, `constants`, `functions`, `classes`, `blueprints`
 - `# ** <category>: <name>` — Mid-level: `core`, `infra`, `app` (for imports); `model: <name>`, `event: <name>`, `context: <name>`, `blueprint: <name>`, etc.
 - `# * <component>` — Low-level: `attribute: <name>`, `init`, `method: <name>`, `method: <name> (static)`
 
@@ -140,12 +145,29 @@ self.verify(
 return feature
 ```
 
+### Annotation Artifacts
+
+Two transient lifecycle markers sit below the structural hierarchy and signal outstanding work or deprecated code:
+
+- **`# ++ todo: <message>`** — deferred work attached to an artifact (`++` = something to add/grow). Remove when resolved.
+- **`# -- obsolete: <reason>`** — deprecated artifact slated for removal (`--` = something to reduce/remove). Remove together with the artifact when retired.
+
+Both appear immediately after the `# *` / `# **` / `# ***` comment they annotate, before the code body. The `(obsolete)` parenthetical suffix on a `# *` label remains valid shorthand when no reason is needed.
+
+**Before starting any implementation session**, scan affected files for open annotations:
+
+```bash
+grep -rn "# ++\|# --" tiferet/
+```
+
+Full grammar and resolution expectations: [`docs/core/code_style.md § Annotation Artifacts`](docs/core/code_style.md).
+
 ## Domain Events
 
 Domain events are the primary operational units. Key patterns:
 
-- Extend `DomainEvent` from `tiferet/events/settings.py`.
-- Dependencies via constructor injection (usually a Service).
+- Extend the module's per-module base event (e.g., `ErrorEvent`, `FeatureEvent`, `AppEvent`, `CliEvent`, `DIEvent`, `LoggingEvent`, `SqliteEvent`), which holds the shared service; extend `DomainEvent` from `tiferet/events/settings.py` directly only when defining a new base event or a service-less event.
+- Dependencies via constructor injection (usually a Service), declared on the base event.
 - `execute(**kwargs)` is the entry point.
 - `@DomainEvent.parameters_required(['param1', 'param2'])` for declarative input validation (decorator on `execute`).
 - `self.verify(expression, error_code, message, **kwargs)` for domain rule enforcement.
@@ -155,6 +177,10 @@ Domain events are the primary operational units. Key patterns:
 ### Static Events
 
 `ParseParameter`, `ImportDependency`, `RaiseError` in `events/static.py` are utility events called with static `.execute()` methods.
+
+### Bootstrap Events
+
+`CreateServiceResolver` in `events/blueprint.py` is a bootstrap domain event that composes a fully wired `ServiceResolver` from an `AppSession`: it locates the `di_service` dependency, constructs the DI repository, builds the typed default-config index, and injects `ParseParameter.execute` so the DI layer never imports the parameter parser itself. It is invoked by `load_app_instance` via `DomainEvent.handle`.
 
 ### Testing Events
 
@@ -170,7 +196,7 @@ result = DomainEvent.handle(
 
 ## Domain Objects
 
-- Extend `DomainObject` from `tiferet/domain/settings.py`.
+- Extend `DomainObject` from `tiferet/domain/core.py`.
 - `DomainObject` extends `pydantic.BaseModel` with `ConfigDict(extra='forbid', populate_by_name=True, validate_assignment=True)`.
 - Declare fields with idiomatic Pydantic annotations: `name: str = Field(...)`.
 - Instantiate via direct constructors: `Error(id='invalid_input', name='Invalid Input')`.
@@ -182,19 +208,20 @@ result = DomainEvent.handle(
 
 ### Domain Modules
 
-- `domain/app.py` — `AppInterface`, `AppServiceDependency`
+- `domain/core.py` — `DomainObject`, `ServiceDependency`
+- `domain/app.py` — `AppSession`, `AppServiceDependency`
 - `domain/cli.py` — `CliCommand`, `CliArgument`
-- `domain/di.py` — `ServiceConfiguration`, `FlaggedDependency`
+- `domain/di.py` — `ServiceRegistration` (with `resolve_service` / `get_service_type`), `FlaggedDependency`
 - `domain/error.py` — `Error`, `ErrorMessage`
-- `domain/feature.py` — `Feature`, `FeatureStep`, `FeatureEvent`
-- `domain/logging.py` — `Formatter`, `Handler`, `Logger`
+- `domain/feature.py` — `Feature`, `FeatureStep`, `EventFeatureStep`
+- `domain/logging.py` — `Formatter`, `Handler`, `Logger`, `LoggingSettings`
 
 ## Interfaces (Services)
 
 - Extend `Service` (ABC) from `tiferet/interfaces/settings.py`.
 - All methods marked `@abstractmethod`.
 - Artifact comments use `# *** interfaces` / `# ** interface: <name>`.
-- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`.
+- Services: `AppService`, `CliService`, `ConfigurationService`, `ContainerService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `CacheService`, `MiddlewareService`.
 
 ## Mappers
 
@@ -205,21 +232,21 @@ Split into two classes:
 
 ### Naming Convention
 
-- `<Domain>Aggregate` (e.g., `FeatureAggregate`, `ErrorAggregate`, `ServiceConfigurationAggregate`)
-- `<Domain>YamlObject` (e.g., `FeatureYamlObject`, `ErrorYamlObject`, `ServiceConfigurationYamlObject`)
+- `<Domain>Aggregate` (e.g., `FeatureAggregate`, `ErrorAggregate`, `ServiceRegistrationAggregate`)
+- `<Domain>ConfigObject` (e.g., `FeatureConfigObject`, `ErrorConfigObject`, `ServiceRegistrationConfigObject`)
 
 ## Repositories
 
-Concrete `Service` implementations in `tiferet/repos/`. Currently all YAML-backed. Repositories are **never exported** from `__init__.py` — they are resolved at runtime through DI configuration.
+Concrete `Service` implementations in `tiferet/repos/`. All configuration repositories extend `ConfigurationRepository` (`repos/settings.py`), which provides format-agnostic I/O via `_load()` / `_save()` with automatic dispatch to YAML or JSON based on file extension. Repositories are **never exported** from `__init__.py` — they are resolved at runtime through DI configuration.
 
-- `AppYamlRepository`, `CliYamlRepository`, `ContainerYamlRepository`
-- `DIYamlRepository`, `ErrorYamlRepository`, `FeatureYamlRepository`, `LoggingYamlRepository`
+- `AppConfigRepository`, `CliConfigRepository`
+- `DIConfigRepository`, `ErrorConfigRepository`, `FeatureConfigRepository`, `LoggingConfigRepository`
 
 Key patterns:
 - Artifact comments use `# *** repos` / `# ** repo: <name>`.
-- Three-attribute foundation: `yaml_file`, `encoding`, `default_role`.
-- Constructor param convention: `<domain>_yaml_file` (e.g., `error_yaml_file`).
-- Reads use `Yaml` utility with `start_node` lambdas and `model_validate` to construct TransferObjects; writes use `TransferObject.from_model` → `to_primitive(default_role)` → `Yaml.save`.
+- All repos extend `ConfigurationRepository` which provides: `config_file`, `encoding`, `default_role` (set to `'to_data'`).
+- Constructor param convention: `<domain>_config` (e.g., `error_config`, `app_config`).
+- Reads use `self._load(start_node=..., data_factory=...)` and `model_validate` to construct TransferObjects; writes use `TransferObject.from_model` → `to_primitive(self.default_role)` → `self._save(data=...)`.
 - Delete operations are always idempotent.
 - Tests are integration tests using `tmp_path` fixtures with real temporary YAML files.
 
@@ -247,8 +274,8 @@ New error constants added in the b2→b3 cycle:
 Applications are configured in a consolidated root `config.yml` file:
 
 - `interfaces` — Interface definitions (name, module_path, class_name, service dependencies)
-- `services` — Feature-level DI service configurations (module_path, class_name, parameters, flagged dependencies)
-- `features` — Feature workflows (commands with service_id, parameters, data mapping, and optional `condition` expressions for conditional step execution)
+- `services` — Feature-level DI service registrations (module_path, class_name, parameters, flagged dependencies)
+- `features` — Feature workflows (commands with service_id, parameters, data mapping, optional `condition` expressions for conditional step execution, and optional `middleware` lists at feature or step level)
 - `errors` — Error definitions with multilingual messages
 - `cli` — CLI command definitions with arguments
 - `logging` — Logging formatters, handlers, loggers
@@ -276,6 +303,8 @@ Current utilities:
 - `Csv` / `CsvLoader` — List-based CSV with helpers.
 - `CsvDict` / `CsvDictLoader` — Dict-based CSV.
 - `Sqlite` / `SqliteClient` — SQLite client implementing `SqliteService` and `FileService`.
+- `LoggingMiddleware` — DEBUG/ERROR logging middleware via stdlib `logging`; takes `logger_id: str`.
+- `TimingMiddleware` — Wall-clock timing middleware via `time.perf_counter`; takes `logger_id: str`.
 
 ### SQLite API (v2.0.0b3)
 
@@ -315,22 +344,118 @@ The top-level `tiferet/__init__.py` exports:
 ## Key Files for Orientation
 
 - `tiferet/__init__.py` — Version and public exports
-- `tiferet/domain/settings.py` — `DomainObject` base class (extends `pydantic.BaseModel`)
+- `tiferet/domain/core.py` — `DomainObject` base class (extends `pydantic.BaseModel`) and `ServiceDependency` core model
 - `tiferet/events/settings.py` — `DomainEvent` base class (execute, verify, parameters_required, handle)
 - `tiferet/mappers/settings.py` — `Aggregate` and `TransferObject` base classes
 - `tiferet/interfaces/settings.py` — `Service` (ABC) base class
-- `tiferet/di/settings.py` — `ServiceProvider` ABC
-- `tiferet/di/dynamic.py` — `DynamicServiceProvider` (app-level DI, backed by `dependency-injector`)
-- `tiferet/blueprints/main.py` — `build_app` (public app orchestration entry point)
-- `tiferet/blueprints/cli.py` — `build_cli` (CLI orchestration entry point, exported as `CLI`)
-- `tiferet/contexts/app.py` — `AppInterfaceContext`
-- `tiferet/contexts/di.py` — `DIContext` (feature-level DI)
-- `tiferet/contexts/feature.py` — `FeatureContext` (feature execution engine)
-- `tiferet/assets/constants.py` — Error codes and default configuration
+- `tiferet/di/core.py` — `ServiceContainer` / `ServiceResolver` ABCs + `injectable_parameter_names` / `normalize_flags`
+- `tiferet/di/dependency_injector.py` — `DIDynamicServiceContainer` (Factory), `DIAppServiceContainer` (Singleton), `DIDynamicServiceResolver` (per-flag)
+- `tiferet/di/settings.py` — legacy `ServiceContainer` (DI engine) and `ServiceResolver` (public provider), still wired by `build_app`
+- `tiferet/blueprints/core.py` — `build_app` (public app orchestration entry point, exported as `App`) plus the composition chain: `build_cache`, `create_app_service`, `get_app_session`, `build_app_service_container`, `build_service_resolver`, `build_app_session_context`
+- `tiferet/blueprints/cli.py` — `build_cli` (CLI orchestration entry point, exported as `CLI`; calls `core.build_app` then `run_cli`)
+- `tiferet/blueprints/tiferet_cli.py` — `build_tiferet_cli` (`TiferetCLI`) plus the relocated module-private legacy feature-DI bootstrap (`_wire_services`, `_load_app_instance`, `_resolve_collaborators`, `_resolve_bootstrap_session`, ...)
+- `tiferet/blueprints/tiferet_app.py` — `build_tiferet_app` (`TiferetApp`; core compose path + shared default-session fallback)
+- `tiferet/contexts/settings.py` — `BaseContext` and `ContextMeta` (domain→context registry, `for_domain`, `from_domain`)
+- `tiferet/contexts/app.py` — `AppSessionContext` (minimal declarative hub bound to the loaded `AppSession`)
+- `tiferet/contexts/cli.py` — `CliContext` (CLI high-level context: argparse parsing helpers + `get_commands`/`parse_cli_request`/`run_cli`)
+- `tiferet/contexts/feature.py` — `FeatureContext` (sync feature execution engine) and `AsyncFeatureContext` (async subclass selected when `Feature.is_async` is set)
+- `tiferet/assets/constants.py` — Error codes plus the `create_default_error` / `create_app_service_dependency` factories
+- `tiferet/assets/app.py` — Default interface definitions and the `CORE_DEFAULT_SERVICES` / `CORE_DEFAULT_CONSTANTS` bootstrap catalogs
 - `tiferet/assets/exceptions.py` — `TiferetError` and `TiferetAPIError`
+- `tiferet/repos/settings.py` — `ConfigurationRepository` base class (format-agnostic config I/O)
 - `examples/basic_calculator/` — Working calculator application example
 
 ## Migration Notes
+
+### Chapter M: Retire `main.py`, promote `core.build_app`
+
+The Chapter M cleanup makes `tiferet/blueprints/core.py` own the public `build_app` entry point and deletes `tiferet/blueprints/main.py`. Key changes:
+
+- **`core.build_app`** — New single-call entry point (exported as `App`), ordered `build_cache()` → `get_app_session(id, cache, ...)` → `build_app_session_context(session, cache)` → `INVALID_APP_SESSION_TYPE` validation. It never calls `apply_defaults` / `resolve_default_interface`; all framework defaults come from the cache seeded by `build_cache`.
+- **`core.get_app_session`** — Gained an optional `cache` build-ordering seam (`# ++ todo:` — default sessions are not yet cache-seeded; kept `= None` so the obsolete `get_app_interface` alias still resolves). The obsolete `core.execute_feature` was removed.
+- **`core.build_app_service_container`** — Now merges the framework default services/constants (from the cache) with the session's own **before** building the container (single `from_dependencies` call) instead of layering overrides onto an already-built container. This fixes the stale-singleton wiring finding for the core path, which no longer passes a defaults-applied session: an interface constant override reaches default services the session does not redeclare.
+- **`cli.build_app`** — Rewritten to call `core.build_app(...)` then `cli_context.run_cli(argv)`.
+- **`tiferet_app.build_tiferet_app`** — Repointed onto the core compose path with the shared default-session fallback.
+- **Relocation** — The legacy declarative feature-DI bootstrap (`wire_services`, `resolve_ctor_kwargs`, `build_wiring_constants`, `resolve_collaborators`, `load_app_instance`) plus a shared `_resolve_bootstrap_session` (relocated `resolve_interface` logic: `get_app_session` → `resolve_default_interface` fallback → `apply_defaults`) moved (module-private, underscore-prefixed) into `tiferet/blueprints/tiferet_cli.py`. `build_tiferet_cli` still needs them; the standard app/CLI path does not.
+- **Removal** — `tiferet/blueprints/main.py` deleted; `blueprints/__init__.py` imports `build_app` / `App` from `core`. `apply_defaults` (`domain/app.py`) and `resolve_default_interface` (`contexts/app.py`) are now downstream-only, used solely by the relocated bootstrap path.
+- **Deferred** — Seeding default app *sessions* into the cache (so the built-in bootstrappers can drop the fallback and call `core.build_app` directly); removing `apply_defaults` / `resolve_default_interface`; deep `build_tiferet_cli` feature-DI parity; N4 (`CreateServiceResolver` disposition); N5 (`di/settings.py` consolidation).
+
+### DI App Service Container & Feature Service Resolver
+
+This cycle introduces an app-level service container and a feature-level service resolver alongside a DI-layer refactor, all additive (the legacy `tiferet/di/settings.py` remains wired by `build_app`):
+
+- **Abstract DI contract** (`tiferet/di/core.py`) — Adds the `ServiceContainer` and `ServiceResolver` ABCs. `ServiceResolver` owns a per-flag container cache plus a template-method `get_dependency`, leaving `build_container` abstract. `normalize_flags` is relocated here (canonical) alongside `injectable_parameter_names`; `settings.py` re-imports `normalize_flags`, and `tiferet/di/__init__.py` repoints it to `core.py`.
+- **Dependency-injector implementations** (`tiferet/di/dependency_injector.py`) — `DIDynamicServiceContainer` (Factory scope); `DIAppServiceContainer` (Singleton scope, `build_singleton`, and a `from_dependencies` classmethod keyed by `service_id`); and `DIDynamicServiceResolver` (holds a `DIService` + injected `parse_parameter`, implements `build_container`). `DIAppServiceContainer` is exported from `tiferet/di/__init__.py`.
+- **`ServiceRegistration.resolve_service`** (`tiferet/domain/di.py`) — Centralizes the flagged-override → default → None precedence, returning the effective core `ServiceDependency` for a flag set; `get_service_type` now delegates to it.
+- **Cache enumeration** — `CacheContext.get_by_prefix(prefix)` (`tiferet/contexts/cache.py`) returns all entries whose keys start with a prefix. `contexts/app.py` adds `get_default_app_services` / `get_default_app_constants` getters that read the `app_service_` / `app_constant_` cache prefixes seeded by the existing `add_default_app_*` decorators.
+- **Blueprint helpers** (`tiferet/blueprints/core.py`) — `build_app_service_container(cache, app_instance, service_container=DIAppServiceContainer)` composes the app service container from cache-seeded defaults plus interface overrides; `parse_parameter` is a thin wrapper over the `ParseParameter` static event for injection into the resolver.
+- **Deferred** — Wiring the new resolver / app container into `build_app`, consolidating the legacy `settings.py` (including its duplicate `ServiceContainer`), and reconciling `tiferet/di/__init__.py` exports remain follow-ups.
+
+### v2.0.0b13: Bootstrap/Default Configuration Finalization
+
+The v2.0.0b13 cycle finalizes the bootstrap/default configuration architecture and applies a behavior-preserving naming refactor. Key changes:
+
+- **`ServiceConfiguration` → `ServiceRegistration`** — The DI domain concept (`domain/di.py`) is renamed to `ServiceRegistration` (it models a DI registration). Mappers become `ServiceRegistrationAggregate`/`ServiceRegistrationConfigObject`; `DIService`/`DIConfigRepository` methods become `registration_exists`, `get_registration`, `save_registration`, `delete_registration` (param `registration_id`); the resolver's `get_dependency(registration_id, *flags)` param is renamed to match; events become `AddServiceRegistration`/`SetDefaultServiceRegistration`/`RemoveServiceRegistration`; error constants become `INVALID_SERVICE_REGISTRATION`, `SERVICE_REGISTRATION_NOT_FOUND`, `SERVICE_REGISTRATION_ALREADY_EXISTS`; bootstrap service ids become `add_service_registration_evt`/`set_default_service_registration_evt`/`remove_service_registration_evt`. `ListAllSettings`, `SetServiceDependency`, `RemoveServiceDependency`, `SetServiceConstants`, the `di_list_all_configs_evt` id, and the persisted `services:` config section are unchanged.
+- **`*YamlObject` → `*ConfigObject`** — All transfer objects are renamed from the `*YamlObject` suffix to `*ConfigObject` (configs load as YAML or JSON by registered extension, completing the b7 `*ConfigRepository` direction): e.g., `FeatureYamlObject` → `FeatureConfigObject`, `ErrorYamlObject` → `ErrorConfigObject`, `ServiceRegistrationConfigObject`, `LoggingSettingsYamlObject` → `LoggingSettingsConfigObject`, plus the non-exported child objects. The `# ** mapper: *_yaml_object` artifact comments become `*_config_object` and "YAML data representation" docstrings become "configuration data representation".
+- **Default configuration hoisting** — The listing/lookup events are now repo-only: `GetFeature`, `ListCliCommands`, `ListAllSettings`, and `GetAppInterface` no longer accept `default_*` params (and `GetAppInterface.get_from_defaults` is removed). Bootstrap defaults are id-keyed asset mappings (`assets/feature.py` `DEFAULT_TIFERET_CLI_FEATURES` and `assets/cli_commands.py` `DEFAULT_TIFERET_CLI_COMMANDS` are now `Dict[str, dict]`) materialized by the pure builders `build_feature_index` / `build_command_list` in `contexts/app.py`. The fallback/merge moves to the orchestration layer: `AppInterfaceContext.load_feature_domain` falls back to the default feature index, `CliContext.get_commands` falls back to the default command list, and the blueprint's `resolve_interface` applies the interface fallback via the context helper `resolve_default_interface` (`contexts/app.py`, beside `build_feature_index` / `build_command_list`) and the service/constant merge via the non-mutating `AppInterface.apply_defaults` domain method (`domain/app.py`); neither imports the `AppInterfaceAggregate`. Consumer-facing `cli list-commands` / `service list` now return repo-only results.
+- **`LoggingSettings` value object** — A runtime value object (`domain/logging.py`, exported from `domain/__init__.py`) bundles `formatters`/`handlers`/`loggers` plus `version`/`disable_existing_loggers` and owns the `format_config()` dictConfig assembly (including the `root` entry drawn from the `is_root` logger). `LoggingContext.build_logger` now constructs a `LoggingSettings` from the `ListAllLoggingConfigs` lists (applying the built-in defaults as the per-section fallback) and calls `settings.format_config()` then `create_logger`; the context's inline `format_config` method is removed. The `logging_list_all_evt` collaborator and `logger_id` handling are unchanged, the value object is runtime-only (no Aggregate/TransferObject), and `logger_id` stays out of it.
+- **Bootstrap service/constant catalogs moved to `assets/app.py`** — The bootstrap service-wiring list and config constants were reshaped from `assets/blueprints.py` (`DEFAULT_SERVICES: List[Tuple]` / `DEFAULT_CONSTANTS: Dict`) into id/model/group constants in `assets/app.py` (exported as `a.app`), mirroring the default-error catalog: a new `create_app_service_dependency` factory (`assets/constants.py`), id and model constants, and the `CORE_DEFAULT_SERVICES` (keyed by service id) / `CORE_DEFAULT_CONSTANTS` (keyed by config id) group mappings. `load_default_services` now builds via `AppServiceDependency.model_validate` over `a.app.CORE_DEFAULT_SERVICES.values()`, and both `resolve_interface`'s `apply_defaults` and the `tiferet_cli` bootstrap merge read `a.app.CORE_DEFAULT_CONSTANTS`; `assets/blueprints.py` retains only `DEFAULT_APP_SERVICE_MODULE_PATH` / `DEFAULT_APP_SERVICE_CLASS_NAME`. The core `build_cache` (`blueprints/core.py`) additionally pre-seeds these catalogs via new `add_default_app_services` / `add_default_app_constants` decorators (`contexts/app.py`), namespacing errors, services, and constants under the `error_`, `app_service_`, and `app_constant_` cache-key prefixes (the `main.py` / `admin.py` `build_cache` variants are unchanged).
+
+### v2.0.0b11: CliContext Reincorporation
+
+The v2.0.0b11 cycle reincorporates `CliContext` as a high-level context and slims both CLI blueprints to thin entrypoints. Key changes:
+
+- **`CliContext`** (`tiferet/contexts/cli.py`) — Extends `AppInterfaceContext` with command-line concerns: `get_commands`, `parse_cli_request`, and `run_cli`, orchestrating the side-effect-free module-level helpers `group_commands_by_key`, `build_parser`, and `derive_feature_request`. It intentionally omits `domain_type`, so the `ContextMeta` registry still maps `AppInterface` to `AppInterfaceContext`; the CLI context is selected via the interface's `module_path`/`class_name`.
+- **Generalized collaborator wiring** — `resolve_collaborators(context_cls, registry)` now inspects the realized context class's injectable constructor parameters (skipping `get_dependency`/`cache` and `default_*`), so a `CliContext` receives `list_commands_evt`/`get_parent_args_evt` while the generic `AppInterfaceContext` still resolves only its original three. `load_app_instance` imports the context class before resolving collaborators.
+- **Slim CLI blueprints** — `tiferet/blueprints/cli.py` (`build_cli`/`CLI`) reduces to resolve → realize → `cli_context.run_cli(argv)`; the old `get_commands`/`get_parent_arguments`/`build_argument_kwargs`/`build_parser`/`parse_argv`/`derive_feature_request` helpers were removed (the shared logic lives in `tiferet/contexts/cli.py`). `tiferet/blueprints/tiferet_cli.py` drops `_build_tiferet_command_map` and the mapper import, seeds bootstrap commands via `default_commands`, and decodes JSON args after `parse_cli_request` before `run`.
+- **Built-in CLI interface** — `DEFAULT_TIFERET_CLI_INTERFACE` (`tiferet/assets/app.py`) now points at `tiferet.contexts.cli` / `CliContext`. Consumer CLI interfaces must likewise opt in.
+- **`CliArgument.to_argparse_kwargs()`** — Per-argument argparse translation moved onto the `CliArgument` domain model (co-located with `get_type()`), replacing the module-level `build_argument_kwargs`.
+
+### v2.0.0b10: DI Redesign, Per-Module Base Events, and Async Feature Split
+
+The v2.0.0b10 cycle reworks dependency injection, introduces per-module base domain events, and splits async feature execution. Key changes:
+
+- **DI redesign** — The `ServiceProvider` ABC, `DynamicServiceProvider`, the `DependenciesServiceProvider` alias, and the feature-level `DIContext` (`tiferet/contexts/di.py`) have been removed. DI now lives in `tiferet/di/settings.py` as `ServiceContainer` (the `dependency-injector`-backed engine) and `ServiceResolver` (the application's single public provider, which takes `DIService` directly and caches a `ServiceContainer` per flag set). `AppInterfaceContext` and `FeatureContext` consume an injected `get_dependency` callable. The blueprint wires the interface declaratively via `wire_services` (no app-level container) and composes the `ServiceResolver` via the `CreateServiceResolver` bootstrap event in `load_app_instance`. The `create_service_provider` blueprint factory was removed.
+- **Per-module base events** — Each single-service event module defines a base event holding the shared service: `ErrorEvent`, `FeatureEvent`, `AppEvent`, `CliEvent`, `DIEvent`, `LoggingEvent`, `SqliteEvent`. Concrete events extend the base and keep only their `execute` (and `@DomainEvent.parameters_required`). Static events (`events/static.py`) are unchanged.
+- **Domain object rename** — The feature step domain object `FeatureEvent` was renamed to `EventFeatureStep` (mappers `FeatureEventAggregate`/`FeatureEventYamlObject` → `EventFeatureStepAggregate`/`EventFeatureStepYamlObject`) to free the `FeatureEvent` name for the new base event.
+- **Async feature split** — Async step execution moved into `AsyncFeatureContext(FeatureContext)`; a `Feature.is_async` flag selects it, and the hub drives it via `_run_coroutine` while keeping `run()` synchronous.
+- **Code style** — A new `# *** functions` module preamble section documents side-effect-free module-level functions (e.g., the SQLite identifier helper in `events/sqlite.py`).
+- **Event-free DI + resolver composition event** — `tiferet/di/settings.py` is now event-free and asset-free: `ServiceContainer.get_service` and `ServiceResolver.build_type_map` assume best-case inputs and let raw exceptions surface; the `container_factory`/`default_container` indirection was removed in favor of an injected `parse_parameter` callable (default identity). The defaults-merge and signature/flag/cache helpers were extracted as pure `# *** functions` (`merge_settings`, `injectable_parameter_names`, `normalize_flags`, `create_cache_key`) and exported from `tiferet/di/__init__.py`. `ServiceResolver` construction moved into the new `CreateServiceResolver` bootstrap event (`tiferet/events/blueprint.py`); the blueprint's `build_config_index` helper was removed and `main.py` gained a `# *** functions` section (`resolve_ctor_kwargs`, `build_wiring_constants`, `resolve_collaborators`). `FeatureContext.load_feature_middleware` now raises a new `MIDDLEWARE_LOADING_FAILED` error, and the dead `AppInterface.service_provider_path` / `service_provider_class_name` fields were removed. `ListAllSettings` (wired as `di_list_all_configs_evt`) is retained and refactored to delegate to `merge_settings`.
+
+### v2.0.0b9: Declarative Context Architecture (Minimal Hub)
+
+The v2.0.0b9 release standardizes contexts under a `BaseContext` registry and makes the application interface context a minimal, declaratively-constructed hub. Key changes:
+
+- **`BaseContext` + `ContextMeta`** (`tiferet/contexts/base.py`) — New base class and metaclass. Contexts declare a `domain_type` ClassVar; the metaclass registers each `{domain_type: context_class}` pair (own-namespace declarations only, so subclasses do not clobber base registrations). `BaseContext.for_domain(DomainType)` resolves the registered class (raising `CONTEXT_NOT_FOUND` when missing); `BaseContext.from_domain(domain_obj, **kwargs)` constructs the context and binds the object as `ctx.domain`.
+- **`AppInterfaceContext` is now a minimal hub** — It no longer stores `interface_id`/`features`/`errors`/`logging`. Its constructor takes collaborators (`get_feature_evt`, `get_error_evt`, `di_list_all_configs_evt`, `logging_list_all_evt`, `create_service_provider`, `cache`) plus bootstrap defaults (`default_features`, `default_commands`, `default_configurations`, `default_constants`). It binds the loaded `AppInterface` via `from_domain` and reads `self.domain.id` / `self.domain.logger_id` on demand. The `FeatureContext` and `ErrorContext` are built on demand (resolved via `BaseContext.for_domain`) inside `execute_feature` / `handle_error`; the shared `DIContext` and `LoggingContext` remain lazily cached (`load_logging_context`). Domain objects are loaded and cached via `load_feature_domain` / `load_error_domain`, all sharing one `CacheContext`. Response handling delegates directly to `RequestContext.handle_response()` — the hub no longer defines its own `handle_response`.
+- **Declarative construction** — `load_app_instance` resolves the events/repos by name from the DI container, imports the context class from the interface's `module_path`/`class_name` (custom contexts like `FlaskApiContext` still work), and constructs it via `from_domain`. The dependency type mapping is built by the static `AppInterfaceContext.get_service_type_mapping(app_interface)` (moved off the `AppInterface` domain model, which retains only `AppServiceDependency.get_service_type()`); it does not add an `app_context` entry, and `DEFAULT_SERVICES` no longer registers the `services`/`features`/`errors`/`logging` contexts.
+- **Specialized contexts are pure operational behavior** — `FeatureContext.execute_feature(feature, request)` (and async/`resolve_feature_steps`) accept a pre-loaded `Feature`; feature retrieval moved to the hub. The feature-step executor is `handle_feature_step` / `handle_feature_step_async` (renamed from `handle_command`). `ErrorContext.format_response(error, exception, lang)` assembles the structured response from a pre-loaded `Error` via `Error.format_message` — response assembly was moved off the `Error` domain model (which keeps `format_message`; `ErrorMessage.format` is unchanged). The b9 `set_default_*` setters were removed; bootstrap defaults are seeded on the hub initializer and threaded through `realize_interface(..., default_*=...)`. Only `BaseContext` and `ContextMeta` are exported from `tiferet/contexts/__init__.py`; domain contexts are imported from their submodules.
+
+### v2.0.0b7: ConfigurationRepository & Role Consolidation
+
+The v2.0.0b7 release introduces a format-agnostic `ConfigurationRepository` base class and consolidates TransferObject serialization roles. Key changes:
+
+- **`ConfigurationRepository`** (`tiferet/repos/settings.py`) — New base class providing `_load()`, `_save()`, and `_get_loader()` methods that dispatch to `YamlLoader` or `JsonLoader` based on the config file extension (`.yml`/`.yaml` → YAML, `.json` → JSON). Raises `UNSUPPORTED_CONFIG_FILE_TYPE` for unknown extensions.
+- **Repository renames** — All six concrete repos have been renamed from `*YamlRepository` to `*ConfigRepository`:
+  - `AppYamlRepository` → `AppConfigRepository`
+  - `CliYamlRepository` → `CliConfigRepository`
+  - `DIYamlRepository` → `DIConfigRepository`
+  - `ErrorYamlRepository` → `ErrorConfigRepository`
+  - `FeatureYamlRepository` → `FeatureConfigRepository`
+  - `LoggingYamlRepository` → `LoggingConfigRepository`
+- **Constructor scalars** — Each repo’s constructor parameter has been renamed from `<domain>_yaml_file` to `<domain>_config` (e.g., `app_yaml_file` → `app_config`, `error_yaml_file` → `error_config`).
+- **Bootstrap defaults** (`tiferet/assets/blueprints.py`) — `DEFAULT_CONSTANTS` keys updated to match (`cli_config`, `di_config`, `error_config`, `logging_config`, `feature_config`). `DEFAULT_APP_SERVICE_CLASS_NAME` changed to `'AppConfigRepository'`. All `DEFAULT_SERVICES` class names updated.
+- **`_ROLES` consolidation** — All TransferObject `_ROLES` dicts have been consolidated: `'to_data.yaml'` → `'to_data'`, and redundant `'to_data.json'` entries have been removed. The `default_role` on all repos is now `'to_data'`.
+- **Usage pattern change**:
+  ```python
+  # Before (v2.0.0b6)
+  from tiferet import App
+  app = App('basic_calc', app_yaml_file='config.yml')
+
+  # After (v2.0.0b7)
+  from tiferet import App
+  app = App('basic_calc', app_config='config.yml')
+  ```
 
 ### v2.0.0b3: Blueprints Pattern
 

--- a/docs/core/assets.md
+++ b/docs/core/assets.md
@@ -22,7 +22,7 @@ There are no domain objects, aggregates, services, events, or contexts here. Tha
 ## The Assets Layer's Role
 
 - **Exceptions** — `TiferetError` and `TiferetAPIError` (`exceptions.py`) are the structured error types raised throughout the framework.
-- **Constants** — error-code identifiers and the `DEFAULT_ERRORS` catalog (`constants.py`), bootstrap wiring defaults (`blueprints.py`), and default logging configuration (`logging.py`).
+- **Constants** — error-code identifier constants (`constants.py`), the `DEFAULT_ERRORS` catalog (`error.py`), bootstrap wiring defaults (`blueprints.py`), and default logging configuration (`logging.py`).
 - **Exports** — `__init__.py` re-exports the commonly used symbols and exposes the `constants` and `blueprints` modules under the short aliases `const` and `bps`.
 
 ## Structured Code Design
@@ -37,14 +37,7 @@ Assets modules follow the standard Tiferet artifact comment hierarchy (see [code
 
 **Spacing rules** match the rest of the framework: one empty line between a top-level comment and the first mid-level comment, one empty line between mid-level entries, and one empty line after docstrings and between code snippets.
 
-### Domain-appropriate specializations
-
-Two modules use specialized labels that are variants of the kinds above, chosen for readability:
-
-- **`# *** exceptions` / `# ** exception: <name>`** (`exceptions.py`) — a specialization of standalone **classes** for exception types.
-- **`# *** configs` / `# ** config: <name>`** (`logging.py`) — a specialization of **constants** for default configuration data structures.
-
-Both remain, fundamentally, standalone classes and constants; the specialized labels simply describe intent.
+There are no specialized top-level labels in this layer. Exception types are plain standalone **classes** (`# *** classes` / `# ** class: <name>`), and default configuration data structures are plain **constants** (`# *** constants` / `# ** constant: <name>`).
 
 ## Artifact Kinds
 
@@ -60,58 +53,74 @@ import json
 
 ### Constants
 
-Constants are `SCREAMING_SNAKE_CASE` module-level values. Large related groups may share a descriptive `# ** constants: <group>` comment, and entries nested inside a data structure are annotated in place (e.g., `# * error: <NAME>` within `DEFAULT_ERRORS`):
+Constants are `SCREAMING_SNAKE_CASE` module-level values. Each constant carries its own `# ** constant: <snake_case_name>` label — related constants are not grouped under a shared `# **` comment. A large constants section may instead be partitioned into top-level **sub-groups** (see [code_style.md](code_style.md)); for example, `constants.py` keeps language constants under `# *** constants` and error-id constants under `# *** constants (error)`:
 
 ```python
 # *** constants
 
+# ** constant: en_us
+EN_US = 'en_US'
+
+# *** constants (error)
+
 # ** constant: error_not_found_id
 ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
+```
+
+Structured data is built from a factory rather than annotated inline. `DEFAULT_ERRORS` keys each error-id constant to a definition produced by `create_default_error`, and each definition is itself a named constant:
+
+```python
+# ** constant: error_not_found
+ERROR_NOT_FOUND = create_default_error(
+    ERROR_NOT_FOUND_ID,
+    'Error Not Found',
+    [(EN_US, 'Error not found: {id}.')],
+)
 
 # ** constant: default_errors
 DEFAULT_ERRORS = {
-
-    # * error: ERROR_NOT_FOUND
-    ERROR_NOT_FOUND_ID: {
-        'id': ERROR_NOT_FOUND_ID,
-        'name': 'Error Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Error not found: {id}.'}
-        ],
-    },
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
 }
 ```
 
 ### Functions
 
-Assets functions are small, stateless helpers with no framework dependencies:
+Assets functions are small, stateless helpers with no framework dependencies. For example, `create_default_error` (in `constants.py`) builds a default error definition from ordered `(lang, text)` message pairs:
 
 ```python
 # *** functions
 
-# ** function: is_blank
-def is_blank(value: str) -> bool:
+# ** function: create_default_error
+def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) -> Dict[str, Any]:
     '''
-    Return True when a string is empty or whitespace-only.
+    Build a default error definition dictionary.
 
-    :param value: The string to inspect.
-    :type value: str
-    :return: True if the value is None or blank, otherwise False.
-    :rtype: bool
+    :param id: The unique identifier of the error.
+    :type id: str
+    :param name: The human-readable error name.
+    :type name: str
+    :param messages: Ordered (lang, text) message pairs.
+    :type messages: List[Tuple[str, str]]
+    :return: The default error definition.
+    :rtype: Dict[str, Any]
     '''
 
-    # Treat None and whitespace-only strings as blank.
-    return value is None or not value.strip()
+    # Assemble and return the default error definition dictionary.
+    return {
+        'id': id,
+        'name': name,
+        'message': [{'lang': lang, 'text': text} for lang, text in messages],
+    }
 ```
 
 ### Classes (standalone)
 
-Standalone classes carry no injected dependencies and extend only stdlib or other assets primitives. Exception types use the `# *** exceptions` / `# ** exception:` specialization:
+Standalone classes carry no injected dependencies and extend only stdlib or other assets primitives. Exception types like `TiferetError` are ordinary standalone classes under `# *** classes` / `# ** class:`:
 
 ```python
-# *** exceptions
+# *** classes
 
-# ** exception: tiferet_error
+# ** class: tiferet_error
 class TiferetError(Exception):
     '''
     The base exception for all Tiferet-related errors.
@@ -145,10 +154,8 @@ Only `__init__.py` carries an `# *** exports` section. It re-exports the public 
 
 # ** app
 from .exceptions import TiferetError, TiferetAPIError
-from .constants import (
-    ERROR_NOT_FOUND_ID,
-    DEFAULT_ERRORS,
-)
+from .constants import ERROR_NOT_FOUND_ID
+from .error import DEFAULT_ERRORS
 from . import constants as const
 from . import blueprints as bps
 ```
@@ -156,7 +163,7 @@ from . import blueprints as bps
 ## Creating and Extending Assets Modules
 
 1. Start the module with a docstring, then an `# *** imports` section limited to the standard library and third-party primitives.
-2. Add content under exactly one primary artifact kind per concern — `# *** constants`, `# *** functions`, or `# *** classes` (or the `# *** exceptions` / `# *** configs` specializations).
+2. Add content under exactly one primary artifact kind per concern — `# *** constants`, `# *** functions`, or `# *** classes`.
 3. Do not introduce domain, service, event, mapper, or context artifacts here; if a concern needs one, it belongs in the corresponding layer.
 4. Surface any new public symbols from `__init__.py` under `# *** exports`.
 
@@ -164,8 +171,8 @@ from . import blueprints as bps
 
 - Keep the layer dependency-light: never import from another Tiferet layer.
 - Restrict modules to the five artifact kinds (imports, constants, functions, standalone classes, exports).
-- Use `SCREAMING_SNAKE_CASE` values with `# ** constant: <snake_case>` labels; group large related blocks under `# ** constants: <group>`.
-- Reserve `# *** exceptions` for exception classes and `# *** configs` for default configuration data — both are specializations of the class/constant kinds.
+- Use `SCREAMING_SNAKE_CASE` values, each with its own `# ** constant: <snake_case>` label; do not group multiple constants under a shared `# ** constants: <group>` comment. To partition a large section, use a top-level sub-group (`# *** constants (<sub-group>)`) instead — see [code_style.md](code_style.md).
+- Place exception classes under `# *** classes` and default configuration data under `# *** constants`; build structured defaults from a `# *** functions` factory (e.g., `create_default_error`) rather than annotating entries inline.
 - Write RST docstrings on functions and classes, and keep code snippets separated by single blank lines.
 
 ## Package Layout
@@ -173,7 +180,8 @@ from . import blueprints as bps
 ```
 tiferet/assets/
 ├── __init__.py      — Public exports; exposes `const` and `bps` module aliases
-├── constants.py     — Error-code constants and the DEFAULT_ERRORS catalog
+├── constants.py     — Error-code identifier constants
+├── error.py         — The DEFAULT_ERRORS catalog (imports ids from constants.py)
 ├── exceptions.py    — TiferetError and TiferetAPIError
 ├── blueprints.py    — Bootstrap default constants and service wiring
 └── logging.py       — Default logging formatters, handlers, and loggers

--- a/docs/core/blueprints.md
+++ b/docs/core/blueprints.md
@@ -2,23 +2,22 @@
 
 Blueprints are a core component of the Tiferet framework in v2.0+. They serve as the primary public entry point for applications, providing a clean, high-level API for loading services, preparing defaults, resolving interfaces, and executing features.
 
-While contexts define the runtime shape and behavior of an individual interface, blueprints orchestrate the overall application lifecycle and wiring. They replace previous direct usage of lower-level contexts for application initialization.
+While contexts define the runtime shape and behavior of an individual interface, blueprints orchestrate the overall application lifecycle and wiring.
 
 ## What is a Blueprint?
 
-A blueprint in Tiferet is a module-level function that encapsulates the initialization and orchestration logic required to prepare and run an application interface. Blueprints are intentionally thin: they focus on service loading, default configuration injection, dependency wiring, and delegation to the appropriate `AppInterfaceContext`.
+A blueprint in Tiferet is a module-level function that encapsulates the initialization and orchestration logic required to prepare and run an application interface. Blueprints are intentionally thin: they focus on service loading, default configuration injection, dependency wiring, and delegation to the appropriate `AppSessionContext`.
 
-The canonical implementation is `build_app` in `tiferet/blueprints/main.py`.
+The canonical implementation is `build_app` in `tiferet/blueprints/core.py` (exported as `App`), which chains the composition functions `build_cache` → `get_app_session` → `build_app_session_context`. The built-in CLI bootstrapper (`build_tiferet_cli`) uses a separate declarative bootstrap path in `tiferet/blueprints/tiferet_cli.py`.
 
 ### Role in the Architecture
 
 Blueprints sit at the highest level of the application graph:
 
-- They load the application service (typically a repository)
-- They prepare default services and constants from `assets.blueprints`
-- They resolve interfaces via domain events (`GetAppInterface`)
-- They wire the dependency injection container
-- They delegate feature execution to the resolved `AppInterfaceContext`
+- They build the shared `CacheContext`, pre-seeded with the framework's default errors, app services, and constants (`build_cache`)
+- They compose the application service and resolve the app session via a domain event (`get_app_session` → `GetAppSession`)
+- They build the app service container from the cache defaults merged with the session's own overrides, and compose a feature-level `ServiceResolver` (`build_app_session_context`)
+- They delegate feature execution to the resolved `AppSessionContext`
 
 This design keeps application code simple while maintaining full extensibility and testability.
 
@@ -27,7 +26,7 @@ This design keeps application code simple while maintaining full extensibility a
 Tiferet currently defines two blueprints:
 
 - **App blueprint**: `build_app` — used for general script and custom interfaces. Exposed globally as `App`.
-- **CLI blueprint**: `build_cli` — extends the app blueprint with argparse-based CLI build-time translation of `sys.argv` into a feature invocation. Exposed globally as `CLI`.
+- **CLI blueprint**: `build_cli` — a thin entrypoint that resolves and realizes a CLI interface (which must point at `CliContext`) and delegates `sys.argv` translation and feature dispatch to `CliContext.run_cli`. Exposed globally as `CLI`.
 
 Future specialized blueprints may include:
 
@@ -36,14 +35,12 @@ Future specialized blueprints may include:
 
 ### CLI Blueprint Build Procedure
 
-The CLI blueprint (`build_cli`) keeps all build-time CLI parsing in the blueprint and delegates runtime execution to the `AppInterfaceContext`. Its flow follows these steps:
+The CLI blueprint (`build_cli`) is a thin entrypoint; argparse parsing and request derivation live in `CliContext` (`tiferet/contexts/cli.py`). Its flow follows these steps:
 
-1. **Resolve the interface** via `resolve_interface(interface_id)`.
-2. **Build the argparse parser** by composing `get_commands()` (resolves `list_commands_evt` and groups returned commands by `group_key`), `get_parent_arguments()` (resolves `get_parent_args_evt`), and `build_parser(cli_commands, parent_arguments)`.
-3. **Parse arguments** with `parse_argv(parser, argv)`; on failure, print to stderr and `sys.exit(2)`.
-4. **Dispatch the feature** by deriving `feature_id` and `headers` via `derive_feature_request(parsed)`, then calling `interface_context.run(feature_id=feature_id, headers=headers, data=parsed)`. On `TiferetAPIError`, print to stderr and `sys.exit(1)`; otherwise print and return the response.
+1. **Build the context** via `core.build_app(interface_id, ...)`. The interface must point at `tiferet.contexts.cli` / `CliContext`, so the composed context is a `CliContext`.
+2. **Delegate to the context** by calling `cli_context.run_cli(argv)`, which builds the parser from the interface's CLI commands and parent arguments, parses `argv` (argparse exits `2` on failure), derives `feature_id`/`headers`, dispatches through the inherited `run`, prints the response, and converts a `TiferetAPIError` into `sys.exit(1)`.
 
-Because the default `AppInterfaceContext` is sufficient for CLI interfaces, CLI interface definitions in YAML no longer require `module_path`/`class_name` overrides.
+Consumer CLI interfaces opt in by declaring `module_path: tiferet.contexts.cli` / `class_name: CliContext` in their interface config.
 
 ## Structured Code Design of Blueprints
 
@@ -52,6 +49,8 @@ Blueprints follow Tiferet's standard artifact comment structure.
 ### Artifact Comments
 
 Blueprints are organized under the `# *** blueprints` top-level comment, with individual blueprints under `# ** blueprint: <snake_case_name>`. Each blueprint function uses standard RST docstrings and code snippet conventions.
+
+Side-effect-free helpers (pure input→output transforms with no I/O, instantiation, or error raising) belong in a `# *** functions` section above `# *** blueprints`, with individual helpers under `# ** function: <snake_case_name>`. In `tiferet/blueprints/tiferet_cli.py` the bootstrap helpers `_resolve_ctor_kwargs`, `_build_wiring_constants`, and `_resolve_collaborators` (module-private, underscore-prefixed) are grouped this way — small pure helpers consumed by the orchestration functions below them (`_wire_services`, `_load_app_instance`, `_resolve_bootstrap_session`). Reserve `# *** blueprints` for the orchestration entry points reused by other blueprints or clients (e.g. `core.build_app`, `core.build_app_session_context`).
 
 **Spacing rules:**
 
@@ -63,15 +62,16 @@ Blueprints are organized under the `# *** blueprints` top-level comment, with in
 
 ### Creating a New Blueprint
 
-1. Place the function under `# *** blueprints` in an appropriate module (for example, `tiferet/blueprints/main.py`).
+1. Place the function under `# *** blueprints` in an appropriate module (for example, `tiferet/blueprints/core.py`).
 2. Use `# ** blueprint: <snake_case_name>`.
-3. Implement the standard lifecycle functions:
-   - `create_service_provider` — provider factory
-   - `load_app_service` — import and construct the app service
-   - `load_default_services` — load default service dependencies
-   - `resolve_interface` — resolve the interface definition
-   - `realize_interface` — build and validate the interface context
-   - `build_app` — high-level entry point
+3. Reuse the core composition functions (`tiferet/blueprints/core.py`):
+   - `build_cache` — build the shared cache pre-seeded with default errors, services, and constants
+   - `create_app_service` — compose the app service via a single-use dynamic container
+   - `get_app_session` — resolve the app session via the `GetAppSession` event
+   - `build_app_service_container` — build the singleton app service container from cache defaults merged with the session's overrides
+   - `build_service_resolver` — compose the feature-level `ServiceResolver`, caching the app container under the `app` flag
+   - `build_app_session_context` — import the declared context class, resolve its collaborators, wire the FE4 handlers, and construct the context
+   - `build_app` — high-level single-call entry point chaining the above
 
 ### Key Patterns
 
@@ -79,54 +79,65 @@ Blueprints are organized under the `# *** blueprints` top-level comment, with in
 `build_app` resolves and realizes in one call:
 
 ```python
-app = App('basic_calc', app_yaml_file='config.yml')
+app = App('basic_calc', app_config='config.yml')
 ```
 
 **Default configuration injection**  
-Blueprints automatically inject `DEFAULT_SERVICES` and `DEFAULT_CONSTANTS` via `GetAppInterface`:
+The core path sources the framework's `CORE_DEFAULT_SERVICES` / `CORE_DEFAULT_CONSTANTS` catalogs (defined in `assets/app.py`, accessed as `a.app`) from the shared cache seeded by `build_cache`. `build_app_service_container` merges those cache defaults with the session's own constants and services (session wins) *before* building the container, so `core.build_app` never calls `apply_defaults`:
 
 ```python
-app_interface = DomainEvent.handle(
-    GetAppInterface,
-    ...,
-    default_services=default_services,
-    default_constants=a.bps.DEFAULT_CONSTANTS,
-)
+container = build_app_service_container(cache, app_session)  # cache defaults + session overrides
 ```
 
-**Service provider registration**  
-The `create_service_provider` function is registered so contexts can create scoped providers:
+The `AppSession.apply_defaults` domain method and the `resolve_default_interface` bootstrap fallback are used by the built-in bootstrappers (`_resolve_bootstrap_session` in `tiferet/blueprints/tiferet_cli.py`), whose sessions (`tiferet_app`, `tiferet_cli`) are not defined in the consumer config.
+
+**Cache pre-seeding**  
+The core `build_cache` blueprint (`tiferet/blueprints/core.py`) pre-seeds a `CacheContext` with three framework catalogs via stacked decorators — `add_default_errors`, `add_default_app_services`, and `add_default_app_constants` (the latter two defined in `contexts/app.py`) — namespacing each catalog under its own cache-key prefix (`error_`, `app_service_`, `app_constant_`). Errors and services are reconstituted into domain objects (`Error`, `AppServiceDependency`); constants are seeded as scalars:
 
 ```python
-dependencies['create_service_provider'] = create_service_provider
+@add_default_app_constants(a.app.CORE_DEFAULT_CONSTANTS)
+@add_default_app_services(a.app.CORE_DEFAULT_SERVICES)
+@add_default_errors(a.error.CORE_DEFAULT_ERRORS)
+def build_cache(cache=None) -> CacheContext:
+    return CacheContext(cache=cache)
 ```
+
+**Service resolver injection**  
+`build_service_resolver` composes a `ServiceResolver` from the app service container (caching it under the `app` flag), and `build_app_session_context` injects its `get_dependency` handler into the context:
+
+```python
+resolver = build_service_resolver(app_container)
+return context_cls.from_domain(app_session, get_dependency=resolver.get_dependency, ...)
+```
+
+The declarative registry wiring (`_wire_services` + the `CreateServiceResolver` bootstrap event) is used in `tiferet/blueprints/tiferet_cli.py` for `build_tiferet_cli`'s feature-DI bootstrap.
 
 ## Testing Blueprints
 
 Blueprint tests use `pytest` with `unittest.mock`. Focus on:
 
-- Correct loading of the app service
-- Delegation to `GetAppInterface` with defaults injected
-- Validation of the resolved `AppInterfaceContext`
-- High-level `build_app()` behavior
+- Correct composition of the app service and app session (`create_app_service` / `get_app_session`)
+- Cache defaults merged with session overrides in `build_app_service_container`
+- Validation of the resolved `AppSessionContext` (raising `INVALID_APP_SESSION_TYPE`)
+- High-level `core.build_app()` behavior
 
 ## Best Practices
 
 - Keep blueprints **thin** — they should orchestrate, not implement domain logic.
-- Always validate the resolved context type in `realize_interface`.
+- Always validate the resolved context type (`INVALID_APP_SESSION_TYPE`) in the single-call entry points (`core.build_app`, `build_tiferet_app`, `build_tiferet_cli`).
 - Use `RaiseError.execute()` for all error paths with proper constants.
-- Register `create_service_provider` so contexts remain decoupled from the blueprint.
+- Inject the `ServiceResolver`'s `get_dependency` handler into the context so contexts remain decoupled from the DI engine.
 
 ## Conclusion
 
-Blueprints provide a clean, high-level API for initializing and running Tiferet applications. They encapsulate service loading, default configuration, and interface resolution while delegating execution to `AppInterfaceContext`. Their functional design ensures consistency, forward-compatibility, and extensibility.
+Blueprints provide a clean, high-level API for initializing and running Tiferet applications. They encapsulate service loading, default configuration, and interface resolution while delegating execution to `AppSessionContext`. Their functional design ensures consistency, forward-compatibility, and extensibility.
 
-Explore source in `tiferet/blueprints/` and tests in `tiferet/blueprints/tests/` for implementation details.
+Explore source in `tiferet/blueprints/` and blueprint tests in the top-level `tests/` tree for implementation details.
 
 ## Related Documentation
 
 - [docs/guides/blueprints.md](../guides/blueprints.md) — blueprint strategies and patterns
 - [docs/core/di.md](../core/di.md) — dependency injection and service provider design
 - [docs/core/events.md](../core/events.md) — domain event design and usage
-- [docs/guides/domain/app.md](../guides/domain/app.md) — application interface and service configuration guide
+- [docs/guides/domain/app.md](../guides/domain/app.md) — application interface and service registration guide
 - [docs/core/code_style.md](../core/code_style.md) — artifact comments and formatting

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -9,16 +9,89 @@ This document defines the required code style for all modules in the `tiferet` p
 Artifact comments provide a predictable, machine-readable structure that organizes code into clear sections and sub-sections.
 
 ### Top-Level (`# ***`)
-Denotes major module sections:
+Top-level comments denote major module sections, which fall into two kinds: **preamble groups** (available in every module) and **construct groups** (the module's primary body).
+
+**Preamble artifact section groups** are available in *any* module, regardless of its construct type (`# *** events`, `# *** utils`, etc.). There are four, and they appear in this order when present:
 - `# *** imports` — all import statements.
-- `# *** exports` — public API (only in `__init__.py`).
-- `# *** models`, `# *** commands`, `# *** contexts`, `# *** contracts`, `# *** data`, `# *** repositories`, `# *** proxies` — component groups.
+- `# *** constants` — module-level constant definitions.
+- `# *** functions` — module-level, side-effect-free helper functions. A helper belongs here when it takes only its arguments and returns a plain value: no `self`, no injected services, and no domain-object returns. Prefer this over duplicating the same logic as a static method across classes.
+- `# *** classes` — generic or base classes not tied to a specific construct type (e.g., the base classes defined in a `settings.py`).
+
+**Construct groups** form the primary body of a module and are selected by what the module defines — for example `# *** models`, `# *** events`, `# *** contexts`, `# *** interfaces`, `# *** mappers`, `# *** repos`, `# *** utils`, `# *** blueprints`. The `# *** exports` group lists the public API and appears only in `__init__.py`.
+
+A module combines its preamble groups with its construct group(s), ordered `imports` → `constants` → `functions`, then `classes` and/or the construct group(s). For example, a domain-event module that needs a pure helper is laid out as:
+```python
+# *** imports
+...
+
+# *** functions
+
+# ** function: _is_valid_identifier
+def _is_valid_identifier(name: str) -> bool:
+    '''
+    Validate that a name is a valid SQLite identifier.
+
+    :param name: The identifier to validate
+    :type name: str
+    :return: True if valid, False otherwise
+    :rtype: bool
+    '''
+
+    # Basic check: alphanumeric and underscore only, doesn't start with digit
+    if not name:
+        return False
+    if name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == '_' for c in name)
+
+# *** events
+...
+```
 
 **Spacing**: One empty line between top-level comment and first mid-level comment.
+
+### Sub-Groups (`# *** <kind> (<sub-group>)`)
+A large section may be partitioned into **sub-groups** by adding a parenthetical qualifier to the top-level comment. The section/artifact kind is preserved — only the parenthetical names a partition within that kind. This reuses the same parenthetical-qualifier idea already applied to methods with `(static)`.
+
+Use a sub-group only when a single section grows large enough that partitioning aids navigation; small sections stay ungrouped. A module may therefore contain one plain section plus one or more sub-grouped sections of the same kind. For example, `constants.py` keeps language constants under `# *** constants` and error-id constants under `# *** constants (error)`:
+```python
+# *** constants
+
+# ** constant: en_us
+EN_US = 'en_US'
+
+# *** constants (error)
+
+# ** constant: error_not_found_id
+ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
+```
+The most common use is grouping unit tests by the class or method under test, so a single test module can hold several focused groups:
+```python
+# *** tests (GetFeature)
+
+# ** test: TestGetFeatureSuccess
+...
+
+# *** tests (AddFeature)
+
+# ** test: TestAddFeatureSuccess
+...
+```
+**Grammar rules:**
+- Preserve the kind: the word after `# ***` stays the normal section kind (`constants`, `tests`, ...); the parenthetical is only a label.
+- The parenthetical names the sub-group; keep it short and consistent within the module.
+- Sub-groups do not nest — use at most one parenthetical qualifier per top-level comment.
+- Order any plain (ungrouped) section of a kind before its sub-grouped variants.
+- Individual artifacts keep their standard mid-level label (`# ** constant:`, `# ** test:`); the sub-group never changes the `# **` line.
+
+**Interim scope**: this convention exists primarily so agents editing source directly (and their human handlers) can navigate large sections consistently. Treat this document as the canonical reference until the full grammar is formalized.
+
+**Spacing**: One empty line between a sub-group comment and its first mid-level comment, the same as any top-level section.
 
 ### Mid-Level (`# **`)
 Specifies categories or individual components:
 - For imports: `# ** core`, `# ** infra`, `# ** app`.
+- For functions: `# ** function: <snake_case_name>`.
 - For components: `# ** model: <snake_case_name>`, `# ** command: <snake_case_name>`, etc.
 
 **Spacing**: One empty line between mid-level comments.
@@ -86,44 +159,71 @@ def load_feature(self, feature_id: str) -> Feature:
   - Methods/attributes within a class.
   - Classes within a component group.
 
-## Deprecation Handling
+## Annotation Artifacts
 
-Mark obsolete methods with:
-- A comment note (e.g., `# NOTE: This method is obsolete and will be removed in v2`).
-- A docstring note indicating deprecation and preferred alternative.
+Annotation artifacts are **transient lifecycle markers** — a fourth tier below the structural `# ***` / `# **` / `# *` hierarchy. Unlike structural comments, annotations describe *state* rather than *shape* and are expected to be resolved over time.
 
-**Example**:
+Two annotation types are defined:
+
+### `# ++ todo: <message>`
+Signals deferred work attached to a specific artifact. The `++` prefix is semantic: *something needs to be added or grown here*. Use it to leave a machine-scannable note for the next agent or developer who touches this artifact.
+
+### `# -- obsolete: <reason or target version>`
+Signals that an artifact is deprecated and slated for removal. The `--` prefix is semantic: *this is being reduced or removed*. Replaces the informal `# NOTE:` docstring approach with a single, consistently placed annotation line.
+
+**Placement grammar** — annotations appear immediately after the structural comment they annotate, on their own line, before the code body:
+
 ```python
-# * method: handle_command (obsolete)
-def handle_command(self, ...):
-    '''
-    Handle the execution of a command.
-    
-    NOTE: This method is obsolete and will be consolidated in v2.
-    Use handle_feature_command instead.
-    '''
+# * method: remove_service
+# ++ todo: remove attribute_id parameter once app event test dependency is resolved
+def remove_service(self, service_id: str | None = None, attribute_id: str | None = None):
     ...
+
+# * attribute: return_to_data
+# -- obsolete: superseded by data_key; remove in v2.1
+return_to_data: bool = Field(default=False, ...)
 ```
 
-**Purpose**: Prevents accidental use of legacy APIs and guides developers to modern patterns.
+Annotations may also appear below `# **` (mid-level) or `# ***` (top-level) comments when the todo or obsolescence applies to an entire section or class. Inside method bodies, `# ++ todo:` follows the same inline-before-snippet placement as any other snippet comment.
+
+**Label-level shorthand** — the `(obsolete)` parenthetical suffix on a `# *` or `# **` label remains valid shorthand when no further reason is needed:
+
+```python
+# * method: handle_command (obsolete)
+```
+
+When a reason or target version is meaningful, prefer `# -- obsolete:` on its own line.
+
+**Resolution expectations**
+- `# ++ todo:` annotations should be removed once the described work is complete. Reference the GitHub issue number in the message when the work is tracked (`# ++ todo: #123 — remove attribute_id once ...`).
+- `# -- obsolete:` annotations should be removed together with the artifact they annotate. Verify no callers remain before deletion.
+- Both types should be surfaced in Collaboration Reports when introduced or resolved during a session.
+
+**Agent scan procedure** — before beginning any implementation session, scan affected files for open annotations:
+
+```bash
+grep -rn "# ++\|# --" tiferet/
+```
+
+This gives an immediate picture of outstanding technical debt and deprecated code in scope.
 
 ## Example: Complete Class with Formatting
 
-**Command Example** – `GetFeature`:
+**Domain Event Example** – `GetFeature`:
 ```python
 # *** imports
 
 # ** app
-from .settings import Command
-from ..contracts.feature import FeatureService
-from ..models.feature import Feature
+from .settings import DomainEvent, a
+from ..interfaces import FeatureService
+from ..domain import Feature
 
-# *** commands
+# *** events
 
-# ** command: get_feature
-class GetFeature(Command):
+# ** event: get_feature
+class GetFeature(DomainEvent):
     '''
-    Command to retrieve a feature by its identifier.
+    Domain event to retrieve a feature by its identifier.
     '''
 
     # * attribute: feature_service
@@ -132,7 +232,7 @@ class GetFeature(Command):
     # * init
     def __init__(self, feature_service: FeatureService) -> None:
         '''
-        Initialize the GetFeature command.
+        Initialize the GetFeature event.
         '''
         self.feature_service = feature_service
 
@@ -155,7 +255,7 @@ class GetFeature(Command):
         # If not found, raise structured error.
         if not feature:
             self.raise_error(
-                const.FEATURE_NOT_FOUND_ID,
+                a.const.FEATURE_NOT_FOUND_ID,
                 f'Feature not found: {id}',
                 feature_id=id
             )
@@ -175,8 +275,10 @@ import pytest
 from unittest import mock
 
 # ** app
-from tiferet.commands.feature import GetFeature
-from tiferet.models.feature import Feature
+from tiferet.events.settings import DomainEvent
+from tiferet.events.feature import GetFeature
+from tiferet.interfaces import FeatureService
+from tiferet.domain import Feature
 
 # *** fixtures
 
@@ -194,7 +296,7 @@ def sample_feature() -> Feature:
     '''
     Sample Feature instance for testing.
     '''
-    return ModelObject.new(Feature, id='test.feature', name='Test Feature')
+    return Feature(id='test.feature', name='Test Feature')
 
 # *** tests
 
@@ -210,7 +312,7 @@ def test_get_feature_success(mock_feature_service: FeatureService, sample_featur
     '''
     mock_feature_service.get.return_value = sample_feature
 
-    result = Command.handle(
+    result = DomainEvent.handle(
         GetFeature,
         dependencies={'feature_service': mock_feature_service},
         id='test.feature'
@@ -235,14 +337,14 @@ Harness test classes use `# ** test: TestClassName` (PascalCase) as the mid-leve
 ```python
 # *** tests
 
-# ** test: TestAddAppInterface
-class TestAddAppInterface(DomainEventTestBase):
+# ** test: TestAddAppSession
+class TestAddAppSession(DomainEventTestBase):
     '''
-    Tests for AddAppInterface using the domain event test harness.
+    Tests for AddAppSession using the domain event test harness.
     '''
 
     # * attribute: event_cls
-    event_cls = AddAppInterface
+    event_cls = AddAppSession
 
     # * attribute: dependencies
     dependencies = {'app_service': AppService}
@@ -267,8 +369,8 @@ class TestAddAppInterface(DomainEventTestBase):
         # Execute via the harness handle helper.
         interface = self.handle(mock_dependencies)
 
-        # Assert the result is an AppInterface instance.
-        assert isinstance(interface, AppInterface)
+        # Assert the result is an AppSession instance.
+        assert isinstance(interface, AppSession)
 
         # Assert the interface is saved via the app service.
         mock_dependencies['app_service'].save.assert_called_once_with(interface)
@@ -295,14 +397,14 @@ When a test class needs a pre-configured service mock (e.g., `get()` returns a r
 ```python
     # * fixture: mock_dependencies
     @pytest.fixture
-    def mock_dependencies(self, app_interface):
+    def mock_dependencies(self, app_session):
         '''
-        Override to provide a service mock pre-configured with an app_interface.
+        Override to provide a service mock pre-configured with an app_session.
         '''
 
-        # Create a mock AppService that returns the app_interface on get.
+        # Create a mock AppService that returns the app_session on get.
         service = mock.Mock(spec=AppService)
-        service.get.return_value = app_interface
+        service.get.return_value = app_session
         return {'app_service': service}
 ```
 
@@ -316,11 +418,13 @@ Harness test classes follow the same spacing conventions as production code:
 ## Best Practices Summary
 
 - Use artifact comments consistently.
+- Partition large sections into sub-groups (`# *** <kind> (<sub-group>)`) when it aids navigation, preserving the section kind and per-artifact labels.
 - Explicitly mark static methods with `(static)`.
 - Deprecate obsolete methods with clear notes.
 - Write clear RST docstrings.
 - Break methods into commented snippets.
 - Maintain consistent spacing.
+- Place module-level, side-effect-free helpers under `# *** functions` instead of duplicating them as static methods across classes.
 - Prefer the domain event test harness (`DomainEventTestBase` / `ServiceEventTestBase`) for all new event tests.
 
 These practices ensure Tiferet code remains consistent, maintainable, and AI-friendly. Explore source modules in `tiferet/` for implementation examples.
@@ -330,11 +434,13 @@ These practices ensure Tiferet code remains consistent, maintainable, and AI-fri
 The Tiferet framework maintains a suite of focused documentation in `docs/core/` to guide consistent implementation across different component types. These documents complement the main **Structured Code Style** guidelines and provide domain-specific conventions.
 
 - **[assets.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md)** – Assets layer conventions (imports, constants, functions, standalone classes, exports).
+- **[blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md)** – Blueprint orchestration conventions.
+- **[contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md)** – Context conventions (high-level and low-level runtime shape).
+- **[di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md)** – Dependency injection layer conventions.
 - **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain object conventions (dual role, factory methods, read-only design).
 - **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event conventions (dependency injection, validation, test harness).
-- **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.
 - **[interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md)** – Service interface conventions.
+- **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.
 - **[repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md)** – Repository implementation conventions.
+- **[testing.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/testing.md)** – Testing harness conventions (AggregateTestBase, TransferObjectTestBase, DomainEventTestBase).
 - **[utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md)** – Utility and infrastructure conventions.
-
-Additional component-style documents (e.g., contexts) will be added as the framework evolves. Refer to this list for the current set of authoritative style guides.

--- a/docs/core/contexts.md
+++ b/docs/core/contexts.md
@@ -7,12 +7,14 @@ Contexts are a core component of the Tiferet framework, representing the structu
 A Context in Tiferet is a class that encapsulates a specific aspect of an application’s runtime behavior, such as user-facing interactions (e.g., CLI, web), feature execution, dependency injection, error handling, caching, or logging. Contexts form a graph-like structure during execution, defining how the application processes inputs, executes domain logic, and returns outputs. They align with Domain-Driven Design (DDD) principles, isolating concerns to ensure modularity and extensibility.
 
 ### Types of Contexts
+All contexts extend `BaseContext` (`tiferet/contexts/settings.py`), which provides a shared `services` slot and a `ContextMeta` registry mapping a domain object type (`domain_type`) to its context class. `BaseContext.for_domain(DomainType)` resolves the registered class, and `BaseContext.from_domain(domain_obj, **kwargs)` constructs a context bound to a loaded domain object (exposed as `ctx.domain`). Caching is not part of the base; contexts that need a `CacheContext` (e.g., `AppSessionContext`, `FeatureContext`) declare and wire it themselves.
+
 Tiferet recognizes two broad categories:
 
-- **High-Level Contexts**: Handle user interactions (e.g., `FlaskApiContext` for web APIs). They typically extend `AppInterfaceContext`. CLI interfaces use `AppInterfaceContext` directly, with argparse wiring handled by the `build_cli` blueprint.
-- **Low-Level Contexts**: Support specific functions (e.g., `FeatureContext`, `DIContext`, `ErrorContext`, `CacheContext`, `RequestContext`, `LoggingContext`).
+- **High-Level Contexts**: Handle user interactions (e.g., `CliContext` for command-line interfaces, `FlaskApiContext` for web APIs). They extend `AppSessionContext`, the minimal hub built declaratively from the loaded `AppSession`. CLI interfaces point at `CliContext`, which owns argparse parsing; the `build_cli` blueprint is a thin entrypoint that delegates to `CliContext.run_cli`.
+- **Low-Level Contexts**: Support specific functions (e.g., `FeatureContext`, `AsyncFeatureContext`, `ErrorContext`, `CacheContext`, `RequestContext`, `LoggingContext`).
 
-In the calculator application, `AppInterfaceContext` handles feature execution, while low-level contexts manage dependency injection, error handling, and logging.
+In the calculator application, `AppSessionContext` handles feature execution, while low-level contexts manage dependency injection, error handling, and logging.
 
 **Note on Method Design**: The nature of methods in Contexts is not restrictive regarding inputs and outputs. Methods must be defined according to the domain requirements of the context containing them, allowing flexibility for domain-specific tasks while maintaining clear, documented signatures.
 
@@ -33,51 +35,50 @@ Contexts are organized under the `# *** contexts` top-level comment, with indivi
 - One empty line between each `# *` section.
 - One empty line after docstrings and between code snippets.
 
-**Example** – `tiferet/contexts/app.py`:
+**Example** – `tiferet/contexts/app.py` (minimal hub):
 ```python
 # *** imports
 
 # ** app
+from .settings import BaseContext
+from .cache import CacheContext
 from .feature import FeatureContext
 from .error import ErrorContext
 from .logging import LoggingContext
+from ..domain import AppSession
 
 # *** contexts
 
 # ** context: app_interface_context
-class AppInterfaceContext:
+class AppSessionContext(BaseContext):
 
-    # * attribute: interface_id
-    interface_id: str
-
-    # * attribute: features
-    features: FeatureContext
-
-    # * attribute: errors
-    errors: ErrorContext
-
-    # * attribute: logging
-    logging: LoggingContext
+    # * attribute: domain_type
+    domain_type = AppSession
 
     # * init
-    def __init__(self, interface_id, features, errors, logging):
+    def __init__(self, get_feature_evt, get_error_evt, logging_list_all_evt,
+                 get_dependency, cache=None,
+                 default_features=None, default_commands=None):
         '''
-        Initialize the application interface context.
+        Initialize the hub. The loaded AppSession is bound via from_domain as
+        self.domain, supplying the interface id and logger id on demand.
         '''
-        self.interface_id = interface_id
-        self.features = features
-        self.errors = errors
-        self.logging = logging
+        super().__init__()
+        self.cache = cache if cache is not None else CacheContext()
+        self.get_feature_evt = get_feature_evt
+        # ... store the remaining events and the injected get_dependency
+        # service-resolution handler, plus validated bootstrap defaults;
+        # sub-contexts are created lazily on first use ...
 
     # * method: run
     def run(self, feature_id, headers=None, data=None, **kwargs):
         '''
         Execute a feature and return the response.
         '''
-        # Build logger.
-        logger = self.logging.build_logger()
+        # Build the logger from the lazily-created logging context.
+        logger = self.load_logging_context().build_logger()
 
-        # Parse request into a RequestContext.
+        # Parse request into a RequestContext (interface id from self.domain.id).
         request = self.parse_request(headers or {}, data or {}, feature_id)
 
         # Execute the feature.
@@ -86,29 +87,48 @@ class AppInterfaceContext:
         except TiferetError as e:
             return self.handle_error(e)
 
-        # Return the response.
-        return self.handle_response(request)
+        # Return the response via the request context.
+        return request.handle_response()
 ```
+
+The hub builds the `FeatureContext` and `ErrorContext` on demand (via `BaseContext.for_domain`) inside `execute_feature` / `handle_error`, lazily caches the `LoggingContext` (`load_logging_context`), and loads domain objects via `load_feature_domain` / `get_error`. The hub owns a `CacheContext` — used by `load_feature_domain` and `get_error` (which resolves an error from the cache, pre-seeded with the framework defaults under `error_`-prefixed keys by `build_cache`, before falling back to the get-error event and caching the result) and shared with the `FeatureContext` it builds; the error and logging contexts no longer take a cache. Feature-step services are resolved through the injected `get_dependency` handler (provided by the `ServiceResolver`), which the hub forwards to each `FeatureContext` it builds.
+
+When a loaded `Feature` has `is_async` set to `True`, `execute_feature` selects the `AsyncFeatureContext` subclass — which extends `FeatureContext` with awaiting (`handle_feature_step_async` / `execute_feature_async`) step execution while inheriting the shared step-resolution, parameter-parsing, condition, and middleware helpers — and drives its `execute_feature_async` coroutine to completion via a `_run_coroutine` helper. The helper uses `asyncio.run` when no event loop is running and falls back to a dedicated worker thread when one is, keeping `run()` synchronous. `AsyncFeatureContext` deliberately does not declare its own `domain_type`, so the `Feature → FeatureContext` registry entry is preserved.
+
+### Cache Context and Default Catalogs
+
+The `CacheContext` (`tiferet/contexts/cache.py`) exposes `get`, `set`, `delete`, `clear`, and `get_by_prefix(prefix)` — the last returns all entries whose keys start with the given prefix as a `Dict[str, Any]`. This backs enumeration of the framework catalogs that `build_cache` seeds under namespaced key prefixes.
+
+The app-context module (`tiferet/contexts/app.py`) provides paired seeders and getters for the bootstrap catalogs:
+
+- `add_default_app_services` / `add_default_app_constants` seed the cache under the `app_service_` and `app_constant_` key prefixes (stacked as decorators on `build_cache`).
+- `get_default_app_services(cache)` returns the seeded `AppServiceDependency` domain objects (the values behind the `app_service_` prefix).
+- `get_default_app_constants(cache)` returns the seeded bootstrap constants keyed by name, stripping the `app_constant_` prefix.
+
+These getters let the `build_app_service_container` blueprint pull the framework defaults back off the shared cache when composing the app-level service container.
 
 ## Writing Contexts
 
 ### Creating a New Context
 1. Place under `# *** contexts` in appropriate module.
-2. Extend `AppInterfaceContext` for high-level contexts or base class for low-level.
+2. Extend `AppSessionContext` for high-level contexts or base class for low-level.
 3. Use `# * attribute`, `# * init`, `# * method` comments.
 4. Follow spacing and docstring conventions.
 
 **Example** – High-level `FlaskApiContext`:
 ```python
 # ** context: flask_api_context
-class FlaskApiContext(AppInterfaceContext):
+class FlaskApiContext(AppSessionContext):
 
     # * attribute: flask_handler
     flask_handler: FlaskApiHandler
 
     # * init
-    def __init__(self, interface_id, features, errors, logging, flask_handler):
-        super().__init__(interface_id, features, errors, logging)
+    def __init__(self, flask_handler, **kwargs):
+        # Forward the resolved hub collaborators/defaults to AppSessionContext.
+        # The blueprint imports this class from the interface's module_path/
+        # class_name and constructs it via from_domain.
+        super().__init__(**kwargs)
         self.flask_handler = flask_handler
 
     # * method: parse_request
@@ -128,32 +148,38 @@ class FlaskApiContext(AppInterfaceContext):
 
 Tests use `pytest` with `unittest.mock`, organized under `# *** fixtures` and `# *** tests`.
 
-**Example** – `AppInterfaceContext` test:
+**Example** – `AppSessionContext` test:
 ```python
 # *** fixtures
 
 # ** fixture: app_interface_context
 @pytest.fixture
-def app_interface_context(feature_context, error_context, logging_context):
-    return AppInterfaceContext(
-        interface_id='basic_calc',
-        features=feature_context,
-        errors=error_context,
-        logging=logging_context,
+def app_interface_context(app_interface, feature_context, error_context, logging_context):
+    # Build the hub declaratively from a loaded interface with mock events.
+    context = AppSessionContext.from_domain(
+        app_interface,
+        get_feature_evt=mock.Mock(),
+        get_error_evt=mock.Mock(),
+        logging_list_all_evt=mock.Mock(),
+        get_dependency=mock.Mock(),
     )
+    # Inject the mock logging context via its cache; feature and error contexts
+    # are built on demand, so patch BaseContext.for_domain to return the mocks.
+    context._logging = logging_context
+    return context
 
 # *** tests
 
 # ** test: app_interface_context_run_success
-def test_app_interface_context_run_success(app_interface_context):
+def test_app_interface_context_run_success(app_interface_context, logging_context):
     # Arrange the logger.
-    app_interface_context.logging.build_logger.return_value = mock.Mock()
+    logging_context.build_logger.return_value = mock.Mock()
 
     # Act.
     result = app_interface_context.run('calc.add', data={'a': 1, 'b': 2})
 
-    # Assert execution was invoked.
-    app_interface_context.features.execute_feature.assert_called_once()
+    # The feature context is built on demand inside execute_feature; assert the
+    # run completed and produced a response.
     assert result is not None
 ```
 
@@ -165,4 +191,4 @@ def test_app_interface_context_run_success(app_interface_context):
 
 ## Conclusion
 
-Contexts define the runtime shape of Tiferet applications, orchestrating user interaction and internal services. Their structured design ensures consistency and extensibility. Developers can create new Contexts or extend existing ones by following artifact patterns and conventions. Explore `tiferet/contexts/` for source and `tiferet/contexts/tests/` for test examples.
+Contexts define the runtime shape of Tiferet applications, orchestrating user interaction and internal services. Their structured design ensures consistency and extensibility. Developers can create new Contexts or extend existing ones by following artifact patterns and conventions. Explore `tiferet/contexts/` for source and `tests/contexts/` for test examples.

--- a/docs/core/di.md
+++ b/docs/core/di.md
@@ -5,98 +5,156 @@
 
 ## Overview
 
-The `tiferet/di/` package provides the **app-level dependency injection** layer for the Tiferet framework. It defines the `ServiceProvider` abstract base class and its concrete implementation, `DynamicServiceProvider`, which backs the `build_app` blueprint during interface loading.
+The `tiferet/di/` package provides the dependency-injection layer for the Tiferet framework. It is structured across three modules:
 
-The `di/` package is distinct from the feature-level DI managed by `DIContext` (`contexts/di.py`):
+- **`tiferet/di/core.py`** — the abstract, domain-only core: the `ServiceContainer` and `ServiceResolver` ABCs plus the pure module functions `injectable_parameter_names` and `normalize_flags`. It imports only the standard library and `..domain` (`ServiceDependency`).
+- **`tiferet/di/dependency_injector.py`** — the concrete implementations backed by `dependency_injector`: `DIDynamicServiceContainer` (feature-level, `Factory` scope), `DIAppServiceContainer` (app-level, `Singleton` scope), and `DIDynamicServiceResolver` (per-flag feature resolver). It may additionally import `..interfaces.di` (`DIService`).
+- **`tiferet/di/settings.py`** — the module-functions layer: `create_cache_key` / `merge_settings` plus the concrete `ServiceContainer` engine and `ServiceResolver` provider wired by `build_app`.
 
-- **`tiferet/di/`** — App-level DI. Manages the lifecycle of injected contexts and repositories for an interface (e.g., `FeatureContext`, `ErrorContext`, `LoggingContext`). Consumed by the `build_app` blueprint (`tiferet/blueprints/main.py`).
-- **`tiferet/contexts/di.py` (`DIContext`)** — Feature-level DI. Loads `ServiceConfiguration` objects, resolves flagged dependencies, and builds per-flag providers for feature execution. Consumed by `FeatureContext`.
+The DI layer is deliberately **event-free and asset-free**: it imports only the standard library, `dependency_injector`, `..domain`, and (in `dependency_injector.py`) `..interfaces.di` (`DIService`). It assumes best-case inputs and raises raw exceptions, leaving structured error handling to callers that have event access. Parameter parsing (e.g. `$env.` references) is injected as a `parse_parameter` callable so DI never imports `ParseParameter` itself.
 
-This document describes the structure, design principles, and best practices for writing and extending the DI layer, adhering to Tiferet's structured code style ([docs/core/code_style.md](code_style.md)).
+App-level core services resolve as shared **Singletons** (`DIAppServiceContainer`), while feature-level services resolve per flag set as **Factories** (`DIDynamicServiceResolver`). Contexts (`AppSessionContext`, `FeatureContext`) consume an injected `get_dependency` callable rather than holding a provider or container directly.
 
-## What is a ServiceProvider?
+This document describes the structure, design principles, and best practices for the DI layer, adhering to Tiferet's structured code style ([docs/core/code_style.md](code_style.md)).
 
-A `ServiceProvider` is an abstract class that manages a registry of service IDs and their corresponding types or values. It wraps the runtime dependency injector and exposes a simple, consistent API for registering and resolving services.
+## Module Functions
+
+The DI package exposes pure, side-effect-free helpers under `# *** functions`:
+
+- **`injectable_parameter_names(service_type)`** (`di/core.py`) — Returns a service type's injectable constructor parameter names, excluding `self` and variadic parameters. Used by every container's `build_factory` / `build_singleton` and `CreateServiceResolver`.
+- **`normalize_flags(*flags)`** (`di/core.py`) — Flattens a mixed sequence of strings, lists, and tuples into a flat list of strings. Re-exported from `tiferet/di/__init__.py`.
+- **`create_cache_key(flags)`** (`di/settings.py`) — Derives the per-flag container cache key (e.g. `feature_services_<flag>...`).
+- **`merge_settings(configs, constants, default_config_index, default_constants)`** (`di/settings.py`) — Appends default-index entries for any service ID not already present and merges default constants beneath the repository constants. Backs both `ServiceResolver.list_all_settings` and the `ListAllSettings` event.
+
+## Abstract DI Contract (`di/core.py`)
+
+`di/core.py` defines the framework's abstract DI contract. It is **domain-only** — it imports the standard library and `..domain` (`ServiceDependency`) and nothing from `..interfaces` — so the abstract layer never depends on service interfaces or events.
+
+### `ServiceContainer` (ABC)
+
+The `ServiceContainer` ABC is the container contract that concrete engines implement. Its methods are keyed on the core `ServiceDependency` domain model:
+
+- **`add_service(service_id, service: ServiceDependency)`** — Register a service dependency. Implementations register the dependency's declared `parameters` as constants (taking precedence) before registering the service.
+- **`add_constant(constant_id, value)`** — Register a single constant value.
+- **`get_dependency(dependency_id)`** — Resolve a registered service or constant by id.
+- **`remove_dependency(dependency_id)`** — Remove a registered dependency (idempotent).
+- **`load_container(services, constants)`** — Bulk-load the container from service dependencies and constants (constants first so factories can wire to them).
+
+### `ServiceResolver` (ABC)
+
+The `ServiceResolver` ABC owns a per-flag `ServiceContainer` cache and a concrete **template-method** `get_dependency`; only `build_container` is abstract. Subclasses implement `build_container(flags)` and inherit the caching/resolution flow for free:
+
+- **`add_container(container, *flags)` / `get_container(*flags)`** — Cache and retrieve containers keyed by the normalized flag tuple (`tuple(normalize_flags(*flags))`).
+- **`build_container(flags)`** (abstract) — Build a `ServiceContainer` for a flag set.
+- **`get_dependency(service_id, *flags)`** (template) — Normalize flags, retrieve the cached container (building and caching one on a miss), then delegate to `container.get_dependency(service_id)`.
+
+```python
+# tiferet/di/core.py (excerpt)
+
+# ** class: service_resolver
+class ServiceResolver(ABC):
+
+    # * method: get_dependency
+    def get_dependency(self, service_id: str, *flags) -> Any:
+        # Normalize the provided flags.
+        normalized = normalize_flags(*flags)
+
+        # Retrieve the cached container, building and caching one on a miss.
+        container = self.get_container(*normalized)
+        if container is None:
+            container = self.add_container(self.build_container(normalized), *normalized)
+
+        # Resolve the dependency from the container.
+        return container.get_dependency(service_id)
+```
+
+Keeping `di_service` off the base preserves the domain-only boundary; the DI-bound state lives on the concrete resolver in `dependency_injector.py`.
+
+## Dependency-Injector Implementations (`di/dependency_injector.py`)
+
+`di/dependency_injector.py` provides the concrete `dependency_injector`-backed implementations. It may import `..interfaces.di` (`DIService`) in addition to `..domain`.
+
+### `DIDynamicServiceContainer`
+
+The feature-level container. It adapts the `ServiceContainer` contract to a `dependency_injector` `DynamicContainer`, registering services as **`Factory`** providers (a new instance per resolution) and constants as **`Object`** providers. `add_service` registers the dependency's `parameters` as constants first, resolves the concrete type via `ServiceDependency.get_service_type()`, then wires constructor kwargs to sibling providers via `build_factory` (using `injectable_parameter_names`). `load_container` registers constants before services.
+
+### `DIAppServiceContainer`
+
+The app-level container, a subclass of `DIDynamicServiceContainer` that registers services as **`Singleton`** providers (one shared instance per app) instead of Factories. It overrides `add_service` to call `build_singleton` and adds a `from_dependencies` classmethod that keys a list of `AppServiceDependency` objects by their `service_id`:
+
+```python
+# tiferet/di/dependency_injector.py (excerpt)
+
+# ** class: di_app_service_container
+class DIAppServiceContainer(DIDynamicServiceContainer):
+
+    # * method: from_dependencies (class)
+    @classmethod
+    def from_dependencies(cls, services=None, constants=None):
+        # Key the app service dependencies by their service id.
+        services_by_id = {service.service_id: service for service in (services or [])}
+
+        # Construct and load the container (constants first, then services).
+        return cls(services=services_by_id, constants=constants)
+```
+
+The blueprint `build_app_service_container` (`tiferet/blueprints/core.py`) composes this container from the framework defaults seeded on the shared cache plus the interface's own service/constant overrides. Because the core catalog registers repositories before the events that depend on them, and constants before services, each Singleton's constructor kwargs wire to already-registered sibling providers.
+
+### `DIDynamicServiceResolver`
+
+The concrete feature-level resolver. It holds a `DIService` and an injected `parse_parameter` callable (default identity), and implements `build_container` by reading `di_service.list_all()`, parsing constants, and unpacking each `ServiceRegistration` into an effective core `ServiceDependency` (via `resolve_service`, below) before building a `DIDynamicServiceContainer`:
+
+```python
+# tiferet/di/dependency_injector.py (excerpt)
+
+# * method: build_container
+def build_container(self, flags: List[str] = None) -> ServiceContainer:
+    # Read the registrations and top-level constants from the DI service.
+    registrations, constants = self.di_service.list_all()
+
+    # Parse the top-level constants once.
+    constants = {key: self.parse_parameter(value) for key, value in constants.items()}
+
+    # Unpack each registration into an effective dependency for these flags.
+    services = {}
+    for registration in registrations:
+        dependency = registration.resolve_service(*(flags or []))
+        if dependency is None:
+            continue
+        services[registration.id] = ServiceDependency(
+            module_path=dependency.module_path,
+            class_name=dependency.class_name,
+            parameters={k: self.parse_parameter(v) for k, v in (dependency.parameters or {}).items()},
+        )
+
+    # Build the container (constants first, then services).
+    return DIDynamicServiceContainer(services=services, constants=constants)
+```
+
+### `ServiceRegistration.resolve_service`
+
+The flagged-override → default → `None` selection used during a build lives in one place on the `ServiceRegistration` domain model (`tiferet/domain/di.py`). `resolve_service(*flags)` returns the effective core `ServiceDependency` for a flag set: a matching flagged override (in flag priority order), else the registration's own default definition when fully specified, else `None`. `get_service_type(*flags)` delegates to it, so the precedence rule is defined exactly once.
+
+## The ServiceContainer Engine
+
+`ServiceContainer` is the low-level engine. It wraps a `dependency_injector` `DynamicContainer` and exposes a small, consistent API for registering and resolving services.
 
 Key characteristics:
-- Extends `ServiceProvider` (ABC) from `tiferet/di/settings.py`.
-- Uses `RaiseError.execute()` for structured error handling.
-- Returns fully resolved instances via `get_service()` — callers never interact with the container directly.
-
-### Role in Runtime
-
-The `build_app` blueprint creates a single `ServiceProvider` instance for the lifetime of an interface load:
-
-1. `create_service_provider()` creates a `DynamicServiceProvider`.
-2. `resolve_interface` calls `GetAppInterface` to load the interface definition and obtain its service type mapping.
-3. `realize_interface` calls `service_provider.add_services(dependencies)` to register all interface dependencies.
-4. `service_provider.get_service('app_context')` resolves and returns the fully constructed `AppInterfaceContext`.
-
-## The ServiceProvider Abstract Base
-
-`ServiceProvider` is defined in `tiferet/di/settings.py` and declares the contract all implementations must satisfy:
+- Backed by `containers.DynamicContainer`, which supports runtime provider registration via `set_provider()`.
+- Class types are registered as `Factory` providers (a new instance per resolution); non-type values (scalars, callables, etc.) are registered as `Object` providers (pass-through).
+- `get_service()` returns fully resolved instances; callers never interact with the container directly.
+- Event-free and asset-free: a missing or failing provider raises a raw exception for a caller with event access to convert into a structured error (no `RaiseError` inside DI).
 
 ```python
 # tiferet/di/settings.py
 
 # *** classes
 
-# ** class: service_provider
-class ServiceProvider(ABC):
+# ** class: service_container
+class ServiceContainer(object):
     '''
-    Service provider for app context dependencies.
+    The low-level dependency-injection engine for the framework.
     '''
-
-    # * method: add_service
-    @abstractmethod
-    def add_service(self, service_id: str, service_type: type): ...
-
-    # * method: add_services
-    @abstractmethod
-    def add_services(self, services: Dict[str, type]): ...
-
-    # * method: add_constants
-    @abstractmethod
-    def add_constants(self, constants: Dict[str, Any]): ...
-
-    # * method: get_service
-    @abstractmethod
-    def get_service(self, service_id: str) -> Any: ...
-
-    # * method: remove_service
-    @abstractmethod
-    def remove_service(self, service_id: str): ...
-```
-
-### Method Semantics
-
-- **`add_service(service_id, service_type)`** — Registers a single service type under an ID as a `Factory` provider.
-- **`add_services(services)`** — Bulk-registers a `Dict[str, type]` mapping. Class types are registered as `Factory` providers (new instance per resolution); non-type values (scalars, callables, etc.) are registered as `Object` providers (pass-through).
-- **`add_constants(constants)`** — Registers scalar values (strings, numbers, booleans) as `Object` providers. Unlike the previous `dependencies` library backend, constants **can** be resolved directly via `get_service`.
-- **`get_service(service_id)`** — Returns the fully resolved service instance. Raises `INVALID_DEPENDENCY_ERROR` if the service cannot be resolved.
-- **`remove_service(service_id)`** — Deregisters a service. No-op if the ID is not present.
-
-## The DynamicServiceProvider
-
-`DynamicServiceProvider` is the concrete implementation in `tiferet/di/dynamic.py`. It satisfies the `ServiceProvider` contract using [`dependency-injector`](https://pypi.org/project/dependency-injector/)'s `DynamicContainer` as its backing resolver.
-
-### Key Design Decisions
-
-**DynamicContainer.** The `dependency-injector` library provides `DynamicContainer`, which supports runtime provider registration via `set_provider()`. Unlike the previous `dependencies` library (which required rebuilding an immutable `Injector` subclass on every mutation), providers can be added and removed incrementally.
-
-**Provider types.** Two provider types are used:
-- `Factory` — Wraps a class type. Each `get_service()` call creates a new instance with constructor kwargs wired to sibling providers.
-- `Object` — Wraps a scalar value or callable. Each `get_service()` call returns the same value.
-
-**Automatic constructor wiring.** `build_factory()` inspects the service class constructor via `inspect.signature()` and wires each parameter to a sibling provider if one exists. This enables cascading dependency resolution without explicit wiring configuration.
-
-**No empty scope guard needed.** Unlike the `dependencies` library, `DynamicContainer` works correctly with zero providers. No special `None` guard is required.
-
-```python
-# tiferet/di/dynamic.py
-
-# ** class: dynamic_service_provider
-class DynamicServiceProvider(ServiceProvider):
 
     # * attribute: container
     container: containers.DynamicContainer
@@ -114,35 +172,143 @@ class DynamicServiceProvider(ServiceProvider):
 
     # * method: add_services
     def add_services(self, services: Dict[str, type]):
+        # Pass 1: register scalar/non-type values first so they are
+        # available when Factory providers are built.
+        for service_id, value in services.items():
+            if not isinstance(value, type):
+                self.container.set_provider(service_id, providers.Object(value))
+        # Pass 2: register all class types as Factory providers.
         for service_id, value in services.items():
             if isinstance(value, type):
                 self.add_service(service_id, value)
-            else:
-                self.container.set_provider(service_id, providers.Object(value))
+
+    # * method: add_constants
+    def add_constants(self, constants: Dict[str, Any]):
+        for name, value in constants.items():
+            self.container.set_provider(name, providers.Object(value))
 
     # * method: get_service
     def get_service(self, service_id: str) -> Any:
+        # Look up the provider and invoke it; a missing/failing provider
+        # raises a raw exception for the caller to convert.
         provider = self.container.providers.get(service_id)
-        if provider is None:
-            RaiseError.execute('INVALID_DEPENDENCY_ERROR', ...)
         return provider()
 
     # * method: build_factory
     def build_factory(self, service_type: type) -> providers.Factory:
-        sig = inspect.signature(service_type.__init__)
+        # Wire each injectable constructor parameter to a sibling provider,
+        # using the shared injectable_parameter_names helper.
         kwargs = {}
-        for param_name, param in sig.parameters.items():
-            if param_name == 'self' or param.kind in (VAR_POSITIONAL, VAR_KEYWORD):
-                continue
+        for param_name in injectable_parameter_names(service_type):
             sibling = self.container.providers.get(param_name)
             if sibling is not None:
                 kwargs[param_name] = sibling
         return providers.Factory(service_type, **kwargs)
 ```
 
+### Method Semantics
+
+- **`add_service(service_id, service_type)`** — Registers a single service type under an ID as a `Factory` provider.
+- **`add_services(services)`** — Bulk-registers a `Dict[str, type]` mapping in two passes: scalars/non-type values first (as `Object` providers), then class types (as `Factory` providers). The two-pass order guarantees that every parameter value is available in the container before any `Factory` provider is built and its kwargs are wired.
+- **`add_constants(constants)`** — Registers scalar values (strings, numbers, booleans) as `Object` providers. Constants can be resolved directly via `get_service`.
+- **`get_service(service_id)`** — Returns the fully resolved service instance. A missing or failing provider raises a raw exception (no DI-level error wrapping); callers with event access convert it into a structured error.
+- **`remove_service(service_id)`** — Deregisters a service. No-op when the ID is not present.
+- **`build_factory(service_type)`** — Wires each injectable constructor parameter (from the shared `injectable_parameter_names` helper) to a sibling provider if one exists, enabling cascading dependency resolution without explicit wiring configuration.
+
+## The ServiceResolver
+
+`ServiceResolver` is the application's single public provider and the only DI class the rest of the framework collaborates with. It takes a `DIService` and a `parse_parameter` callable as direct constructor dependencies (in the spirit of a domain event), reads the service registrations and constants, assembles a per-flag type map and constant set, and builds and caches a `ServiceContainer` engine per flag set.
+
+```python
+# ** class: service_resolver
+class ServiceResolver(object):
+    '''
+    The application's service provider.
+    '''
+
+    # * attribute: di_service
+    di_service: DIService
+
+    # * attribute: parse_parameter
+    parse_parameter: Callable
+
+    # * attribute: default_config_index
+    default_config_index: Dict[str, ServiceRegistration]
+
+    # * attribute: default_di_constants
+    default_di_constants: Dict[str, Any]
+
+    # * init
+    def __init__(self,
+            di_service: DIService,
+            parse_parameter: Callable = None,
+            default_config_index: Dict[str, ServiceRegistration] = None,
+            default_di_constants: Dict[str, Any] = None,
+        ):
+        self.di_service = di_service
+        # Default to an identity parser so DI never imports ParseParameter;
+        # the bootstrap event injects the real ParseParameter.execute.
+        self.parse_parameter = parse_parameter if parse_parameter else (lambda v: v)
+        self.default_config_index = default_config_index if default_config_index is not None else {}
+        self.default_di_constants = default_di_constants if default_di_constants is not None else {}
+        self._containers: Dict[str, ServiceContainer] = {}
+```
+
+### Responsibilities
+
+- **`normalize_flags(*flags)` (static)** — Flattens a mixed sequence of strings, lists, and tuples into a flat list of strings. Delegates to the module-level `normalize_flags` helper.
+- **`create_cache_key(flags)`** — Derives the per-flag cache key (e.g. `feature_services_<flag>...`). Delegates to the module-level `create_cache_key` helper.
+- **`list_all_settings()`** — Calls `di_service.list_all()` for repository configurations and constants, then delegates to the module-level `merge_settings` helper to append `default_config_index` entries for any service ID not present and merge `default_di_constants` beneath the repository constants (defaults are lower priority).
+- **`load_constants(configurations, constants, flags)`** — Parses top-level constants and per-configuration parameters (honoring flagged dependencies) via the injected `parse_parameter` callable.
+- **`build_type_map(configurations, flags)`** — Resolves each configuration to a concrete type via `ServiceRegistration.get_service_type(*flags)`, skipping any configuration that resolves to no type (so it is simply not registered); an unresolved service then surfaces as a raw resolution error at the consuming context.
+- **`build_container(flags)`** — Builds (and caches per flag set) a `ServiceContainer` directly by combining `list_all_settings`, `load_constants`, and `build_type_map` (registering constants before service types).
+- **`get_dependency(registration_id, *flags)`** — The public resolution entry point: normalizes flags, builds/retrieves the per-flag container, and returns the resolved service. This bound method is the `get_dependency` callable injected into the contexts.
+
+### Bootstrap Default Merging
+
+`ServiceResolver` preserves the bootstrap `default_*` merge behavior. The `CreateServiceResolver` bootstrap event routes any bootstrap DI defaults into the resolver:
+
+- `default_config_index` — a typed `Dict[str, ServiceRegistration]` keyed by id, merged beneath the repository's configurations (only for IDs not already present).
+- `default_di_constants` — constants merged beneath the repository's constants at lower priority.
+
+## How Contexts Consume DI
+
+The contexts do not hold a container or provider. Instead, the resolver's bound `get_dependency` method is injected as a plain callable:
+
+- `AppSessionContext` receives `get_dependency` and forwards it to the feature context it builds on demand.
+- `FeatureContext` (and `AsyncFeatureContext`) call `self.get_dependency(service_id, *flags)` to resolve each step's domain event and any configured middleware.
+
+```python
+# tiferet/contexts/feature.py (excerpt)
+return self.get_dependency(service_id, *combined_flags)
+```
+
+This keeps the contexts decoupled from the DI engine: any callable with the `get_dependency(registration_id, *flags)` signature can be injected, which simplifies testing (a `mock.Mock()` suffices).
+
+## Blueprint Wiring
+
+The standard path is `core.build_app` in `tiferet/blueprints/core.py`. It does not use a declarative wiring registry; instead it composes the DI layer from two composition functions:
+
+1. `build_app_service_container(cache, app_session)` — merges the cache-seeded framework defaults (`CORE_DEFAULT_SERVICES`, `CORE_DEFAULT_CONSTANTS`) with the session's own services and constants (session wins) and constructs a `DIAppServiceContainer`. App-level services resolve as Singletons.
+2. `build_service_resolver(app_container)` — wraps the app container in a `DIDynamicServiceResolver`, caching it under the `app` flag so feature-step resolution inherits the app-level singletons.
+3. `build_app_session_context(app_session, cache)` — imports the declared context class, resolves its event collaborators from the app container, and constructs the context via `BaseContext.from_domain`, injecting `resolver.get_dependency`.
+
+```python
+# tiferet/blueprints/core.py (excerpt)
+app_container = build_app_service_container(cache, app_session)
+resolver = build_service_resolver(app_container)
+return context_cls.from_domain(
+    app_session,
+    get_dependency=resolver.get_dependency,
+    **resolved_collaborators,
+)
+```
+
+The older declarative-wiring path (`wire_services`, `load_app_instance`, `CreateServiceResolver`) survives module-private inside `tiferet/blueprints/tiferet_cli.py` for the built-in `tiferet_cli` session, which the core compose path cannot yet replace. Consumer applications always use the core path.
+
 ## Structured Code Design
 
-The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consistent with other `settings.py` modules in the framework (e.g., `domain/settings.py`).
+The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consistent with other `settings.py` modules in the framework (e.g., `contexts/settings.py`).
 
 ### Artifact Comments
 
@@ -155,61 +321,6 @@ The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consis
 
 **Spacing rules** follow `code_style.md`: one empty line between `# ***` and the first `# **`, one empty line between each `# *` section, one empty line after docstrings, and one empty line between code snippets.
 
-**Example** — `settings.py` layout:
-```python
-# *** imports
-
-# ** core
-from abc import ABC, abstractmethod
-from typing import Dict, Any
-
-
-# *** classes
-
-# ** class: service_provider
-class ServiceProvider(ABC):
-    '''...'''
-
-    # * method: add_service
-    @abstractmethod
-    def add_service(self, service_id: str, service_type: type):
-        ...
-```
-
-**Example** — `dynamic.py` layout:
-```python
-# *** imports
-
-# ** core
-from typing import Any, Dict
-import inspect
-
-# ** infra
-from dependency_injector import containers, providers
-
-# ** app
-from ..events import RaiseError
-from .settings import ServiceProvider
-
-
-# *** classes
-
-# ** class: dynamic_service_provider
-class DynamicServiceProvider(ServiceProvider):
-    '''...'''
-
-    # * attribute: container
-    container: containers.DynamicContainer
-
-    # * init
-    def __init__(self, services: Dict[str, type] = None):
-        ...
-
-    # * method: add_service
-    def add_service(self, service_id: str, service_type: type):
-        ...
-```
-
 ## Provider Types and Registration
 
 ### Factory Providers (Class Types)
@@ -217,11 +328,11 @@ class DynamicServiceProvider(ServiceProvider):
 When a class type is registered via `add_service()`, it is wrapped in a `providers.Factory`. Each resolution creates a new instance with constructor kwargs wired to sibling providers:
 
 ```python
-provider.add_service('feature_service', FeatureYamlRepository)
-provider.add_constants({'feature_yaml_file': 'app/configs/feature.yml'})
+container.add_constants({'feature_config': 'app/configs/feature.yml'})
+container.add_service('feature_service', FeatureConfigRepository)
 
-# FeatureYamlRepository(feature_yaml_file='app/configs/feature.yml') is resolved:
-repo = provider.get_service('feature_service')  # ✓ new instance each time
+# FeatureConfigRepository(feature_config='app/configs/feature.yml') is resolved:
+repo = container.get_service('feature_service')  # ✓ new instance each time
 ```
 
 ### Object Providers (Scalars and Callables)
@@ -229,171 +340,76 @@ repo = provider.get_service('feature_service')  # ✓ new instance each time
 Non-type values registered via `add_services()` or `add_constants()` are wrapped in `providers.Object`. Each resolution returns the same value:
 
 ```python
-provider.add_constants({'app_config_file': 'app/configs/app.yml'})
+container.add_constants({'app_config': 'app/configs/app.yml'})
 
-# Direct scalar resolution works (unlike the previous dependencies library):
-path = provider.get_service('app_config_file')  # ✓ returns 'app/configs/app.yml'
+# Direct scalar resolution works:
+path = container.get_service('app_config')  # ✓ returns 'app/configs/app.yml'
 ```
 
-## Creating a New ServiceProvider Implementation
+## Customizing Parameter Parsing
 
-To provide an alternative DI backend (e.g., for testing), extend `ServiceProvider` from `tiferet/di/settings.py` and implement all abstract methods.
+The resolver accepts a `parse_parameter` callable used to resolve constant and parameter values (e.g. `$env.` references). It defaults to an identity function so the DI layer never imports `ParseParameter`; the `CreateServiceResolver` bootstrap event injects the real `ParseParameter.execute`. Tests can inject a custom parser to assert parsing behavior:
 
-**Example** — `SimpleServiceProvider` (dict-backed, for testing):
 ```python
-# *** imports
-
-# ** core
-from typing import Any, Dict
-
-# ** app
-from ..events import RaiseError
-from .settings import ServiceProvider
-
-
-# *** classes
-
-# ** class: simple_service_provider
-class SimpleServiceProvider(ServiceProvider):
-    '''
-    A minimal dict-backed service provider for testing.
-    '''
-
-    # * attribute: registry
-    registry: Dict[str, Any]
-
-    # * init
-    def __init__(self):
-        '''Initialize with an empty registry.'''
-
-        # Initialize the registry.
-        self.registry = {}
-
-    # * method: add_service
-    def add_service(self, service_id: str, service_type: type):
-        '''Register a service type by ID.'''
-
-        # Store the type in the registry.
-        self.registry[service_id] = service_type
-
-    # * method: add_services
-    def add_services(self, services: Dict[str, type]):
-        '''Bulk-register service types.'''
-
-        # Merge the services into the registry.
-        self.registry.update(services)
-
-    # * method: add_constants
-    def add_constants(self, constants: Dict[str, Any]):
-        '''Register scalar constants.'''
-
-        # Merge the constants into the registry.
-        self.registry.update(constants)
-
-    # * method: get_service
-    def get_service(self, service_id: str) -> Any:
-        '''Return the registered value for service_id.'''
-
-        # Raise an error if the service is not registered.
-        if service_id not in self.registry:
-            RaiseError.execute(
-                'INVALID_DEPENDENCY_ERROR',
-                f'Dependency {service_id} could not be resolved.',
-                dependency_name=service_id,
-                exception='Service not registered.',
-            )
-
-        # Return the registered value.
-        return self.registry[service_id]
-
-    # * method: remove_service
-    def remove_service(self, service_id: str):
-        '''Deregister a service by ID.'''
-
-        # Remove the service from the registry if present.
-        self.registry.pop(service_id, None)
+resolver = ServiceResolver(
+    di_service=mock_di_service,
+    parse_parameter=lambda v: v.upper(),
+)
 ```
 
-Inject a custom provider into `build_app` via the `provider_type` parameter of `create_service_provider`.
+For most tests, contexts can be exercised by injecting a `get_dependency` mock directly, bypassing the resolver entirely.
 
-## Testing ServiceProvider Implementations
+## Testing the DI Layer
 
-Tests live in `tiferet/di/tests/` and follow the standard artifact comment structure.
+Tests live in `tests/di/test_settings.py` and follow the standard artifact comment structure.
 
 ### Key Patterns
 
-- Test `init` with no services — assert container has no providers.
-- Test `init` with services — assert types are registered and resolvable.
-- Test `add_service` / `add_services` — assert services resolve to the correct types.
-- Test `add_constants` — register a constant, resolve it directly, and register a service that depends on it to verify injection.
-- Test `get_service` on an unregistered ID — assert `TiferetError` with `error_code == 'INVALID_DEPENDENCY_ERROR'`.
-- Test `remove_service` — assert the service is gone and no longer resolvable.
-- Test `remove_service` on an unknown ID — assert no exception is raised.
+- Test `ServiceContainer` registration and resolution — register types/constants and assert `get_service` returns the correct instances.
+- Test `get_service` on an unregistered ID — assert a raw exception propagates (DI does not raise structured `TiferetError`s).
+- Test `remove_service` — assert the service is gone, and that removing an unknown ID raises nothing.
+- Test `ServiceResolver.list_all_settings` merge behavior — assert repository configs/constants take priority over bootstrap defaults.
+- Test `ServiceResolver.get_dependency` — assert per-flag containers are cached and that flagged dependency types resolve correctly.
 
 ```python
-# *** fixtures
-
-# ** fixture: populated_provider
-@pytest.fixture
-def populated_provider() -> DynamicServiceProvider:
-    '''Pre-populated provider for success-path tests.'''
-    return DynamicServiceProvider(services={'my_service': MyService})
-
-
 # *** tests
 
-# ** test: get_service_success
-def test_get_service_success(populated_provider: DynamicServiceProvider):
-    '''Test that a registered service resolves to the correct type.'''
+# ** test: get_dependency_success
+def test_get_dependency_success(resolver: ServiceResolver):
+    '''Test that a configured service resolves via get_dependency.'''
 
-    # Resolve the service.
-    service = populated_provider.get_service('my_service')
+    # Resolve the service by configuration id.
+    service = resolver.get_dependency('feature_service')
 
     # Assert it is the expected type.
-    assert isinstance(service, MyService)
-
-
-# ** test: get_service_not_found
-def test_get_service_not_found():
-    '''Test that an unregistered service raises INVALID_DEPENDENCY_ERROR.'''
-
-    # Create an empty provider.
-    provider = DynamicServiceProvider()
-
-    # Attempt to resolve an unknown service.
-    with pytest.raises(TiferetError) as exc_info:
-        provider.get_service('missing')
-
-    # Assert the correct error code.
-    assert exc_info.value.error_code == 'INVALID_DEPENDENCY_ERROR'
+    assert isinstance(service, FeatureConfigRepository)
 ```
-
-## Backward Compatibility
-
-A backward-compatible alias is provided in `tiferet/di/__init__.py`:
-
-```python
-DependenciesServiceProvider = DynamicServiceProvider
-```
-
-Downstream consumers importing `DependenciesServiceProvider` will receive `DynamicServiceProvider` transparently. The `ServiceProvider` ABC is unchanged.
 
 ## Package Layout
 
 ```
 tiferet/di/
-├── __init__.py          — Exports: ServiceProvider, DynamicServiceProvider (+ backward-compat alias)
-├── settings.py          — ServiceProvider (ABC)
-├── dynamic.py           — DynamicServiceProvider (dependency-injector-backed)
-└── tests/
-    ├── __init__.py
-    └── test_dynamic.py
+├── __init__.py                — Exports: ServiceContainer, ServiceResolver,
+│                                DIAppServiceContainer, injectable_parameter_names,
+│                                normalize_flags, create_cache_key, merge_settings
+├── core.py                    — # *** functions (injectable_parameter_names,
+│                                normalize_flags) + ServiceContainer (ABC)
+│                                + ServiceResolver (ABC, template get_dependency)
+├── dependency_injector.py     — DIDynamicServiceContainer (Factory),
+│                                DIAppServiceContainer (Singleton),
+│                                DIDynamicServiceResolver (per-flag)
+└── settings.py                — # *** functions (create_cache_key,
+                                 merge_settings) + concrete ServiceContainer engine
+                                 + ServiceResolver provider
+
+tests/di/
+├── test_core.py                  — ABC contract + resolver template + normalize_flags
+├── test_dependency_injector.py   — DIDynamic/DIApp container + resolver tests
+└── test_settings.py              — ServiceContainer engine and ServiceResolver tests
 ```
 
 ## Conclusion
 
-The `tiferet/di/` package provides the app-level DI foundation for the Tiferet framework, abstracting the lifecycle of contexts and repositories behind the `ServiceProvider` contract. The `DynamicServiceProvider` satisfies this contract using the `dependency-injector` library's `DynamicContainer`, providing incremental provider registration, automatic constructor wiring, and direct scalar resolution.
+The `tiferet/di/` package provides the DI foundation for Tiferet. Its abstract contract (`di/core.py`) defines the `ServiceContainer` and `ServiceResolver` ABCs, and its `dependency_injector`-backed implementations (`di/dependency_injector.py`) provide the app-level Singleton container (`DIAppServiceContainer`), the feature-level Factory container (`DIDynamicServiceContainer`), and the per-flag resolver (`DIDynamicServiceResolver`). The `di/settings.py` module supplies the concrete engine and resolver wired by `build_app`, together preserving per-flag caching, automatic constructor wiring, and bootstrap default merging.
 
-New implementations extend `ServiceProvider` and override all abstract methods. Inject them into the `build_app` blueprint via the `provider_type` parameter of `create_service_provider` to swap backends without changing application code.
-
-Explore source in `tiferet/di/`, runtime consumers in `tiferet/blueprints/main.py`, and tests in `tiferet/di/tests/`.
+Explore source in `tiferet/di/core.py`, `tiferet/di/dependency_injector.py`, and `tiferet/di/settings.py`; runtime consumers in `tiferet/blueprints/` and `tiferet/contexts/`; and tests in `tests/di/`.

--- a/docs/core/domain.md
+++ b/docs/core/domain.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Domain objects are the structural core of the Tiferet framework. Every domain concept — errors, features, containers, app interfaces, CLI commands, and logging configurations — is expressed as a class extending `DomainObject` from `tiferet.domain.settings`.
+Domain objects are the structural core of the Tiferet framework. Every domain concept — errors, features, containers, app interfaces, CLI commands, and logging configurations — is expressed as a class extending `DomainObject` from `tiferet.domain.core`.
 
 Domain objects serve a **dual role**:
 
@@ -15,8 +15,8 @@ Domain objects serve a **dual role**:
    - Used by Contexts to perform domain-specific work (e.g., `ErrorContext` retrieves and formats an `Error` for response generation).
 
 2. **Structural Foundation for the Mappers Layer**  
-   - Aggregates extend domain objects with mutation logic (e.g., `ErrorAggregate(Error, Aggregate)`).
-   - TransferObjects extend domain objects with serialization roles (e.g., `ErrorConfigObject(Error, TransferObject)`).
+  - Aggregates extend domain objects with mutation logic (e.g., `ErrorAggregate(Error, Aggregate)`).
+  - TransferObjects extend domain objects with serialization roles (e.g., `ErrorConfigObject(Error, TransferObject)`).
    - Define the field shape mirrored in YAML/JSON configuration files.
    - Enable reliable round-trip mapping between persistent configuration and runtime models.
 
@@ -48,7 +48,7 @@ This duality ensures a single source of truth for domain structure and behavior,
 `DomainObject` extends `pydantic.BaseModel` with a shared `ConfigDict`:
 
 ```python
-# tiferet/domain/settings.py
+# tiferet/domain/core.py
 
 from pydantic import BaseModel, ConfigDict
 
@@ -79,7 +79,7 @@ Key characteristics:
 
 Domain objects follow a strict artifact comment structure for consistency and AI/human readability:
 
-- `# *** models` – top-level section (retained for backward compatibility; these are domain objects).
+- `# *** models` – top-level section for domain object modules.
 - `# ** model: <name>` – individual domain object (snake_case).
 - `# * attribute: <name>` – instance attributes (Pydantic `Field(...)` annotations).
 - `# * method: <name>` – domain methods.
@@ -93,7 +93,7 @@ Domain objects follow a strict artifact comment structure for consistency and AI
 ## Creating and Extending Domain Objects
 
 ### 1. Define the Domain Object
-- Extend `DomainObject` from `tiferet.domain.settings`.
+- Extend `DomainObject` from `tiferet.domain.core`.
 - Declare fields with Pydantic `Field(...)` annotations.
 - Instantiate directly via the constructor or `model_validate()`.
 - Use `@model_validator(mode='before')` for derivation logic that was previously in custom `new()` factories.
@@ -141,7 +141,7 @@ Domain objects are extended in the mappers layer as Aggregates (with mutation me
 - Declare fields with `Field(...)` including `description` metadata.
 - Keep domain objects focused on **structure and read-only behavior** (formatting, lookups).
 - Place **mutation logic** (e.g., `rename`, `add_command`, `set_message`) in Aggregate classes in the mappers layer.
-- Instantiate directly via the constructor or `model_validate()` — there is no `DomainObject.new()` factory.
+- Instantiate directly via the constructor or `model_validate()`.
 - Use `@model_validator(mode='before')` for domain-specific derivation logic (e.g., `Error._derive_error_code` computes `error_code` from `id`).
 
 ## Testing Domain Objects
@@ -160,26 +160,16 @@ Tests validate instantiation, behavior, and edge cases using `pytest`.
 
 Domain objects are defined in `tiferet/domain/`:
 
-- `settings.py` – `DomainObject` base class (extends `pydantic.BaseModel` with `ConfigDict`).
-- `app.py` – `AppInterface`, `AppServiceDependency`.
+- `core.py` – `DomainObject` base class (extends `pydantic.BaseModel` with `ConfigDict`) and the shared `ServiceDependency` core model.
+- `app.py` – `AppSession`, `AppServiceDependency`.
 - `cli.py` – `CliCommand`, `CliArgument`.
 - `di.py` – `ServiceRegistration`, `FlaggedDependency`.
 - `error.py` – `Error`, `ErrorMessage`.
 - `feature.py` – `Feature`, `FeatureStep`, `EventFeatureStep`.
-- `logging.py` – `Formatter`, `Handler`, `Logger`.
+- `logging.py` – `Formatter`, `Handler`, `Logger`, `LoggingSettings`.
 - `__init__.py` – Public exports for all domain objects.
 
 Tests live in `tiferet/domain/tests/`.
-
-## Migration from Schematics to Pydantic v2
-
-In v2.0, the domain layer was migrated from `schematics.Model` to `pydantic.BaseModel`:
-
-- `DomainObject` now extends `pydantic.BaseModel` with a shared `ConfigDict` instead of `schematics.Model`.
-- Schematics type descriptors (`StringType`, `IntegerType`, `FloatType`, etc.) are replaced with standard Python type annotations and `pydantic.Field(...)`.
-- The `DomainObject.new(Type, **kwargs)` static factory is removed; use the Pydantic constructor directly or `model_validate()` for external data.
-- Custom `new()` factory methods with derivation logic are replaced by `@model_validator(mode='before')` class methods.
-- `tiferet/entities/` was renamed to `tiferet/domain/`, and `ModelObject` was renamed to `DomainObject`.
 
 ## Conclusion
 

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -405,14 +405,13 @@ Domain events are defined in `tiferet/events/`:
 
 - `settings.py` – `DomainEvent` base class, `@parameters_required` decorator.
 - `static.py` – Static utility events (`ParseParameter`, `ImportDependency`, `RaiseError`).
-- `app.py` – App interface management events.
-- `cli.py` – CLI command management events.
-- `container.py` – Container attribute management events.
-- `dependencies.py` – DI service configuration events.
-- `error.py` – Error management events.
-- `feature.py` – Feature workflow management events.
-- `logging.py` – Logging configuration events.
-- `sqlite.py` – SQLite management events.
+- `app.py` – `AppEvent` base + app interface management events.
+- `cli.py` – `CliEvent` base + CLI command management events.
+- `di.py` – `DIEvent` base + DI service registration events.
+- `error.py` – `ErrorEvent` base + error management events.
+- `feature.py` – `FeatureEvent` base + feature workflow management events.
+- `logging.py` – `LoggingEvent` base + logging configuration events.
+- `sqlite.py` – `SqliteEvent` base + SQLite management events.
 - `__init__.py` – Public exports (`DomainEvent`, `TiferetError`, `a`).
 
 Tests live in `tiferet/events/tests/`:

--- a/docs/core/interfaces.md
+++ b/docs/core/interfaces.md
@@ -159,30 +159,6 @@ class FileService(Service):
    - Declare the Service as a constructor dependency (e.g., `error_service: ErrorService`).
    - Depend only on the interface for all vertical operations.
 
-## Migration from Contracts
-
-The `tiferet.interfaces` package is the successor to `tiferet.contracts` and represents the canonical location for service interfaces going forward.
-
-### Package Rename Rationale
-The rename from `contracts` to `interfaces` better reflects the purpose of these components as abstract service interfaces, aligning with widely understood software engineering terminology and the v2.0 architectural direction.
-
-### Artifact Comment Changes
-When migrating service files from `tiferet.contracts` to `tiferet.interfaces`, update the artifact comments as follows:
-
-- `# *** contracts` → `# *** interfaces`
-- `# ** contract: <name>` → `# ** interface: <name>`
-
-All other artifact comments (`# * method:`, `# * attribute:`, etc.) remain unchanged.
-
-### Incremental Migration Path
-Migration of concrete service interfaces (e.g., `ErrorService`, `FeatureService`, `ContainerService`) from `tiferet.contracts` to `tiferet.interfaces` will proceed incrementally:
-
-1. **Phase 1 (current)**: Only the base `Service` class is ported to `tiferet.interfaces.settings`. All domain-specific interfaces remain in `tiferet.contracts`.
-2. **Phase 2 (future)**: Individual service interfaces will be migrated as their dependent aggregates, mappers, and domain events become available in the v2.0 architecture.
-3. **Backward compatibility**: During migration, `tiferet.contracts` will continue to function. No existing imports will break until an explicit deprecation cycle is initiated.
-
-New service interfaces should be created in `tiferet.interfaces` from the start.
-
 ## Best Practices
 - Use artifact comments consistently (`# * method`, `# * attribute`).
 - Define methods with clear RST docstrings, type hints, and domain intent.
@@ -225,4 +201,4 @@ For async middleware, implement `async def __call__` and `await next_fn()`. The 
 
 Services are the unified vertical interfaces in Tiferet, serving as the primary interface for middleware, data access, configuration management, and utilities. Commands and domain events depend exclusively on these Service interfaces, achieving high decoupling, testability, and extensibility. Concrete implementations satisfy the Service interfaces while hiding infrastructure details.
 
-Explore `tiferet/interfaces/` for base definitions, `tiferet/contracts/` for current domain-specific Service interfaces, and `tiferet/middleware/` and `tiferet/repos/` for implementation patterns.
+Explore `tiferet/interfaces/` for base definitions and `tiferet/repos/` for implementation patterns.

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -405,27 +405,17 @@ FIELD_NORMALIZERS = {
 ```
 
 #### Child Mapper Tests
-When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyConfigObject` inside `AppInterfaceConfigObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
+When a TransferObject contains nested child mappers (e.g., `AppServiceDependencyConfigObject` inside `AppSessionConfigObject`), test the child within the parent's test class under a `# *** child mapper: <ChildName>` sub-section.
 
 #### Standalone Tests
 Small leaf-level mappers without mutation logic (e.g., `ErrorMessageConfigObject`) may use standalone test functions instead of the harness, placed after the class-based tests.
-
-### Migration Status
-
-The following test modules have been migrated to the harness-based style:
-- `test_app.py`, `test_cli.py`, `test_di.py`, `test_error.py`, `test_feature.py`, `test_logging.py`
-
-The following use the legacy standalone style and are candidates for migration:
-- `test_container.py`
-
-`test_settings.py` tests the base classes themselves and appropriately uses standalone functions.
 
 ## Package Layout
 
 Mappers are defined in `tiferet/mappers/`:
 
 - `settings.py` — `Aggregate` and `TransferObject` base classes + constants.
-- `app.py` — `AppInterfaceAggregate`, `AppInterfaceConfigObject`.
+- `app.py` — `AppSessionAggregate`, `AppSessionConfigObject`.
 - `cli.py` — `CliArgumentAggregate`, `CliCommandAggregate`, `CliCommandConfigObject`.
 - `di.py` — `ServiceRegistrationAggregate`, `ServiceRegistrationConfigObject`.
 - `error.py` — `ErrorAggregate`, `ErrorConfigObject`, `ErrorMessageConfigObject`.
@@ -435,23 +425,10 @@ Mappers are defined in `tiferet/mappers/`:
 
 Tests live in `tiferet/mappers/tests/`.
 
-## Migration from Schematics to Pydantic v2
-
-The mappers layer was migrated from `schematics.Model` to Pydantic v2:
-
-- `Aggregate.new(Type, **kwargs)` → Direct Pydantic constructor: `Type(**kwargs)`.
-- `set_attribute` now checks `model_fields` instead of `hasattr`; `validate_assignment=True` handles re-validation.
-- `TransferObject.from_data(Type, **kwargs)` → `Type.model_validate(data_dict)`.
-- `TransferObject.allow()` / `deny()` / `class Options` / `serialize_when_none` → `_ROLES` ClassVar with `model_dump` kwargs (`include`, `exclude`, `by_alias`, `exclude_none`).
-- `to_primitive(role)` now delegates to `model_dump` with role-resolved kwargs.
-- `from_model` is now a `@classmethod` on `TransferObject` using `model_dump(by_alias=False)` + `model_validate`.
-- Attribute aliasing: `serialized_name` → `serialization_alias`; `deserialize_from` → `validation_alias` with `AliasChoices`.
-
 ## Conclusion
 
 The mappers layer provides the structural bridge between persistent configuration and runtime domain objects, with clear separation between mutation (`Aggregate`) and serialization (`TransferObject`). This design enables:
 - Validated, mutation-safe domain updates.
 - Role-based serialization for multiple output formats.
-- Incremental migration from the legacy `DataObject` pattern.
 
 Explore source in `tiferet/mappers/` and tests in `tiferet/mappers/tests/` for implementation details.

--- a/docs/core/repos.md
+++ b/docs/core/repos.md
@@ -393,17 +393,6 @@ Repositories are defined in `tiferet/repos/`:
 
 Tests live in `tests/repos/`.
 
-## Migration from Proxies and Schematics
-
-Repositories are the v2.0 successor to Proxies (`tiferet/proxies/`). Key changes:
-
-- **Package rename**: `tiferet/proxies/yaml/<domain>.py` → `tiferet/repos/<domain>.py`. The nested middleware-specific directory structure is flattened; the shared `ConfigurationRepository` base resolves the backing loader from the configuration file extension.
-- **Base class**: Proxies extended `YamlConfigurationProxy` (a middleware base class). Repositories extend the Service interface together with the `ConfigurationRepository` base, which dispatches to `YamlLoader` or `JsonLoader` internally.
-- **Artifact comments**: `# *** proxies` / `# ** proxy:` → `# *** repos` / `# ** repo:`.
-- **Data mapping**: Proxies used `DataObject.from_data()` and `DataObject.map()`. Repositories use `model_validate()` for reads and `from_model()` classmethod + `to_primitive(role)` for writes.
-- **Contract alignment**: Proxies implemented `Repository` contracts. Repositories implement `Service` interfaces — the unified v2.0 contract type.
-- **Pydantic v2 migration**: `TransferObject.from_data(Type, **kwargs)` → `Type.model_validate(data_dict)`; `Aggregate.new(Type, **kwargs)` → direct Pydantic constructor.
-
 ## Conclusion
 
 Repositories provide the concrete data-access layer for the Tiferet framework, implementing Service interfaces with utility-backed persistence. Their structured design ensures consistency, testability, and clean DI resolution. Repositories are never exported directly — consuming code depends only on the abstract Service interface.

--- a/docs/core/testing.md
+++ b/docs/core/testing.md
@@ -128,11 +128,11 @@ Base class for testing TransferObject components. Provides `test_map`, `test_fro
 **Example:**
 
 ```python
-from tiferet.mappers.error import ErrorAggregate, ErrorYamlObject
+from tiferet.mappers.error import ErrorAggregate, ErrorConfigObject
 from tiferet.testing import TransferObjectTestBase
 
-class TestErrorYamlObject(TransferObjectTestBase):
-    transfer_cls = ErrorYamlObject
+class TestErrorConfigObject(TransferObjectTestBase):
+    transfer_cls = ErrorConfigObject
     aggregate_cls = ErrorAggregate
     sample_data = ERROR_SAMPLE_DATA
     aggregate_sample_data = ERROR_SAMPLE_DATA
@@ -140,7 +140,7 @@ class TestErrorYamlObject(TransferObjectTestBase):
 
     # Domain-specific tests beyond the harness:
     def test_map_messages(self):
-        yaml_obj = ErrorYamlObject.model_validate(self.sample_data)
+        yaml_obj = ErrorConfigObject.model_validate(self.sample_data)
         mapped = yaml_obj.map()
         assert len(mapped.message) == 1
 ```
@@ -290,9 +290,9 @@ class TestSomeAggregate(AggregateTestBase):
 
     # Domain-specific mutation tests go here.
 
-# ** class: TestSomeYamlObject
-class TestSomeYamlObject(TransferObjectTestBase):
-    transfer_cls = SomeYamlObject
+# ** class: TestSomeConfigObject
+class TestSomeConfigObject(TransferObjectTestBase):
+    transfer_cls = SomeConfigObject
     aggregate_cls = SomeAggregate
     sample_data = { ... }  # YAML-format
     aggregate_sample_data = SAMPLE_DATA

--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -9,7 +9,7 @@ Utilities are a core component of the Tiferet framework, providing concrete infr
 
 The utility pattern encapsulates **any reusable infrastructure concern** behind a consistent, injectable, and testable Service contract. While the current `tiferet/utils/` package contains file and data access utilities (YAML, JSON, CSV, SQLite), the architectural role extends to computational infrastructure as well — sorting algorithms, heuristics, AI model invocations, embedding pipelines, or any other repeatable process that domain events should consume without coupling to implementation details.
 
-This document describes the structure, design principles, and best practices for writing and extending utilities, adhering to Tiferet's structured code style ([docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/v2.0a1-release/docs/core/code_style.md)).
+This document describes the structure, design principles, and best practices for writing and extending utilities, adhering to Tiferet's structured code style ([docs/core/code_style.md](code_style.md)).
 
 ## What is a Utility?
 


### PR DESCRIPTION
## Problem

`main`'s `docs/core/` guides were multiple release cycles behind the codebase's actual API surface: stale class names (`AppInterfaceContext`, `AppInterface`, `AppInterfaceAggregate`, `AppInterfaceConfigObject`) appeared throughout, two guides (`assets.md`, `testing.md`) were missing key content, five guides (`contexts.md`, `blueprints.md`, `di.md`, `events.md`, `repos.md`) reflected architectures from b7–b9 rather than v2.0.0, `utils.md` contained a dead link to a retired branch, and the `code_style.md` footer listed only 7 of the 12 guides.

Additionally, `v2.x-proto` itself had residual naming drift from the `AppInterface → AppSession` rename (commit `aa54a2e`) that the subsequent doc alignment commit (`4a90a7d`) missed. Those corrections are applied here as each file lands.

## Changes

### Naming corrections applied throughout (not a blind port)

The following class renames were propagated into every affected guide and `AGENTS.md`:

- `AppInterfaceContext` → `AppSessionContext` (`contexts.md`, `blueprints.md`, `di.md`, `code_style.md`, `AGENTS.md`)
- `AppInterface` → `AppSession` (`contexts.md`, `domain.md` package layout, `AGENTS.md` Key Concepts / Domain Modules / Key Files)
- `AppInterfaceAggregate` → `AppSessionAggregate` (`mappers.md` package layout)
- `AppInterfaceConfigObject` → `AppSessionConfigObject` (`mappers.md` package layout + child-mapper example)
- `AppSession.apply_defaults` fixed in `blueprints.md` (was still `AppInterface.apply_defaults`)

Historical beta-version markers inside `AGENTS.md` Migration Notes are preserved verbatim.

### Guide-by-guide substance

**`testing.md`** — Updated harness docs: `DomainEventTestBase`, `ServiceEventTestBase`, and `register_event_hooks` now documented; conftest hook usage clarified.

**`assets.md`** — Updated constants/functions/classes structure docs to match the `create_default_error` factory pattern and per-constant `# ** constant:` labeling.

**`domain.md`** — Updated `DomainObject` home to `domain/core.py`; corrected `AppSession` in package layout; added `LoggingSettings` and `ServiceDependency`; removed stale Schematics migration section.

**`events.md`** — Added per-module base events section (`ErrorEvent`, `FeatureEvent`, etc.), middleware support docs, and the `DomainEventTestBase`/`ServiceEventTestBase` test harness section.

**`mappers.md`** — Applied `AppSessionAggregate`/`AppSessionConfigObject` naming; removed stale Migration Status and Schematics migration sections; corrected child-mapper example.

**`interfaces.md`** — Added `MiddlewareService` documentation and updated `Services as Vertical Contracts` framing.

**`repos.md`** — Updated to `ConfigurationRepository` base class, `*ConfigRepository` naming, `<domain>_config` constructor convention, and `ConfigObject` pattern.

**`contexts.md`** — Full `AppSessionContext`/`AppSession` rename; replaced old four-attribute hub example with the current minimal-hub design (`from_domain`, `get_dependency`, sub-contexts built on demand); added `CacheContext` and bootstrap catalog docs.

**`blueprints.md`** — Replaced old `build_app`/`main.py`/`GetAppInterface` description with the current `core.build_app` composition chain (`build_cache → get_app_session → build_app_session_context`); updated CLI blueprint to thin-entrypoint description.

**`di.md`** — Documented `di/core.py` ABCs, `di/dependency_injector.py` implementations (`DIDynamicServiceContainer`, `DIAppServiceContainer`, `DIDynamicServiceResolver`), and the legacy `ServiceContainer`/`ServiceResolver` in `settings.py`.

**`utils.md`** — Single change: replaced dead `blob/v2.0a1-release` URL in the introduction with a relative `code_style.md` reference. Content is otherwise unchanged.

**`code_style.md`** — Replaced Deprecation Handling section with Annotation Artifacts (`# ++ todo:` / `# -- obsolete:`); updated Top-Level section with preamble/construct group model and sub-group grammar; updated example code to use `DomainEvent.handle` and direct Pydantic constructor; fixed `AppSession` in harness test example; expanded linked-docs footer from 7 to 11 guides (adding `contexts.md`, `blueprints.md`, `di.md`, `testing.md`).

**`AGENTS.md`** — Fixed `AppSessionContext`/`AppSession` naming in Layer Overview, Key Concepts, Runtime Flow, Dependency Injection, Domain Modules, and Key Files; ported updated content for all above sections.

Co-Authored-By: Oz <oz-agent@warp.dev>