### PR TITLE
Docs/Collab – Introduce tiferet-code-* skill suite

### DIFF
--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -2,14 +2,38 @@
 
 Canonical, version-controlled copies of the reusable agent **skills** for Tiferet-family work. They live here so they're shareable and reviewable; to use them, each contributor copies them into an auto-discoverable skills directory.
 
-## Skills in this folder
+## Collaboration skills
+- **`tiferet-annotation-artifacts`** — scan, add, and resolve `# ++ todo:` / `# -- obsolete:` annotation artifacts; covers the pre-session scan, resolution procedure, and Collaboration Report integration. **Use at the start of every implementation session.**
 - **`tiferet-create-milestone`** — create or format a GitHub milestone.
 - **`tiferet-author-trd`** — author a Technical Requirements Document.
 - **`tiferet-collab-report`** — generate a Collaboration Report when an issue is confirmed complete.
 - **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop.
 - **`tiferet-pr-code-review`** — review a PR by comparing its feature branch against a prototype source of truth and posting only actionable comments.
 
-Each is a directory with a `SKILL.md` (YAML frontmatter + instructions). The skills are thin wrappers that reference `docs/collab/` and `docs/core/` as the source of truth — they don't copy that content, so the docs stay authoritative.
+Collaboration skills are thin wrappers that reference `docs/collab/` and `docs/core/` as the source of truth — they don't copy that content, so the docs stay authoritative.
+
+## Code style skills
+
+Twelve self-contained code style skills — one per component — that embed the artifact comment labels, naming conventions, spacing rules, and a minimal working example so an implementation agent can apply the conventions without fetching any external URL. Each skill's **Canonical source** section links to the full `docs/core/` guide as a fallback.
+
+**Read `tiferet-code-style` at the start of every implementation session** (same standing as `tiferet-annotation-artifacts`).
+
+| Skill | Source doc | When to use |
+|---|---|---|
+| **`tiferet-code-style`** | `docs/core/code_style.md` | Every implementation session — read first |
+| **`tiferet-code-domain`** | `docs/core/domain.md` | Adding or modifying domain objects |
+| **`tiferet-code-events`** | `docs/core/events.md` | Adding or modifying domain events |
+| **`tiferet-code-mappers`** | `docs/core/mappers.md` | Adding or modifying aggregates or config objects |
+| **`tiferet-code-interfaces`** | `docs/core/interfaces.md` | Adding or modifying service interfaces |
+| **`tiferet-code-repos`** | `docs/core/repos.md` | Adding or modifying repositories |
+| **`tiferet-code-contexts`** | `docs/core/contexts.md` | Adding or modifying contexts |
+| **`tiferet-code-assets`** | `docs/core/assets.md` | Adding or modifying assets constants, errors, or exceptions |
+| **`tiferet-code-blueprints`** | `docs/core/blueprints.md` | Adding or modifying blueprints |
+| **`tiferet-code-utils`** | `docs/core/utils.md` | Adding or modifying utilities |
+| **`tiferet-code-di`** | `docs/core/di.md` | Adding or modifying DI layer classes or functions |
+| **`tiferet-code-testing`** | `docs/core/testing.md` | Writing or extending tests using the harness |
+
+Each is a directory with a `SKILL.md` (YAML frontmatter + instructions). Code style skills are self-contained distillations — they embed key conventions and a working example so agents can apply them without fetching external URLs.
 
 ## Why they aren't active from here
 Agents only auto-discover skills in specific directories — notably `.agents/skills/` (note the leading dot) at a repository root or in your home folder. This `docs/collab/agents/skills/` path deliberately is **not** one of them, so the templates stay versioned without auto-loading. You activate them by copying into a discoverable location.
@@ -32,7 +56,7 @@ cp -R docs/collab/agents/skills/tiferet-* .agents/skills/
 Other tools work the same way with their own folder names (`.claude/skills/`, `.warp/skills/`, `.codex/skills/`, etc.) — copy into whichever your agent uses.
 
 ## Verify
-Start an agent and ask "what skills do I have?", or invoke one directly such as `/tiferet-create-milestone`. The five `tiferet-*` skills should appear.
+Start an agent and ask "what skills do I have?", or invoke one directly such as `/tiferet-code-style`. All `tiferet-*` skills should appear.
 
 ## Keep in sync
 These repo copies are canonical. When they change here, re-run the copy command above to refresh your active install. Pair the skills with the global rule template in [../../agent_rule.md](../../agent_rule.md).

--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -14,16 +14,17 @@ Collaboration skills are thin wrappers that reference `docs/collab/` and `docs/c
 
 ## Code style skills
 
-Twelve self-contained code style skills — one per component — that embed the artifact comment labels, naming conventions, spacing rules, and a minimal working example so an implementation agent can apply the conventions without fetching any external URL. Each skill's **Canonical source** section links to the full `docs/core/` guide as a fallback.
+Thirteen self-contained code style skills that embed artifact comment labels, naming conventions, spacing rules, layer boundary import rules, and a minimal working example so an implementation agent can apply the conventions without fetching any external URL. Each skill's **Canonical source** section links to the full `docs/core/` guide as a fallback.
 
-**Read `tiferet-code-style` at the start of every implementation session** (same standing as `tiferet-annotation-artifacts`).
+**Read `tiferet-code-style` at the start of every implementation session** (same standing as `tiferet-annotation-artifacts`). **Read `tiferet-code-architecture` before any multi-component implementation.**
 
 | Skill | Source doc | When to use |
 |---|---|---|
+| **`tiferet-code-architecture`** | `docs/core/` | Any multi-component task — layer graph, import rules, runtime flow |
 | **`tiferet-code-style`** | `docs/core/code_style.md` | Every implementation session — read first |
 | **`tiferet-code-domain`** | `docs/core/domain.md` | Adding or modifying domain objects |
 | **`tiferet-code-events`** | `docs/core/events.md` | Adding or modifying domain events |
-| **`tiferet-code-mappers`** | `docs/core/mappers.md` | Adding or modifying aggregates or config objects |
+| **`tiferet-code-mappers`** | `docs/core/mappers.md` | Adding or modifying aggregates or transfer objects |
 | **`tiferet-code-interfaces`** | `docs/core/interfaces.md` | Adding or modifying service interfaces |
 | **`tiferet-code-repos`** | `docs/core/repos.md` | Adding or modifying repositories |
 | **`tiferet-code-contexts`** | `docs/core/contexts.md` | Adding or modifying contexts |

--- a/docs/collab/agents/skills/tiferet-code-architecture/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-architecture/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: tiferet-code-architecture
+description: Understand the Tiferet v2 layer architecture before starting any multi-component implementation. Read this when a task spans more than one package or when deciding where a new class belongs. Covers the Accessor/Actor/Infrastructure layer graph, per-layer import rules, and the runtime execution flow.
+---
+
+# Architecture – Tiferet v2
+
+## When to use
+- Before starting any implementation that touches more than one layer.
+- When deciding which layer a new class or function belongs in.
+- When verifying that import statements respect layer boundaries.
+- Read in combination with `tiferet-code-style` and the relevant component skill.
+
+## Layer graph
+
+Tiferet v2 packages sit in three layers. **Upper layers depend on lower ones; lower layers never import from upper ones.**
+
+```
+┌─────────────── Accessor ────────────────┐
+│   assets       contexts     blueprints  │
+└─────────────────────────────────────────┘
+           ↓           ↓           ↓
+┌─────────────── Actor ───────────────────┐
+│   domain        events         di       │
+└─────────────────────────────────────────┘
+           ↓           ↓           ↓
+┌─────────────── Infrastructure ──────────┐
+│  interfaces    mappers    utils         │
+│                   repos                 │
+└─────────────────────────────────────────┘
+```
+
+```mermaid
+flowchart TD
+  subgraph Accessor
+    assets
+    contexts
+    blueprints
+  end
+  subgraph Actor
+    domain
+    events
+    di
+  end
+  subgraph Infrastructure
+    interfaces
+    mappers
+    utils
+    repos
+  end
+
+  contexts --> assets & events & domain & mappers & di
+  blueprints --> assets & contexts & di & events
+  events --> assets & domain & interfaces & mappers & di
+  domain --> assets
+  di --> domain & interfaces
+  mappers --> domain & events
+  interfaces --> domain
+  utils --> interfaces & events
+  repos --> interfaces & mappers & utils & events
+```
+
+**Key notes on position:**
+- `assets` is the **root node** of the Accessor layer — it has no framework imports, but every other layer may import from it.
+- `blueprints` accesses domain models **via `contexts` or `di`**, never by importing directly from `domain`.
+- `di` is **event-free and asset-free** — it imports only from `domain` and `interfaces`.
+- `repos` and `utils` are resolved through DI at runtime; `contexts` and `blueprints` do not import them directly.
+
+## Per-layer import rules
+
+These rules govern what is valid in the `# ** app` import group of each package.
+
+**`assets`** — root; no framework imports
+- `# ** app`: none. Only `# ** core` (stdlib) and `# ** infra` (minimal third-party, e.g. `json`).
+- ✗ Never: any other framework layer.
+
+**`domain`** — structural definitions
+- `# ** app`: `assets` sub-modules (e.g. `from .. import assets as a`).
+- ✗ Never: `events`, `mappers`, `interfaces`, `repos`, `utils`, `contexts`, `blueprints`.
+
+**`interfaces`** — abstract service contracts
+- `# ** app`: `domain` (for type hints in abstract method signatures); sibling `interfaces` modules.
+- ✗ Never: `events`, `mappers`, `repos`, `utils`, `contexts`, `blueprints`.
+
+**`events`** — central actor; the hub of the Actor layer
+- `# ** app`: `assets`, `domain`, `interfaces`, `mappers`, `di`.
+- ✗ Never: `repos`, `utils`, `contexts`, `blueprints`.
+
+**`mappers`** — mutation and serialization bridge
+- `# ** app`: `domain` (the domain object being extended), `events` (`RaiseError`, `a`).
+- ✗ Never: `interfaces`, `repos`, `utils`, `contexts`, `blueprints`.
+
+**`di`** — dependency injection (event-free, asset-free)
+- `# ** app`: `domain` (`ServiceDependency`), `interfaces.di` (`DIService`).
+- ✗ Never: `events`, `assets`, `mappers`, `repos`, `utils`, `contexts`, `blueprints`.
+
+**`utils`** — infrastructure implementations
+- `# ** app`: `interfaces` (to implement a Service contract), `events` (`RaiseError`, `a`).
+- ✗ Never: `domain`, `mappers`, `repos`, `di`, `contexts`, `blueprints`.
+
+**`repos`** — configuration and database persistence
+- `# ** app`: `interfaces` (the Service to implement), `mappers` (transfer objects and aggregates), `utils` (loader utilities), `events` (`RaiseError`, `a`).
+- ✗ Never: `domain` directly (use `mappers` instead), `di`, `contexts`, `blueprints`.
+
+**`contexts`** — runtime orchestration
+- `# ** app`: `assets`, `domain`, `events`, `mappers`, `di`.
+- ✗ Never: `repos`, `utils` (resolved via DI at runtime), `blueprints`.
+
+**`blueprints`** — application entry points
+- `# ** app`: `assets`, `contexts` (to build and wire AppSessionContext), `di` (container and resolver classes), `events` (for bootstrap events via `DomainEvent.handle`).
+- Domain models are accessed **via `contexts` or `di`**, not by importing directly from `domain`.
+- ✗ Never: `domain` directly, `interfaces`, `mappers`, `utils`, `repos`.
+
+## Runtime flow
+
+```
+App('interface_id')                               # blueprints/core.py: build_app()
+  └─ build_cache()                               # CacheContext pre-seeded with framework defaults
+  └─ get_app_session(id, cache)                  # GetAppSession event → AppSession domain object
+  └─ build_app_session_context(session, cache)   # wires DI, imports context class, constructs hub
+       └─ AppSessionContext.run(feature_id, data)
+            ├─ build_request()                   # → RequestContext
+            ├─ execute_feature()
+            │    └─ FeatureContext.execute_feature(feature, request)
+            │         └─ for each step:
+            │              get_dependency(service_id, *flags)
+            │                  └─ DomainEvent.handle(EventCls, dependencies, **kwargs)
+            │                       └─ event.execute(**kwargs) → result on request
+            └─ build_response()                  # → RequestContext.handle_response()
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/

--- a/docs/collab/agents/skills/tiferet-code-architecture/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-architecture/SKILL.md
@@ -49,20 +49,21 @@ flowchart TD
     repos
   end
 
-  contexts --> assets & events & domain & mappers & di
+  contexts --> assets & events & domain
   blueprints --> assets & contexts & di & events
   events --> assets & domain & interfaces & mappers & di
-  domain --> assets
   di --> domain & interfaces
   mappers --> domain & events
   interfaces --> domain
-  utils --> interfaces & events
-  repos --> interfaces & mappers & utils & events
+  utils --> interfaces & mappers
+  repos --> interfaces & mappers & utils
 ```
 
 **Key notes on position:**
 - `assets` is the **root node** of the Accessor layer — it has no framework imports, but every other layer may import from it.
-- `blueprints` accesses domain models **via `contexts` or `di`**, never by importing directly from `domain`.
+- `domain` has **no framework dependencies** — it is pure Pydantic model definitions only.
+- `blueprints` accesses domain models via `contexts` and wires DI through blueprint-injected handler functions; it never imports `domain` or `mappers` directly.
+- `contexts` receive DI resolution through blueprint-injected handler callables — they do not import `di` or `mappers` directly.
 - `di` is **event-free and asset-free** — it imports only from `domain` and `interfaces`.
 - `repos` and `utils` are resolved through DI at runtime; `contexts` and `blueprints` do not import them directly.
 
@@ -75,8 +76,8 @@ These rules govern what is valid in the `# ** app` import group of each package.
 - ✗ Never: any other framework layer.
 
 **`domain`** — structural definitions
-- `# ** app`: `assets` sub-modules (e.g. `from .. import assets as a`).
-- ✗ Never: `events`, `mappers`, `interfaces`, `repos`, `utils`, `contexts`, `blueprints`.
+- `# ** app`: none. Pure Pydantic model definitions; no framework imports.
+- ✗ Never: `assets`, `events`, `mappers`, `interfaces`, `repos`, `utils`, `contexts`, `blueprints`.
 
 **`interfaces`** — abstract service contracts
 - `# ** app`: `domain` (for type hints in abstract method signatures); sibling `interfaces` modules.
@@ -95,16 +96,16 @@ These rules govern what is valid in the `# ** app` import group of each package.
 - ✗ Never: `events`, `assets`, `mappers`, `repos`, `utils`, `contexts`, `blueprints`.
 
 **`utils`** — infrastructure implementations
-- `# ** app`: `interfaces` (to implement a Service contract), `events` (`RaiseError`, `a`).
-- ✗ Never: `domain`, `mappers`, `repos`, `di`, `contexts`, `blueprints`.
+- `# ** app`: `interfaces` (to implement a Service contract), `mappers` (for aggregate and transfer types).
+- ✗ Never: `events`, `domain`, `repos`, `di`, `contexts`, `blueprints`.
 
 **`repos`** — configuration and database persistence
-- `# ** app`: `interfaces` (the Service to implement), `mappers` (transfer objects and aggregates), `utils` (loader utilities), `events` (`RaiseError`, `a`).
-- ✗ Never: `domain` directly (use `mappers` instead), `di`, `contexts`, `blueprints`.
+- `# ** app`: `interfaces` (the Service to implement), `mappers` (transfer objects and aggregates), `utils` (loader utilities).
+- ✗ Never: `events`, `domain` directly (use `mappers` instead), `di`, `contexts`, `blueprints`.
 
 **`contexts`** — runtime orchestration
-- `# ** app`: `assets`, `domain`, `events`, `mappers`, `di`.
-- ✗ Never: `repos`, `utils` (resolved via DI at runtime), `blueprints`.
+- `# ** app`: `assets`, `domain`, `events`.
+- ✗ Never: `mappers`, `di` (wired via blueprint-injected handlers), `repos`, `utils` (resolved via DI at runtime), `blueprints`.
 
 **`blueprints`** — application entry points
 - `# ** app`: `assets`, `contexts` (to build and wire AppSessionContext), `di` (container and resolver classes), `events` (for bootstrap events via `DomainEvent.handle`).

--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: tiferet-code-assets
+description: Apply assets layer conventions when adding or modifying constants, exceptions, or bootstrap defaults in a Tiferet-family repo. Covers the five permitted artifact kinds, SCREAMING_SNAKE_CASE constants, factory functions, standalone classes, and the exports pattern.
+---
+
+# Assets Code Style – Tiferet
+
+## When to use
+- When adding a new error-code constant, default error definition, or bootstrap constant in `tiferet/assets/`.
+- When adding or modifying an exception class (`TiferetError`, `TiferetAPIError`).
+- When adding a stateless helper function to the assets layer.
+- Do NOT use for domain objects, events, services, mappers, or any component that depends on other Tiferet layers — assets must remain dependency-light.
+
+## Artifact comment structure
+
+Assets modules restrict themselves to exactly **five artifact kinds**:
+
+```
+# *** imports         ← stdlib and third-party primitives only
+# *** constants       ← SCREAMING_SNAKE_CASE module-level values
+# *** functions       ← stateless helper functions
+# *** classes         ← standalone exception or utility classes
+# *** exports         ← public re-exports (only in __init__.py)
+```
+
+Mid-level labels for each kind:
+```
+# ** constant: <snake_case_name>    ← individual constant
+# ** function: <snake_case_name>    ← individual function
+# ** class: <snake_case_name>       ← individual class
+```
+
+**Sub-groups** — use a parenthetical qualifier to partition a large `# *** constants` section instead of grouping under a shared `# **` entry:
+```python
+# *** constants
+# ** constant: en_us
+EN_US = 'en_US'
+
+# *** constants (error)
+# ** constant: feature_not_found_id
+FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
+```
+
+## Key conventions
+
+- **Imports:** Only `# ** core` (stdlib) and `# ** infra` (third-party primitives like `json`). Never import from `domain`, `events`, `interfaces`, `mappers`, `repos`, `contexts`, or `blueprints`.
+- **Constants:** `SCREAMING_SNAKE_CASE`. Each constant has its own `# ** constant: <snake_case>` label. Do not group multiple constants under a single `# ** constants: <group>` mid-level label — use a top-level sub-group instead.
+- **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error`), not inline dicts. Define each entry as a named constant, then assemble the catalog dict as a separate constant.
+- **Functions:** Small, stateless, no framework dependencies. Use RST docstrings.
+- **Classes:** Plain standalone classes (exception types, data primitives). Use `# *** classes` / `# ** class: <name>`, `# * attribute: <name>`, `# * init`.
+- **Exports:** Only in `__init__.py` under `# *** exports`. Use short module aliases for frequently consumed modules (e.g. `from . import constants as const`).
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from typing import List, Tuple, Dict, Any
+import json
+
+# *** constants (error)
+
+# ** constant: feature_not_found_id
+FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
+
+# ** constant: feature_already_exists_id
+FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
+
+# *** functions
+
+# ** function: create_default_error
+def create_default_error(id: str,
+        name: str,
+        messages: List[Tuple[str, str]]) -> Dict[str, Any]:
+    '''
+    Build a default error definition dictionary.
+
+    :param id: The unique error identifier.
+    :type id: str
+    :param name: The human-readable error name.
+    :type name: str
+    :param messages: Ordered (lang, text) message pairs.
+    :type messages: List[Tuple[str, str]]
+    :return: The error definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the error definition.
+    return {
+        'id': id,
+        'name': name,
+        'message': [{'lang': lang, 'text': text} for lang, text in messages],
+    }
+
+# *** constants
+
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = create_default_error(
+    FEATURE_NOT_FOUND_ID,
+    'Feature Not Found',
+    [('en_US', 'Feature not found: {feature_id}.')],
+)
+
+# ** constant: default_errors
+DEFAULT_ERRORS = {
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+}
+
+# *** classes
+
+# ** class: tiferet_error
+class TiferetError(Exception):
+    '''
+    The base exception for all Tiferet-related errors.
+    '''
+
+    # * attribute: error_code
+    error_code: str
+
+    # * init
+    def __init__(self, error_code: str, message: str = None, **kwargs):
+        '''
+        Initialize TiferetError.
+
+        :param error_code: The structured error code.
+        :type error_code: str
+        :param message: Optional human-readable message.
+        :type message: str
+        :param kwargs: Additional error context.
+        :type kwargs: dict
+        '''
+
+        # Set the error code and context.
+        self.error_code = error_code
+        self.kwargs = kwargs
+
+        # Initialize with serialized error data.
+        super().__init__(
+            json.dumps({'error_code': error_code, 'message': message, **kwargs})
+        )
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md

--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -13,37 +13,40 @@ description: Apply assets layer conventions when adding or modifying constants, 
 
 ## Artifact comment structure
 
-Assets modules restrict themselves to exactly **five artifact kinds**:
-
+Module skeleton (assets modules use exactly five artifact kinds, in this order):
 ```
 # *** imports         ← stdlib and third-party primitives only
 # *** constants       ← SCREAMING_SNAKE_CASE module-level values
 # *** functions       ← stateless helper functions
 # *** classes         ← standalone exception or utility classes
-# *** exports         ← public re-exports (only in __init__.py)
+# *** exports         ← public re-exports (__init__.py only)
 ```
 
-Mid-level labels for each kind:
+Artifact labels:
 ```
 # ** constant: <snake_case_name>    ← individual constant
 # ** function: <snake_case_name>    ← individual function
 # ** class: <snake_case_name>       ← individual class
 ```
 
-**Sub-groups** — use a parenthetical qualifier to partition a large `# *** constants` section instead of grouping under a shared `# **` entry:
+**Sub-groups** — partition a large `# *** constants` section with a parenthetical qualifier. The framework convention (e.g. `assets/error.py`) uses three sub-groups:
 ```python
-# *** constants
-# ** constant: en_us
-EN_US = 'en_US'
-
-# *** constants (error)
+# *** constants (ids)               ← raw error-code identifier strings
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
+
+# *** constants (models)            ← assembled default definition dicts
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = create_default_error(...)
+
+# *** constants (groups)            ← catalog dicts grouping the above
+# ** constant: default_errors
+DEFAULT_ERRORS = { FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND }
 ```
 
 ## Key conventions
 
-- **Imports:** Only `# ** core` (stdlib) and `# ** infra` (third-party primitives like `json`). Never import from `domain`, `events`, `interfaces`, `mappers`, `repos`, `contexts`, or `blueprints`.
+- **Layer boundary — valid `# ** app` imports:** none. `assets` is the root layer; it has no framework imports. Only `# ** core` (stdlib) and `# ** infra` (minimal third-party, e.g. `json`) are valid. Never import from any other framework layer.
 - **Constants:** `SCREAMING_SNAKE_CASE`. Each constant has its own `# ** constant: <snake_case>` label. Do not group multiple constants under a single `# ** constants: <group>` mid-level label — use a top-level sub-group instead.
 - **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error`), not inline dicts. Define each entry as a named constant, then assemble the catalog dict as a separate constant.
 - **Functions:** Small, stateless, no framework dependencies. Use RST docstrings.
@@ -59,7 +62,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 from typing import List, Tuple, Dict, Any
 import json
 
-# *** constants (error)
+# *** constants (ids)
 
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
@@ -93,7 +96,7 @@ def create_default_error(id: str,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
 
-# *** constants
+# *** constants (models)
 
 # ** constant: feature_not_found
 FEATURE_NOT_FOUND = create_default_error(
@@ -101,6 +104,8 @@ FEATURE_NOT_FOUND = create_default_error(
     'Feature Not Found',
     [('en_US', 'Feature not found: {feature_id}.')],
 )
+
+# *** constants (groups)
 
 # ** constant: default_errors
 DEFAULT_ERRORS = {

--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -35,9 +35,9 @@ Artifact labels:
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
-# *** constants (models)            ← assembled default definition dicts
+# *** constants (errors)            ← assembled default definition dicts
 # ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(...)
+FEATURE_NOT_FOUND = { 'id': FEATURE_NOT_FOUND_ID, 'name': 'Feature Not Found', ... }
 
 # *** constants (groups)            ← catalog dicts grouping the above
 # ** constant: default_errors
@@ -70,6 +70,22 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 # ** constant: feature_already_exists_id
 FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
 
+# *** constants (errors)
+
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = {
+    'id': FEATURE_NOT_FOUND_ID,
+    'name': 'Feature Not Found',
+    'message': [{'lang': 'en_US', 'text': 'Feature not found: {feature_id}.'}],
+}
+
+# *** constants (groups)
+
+# ** constant: default_errors
+DEFAULT_ERRORS = {
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+}
+
 # *** functions
 
 # ** function: create_default_error
@@ -95,22 +111,6 @@ def create_default_error(id: str,
         'name': name,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
-
-# *** constants (models)
-
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
-    'Feature Not Found',
-    [('en_US', 'Feature not found: {feature_id}.')],
-)
-
-# *** constants (groups)
-
-# ** constant: default_errors
-DEFAULT_ERRORS = {
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
-}
 
 # *** classes
 

--- a/docs/collab/agents/skills/tiferet-code-blueprints/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-blueprints/SKILL.md
@@ -13,18 +13,30 @@ description: Apply blueprint conventions when adding or modifying blueprint orch
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** functions                         ← pure, side-effect-free composition helpers
-# ** function: <snake_case_name>        ← individual helper
+# *** imports
+# *** constants          ← optional
+# *** functions          ← pure, side-effect-free composition helpers
+# *** classes            ← base classes only (core.py modules)
+# *** blueprints         ← construct group for this skill
+# *** exports            ← __init__.py only
+```
 
-# *** blueprints                        ← orchestration entry points
-# ** blueprint: <snake_case_name>       ← individual blueprint function
+Blueprint-specific labels:
+```
+# *** functions                         ← artifact section: pure, side-effect-free composition helpers
+# ** function: <snake_case_name>        ← artifact
+
+# *** blueprints                        ← artifact section: orchestration entry points
+# ** blueprint: <snake_case_name>       ← artifact
 ```
 
 Both sections may appear in the same module. `# *** functions` must appear first. Use `# *** functions` for helpers that take only input args and return a plain value (no I/O, no error raising, no instantiation of domain objects from services). Reserve `# *** blueprints` for the orchestration entry points (e.g. `build_app`, `build_cli`).
 
 ## Key conventions
 
+- **Layer boundary — valid `# ** app` imports:** `assets`, `contexts`, `di`, `events`. Blueprints access domain models **via `contexts` or `di`**, not by importing directly from `domain`. Never import from `interfaces`, `mappers`, `utils`, or `repos`.
 - Blueprints are **module-level functions**, not classes.
 - Blueprints are **thin orchestrators** — they wire and delegate; they do not implement domain logic.
 - The canonical entry point is `build_app` in `tiferet/blueprints/core.py`, exported as `App`. The CLI entry point is `build_cli` in `tiferet/blueprints/cli.py`, exported as `CLI`.

--- a/docs/collab/agents/skills/tiferet-code-blueprints/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-blueprints/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: tiferet-code-blueprints
+description: Apply blueprint conventions when adding or modifying blueprint orchestration functions in a Tiferet-family repo. Covers the build_app composition chain, thin entrypoint design, functions vs blueprints sections, and the App/CLI export pattern.
+---
+
+# Blueprints Code Style – Tiferet
+
+## When to use
+- When adding a new blueprint entrypoint or modifying the application initialization flow in `tiferet/blueprints/`.
+- When creating a new interface type (e.g. a web blueprint wrapping Flask or FastAPI).
+- When adding a side-effect-free composition helper that feeds into a blueprint.
+- Do NOT use for domain logic — blueprints orchestrate, they do not implement.
+
+## Artifact comment structure
+
+```
+# *** functions                         ← pure, side-effect-free composition helpers
+# ** function: <snake_case_name>        ← individual helper
+
+# *** blueprints                        ← orchestration entry points
+# ** blueprint: <snake_case_name>       ← individual blueprint function
+```
+
+Both sections may appear in the same module. `# *** functions` must appear first. Use `# *** functions` for helpers that take only input args and return a plain value (no I/O, no error raising, no instantiation of domain objects from services). Reserve `# *** blueprints` for the orchestration entry points (e.g. `build_app`, `build_cli`).
+
+## Key conventions
+
+- Blueprints are **module-level functions**, not classes.
+- Blueprints are **thin orchestrators** — they wire and delegate; they do not implement domain logic.
+- The canonical entry point is `build_app` in `tiferet/blueprints/core.py`, exported as `App`. The CLI entry point is `build_cli` in `tiferet/blueprints/cli.py`, exported as `CLI`.
+- The `core.build_app` composition chain:
+  1. `build_cache()` — build the `CacheContext` pre-seeded with framework defaults
+  2. `get_app_session(interface_id, cache, ...)` — resolve the app session via `GetAppSession`
+  3. `build_app_session_context(app_session, cache)` — build the app service container, compose the `ServiceResolver`, import the context class, and construct via `from_domain`
+- `build_cli` is a thin entrypoint: call `core.build_app(...)` then `cli_context.run_cli(argv)`.
+- Always validate the resolved context type (`INVALID_APP_SESSION_TYPE`) in single-call entry points.
+- Use `RaiseError.execute()` for all error paths.
+- Module-private helpers are underscore-prefixed (`_resolve_bootstrap_session`).
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from typing import Any
+
+# ** app
+from .core import build_app as _core_build_app
+from ..events.static import RaiseError
+from .. import assets as a
+
+# *** functions
+
+# ** function: _derive_argv
+def _derive_argv(argv: list | None) -> list:
+    '''
+    Return argv as-is or fall back to sys.argv[1:].
+
+    :param argv: Explicit argv list, or None to use sys.argv.
+    :type argv: list | None
+    :return: The resolved argv list.
+    :rtype: list
+    '''
+
+    # Import sys only when needed.
+    import sys
+
+    # Return the explicit argv or fall back to sys.argv.
+    return argv if argv is not None else sys.argv[1:]
+
+# *** blueprints
+
+# ** blueprint: build_cli
+def build_cli(interface_id: str,
+        argv: list | None = None,
+        **kwargs) -> Any:
+    '''
+    Build and run a CLI interface.
+
+    Delegates argparse parsing and feature dispatch to CliContext.run_cli.
+
+    :param interface_id: The interface identifier.
+    :type interface_id: str
+    :param argv: Explicit argv list; defaults to sys.argv[1:].
+    :type argv: list | None
+    :param kwargs: Additional kwargs forwarded to core.build_app.
+    :type kwargs: dict
+    :return: The feature execution result.
+    :rtype: Any
+    '''
+
+    # Resolve the argv list.
+    resolved_argv = _derive_argv(argv)
+
+    # Build the app context (must resolve to a CliContext).
+    cli_context = _core_build_app(interface_id, **kwargs)
+
+    # Delegate CLI parsing and feature dispatch to the context.
+    return cli_context.run_cli(resolved_argv)
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md

--- a/docs/collab/agents/skills/tiferet-code-contexts/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-contexts/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: tiferet-code-contexts
+description: Apply context conventions when adding or modifying runtime contexts in a Tiferet-family repo. Covers BaseContext registry, AppSessionContext hub, high-level vs low-level contexts, domain_type, and from_domain construction.
+---
+
+# Contexts Code Style – Tiferet
+
+## When to use
+- When adding a new context class or modifying an existing one in `tiferet/contexts/`.
+- When extending `AppSessionContext` for a new high-level interface (e.g. Flask API, gRPC).
+- When adding behavior to a low-level context (`FeatureContext`, `ErrorContext`, `LoggingContext`).
+
+## Artifact comment structure
+
+```
+# *** contexts                          ← top-level
+# ** context: <snake_case_name>         ← individual context
+# * attribute: <name>                   ← instance attributes (type hints)
+# * attribute: domain_type              ← ClassVar mapping this context to its domain type
+# * init                                ← constructor
+# * method: <name>                      ← runtime behavior methods
+```
+
+## Key conventions
+
+**Base class:** All contexts extend `BaseContext` from `tiferet/contexts/settings.py`.
+- `BaseContext` provides a `ContextMeta` registry keyed by `domain_type`.
+- `BaseContext.for_domain(DomainType)` — resolves the registered context class.
+- `BaseContext.from_domain(domain_obj, **kwargs)` — constructs a context bound to a domain object; the object is exposed as `ctx.domain`.
+- Caching is NOT in the base — declare a `CacheContext` on contexts that need one.
+
+**High-level contexts** (user-facing, e.g. `FlaskApiContext`):
+- Extend `AppSessionContext` (the minimal hub in `tiferet/contexts/app.py`).
+- The `AppSessionContext` hub takes event collaborators (`get_feature_evt`, `get_error_evt`, `logging_list_all_evt`), `get_dependency`, and optional `cache` and defaults. It binds the loaded `AppSession` via `from_domain` and exposes `self.domain.id`.
+- Override only the methods your interface specializes (e.g. `parse_request`).
+
+**Low-level contexts** (supporting, e.g. `FeatureContext`, `ErrorContext`):
+- Extend `BaseContext` directly.
+- Declared in `tiferet/contexts/<concern>.py`.
+
+**`domain_type` ClassVar:**
+- Declare on each context to register it in the `ContextMeta` registry.
+- `AppSessionContext` declares `domain_type = AppSession`.
+- `CliContext` intentionally omits `domain_type` — it is selected via the interface config's `module_path`/`class_name`, not the registry.
+
+**Construction:** The blueprint resolves the context class from `module_path`/`class_name`, then constructs via `BaseContext.from_domain(app_session, **collaborators)`. Never instantiate contexts directly with `ContextClass(...)`.
+
+**`run(feature_id, headers, data, **kwargs)`** is the standard high-level execution entry point (inherited from `AppSessionContext`).
+
+## Example
+
+```python
+# *** imports
+
+# ** app
+from .settings import BaseContext
+from .app import AppSessionContext
+from ..domain import AppSession
+
+# *** contexts
+
+# ** context: flask_api_context
+class FlaskApiContext(AppSessionContext):
+    '''
+    High-level context for Flask API interfaces.
+
+    Extends AppSessionContext with Flask-specific request parsing.
+    The loaded AppSession is bound as self.domain via from_domain.
+    '''
+
+    # * attribute: domain_type
+    domain_type = AppSession
+
+    # * attribute: flask_handler
+    flask_handler: object
+
+    # * init
+    def __init__(self, flask_handler, **kwargs):
+        '''
+        Initialize the Flask API context.
+
+        :param flask_handler: The Flask application handler.
+        :type flask_handler: object
+        :param kwargs: Hub collaborators forwarded to AppSessionContext.
+        :type kwargs: dict
+        '''
+
+        # Forward all hub collaborators to the parent context.
+        super().__init__(**kwargs)
+
+        # Store the Flask handler.
+        self.flask_handler = flask_handler
+
+    # * method: parse_flask_request
+    def parse_flask_request(self, flask_request) -> dict:
+        '''
+        Parse a Flask request into a data dict for feature execution.
+
+        :param flask_request: The Flask request object.
+        :type flask_request: object
+        :return: A dict of feature input data.
+        :rtype: dict
+        '''
+
+        # Extract and return the JSON payload from the request.
+        return flask_request.get_json(force=True) or {}
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md

--- a/docs/collab/agents/skills/tiferet-code-contexts/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-contexts/SKILL.md
@@ -7,36 +7,50 @@ description: Apply context conventions when adding or modifying runtime contexts
 
 ## When to use
 - When adding a new context class or modifying an existing one in `tiferet/contexts/`.
-- When extending `AppSessionContext` for a new high-level interface (e.g. Flask API, gRPC).
-- When adding behavior to a low-level context (`FeatureContext`, `ErrorContext`, `LoggingContext`).
+- When extending `AppSessionContext` for a new high-level interface (e.g. CLI, web API, gRPC).
+- When adding behavior to a low-level context (`FeatureContext`, `ErrorContext`, `LoggingContext`) or introducing a new domain-specific context for a framework extension.
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** contexts                          ← top-level
-# ** context: <snake_case_name>         ← individual context
-# * attribute: <name>                   ← instance attributes (type hints)
-# * attribute: domain_type              ← ClassVar mapping this context to its domain type
-# * init                                ← constructor
-# * method: <name>                      ← runtime behavior methods
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** contexts           ← construct group for this skill
+# *** exports            ← __init__.py only
+```
+
+Context-specific labels:
+```
+# *** contexts                          ← artifact section
+# ** context: <snake_case_name>         ← artifact
+# * attribute: <name>                   ← artifact member: instance attributes (type hints)
+# * attribute: domain_type              ← artifact member: ClassVar mapping this context to its domain type
+# * init                                ← artifact member: constructor
+# * method: <name>                      ← artifact member: runtime behavior methods
 ```
 
 ## Key conventions
 
-**Base class:** All contexts extend `BaseContext` from `tiferet/contexts/settings.py`.
+**Layer boundary — valid `# ** app` imports:** `assets`, `domain`, `events`, `mappers`, `di`. Never import from `repos` or `utils` directly (resolved via DI at runtime), or from `blueprints`.
+
+**Base class:** All contexts extend `BaseContext` from `tiferet/contexts/core.py`.
 - `BaseContext` provides a `ContextMeta` registry keyed by `domain_type`.
 - `BaseContext.for_domain(DomainType)` — resolves the registered context class.
 - `BaseContext.from_domain(domain_obj, **kwargs)` — constructs a context bound to a domain object; the object is exposed as `ctx.domain`.
 - Caching is NOT in the base — declare a `CacheContext` on contexts that need one.
 
-**High-level contexts** (user-facing, e.g. `FlaskApiContext`):
+**High-level contexts** (user-facing, e.g. `CliContext`, `FlaskApiContext`):
 - Extend `AppSessionContext` (the minimal hub in `tiferet/contexts/app.py`).
-- The `AppSessionContext` hub takes event collaborators (`get_feature_evt`, `get_error_evt`, `logging_list_all_evt`), `get_dependency`, and optional `cache` and defaults. It binds the loaded `AppSession` via `from_domain` and exposes `self.domain.id`.
-- Override only the methods your interface specializes (e.g. `parse_request`).
+- `AppSessionContext` receives blueprint-injected handler callables — `execute_feature_handler`, `create_request_handler`, `raise_error_handler`, `response_handler` — plus `get_dependency`, `logging_context`, and `cache`. These are wired by the blueprint during app initialization, not declared as named event collaborators.
+- Override only the methods your interface specializes (e.g. `parse_request`, `build_response`).
 
-**Low-level contexts** (supporting, e.g. `FeatureContext`, `ErrorContext`):
+**Low-level contexts** (supporting any domain concern at the app-operation level):
 - Extend `BaseContext` directly.
 - Declared in `tiferet/contexts/<concern>.py`.
+- Not limited to the built-in trio (FeatureContext, ErrorContext, LoggingContext). Framework extensions introduce their own low-level contexts for domain-specific concerns; blueprints and handler injection are the mechanism for composing them alongside the built-in ones.
 
 **`domain_type` ClassVar:**
 - Declare on each context to register it in the `ContextMeta` registry.
@@ -52,58 +66,46 @@ description: Apply context conventions when adding or modifying runtime contexts
 ```python
 # *** imports
 
+# ** core
+import sys
+from typing import Any
+
 # ** app
-from .settings import BaseContext
+from .core import BaseContext
 from .app import AppSessionContext
 from ..domain import AppSession
 
 # *** contexts
 
-# ** context: flask_api_context
-class FlaskApiContext(AppSessionContext):
+# ** context: cli_context
+class CliContext(AppSessionContext):
     '''
-    High-level context for Flask API interfaces.
+    High-level context for CLI interfaces.
 
-    Extends AppSessionContext with Flask-specific request parsing.
-    The loaded AppSession is bound as self.domain via from_domain.
+    Extends AppSessionContext with argparse-based command parsing and
+    feature dispatch. The loaded AppSession is bound as self.domain via
+    from_domain. CLI parsing is owned by this context, not the blueprint.
     '''
 
-    # * attribute: domain_type
-    domain_type = AppSession
-
-    # * attribute: flask_handler
-    flask_handler: object
-
-    # * init
-    def __init__(self, flask_handler, **kwargs):
+    # * method: run_cli
+    def run_cli(self, argv: list | None = None) -> Any:
         '''
-        Initialize the Flask API context.
+        Parse argv and dispatch the resolved feature request.
 
-        :param flask_handler: The Flask application handler.
-        :type flask_handler: object
-        :param kwargs: Hub collaborators forwarded to AppSessionContext.
-        :type kwargs: dict
+        :param argv: Explicit argv list; defaults to sys.argv[1:].
+        :type argv: list | None
+        :return: The feature execution result.
+        :rtype: Any
         '''
 
-        # Forward all hub collaborators to the parent context.
-        super().__init__(**kwargs)
+        # Resolve argv, falling back to sys.argv.
+        resolved = argv if argv is not None else sys.argv[1:]
 
-        # Store the Flask handler.
-        self.flask_handler = flask_handler
+        # Parse the CLI request into feature_id and data.
+        feature_id, data = self.parse_cli_request(resolved)
 
-    # * method: parse_flask_request
-    def parse_flask_request(self, flask_request) -> dict:
-        '''
-        Parse a Flask request into a data dict for feature execution.
-
-        :param flask_request: The Flask request object.
-        :type flask_request: object
-        :return: A dict of feature input data.
-        :rtype: dict
-        '''
-
-        # Extract and return the JSON payload from the request.
-        return flask_request.get_json(force=True) or {}
+        # Delegate to the standard run entry point.
+        return self.run(feature_id=feature_id, data=data)
 ```
 
 ## Canonical source

--- a/docs/collab/agents/skills/tiferet-code-di/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-di/SKILL.md
@@ -1,38 +1,53 @@
 ---
 name: tiferet-code-di
-description: Apply DI layer conventions when adding or modifying ServiceContainer, ServiceResolver, or pure DI helper functions in a Tiferet-family repo. Covers the event-free/asset-free design constraint, Factory vs Singleton scope, and the injectable_parameter_names helper.
+description: Apply DI layer conventions when adding or modifying ServiceContainer, ServiceResolver, or pure DI helper functions in a Tiferet-family repo. Covers the event-free/asset-free design constraint, ABC inheritance requirements, Factory vs Singleton scope, and the injectable_parameter_names helper.
 ---
 
 # Dependency Injection Code Style – Tiferet
 
 ## When to use
 - When adding or modifying classes in `tiferet/di/` (container, resolver, or base ABCs).
-- When adding a pure DI helper function (`injectable_parameter_names`, `normalize_flags`, `create_cache_key`, `merge_settings`).
+- When adding a pure DI helper function (`injectable_parameter_names`, `normalize_flags`).
 - Do NOT use for domain events or assets — the DI layer is deliberately event-free and asset-free.
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** functions                         ← pure, stateless DI helpers
-# ** function: <snake_case_name>        ← individual function
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; pure, stateless DI helpers
+# *** classes            ← base classes and concrete implementations
+# *** exports            ← __init__.py only
+```
 
-# *** classes                           ← base classes and concrete implementations
-# ** class: <snake_case_name>           ← individual class (ABCs and implementations)
-# * attribute: <name>                   ← instance attributes
-# * init                                ← constructor
-# * method: <name>                      ← instance methods
-# * method: <name> (static)             ← static methods
-# * method: <name> (class)              ← classmethods
+DI-specific labels:
 ```
+# *** functions                         ← artifact section: pure, stateless DI helpers
+# ** function: <snake_case_name>        ← artifact
+
+# *** classes                           ← artifact section: ABCs and implementations
+# ** class: <snake_case_name>           ← artifact
+# * attribute: <name>                   ← artifact member: instance attributes
+# * init                                ← artifact member: constructor
+# * method: <name>                      ← artifact member: instance methods
+# * method: <name> (static)            ← artifact member: static methods
+# * method: <name> (class)             ← artifact member: classmethods
+```
+
+Note: DI modules use `# *** classes` (not a construct-specific group) because the DI layer defines base classes, not domain constructs.
 
 ## Key conventions
 
-- The DI layer is **event-free and asset-free**: imports only stdlib, `dependency_injector`, `..domain`, and (in `dependency_injector.py`) `..interfaces.di`. Never import `RaiseError`, `TiferetError`, `a.const`, or any other event/asset.
+- **Layer boundary — valid `# ** app` imports:** `domain` (`ServiceDependency`), `interfaces.di` (`DIService`). Never import from `events`, `assets`, `mappers`, `repos`, `utils`, `contexts`, or `blueprints`.
+- The DI layer is **event-free and asset-free**: imports only stdlib, `dependency_injector`, `..domain`, and (in `dependency_injector.py`) `..interfaces.di`. Never import `RaiseError`, `TiferetError`, `a.error`, or any other event/asset.
 - Raw exceptions surface from DI classes; callers with event access convert them to structured errors.
-- **`injectable_parameter_names(service_type)`** — returns constructor parameter names eligible for automatic wiring (excludes `self`, `*args`, `**kwargs`). Use in `build_factory` / `build_singleton` to wire sibling providers automatically.
+- **All new DI components must extend either `ServiceContainer` or `ServiceResolver`** — there is no valid DI class that does not inherit from one of these two ABCs.
+- **DI inverts the domain event principle:** Domain events expose a minimal interface (`execute`) to serve unlimited domain use cases. DI components expose a richer interface to solve one highly specific concern — dependency resolution. Both are injection targets, but in opposite directions of interface breadth vs. domain breadth.
+- **`injectable_parameter_names(service_type)`** — returns constructor parameter names eligible for automatic wiring (excludes `self`, `*args`, `**kwargs`). Uninspectable types are treated as no-arg.
 - **`normalize_flags(*flags)`** — flattens mixed string/list/tuple input into a flat string list. Key for cache-key consistency.
-- **`ServiceContainer`** (engine): registers services as `Factory` providers (one new instance per resolution) or `Object` providers (scalars/callables). `add_service(id, dependency)` wires constructor kwargs to sibling providers.
-- **`ServiceResolver`** (provider): owns a per-flag `ServiceContainer` cache. Template-method `get_dependency(service_id, *flags)` normalizes flags, looks up or builds a container, then delegates. Only `build_container(flags)` is abstract.
+- **`ServiceContainer`** (ABC engine): abstract contract for registering and resolving dependencies. Methods: `add_service`, `add_constant`, `get_dependency`, `has_dependency`, `remove_dependency`, `load_container`.
+- **`ServiceResolver`** (ABC provider): owns a per-flag `ServiceContainer` cache. Provides `add_container`, `get_container`, `get_dependency` (template method); leaves `build_container(flags)` abstract for subclasses.
 - **App-level:** `DIAppServiceContainer` uses `Singleton` scope — one shared instance per app. Created via `from_dependencies(services, constants)` classmethod.
 - **Feature-level:** `DIDynamicServiceResolver` uses `Factory` scope — a new instance per resolution. Built per flag set by `build_container`.
 - Use `# *** classes` in all DI modules (no `# *** di` group). Use `# * method: <name> (class)` for `@classmethod` entries.
@@ -45,9 +60,7 @@ description: Apply DI layer conventions when adding or modifying ServiceContaine
 # ** core
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
-
-# ** infra
-from dependency_injector import containers, providers
+import inspect
 
 # ** app
 from ..domain.core import ServiceDependency
@@ -59,7 +72,8 @@ def injectable_parameter_names(service_type: type) -> List[str]:
     '''
     Return the injectable constructor parameter names of a service type.
 
-    Excludes self and variadic parameters (*args, **kwargs).
+    Excludes self, *args, and **kwargs. Types whose constructor cannot be
+    inspected are treated as no-arg.
 
     :param service_type: The service class to inspect.
     :type service_type: type
@@ -67,12 +81,13 @@ def injectable_parameter_names(service_type: type) -> List[str]:
     :rtype: List[str]
     '''
 
-    import inspect
+    # Inspect the constructor signature; treat uninspectable types as no-arg.
+    try:
+        sig = inspect.signature(service_type.__init__)
+    except (ValueError, TypeError):
+        return []
 
-    # Inspect the constructor signature.
-    sig = inspect.signature(service_type.__init__)
-
-    # Collect injectable parameter names.
+    # Collect injectable parameter names, skipping self and variadic params.
     return [
         name for name, param in sig.parameters.items()
         if name != 'self'
@@ -85,86 +100,94 @@ def injectable_parameter_names(service_type: type) -> List[str]:
 # *** classes
 
 # ** class: service_container
-class ServiceContainer(object):
+class ServiceContainer(ABC):
     '''
-    Low-level dependency-injection engine backed by DynamicContainer.
+    Abstract DI container contract for the framework.
 
-    Event-free: missing or failing providers raise raw exceptions.
+    Defines core operations for registering service dependencies and constants,
+    resolving them, and removing them. All new DI containers must extend this ABC.
+
+    Event-free: raw exceptions surface; callers convert to structured errors.
     '''
 
-    # * attribute: container
-    container: containers.DynamicContainer
-
-    # * init
-    def __init__(self, services: Dict[str, type] = None):
+    # * method: add_service
+    @abstractmethod
+    def add_service(self, service_id: str, service: ServiceDependency):
         '''
-        Initialize the service container.
-
-        :param services: Optional initial service type mapping.
-        :type services: Dict[str, type]
-        '''
-
-        # Create the dynamic container.
-        self.container = containers.DynamicContainer()
-
-        # Bulk-load any initial services.
-        if services:
-            self.add_services(services)
-
-    # * method: add_services
-    def add_services(self, services: Dict[str, Any]):
-        '''
-        Bulk-register services: scalars as Object providers, types as Factories.
-
-        :param services: Mapping of service ID to type or scalar value.
-        :type services: Dict[str, Any]
-        '''
-
-        # Register scalars first so factories can wire to them.
-        for service_id, value in services.items():
-            if not isinstance(value, type):
-                self.container.set_provider(service_id, providers.Object(value))
-
-        # Register class types as Factory providers.
-        for service_id, value in services.items():
-            if isinstance(value, type):
-                factory = self._build_factory(value)
-                self.container.set_provider(service_id, factory)
-
-    # * method: get_service
-    def get_service(self, service_id: str) -> Any:
-        '''
-        Resolve and return a registered service instance.
+        Register a service dependency in the container.
 
         :param service_id: The service identifier.
         :type service_id: str
-        :return: The resolved service instance.
+        :param service: The core service dependency.
+        :type service: ServiceDependency
+        '''
+        raise NotImplementedError()
+
+    # * method: add_constant
+    @abstractmethod
+    def add_constant(self, constant_id: str, value: Any):
+        '''
+        Register a constant value in the container.
+
+        :param constant_id: The constant identifier.
+        :type constant_id: str
+        :param value: The constant value.
+        :type value: Any
+        '''
+        raise NotImplementedError()
+
+    # * method: get_dependency
+    @abstractmethod
+    def get_dependency(self, dependency_id: str) -> Any:
+        '''
+        Resolve a registered dependency by identifier.
+
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        :return: The resolved instance or value.
         :rtype: Any
         '''
+        raise NotImplementedError()
 
-        # Look up and invoke the provider; raises raw exception if missing.
-        provider = self.container.providers.get(service_id)
-        return provider()
-
-    # * method: _build_factory (static)
-    @staticmethod
-    def _build_factory(service_type: type) -> providers.Factory:
+    # * method: has_dependency
+    @abstractmethod
+    def has_dependency(self, dependency_id: str) -> bool:
         '''
-        Build a Factory provider with constructor kwargs wired to sibling providers.
+        Return True when a dependency is registered under the given identifier.
 
-        :param service_type: The class to wrap in a Factory provider.
-        :type service_type: type
-        :return: The configured Factory provider.
-        :rtype: providers.Factory
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        :return: True when registered, False otherwise.
+        :rtype: bool
         '''
+        raise NotImplementedError()
 
-        # Wire each injectable parameter to a sibling provider.
-        kwargs = {}
-        for param_name in injectable_parameter_names(service_type):
-            sibling = ServiceContainer.container.providers.get(param_name)
-            if sibling is not None:
-                kwargs[param_name] = sibling
-        return providers.Factory(service_type, **kwargs)
+    # * method: remove_dependency
+    @abstractmethod
+    def remove_dependency(self, dependency_id: str):
+        '''
+        Remove a registered dependency from the container. Idempotent.
+
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        '''
+        raise NotImplementedError()
+
+    # * method: load_container
+    @abstractmethod
+    def load_container(self,
+            services: Dict[str, ServiceDependency] = None,
+            constants: Dict[str, Any] = None,
+        ):
+        '''
+        Bulk-load the container from service dependencies and constants.
+
+        :param services: A mapping of service id to core service dependency.
+        :type services: Dict[str, ServiceDependency] | None
+        :param constants: A mapping of constant id to value.
+        :type constants: Dict[str, Any] | None
+        '''
+        raise NotImplementedError()
 ```
 
 ## Canonical source

--- a/docs/collab/agents/skills/tiferet-code-di/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-di/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: tiferet-code-di
+description: Apply DI layer conventions when adding or modifying ServiceContainer, ServiceResolver, or pure DI helper functions in a Tiferet-family repo. Covers the event-free/asset-free design constraint, Factory vs Singleton scope, and the injectable_parameter_names helper.
+---
+
+# Dependency Injection Code Style – Tiferet
+
+## When to use
+- When adding or modifying classes in `tiferet/di/` (container, resolver, or base ABCs).
+- When adding a pure DI helper function (`injectable_parameter_names`, `normalize_flags`, `create_cache_key`, `merge_settings`).
+- Do NOT use for domain events or assets — the DI layer is deliberately event-free and asset-free.
+
+## Artifact comment structure
+
+```
+# *** functions                         ← pure, stateless DI helpers
+# ** function: <snake_case_name>        ← individual function
+
+# *** classes                           ← base classes and concrete implementations
+# ** class: <snake_case_name>           ← individual class (ABCs and implementations)
+# * attribute: <name>                   ← instance attributes
+# * init                                ← constructor
+# * method: <name>                      ← instance methods
+# * method: <name> (static)             ← static methods
+# * method: <name> (class)              ← classmethods
+```
+
+## Key conventions
+
+- The DI layer is **event-free and asset-free**: imports only stdlib, `dependency_injector`, `..domain`, and (in `dependency_injector.py`) `..interfaces.di`. Never import `RaiseError`, `TiferetError`, `a.const`, or any other event/asset.
+- Raw exceptions surface from DI classes; callers with event access convert them to structured errors.
+- **`injectable_parameter_names(service_type)`** — returns constructor parameter names eligible for automatic wiring (excludes `self`, `*args`, `**kwargs`). Use in `build_factory` / `build_singleton` to wire sibling providers automatically.
+- **`normalize_flags(*flags)`** — flattens mixed string/list/tuple input into a flat string list. Key for cache-key consistency.
+- **`ServiceContainer`** (engine): registers services as `Factory` providers (one new instance per resolution) or `Object` providers (scalars/callables). `add_service(id, dependency)` wires constructor kwargs to sibling providers.
+- **`ServiceResolver`** (provider): owns a per-flag `ServiceContainer` cache. Template-method `get_dependency(service_id, *flags)` normalizes flags, looks up or builds a container, then delegates. Only `build_container(flags)` is abstract.
+- **App-level:** `DIAppServiceContainer` uses `Singleton` scope — one shared instance per app. Created via `from_dependencies(services, constants)` classmethod.
+- **Feature-level:** `DIDynamicServiceResolver` uses `Factory` scope — a new instance per resolution. Built per flag set by `build_container`.
+- Use `# *** classes` in all DI modules (no `# *** di` group). Use `# * method: <name> (class)` for `@classmethod` entries.
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+# ** infra
+from dependency_injector import containers, providers
+
+# ** app
+from ..domain.core import ServiceDependency
+
+# *** functions
+
+# ** function: injectable_parameter_names
+def injectable_parameter_names(service_type: type) -> List[str]:
+    '''
+    Return the injectable constructor parameter names of a service type.
+
+    Excludes self and variadic parameters (*args, **kwargs).
+
+    :param service_type: The service class to inspect.
+    :type service_type: type
+    :return: A list of injectable parameter names.
+    :rtype: List[str]
+    '''
+
+    import inspect
+
+    # Inspect the constructor signature.
+    sig = inspect.signature(service_type.__init__)
+
+    # Collect injectable parameter names.
+    return [
+        name for name, param in sig.parameters.items()
+        if name != 'self'
+        and param.kind not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
+    ]
+
+# *** classes
+
+# ** class: service_container
+class ServiceContainer(object):
+    '''
+    Low-level dependency-injection engine backed by DynamicContainer.
+
+    Event-free: missing or failing providers raise raw exceptions.
+    '''
+
+    # * attribute: container
+    container: containers.DynamicContainer
+
+    # * init
+    def __init__(self, services: Dict[str, type] = None):
+        '''
+        Initialize the service container.
+
+        :param services: Optional initial service type mapping.
+        :type services: Dict[str, type]
+        '''
+
+        # Create the dynamic container.
+        self.container = containers.DynamicContainer()
+
+        # Bulk-load any initial services.
+        if services:
+            self.add_services(services)
+
+    # * method: add_services
+    def add_services(self, services: Dict[str, Any]):
+        '''
+        Bulk-register services: scalars as Object providers, types as Factories.
+
+        :param services: Mapping of service ID to type or scalar value.
+        :type services: Dict[str, Any]
+        '''
+
+        # Register scalars first so factories can wire to them.
+        for service_id, value in services.items():
+            if not isinstance(value, type):
+                self.container.set_provider(service_id, providers.Object(value))
+
+        # Register class types as Factory providers.
+        for service_id, value in services.items():
+            if isinstance(value, type):
+                factory = self._build_factory(value)
+                self.container.set_provider(service_id, factory)
+
+    # * method: get_service
+    def get_service(self, service_id: str) -> Any:
+        '''
+        Resolve and return a registered service instance.
+
+        :param service_id: The service identifier.
+        :type service_id: str
+        :return: The resolved service instance.
+        :rtype: Any
+        '''
+
+        # Look up and invoke the provider; raises raw exception if missing.
+        provider = self.container.providers.get(service_id)
+        return provider()
+
+    # * method: _build_factory (static)
+    @staticmethod
+    def _build_factory(service_type: type) -> providers.Factory:
+        '''
+        Build a Factory provider with constructor kwargs wired to sibling providers.
+
+        :param service_type: The class to wrap in a Factory provider.
+        :type service_type: type
+        :return: The configured Factory provider.
+        :rtype: providers.Factory
+        '''
+
+        # Wire each injectable parameter to a sibling provider.
+        kwargs = {}
+        for param_name in injectable_parameter_names(service_type):
+            sibling = ServiceContainer.container.providers.get(param_name)
+            if sibling is not None:
+                kwargs[param_name] = sibling
+        return providers.Factory(service_type, **kwargs)
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md

--- a/docs/collab/agents/skills/tiferet-code-di/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-di/SKILL.md
@@ -17,7 +17,7 @@ Module skeleton (any module):
 # *** imports
 # *** constants          ← optional
 # *** functions          ← optional; pure, stateless DI helpers
-# *** classes            ← base classes and concrete implementations
+# *** di                 ← DI containers and resolvers
 # *** exports            ← __init__.py only
 ```
 
@@ -26,16 +26,14 @@ DI-specific labels:
 # *** functions                         ← artifact section: pure, stateless DI helpers
 # ** function: <snake_case_name>        ← artifact
 
-# *** classes                           ← artifact section: ABCs and implementations
-# ** class: <snake_case_name>           ← artifact
+# *** di                                ← artifact section: containers and resolvers
+# ** di: <snake_case_name>             ← artifact
 # * attribute: <name>                   ← artifact member: instance attributes
 # * init                                ← artifact member: constructor
 # * method: <name>                      ← artifact member: instance methods
 # * method: <name> (static)            ← artifact member: static methods
 # * method: <name> (class)             ← artifact member: classmethods
 ```
-
-Note: DI modules use `# *** classes` (not a construct-specific group) because the DI layer defines base classes, not domain constructs.
 
 ## Key conventions
 
@@ -50,7 +48,7 @@ Note: DI modules use `# *** classes` (not a construct-specific group) because th
 - **`ServiceResolver`** (ABC provider): owns a per-flag `ServiceContainer` cache. Provides `add_container`, `get_container`, `get_dependency` (template method); leaves `build_container(flags)` abstract for subclasses.
 - **App-level:** `DIAppServiceContainer` uses `Singleton` scope — one shared instance per app. Created via `from_dependencies(services, constants)` classmethod.
 - **Feature-level:** `DIDynamicServiceResolver` uses `Factory` scope — a new instance per resolution. Built per flag set by `build_container`.
-- Use `# *** classes` in all DI modules (no `# *** di` group). Use `# * method: <name> (class)` for `@classmethod` entries.
+- Use `# *** di` as the construct group for all DI component classes. Use `# * method: <name> (class)` for `@classmethod` entries.
 
 ## Example
 
@@ -97,9 +95,9 @@ def injectable_parameter_names(service_type: type) -> List[str]:
         )
     ]
 
-# *** classes
+# *** di
 
-# ** class: service_container
+# ** di: service_container
 class ServiceContainer(ABC):
     '''
     Abstract DI container contract for the framework.

--- a/docs/collab/agents/skills/tiferet-code-domain/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-domain/SKILL.md
@@ -13,24 +13,30 @@ description: Apply domain object conventions when adding or modifying domain obj
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** models                        ← top-level for domain object modules
-# ** model: <snake_case_name>       ← individual domain object
-# * attribute: <name>               ← Pydantic Field(...) annotation
-# * method: <name>                  ← read-only domain behavior
-# * method: _derive_<name> (validator) ← @model_validator derivation logic
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** models             ← construct group for this skill
+# *** exports            ← __init__.py only
 ```
 
-Import organization follows the standard three groups:
-```python
-# *** imports
-# ** core      ← stdlib (typing, etc.)
-# ** infra     ← pydantic (Field, model_validator, AliasChoices)
-# ** app       ← framework imports (DomainObject, other domain objects)
+Model-specific labels:
 ```
+# *** models                              ← artifact section
+# ** model: <snake_case_name>             ← artifact
+# * attribute: <name>                     ← artifact member: Pydantic Field(...) annotation
+# * method: <name>                        ← artifact member: read-only domain behavior
+# * method: _derive_<name> (validator)    ← artifact member: @model_validator derivation logic
+```
+
+Import artifact groups: `# ** core` (stdlib), `# ** infra` (pydantic), `# ** app` (framework).
 
 ## Key conventions
 
+- **Layer boundary — valid `# ** app` imports:** `assets` sub-modules only (e.g. `from .. import assets as a`). Never import from `events`, `mappers`, `interfaces`, `repos`, `utils`, `contexts`, or `blueprints`.
 - Extend `DomainObject` from `tiferet.domain.core` (which extends `pydantic.BaseModel`).
 - `DomainObject` config: `extra='forbid'`, `populate_by_name=True`, `validate_assignment=True`, `arbitrary_types_allowed=True`, `coerce_numbers_to_str=True`.
 - Declare all fields with `pydantic.Field(...)` including a `description` kwarg.

--- a/docs/collab/agents/skills/tiferet-code-domain/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-domain/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: tiferet-code-domain
+description: Apply domain object conventions when adding or modifying domain objects in a Tiferet-family repo. Covers the DomainObject base class, Pydantic field declarations, model validators, read-only design, and package layout.
+---
+
+# Domain Objects Code Style – Tiferet
+
+## When to use
+- When adding a new domain object or modifying an existing one in `tiferet/domain/`.
+- When defining a new field, a derivation validator, or a read-only behavior method on a domain class.
+- When creating domain objects for a Tiferet-family application (e.g. a calculator result, an order item).
+- Do NOT use for mutation logic — that belongs in Aggregates (`tiferet-code-mappers`).
+
+## Artifact comment structure
+
+```
+# *** models                        ← top-level for domain object modules
+# ** model: <snake_case_name>       ← individual domain object
+# * attribute: <name>               ← Pydantic Field(...) annotation
+# * method: <name>                  ← read-only domain behavior
+# * method: _derive_<name> (validator) ← @model_validator derivation logic
+```
+
+Import organization follows the standard three groups:
+```python
+# *** imports
+# ** core      ← stdlib (typing, etc.)
+# ** infra     ← pydantic (Field, model_validator, AliasChoices)
+# ** app       ← framework imports (DomainObject, other domain objects)
+```
+
+## Key conventions
+
+- Extend `DomainObject` from `tiferet.domain.core` (which extends `pydantic.BaseModel`).
+- `DomainObject` config: `extra='forbid'`, `populate_by_name=True`, `validate_assignment=True`, `arbitrary_types_allowed=True`, `coerce_numbers_to_str=True`.
+- Declare all fields with `pydantic.Field(...)` including a `description` kwarg.
+- Instantiate via the Pydantic constructor: `Feature(id='calc.add', name='Add')`.
+- Use `model_validate(data_dict)` for external/untrusted data.
+- Domain objects are **read-only** at the domain layer — place all mutation in Aggregates.
+- Use `@model_validator(mode='before')` for pre-construction derivation logic (e.g. deriving `error_code` from `id`); label with `# * method: _derive_<name> (validator)`.
+- Keep domain methods focused on **structure and read-only behavior** (formatting, lookups, derived values).
+- Naming: PascalCase class names matching the domain concept (`AppSession`, `Feature`, `Error`, `CliCommand`).
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from typing import List, Optional
+
+# ** infra
+from pydantic import Field, model_validator
+
+# ** app
+from tiferet.domain.core import DomainObject
+
+# *** models
+
+# ** model: calculator_result
+class CalculatorResult(DomainObject):
+    '''
+    Stores the result of a calculator computation.
+    '''
+
+    # * attribute: id
+    id: str = Field(..., description='The unique result identifier.')
+
+    # * attribute: operation
+    operation: str = Field(..., description='The operation that produced this result.')
+
+    # * attribute: value
+    value: float = Field(..., description='The computed result value.')
+
+    # * attribute: display_label
+    display_label: str = Field(
+        default='',
+        description='Auto-derived display label (e.g. "add: 42.00").',
+    )
+
+    # * method: _derive_display_label (validator)
+    @model_validator(mode='before')
+    @classmethod
+    def _derive_display_label(cls, values: dict) -> dict:
+        '''
+        Derive the display_label from operation and value when not supplied.
+
+        :param values: The raw field values before construction.
+        :type values: dict
+        :return: The updated field values dict.
+        :rtype: dict
+        '''
+
+        # Derive the display label if not explicitly provided.
+        if not values.get('display_label') and values.get('operation') and values.get('value') is not None:
+            values['display_label'] = f"{values['operation']}: {float(values['value']):.2f}"
+
+        # Return the updated values.
+        return values
+
+    # * method: format_result
+    def format_result(self, precision: int = 2) -> str:
+        '''
+        Format the result for display.
+
+        :param precision: The decimal precision to use.
+        :type precision: int
+        :return: A formatted result string.
+        :rtype: str
+        '''
+
+        # Return the formatted operation and value.
+        return f'{self.operation}: {self.value:.{precision}f}'
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md

--- a/docs/collab/agents/skills/tiferet-code-events/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-events/SKILL.md
@@ -13,26 +13,38 @@ description: Apply domain event conventions when adding or modifying domain even
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** events                      ← top-level (use # *** classes in settings.py)
-# ** event: <snake_case_name>     ← individual event
-# * attribute: <name>             ← injected dependency (on base event only)
-# * init                          ← constructor (on base event only)
-# * method: execute               ← main execution method
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** events             ← construct group for this skill
+# *** exports            ← __init__.py only
 ```
 
-Side-effect-free module-level helpers go in a `# *** functions` section above `# *** events`.
+Event-specific labels:
+```
+# *** events                      ← artifact section
+# ** event: <snake_case_name>     ← artifact
+# * attribute: <name>             ← artifact member: injected dependency (base event only)
+# * init                          ← artifact member: constructor (base event only)
+# * method: execute               ← artifact member: main execution method
+```
 
 ## Key conventions
 
-- Extend `DomainEvent` from `tiferet.events.settings` — either directly (new base or service-less event) or via the **per-module base event** (most common).
+- **Layer boundary — valid `# ** app` imports:** `assets`, `domain`, `interfaces`, `mappers`, `di`. Never import from `repos`, `utils`, `contexts`, or `blueprints`.
+- Extend `DomainEvent` from `tiferet.events.core` — either directly (new base or service-less event) or via the **per-module base event** (most common).
 - **Per-module base events:** Each single-service module defines one base event (e.g. `ErrorEvent`, `FeatureEvent`, `AppEvent`, `CliEvent`, `DIEvent`, `LoggingEvent`, `SqliteEvent`) that holds the shared service. Concrete events extend the base and declare only `execute`.
 - `@DomainEvent.parameters_required(['param1', 'param2'])` — declarative required-input validator placed as a decorator on `execute`. A parameter is invalid if absent, `None`, or an empty string after `.strip()`; falsy-but-valid values (`0`, `False`, `[]`) pass.
 - `self.verify(expression, error_code, message=None, **kwargs)` — domain rule assertions inside `execute`.
 - `self.raise_error(error_code, message=None, **kwargs)` — direct error raising when `verify` is not appropriate.
-- Access error constants via `a.const.ERROR_CODE_ID` (import `a` from `tiferet.events.settings`).
+- Access error constants via `a.<submodule>.ERROR_CODE_ID` (e.g. `a.error.COMMAND_PARAMETER_REQUIRED_ID`). `a` is imported as `from .. import assets as a`; constants are namespaced by sub-module: `a.error`, `a.app`, `a.feat`, `a.cli`, `a.logging`.
 - Return a domain object or identifier; never return `None` on success.
-- `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` — standard invocation pattern in tests and contexts.
+- `DomainEvent.handle(EventClass, dependencies={...}, middleware=None, **kwargs)` — standard invocation pattern in tests and contexts. `middleware` is an optional outermost-first list of `(event, kwargs, next_fn)` callables.
+- `DomainEvent.handle_async(...)` — async equivalent; use when driving `AsyncDomainEvent` subclasses.
+- **`AsyncDomainEvent`** — extend this instead of `DomainEvent` when `execute` is a coroutine (`async def execute`). Inherits `verify`, `raise_error`, and `parameters_required` unchanged.
 
 ## Example
 
@@ -40,7 +52,7 @@ Side-effect-free module-level helpers go in a `# *** functions` section above `#
 # *** imports
 
 # ** app
-from .settings import DomainEvent, a
+from .core import DomainEvent, a
 from ..domain import Error
 from ..mappers import ErrorAggregate
 from .error import ErrorEvent     # per-module base event
@@ -82,7 +94,7 @@ class AddError(ErrorEvent):
         # Verify the error does not already exist.
         self.verify(
             not self.error_service.exists(id),
-            a.const.ERROR_ALREADY_EXISTS_ID,
+            a.error.ERROR_ALREADY_EXISTS_ID,
             message=f'An error with ID {id} already exists.',
             id=id,
         )

--- a/docs/collab/agents/skills/tiferet-code-events/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-events/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: tiferet-code-events
+description: Apply domain event conventions when adding or modifying domain events in a Tiferet-family repo. Covers per-module base events, the parameters_required decorator, verify/raise_error patterns, and the DomainEventTestBase harness.
+---
+
+# Domain Events Code Style – Tiferet
+
+## When to use
+- When adding a new domain event class or modifying an existing one in `tiferet/events/`.
+- When implementing event-driven domain logic: validation, service interaction, orchestration.
+- When writing event tests using `DomainEventTestBase` or `ServiceEventTestBase`.
+- Pair with `tiferet-code-testing` for the full testing harness reference.
+
+## Artifact comment structure
+
+```
+# *** events                      ← top-level (use # *** classes in settings.py)
+# ** event: <snake_case_name>     ← individual event
+# * attribute: <name>             ← injected dependency (on base event only)
+# * init                          ← constructor (on base event only)
+# * method: execute               ← main execution method
+```
+
+Side-effect-free module-level helpers go in a `# *** functions` section above `# *** events`.
+
+## Key conventions
+
+- Extend `DomainEvent` from `tiferet.events.settings` — either directly (new base or service-less event) or via the **per-module base event** (most common).
+- **Per-module base events:** Each single-service module defines one base event (e.g. `ErrorEvent`, `FeatureEvent`, `AppEvent`, `CliEvent`, `DIEvent`, `LoggingEvent`, `SqliteEvent`) that holds the shared service. Concrete events extend the base and declare only `execute`.
+- `@DomainEvent.parameters_required(['param1', 'param2'])` — declarative required-input validator placed as a decorator on `execute`. A parameter is invalid if absent, `None`, or an empty string after `.strip()`; falsy-but-valid values (`0`, `False`, `[]`) pass.
+- `self.verify(expression, error_code, message=None, **kwargs)` — domain rule assertions inside `execute`.
+- `self.raise_error(error_code, message=None, **kwargs)` — direct error raising when `verify` is not appropriate.
+- Access error constants via `a.const.ERROR_CODE_ID` (import `a` from `tiferet.events.settings`).
+- Return a domain object or identifier; never return `None` on success.
+- `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)` — standard invocation pattern in tests and contexts.
+
+## Example
+
+```python
+# *** imports
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..mappers import ErrorAggregate
+from .error import ErrorEvent     # per-module base event
+
+# *** events
+
+# ** event: add_error
+class AddError(ErrorEvent):
+    '''
+    Event to add a new Error domain object to the repository.
+
+    Extends ErrorEvent (the per-module base), which injects error_service;
+    only execute is defined here.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'message'])
+    def execute(self,
+            id: str,
+            name: str,
+            message: str,
+            **kwargs,
+        ) -> Error:
+        '''
+        Add a new Error.
+
+        :param id: The unique error identifier.
+        :type id: str
+        :param name: The human-readable error name.
+        :type name: str
+        :param message: The default English error message.
+        :type message: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The created Error domain object.
+        :rtype: Error
+        '''
+
+        # Verify the error does not already exist.
+        self.verify(
+            not self.error_service.exists(id),
+            a.const.ERROR_ALREADY_EXISTS_ID,
+            message=f'An error with ID {id} already exists.',
+            id=id,
+        )
+
+        # Create and save the error aggregate.
+        new_error = ErrorAggregate(
+            id=id,
+            name=name,
+            message=[{'lang': 'en_US', 'text': message}],
+        )
+        self.error_service.save(new_error)
+
+        # Return the newly created error.
+        return new_error
+```
+
+The corresponding per-module base event (already defined in `tiferet/events/error.py`) is:
+
+```python
+# ** event: error_event
+class ErrorEvent(DomainEvent):
+    '''
+    Base event providing the shared ErrorService dependency.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize with the shared error service.
+
+        :param error_service: The error service dependency.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md

--- a/docs/collab/agents/skills/tiferet-code-interfaces/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-interfaces/SKILL.md
@@ -12,16 +12,28 @@ description: Apply service interface conventions when adding or modifying Servic
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** interfaces                        ← top-level
-# ** interface: <snake_case_name>       ← individual service interface
-# * attribute: <name>                   ← type-hinted instance attribute (rare; no assignment)
-# * method: <name>                      ← abstract method
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** interfaces         ← construct group for this skill
+# *** exports            ← __init__.py only
+```
+
+Interface-specific labels:
+```
+# *** interfaces                        ← artifact section
+# ** interface: <snake_case_name>       ← artifact
+# * attribute: <name>                   ← artifact member: type-hinted instance attribute (rare; no assignment)
+# * method: <name>                      ← artifact member: abstract method
 ```
 
 ## Key conventions
 
-- Extend `Service` from `tiferet.interfaces.settings` (a minimal `ABC`).
+- **Layer boundary — valid `# ** app` imports:** `domain` (for type hints in abstract method signatures); sibling `interfaces` modules. Never import from `events`, `mappers`, `repos`, `utils`, `contexts`, or `blueprints`.
+- Extend `Service` from `tiferet.interfaces.core` (a minimal `ABC`).
 - Mark every method `@abstractmethod` and raise `NotImplementedError()` in the body.
 - Use RST docstrings with `:param`/`:type`/`:return`/`:rtype` on every method.
 - No `# * init` — services are abstract definitions, not instantiated directly.
@@ -29,6 +41,7 @@ description: Apply service interface conventions when adding or modifying Servic
 - Services are **unified vertical contracts**: data repositories, utility wrappers, and middleware all satisfy this same base.
 - **`MiddlewareService`** (`tiferet/interfaces/middleware.py`) is the special abstract contract for domain event middleware — implement `__call__(self, event, kwargs, next_fn)` (sync) or `async def __call__` (async); label with `# * method: __call__`.
 - Domain events and contexts depend exclusively on these Service interfaces; never depend on concrete classes.
+- **Exported interfaces:** `Service`, `AppService`, `CliService`, `ConfigurationService`, `DIService`, `ErrorService`, `FeatureService`, `FileService`, `LoggingService`, `SqliteService`, `MiddlewareService`.
 
 ## Example
 
@@ -40,7 +53,7 @@ from abc import abstractmethod
 from typing import List, Optional
 
 # ** app
-from .settings import Service
+from .core import Service
 from ..domain.error import Error
 
 # *** interfaces

--- a/docs/collab/agents/skills/tiferet-code-interfaces/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-interfaces/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: tiferet-code-interfaces
+description: Apply service interface conventions when adding or modifying Service interfaces in a Tiferet-family repo. Covers the Service ABC, abstractmethod usage, MiddlewareService, and vertical contract design.
+---
+
+# Interfaces (Services) Code Style – Tiferet
+
+## When to use
+- When adding a new Service interface or modifying an existing one in `tiferet/interfaces/`.
+- When defining the abstract contract for a new domain concern (data access, middleware, computation).
+- Do NOT use for concrete implementations — those are repositories (`tiferet-code-repos`) or utilities (`tiferet-code-utils`).
+
+## Artifact comment structure
+
+```
+# *** interfaces                        ← top-level
+# ** interface: <snake_case_name>       ← individual service interface
+# * attribute: <name>                   ← type-hinted instance attribute (rare; no assignment)
+# * method: <name>                      ← abstract method
+```
+
+## Key conventions
+
+- Extend `Service` from `tiferet.interfaces.settings` (a minimal `ABC`).
+- Mark every method `@abstractmethod` and raise `NotImplementedError()` in the body.
+- Use RST docstrings with `:param`/`:type`/`:return`/`:rtype` on every method.
+- No `# * init` — services are abstract definitions, not instantiated directly.
+- Keep methods focused on a single vertical concern (data access, file I/O, configuration, middleware).
+- Services are **unified vertical contracts**: data repositories, utility wrappers, and middleware all satisfy this same base.
+- **`MiddlewareService`** (`tiferet/interfaces/middleware.py`) is the special abstract contract for domain event middleware — implement `__call__(self, event, kwargs, next_fn)` (sync) or `async def __call__` (async); label with `# * method: __call__`.
+- Domain events and contexts depend exclusively on these Service interfaces; never depend on concrete classes.
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List, Optional
+
+# ** app
+from .settings import Service
+from ..domain.error import Error
+
+# *** interfaces
+
+# ** interface: error_service
+class ErrorService(Service):
+    '''
+    Vertical interface for managing Error domain objects.
+    '''
+
+    # * method: exists
+    @abstractmethod
+    def exists(self, id: str) -> bool:
+        '''
+        Check whether an error with the given ID exists.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: True if the error exists, otherwise False.
+        :rtype: bool
+        '''
+        raise NotImplementedError()
+
+    # * method: get
+    @abstractmethod
+    def get(self, id: str) -> Optional[Error]:
+        '''
+        Retrieve an Error by its ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: The Error domain object, or None if not found.
+        :rtype: Optional[Error]
+        '''
+        raise NotImplementedError()
+
+    # * method: list
+    @abstractmethod
+    def list(self) -> List[Error]:
+        '''
+        List all Error domain objects.
+
+        :return: All stored errors.
+        :rtype: List[Error]
+        '''
+        raise NotImplementedError()
+
+    # * method: save
+    @abstractmethod
+    def save(self, error: Error) -> None:
+        '''
+        Persist an Error domain object.
+
+        :param error: The error to persist.
+        :type error: Error
+        '''
+        raise NotImplementedError()
+
+    # * method: delete
+    @abstractmethod
+    def delete(self, id: str) -> None:
+        '''
+        Delete an Error by ID (idempotent).
+
+        :param id: The error identifier.
+        :type id: str
+        '''
+        raise NotImplementedError()
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md

--- a/docs/collab/agents/skills/tiferet-code-mappers/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-mappers/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: tiferet-code-mappers
+description: Apply mapper conventions when adding or modifying Aggregates or TransferObjects (ConfigObjects) in a Tiferet-family repo. Covers the Aggregate/TransferObject base classes, _ROLES serialization, aliasing, and the AggregateTestBase/TransferObjectTestBase harnesses.
+---
+
+# Mappers Code Style – Tiferet
+
+## When to use
+- When adding or modifying an Aggregate or TransferObject (ConfigObject) in `tiferet/mappers/`.
+- When adding mutation methods to a domain aggregate.
+- When defining serialization roles for a configuration object.
+- Pair with `tiferet-code-domain` (field shapes) and `tiferet-code-testing` (harness details).
+
+## Artifact comment structure
+
+```
+# *** mappers                       ← top-level for mapper modules
+# ** mapper: <snake_case_name>      ← individual mapper (Aggregate or ConfigObject)
+# * attribute: <name>               ← Pydantic Field or ClassVar
+# * method: <name>                  ← mutation methods (Aggregate) or map/from_model (ConfigObject)
+```
+
+Use `# *** classes` in `settings.py` for the `Aggregate` and `TransferObject` base classes themselves.
+
+## Key conventions
+
+**Naming:**
+- `<Domain>Aggregate` — mutable extension of a domain object (e.g. `ErrorAggregate`, `FeatureAggregate`).
+- `<Domain>ConfigObject` — serialization transfer object (e.g. `ErrorConfigObject`, `FeatureConfigObject`).
+
+**Aggregate:**
+- Combine the domain object + `Aggregate`: `class ErrorAggregate(Error, Aggregate)`.
+- Instantiate via direct Pydantic constructor: `ErrorAggregate(id='ERR', name='Error')`.
+- Add mutation methods; `validate_assignment=True` (inherited) triggers field validation on every `setattr`.
+- Use `set_attribute(attr, value)` for safe mutations with unknown-field checking; raises `INVALID_MODEL_ATTRIBUTE_ID` for unknown attrs.
+- No `Aggregate.new()` factory — use the constructor directly.
+
+**TransferObject (ConfigObject):**
+- Combine the domain object + `TransferObject`: `class ErrorConfigObject(Error, TransferObject)`.
+- Lenient config: `extra='ignore'`, `validate_assignment=False`.
+- Declare a `_ROLES: ClassVar[Dict[str, Dict[str, Any]]]` mapping role names to `model_dump` kwargs.
+  - `'to_model'` — for mapping to an aggregate (typically excludes nested child lists already mapped).
+  - `'to_data'` — for serializing back to configuration file format.
+- `to_primitive(role, **overrides)` — serializes with `model_dump` + role kwargs; defaults to `exclude_none=True`.
+- `map(**overrides)` — serializes via `to_model` role then constructs the target aggregate.
+- `from_model(cls, model, **overrides)` — `@classmethod` creating a ConfigObject from a domain model or aggregate.
+- Attribute aliasing: `serialization_alias` for output aliasing, `validation_alias=AliasChoices(...)` for multiple input names.
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from typing import ClassVar, Dict, Any, List
+
+# ** infra
+from pydantic import Field, AliasChoices
+
+# ** app
+from ..domain.feature import Feature, EventFeatureStep
+from ..mappers.settings import Aggregate, TransferObject
+
+# *** mappers
+
+# ** mapper: feature_aggregate
+class FeatureAggregate(Feature, Aggregate):
+    '''
+    Mutable aggregate for the Feature domain object.
+    '''
+
+    # * method: rename
+    def rename(self, name: str) -> None:
+        '''
+        Rename the feature.
+
+        :param name: The new feature name.
+        :type name: str
+        '''
+
+        # Assign the new name; validate_assignment=True re-validates.
+        self.name = name
+
+
+# ** mapper: feature_config_object
+class FeatureConfigObject(Feature, TransferObject):
+    '''
+    Configuration data representation of the Feature domain object.
+    '''
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'steps'}},
+        'to_data': {
+            'by_alias': True,
+            'exclude': {'feature_key', 'group_id', 'id'},
+        },
+    }
+
+    # * attribute: steps
+    steps: List[EventFeatureStepConfigObject] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices('handlers', 'functions', 'commands', 'steps'),
+        description='The step workflow for the feature.',
+    )
+
+    # * method: map
+    def map(self, **overrides) -> FeatureAggregate:
+        '''
+        Map the feature configuration data to a FeatureAggregate.
+
+        :param overrides: Additional field overrides.
+        :type overrides: dict
+        :return: The mapped FeatureAggregate.
+        :rtype: FeatureAggregate
+        '''
+
+        # Map each step then delegate to the base map.
+        return super().map(
+            FeatureAggregate,
+            steps=[step.map() for step in (self.steps or [])],
+            **overrides,
+        )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, feature: Feature, **overrides) -> 'FeatureConfigObject':
+        '''
+        Create a FeatureConfigObject from a Feature model.
+
+        :param feature: The Feature domain object.
+        :type feature: Feature
+        :param overrides: Additional field overrides.
+        :type overrides: dict
+        :return: The constructed FeatureConfigObject.
+        :rtype: FeatureConfigObject
+        '''
+
+        # Convert each step then delegate to the base from_model.
+        return super().from_model(
+            feature,
+            steps=[EventFeatureStepConfigObject.from_model(s) for s in feature.steps],
+            **overrides,
+        )
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md

--- a/docs/collab/agents/skills/tiferet-code-mappers/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-mappers/SKILL.md
@@ -6,27 +6,41 @@ description: Apply mapper conventions when adding or modifying Aggregates or Tra
 # Mappers Code Style – Tiferet
 
 ## When to use
-- When adding or modifying an Aggregate or TransferObject (ConfigObject) in `tiferet/mappers/`.
+- When adding or modifying an Aggregate or TransferObject in `tiferet/mappers/`.
 - When adding mutation methods to a domain aggregate.
-- When defining serialization roles for a configuration object.
+- When defining serialization roles for domain objects going to and from any persistence or transport layer (config files, databases, REST, etc.). `ConfigObject` is the framework's own example of the pattern.
 - Pair with `tiferet-code-domain` (field shapes) and `tiferet-code-testing` (harness details).
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** mappers                       ← top-level for mapper modules
-# ** mapper: <snake_case_name>      ← individual mapper (Aggregate or ConfigObject)
-# * attribute: <name>               ← Pydantic Field or ClassVar
-# * method: <name>                  ← mutation methods (Aggregate) or map/from_model (ConfigObject)
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** mappers            ← construct group for this skill
+# *** exports            ← __init__.py only
 ```
 
-Use `# *** classes` in `settings.py` for the `Aggregate` and `TransferObject` base classes themselves.
+Mapper-specific labels:
+```
+# *** mappers                       ← artifact section
+# ** mapper: <snake_case_name>      ← artifact (Aggregate or TransferObject)
+# * attribute: <name>               ← artifact member: Pydantic Field or ClassVar
+# * method: <name>                  ← artifact member: mutation methods (Aggregate) or map/from_model (TransferObject)
+```
+
+Use `# *** classes` in `core.py` for the `Aggregate` and `TransferObject` base classes themselves.
 
 ## Key conventions
 
+**Layer boundary — valid `# ** app` imports:** `domain` (the domain object being extended), `events` (`RaiseError`, `a`). Never import from `interfaces`, `repos`, `utils`, `contexts`, or `blueprints`.
+
 **Naming:**
 - `<Domain>Aggregate` — mutable extension of a domain object (e.g. `ErrorAggregate`, `FeatureAggregate`).
-- `<Domain>ConfigObject` — serialization transfer object (e.g. `ErrorConfigObject`, `FeatureConfigObject`).
+- `<Domain>TransferObject` — default name for a serialization transfer object when the backing medium is not known or is general-purpose.
+- Use a precision suffix when the backing medium is specific: `<Domain>ConfigObject` (YAML/JSON config), `<Domain>SqliteObject` (SQLite). These replace `TransferObject` in the class name when the medium is known.
 
 **Aggregate:**
 - Combine the domain object + `Aggregate`: `class ErrorAggregate(Error, Aggregate)`.
@@ -34,6 +48,7 @@ Use `# *** classes` in `settings.py` for the `Aggregate` and `TransferObject` ba
 - Add mutation methods; `validate_assignment=True` (inherited) triggers field validation on every `setattr`.
 - Use `set_attribute(attr, value)` for safe mutations with unknown-field checking; raises `INVALID_MODEL_ATTRIBUTE_ID` for unknown attrs.
 - No `Aggregate.new()` factory — use the constructor directly.
+- `to_dict(role=None, **overrides)` — serialize an aggregate to a dict; mirrors `TransferObject.to_primitive` for consistent serialization without going through a transfer object.
 
 **TransferObject (ConfigObject):**
 - Combine the domain object + `TransferObject`: `class ErrorConfigObject(Error, TransferObject)`.
@@ -59,7 +74,7 @@ from pydantic import Field, AliasChoices
 
 # ** app
 from ..domain.feature import Feature, EventFeatureStep
-from ..mappers.settings import Aggregate, TransferObject
+from ..mappers.core import Aggregate, TransferObject
 
 # *** mappers
 

--- a/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
@@ -12,17 +12,32 @@ description: Apply repository conventions when adding or modifying configuration
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** repos                            ← top-level
-# ** repo: <snake_case_name>           ← individual repository
-# * attribute: <name>                  ← instance attributes (inherited; rarely redeclared)
-# * init                               ← constructor
-# * method: <name>                     ← Service interface implementation
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** repos              ← construct group for this skill
+# *** exports            ← __init__.py only
+```
+
+Repo-specific labels:
+```
+# *** repos                            ← artifact section
+# ** repo: <snake_case_name>           ← artifact
+# * attribute: <name>                  ← artifact member: instance attributes (inherited; rarely redeclared)
+# * init                               ← artifact member: constructor
+# * method: <name>                     ← artifact member: Service interface implementation
 ```
 
 ## Key conventions
 
-**Naming:** `<Domain>ConfigRepository` (e.g. `ErrorConfigRepository`, `FeatureConfigRepository`).
+**Layer boundary — valid `# ** app` imports:** `interfaces` (the Service to implement), `mappers` (transfer objects and aggregates), `utils` (loader utilities), `events` (`RaiseError`, `a`). Never import from `domain` directly (use `mappers` instead), `di`, `contexts`, or `blueprints`.
+
+**Naming:**
+- `<Domain>ConfigRepository` — for YAML/JSON config-backed repos (e.g. `ErrorConfigRepository`, `FeatureConfigRepository`). Both formats are handled by `ConfigurationRepository`.
+- `<Domain>SqliteRepository` — for SQLite-backed repos (e.g. `OrderSqliteRepository`). The suffix reflects the backing connector (`SqliteClient`) rather than the file format.
 
 **Class declaration:** Extend the Service interface **and** `ConfigurationRepository`:
 ```python
@@ -75,7 +90,7 @@ from typing import List, Optional
 # ** app
 from ..interfaces import ErrorService
 from ..mappers import ErrorAggregate, ErrorConfigObject
-from .settings import ConfigurationRepository
+from .core import ConfigurationRepository
 
 # *** repos
 

--- a/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: tiferet-code-repos
+description: Apply repository conventions when adding or modifying configuration repositories in a Tiferet-family repo. Covers ConfigurationRepository base, naming, read/write patterns, DI registration, and integration testing.
+---
+
+# Repositories Code Style – Tiferet
+
+## When to use
+- When adding a new repository or modifying an existing one in `tiferet/repos/`.
+- When implementing persistence for a domain concept backed by YAML or JSON config files.
+- Do NOT export repositories from `__init__.py` — they are DI-resolved at runtime.
+
+## Artifact comment structure
+
+```
+# *** repos                            ← top-level
+# ** repo: <snake_case_name>           ← individual repository
+# * attribute: <name>                  ← instance attributes (inherited; rarely redeclared)
+# * init                               ← constructor
+# * method: <name>                     ← Service interface implementation
+```
+
+## Key conventions
+
+**Naming:** `<Domain>ConfigRepository` (e.g. `ErrorConfigRepository`, `FeatureConfigRepository`).
+
+**Class declaration:** Extend the Service interface **and** `ConfigurationRepository`:
+```python
+class ErrorConfigRepository(ErrorService, ConfigurationRepository):
+```
+
+**Constructor:** Accept `<domain>_config: str` and forward to the base:
+```python
+def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
+    ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
+```
+
+**`ConfigurationRepository` base** (inherited from `tiferet/repos/settings.py`):
+- `config_file`, `encoding`, `default_role` (fixed to `'to_data'`)
+- `_load(start_node=..., data_factory=...)` — format-dispatched read (YAML or JSON based on file extension)
+- `_save(data)` — format-dispatched write
+
+**Read pattern** (`exists`, `get`, `list`): use `_load` with a `start_node` lambda:
+```python
+data = self._load(start_node=lambda d: d.get('errors', {}))
+return ErrorConfigObject.model_validate({**data[id], 'id': id}).map()
+```
+
+**Write pattern** (`save`): serialize → load full file → update section → save:
+```python
+error_data = ErrorConfigObject.from_model(error)
+full_data = self._load()
+full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
+self._save(full_data)
+```
+
+**Delete pattern**: always idempotent — use `.pop(id, None)`:
+```python
+full_data.get('errors', {}).pop(id, None)
+self._save(full_data)
+```
+
+**Testing:** Integration tests only — use `tmp_path` fixtures with real temp YAML/JSON files. Use `# ** test_int: <name>` labels for integration test cases.
+
+## Example
+
+```python
+"""Tiferet Error Configuration Repository"""
+
+# *** imports
+
+# ** core
+from typing import List, Optional
+
+# ** app
+from ..interfaces import ErrorService
+from ..mappers import ErrorAggregate, ErrorConfigObject
+from .settings import ConfigurationRepository
+
+# *** repos
+
+# ** repo: error_config_repository
+class ErrorConfigRepository(ErrorService, ConfigurationRepository):
+    '''
+    The error configuration repository.
+    '''
+
+    # * init
+    def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the error configuration repository.
+
+        :param error_config: Path to the configuration file.
+        :type error_config: str
+        :param encoding: File encoding.
+        :type encoding: str
+        '''
+
+        # Initialize the configuration repository base.
+        ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
+
+    # * method: exists
+    def exists(self, id: str) -> bool:
+        '''
+        Check if an error exists by ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: True if the error exists, otherwise False.
+        :rtype: bool
+        '''
+
+        # Load the errors mapping.
+        errors_data = self._load(start_node=lambda data: data.get('errors', {}))
+
+        # Return whether the id is present.
+        return id in errors_data
+
+    # * method: get
+    def get(self, id: str) -> Optional[ErrorAggregate]:
+        '''
+        Retrieve an Error by ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :return: The ErrorAggregate, or None if not found.
+        :rtype: Optional[ErrorAggregate]
+        '''
+
+        # Load the specific error entry.
+        error_data = self._load(
+            start_node=lambda data: data.get('errors', {}).get(id)
+        )
+
+        # Return None if not found.
+        if not error_data:
+            return None
+
+        # Map to an aggregate and return.
+        return ErrorConfigObject.model_validate({**error_data, 'id': id}).map()
+
+    # * method: save
+    def save(self, error: ErrorAggregate) -> None:
+        '''
+        Persist an Error aggregate to the configuration file.
+
+        :param error: The error aggregate to persist.
+        :type error: ErrorAggregate
+        '''
+
+        # Convert the aggregate to configuration data.
+        error_data = ErrorConfigObject.from_model(error)
+
+        # Load the full configuration file.
+        full_data = self._load()
+
+        # Insert or update the error entry.
+        full_data.setdefault('errors', {})[error.id] = error_data.to_primitive(self.default_role)
+
+        # Persist the updated configuration.
+        self._save(full_data)
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md

--- a/docs/collab/agents/skills/tiferet-code-style/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-style/SKILL.md
@@ -16,18 +16,18 @@ description: Apply the Tiferet structured code style during any implementation s
 Three structural tiers organize every module:
 
 ```
-# *** <section>          ← top-level (preamble or construct group)
-# ** <kind>: <name>      ← mid-level (category or individual component)
-# * <component>          ← low-level (attribute, init, method)
+# *** <section>          ← artifact section (preamble or construct group)
+# ** <kind>: <name>      ← artifact (category or individual component)
+# * <component>          ← artifact member (attribute, init, method)
 ```
 
-**Top-level sections — preamble groups** (available in any module, in this order when present):
+**Artifact sections — preamble groups** (available in any module, in this order when present):
 - `# *** imports` — all imports
 - `# *** constants` — module-level constants
 - `# *** functions` — side-effect-free module-level helpers (no `self`, no injected services, plain return values)
-- `# *** classes` — generic/base classes not tied to a construct type (used in `settings.py` files)
+- `# *** classes` — generic/base classes not tied to a construct type (used in `core.py` files)
 
-**Top-level sections — construct groups** (one per module, based on what it defines):
+**Artifact sections — construct groups** (one per module, based on what it defines):
 - `# *** models`, `# *** events`, `# *** contexts`, `# *** interfaces`, `# *** mappers`, `# *** repos`, `# *** utils`, `# *** blueprints`
 - `# *** exports` — only in `__init__.py`
 
@@ -46,7 +46,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
 **Mid-level labels by construct:** `# ** model: <name>`, `# ** event: <name>`, `# ** context: <name>`, `# ** mapper: <name>`, `# ** interface: <name>`, `# ** repo: <name>`, `# ** util: <name>`, `# ** blueprint: <name>`, `# ** function: <name>`, `# ** constant: <name>`, `# ** class: <name>`
 
-**Low-level labels within a class:**
+**Artifact member labels within a class:**
 - `# * attribute: <name>` — instance attributes
 - `# * init` — constructor
 - `# * method: <name>` — instance methods
@@ -55,7 +55,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
 ## Key conventions
 
-- **Spacing:** One empty line between top-level comment and first mid-level; one empty line between mid-level entries; one empty line between low-level (`# *`) sections; one empty line after docstrings; one empty line between code snippets within a method.
+- **Spacing:** One empty line between artifact section and first artifact; one empty line between artifacts; one empty line between artifact members (`# *`); one empty line after docstrings; one empty line between code snippets within a method.
 - **Docstrings:** RST format — include `:param`/`:type` for every parameter and `:return`/`:rtype` for every return value.
 - **Parameter indentation:** For methods with >3 parameters, align subsequent params to the opening parenthesis.
 - **Code snippets:** Each logical step is a separate snippet preceded by a 1–2 line comment describing intent.
@@ -73,7 +73,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 from typing import Any
 
 # ** app
-from .settings import DomainEvent, a
+from .core import DomainEvent, a
 from ..domain import Feature
 from ..interfaces import FeatureService
 
@@ -120,7 +120,7 @@ class GetFeature(DomainEvent):
         # Verify the feature exists; raise structured error if not.
         self.verify(
             expression=feature is not None,
-            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            error_code=a.error.FEATURE_NOT_FOUND_ID,
             feature_id=id,
         )
 

--- a/docs/collab/agents/skills/tiferet-code-style/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-style/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: tiferet-code-style
+description: Apply the Tiferet structured code style during any implementation session in a Tiferet-family repo. Read this at the start of every implementation session before touching any source file — it covers artifact comment hierarchy, spacing rules, docstrings, annotation artifacts, and the domain event test harness style.
+---
+
+# Structured Code Style – Tiferet
+
+## When to use
+- **Always** — read this at the start of every implementation session in a Tiferet-family repo.
+- Before writing or editing any module: domain objects, events, mappers, interfaces, repos, contexts, utils, blueprints, assets, or tests.
+- When unsure of comment label syntax, spacing rules, or docstring format.
+- Component-specific skills (`tiferet-code-domain`, `tiferet-code-events`, etc.) add detail on top of this foundation.
+
+## Artifact comment structure
+
+Three structural tiers organize every module:
+
+```
+# *** <section>          ← top-level (preamble or construct group)
+# ** <kind>: <name>      ← mid-level (category or individual component)
+# * <component>          ← low-level (attribute, init, method)
+```
+
+**Top-level sections — preamble groups** (available in any module, in this order when present):
+- `# *** imports` — all imports
+- `# *** constants` — module-level constants
+- `# *** functions` — side-effect-free module-level helpers (no `self`, no injected services, plain return values)
+- `# *** classes` — generic/base classes not tied to a construct type (used in `settings.py` files)
+
+**Top-level sections — construct groups** (one per module, based on what it defines):
+- `# *** models`, `# *** events`, `# *** contexts`, `# *** interfaces`, `# *** mappers`, `# *** repos`, `# *** utils`, `# *** blueprints`
+- `# *** exports` — only in `__init__.py`
+
+**Sub-groups** — partition a large section with a parenthetical qualifier (kind preserved):
+```python
+# *** constants
+# ** constant: en_us
+EN_US = 'en_US'
+
+# *** constants (error)
+# ** constant: feature_not_found_id
+FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
+```
+
+**Mid-level labels by import group:** `# ** core`, `# ** infra`, `# ** app`
+
+**Mid-level labels by construct:** `# ** model: <name>`, `# ** event: <name>`, `# ** context: <name>`, `# ** mapper: <name>`, `# ** interface: <name>`, `# ** repo: <name>`, `# ** util: <name>`, `# ** blueprint: <name>`, `# ** function: <name>`, `# ** constant: <name>`, `# ** class: <name>`
+
+**Low-level labels within a class:**
+- `# * attribute: <name>` — instance attributes
+- `# * init` — constructor
+- `# * method: <name>` — instance methods
+- `# * method: <name> (static)` — static methods
+- `# * method: <name> (validator)` — `@model_validator` methods on domain objects
+
+## Key conventions
+
+- **Spacing:** One empty line between top-level comment and first mid-level; one empty line between mid-level entries; one empty line between low-level (`# *`) sections; one empty line after docstrings; one empty line between code snippets within a method.
+- **Docstrings:** RST format — include `:param`/`:type` for every parameter and `:return`/`:rtype` for every return value.
+- **Parameter indentation:** For methods with >3 parameters, align subsequent params to the opening parenthesis.
+- **Code snippets:** Each logical step is a separate snippet preceded by a 1–2 line comment describing intent.
+- **Annotation artifacts** (transient lifecycle markers, placed immediately after the `# *` label they annotate):
+  - `# ++ todo: <message>` — deferred work; remove when done.
+  - `# -- obsolete: <reason>` — deprecated artifact; remove with the artifact. Shorthand: `# * method: foo (obsolete)`.
+- **Pre-session scan:** Before editing, run `grep -rn "# ++\|# --" tiferet/` to find open annotations.
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+from typing import Any
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Feature
+from ..interfaces import FeatureService
+
+# *** events
+
+# ** event: get_feature
+class GetFeature(DomainEvent):
+    '''
+    Domain event to retrieve a feature by its identifier.
+    '''
+
+    # * attribute: feature_service
+    feature_service: FeatureService
+
+    # * init
+    def __init__(self, feature_service: FeatureService) -> None:
+        '''
+        Initialize the GetFeature event.
+
+        :param feature_service: The feature service.
+        :type feature_service: FeatureService
+        '''
+
+        # Set the feature service dependency.
+        self.feature_service = feature_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> Feature:
+        '''
+        Retrieve a feature by ID.
+
+        :param id: The feature ID.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The Feature domain object.
+        :rtype: Feature
+        '''
+
+        # Retrieve the feature from the service.
+        feature = self.feature_service.get(id)
+
+        # Verify the feature exists; raise structured error if not.
+        self.verify(
+            expression=feature is not None,
+            error_code=a.const.FEATURE_NOT_FOUND_ID,
+            feature_id=id,
+        )
+
+        # Return the feature.
+        return feature
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md

--- a/docs/collab/agents/skills/tiferet-code-testing/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-testing/SKILL.md
@@ -13,7 +13,18 @@ description: Apply Tiferet test harness conventions when writing or extending te
 
 ## Artifact comment structure
 
-Harness-based test modules follow standard artifact comments:
+Test modules introduce two testing-specific artifact sections as their primary additions:
+
+```
+# *** fixtures                          ← module-level pytest fixtures (testing-specific)
+# ** fixture: <snake_case_name>         ← individual fixture
+
+# *** tests                             ← test classes or standalone tests (testing-specific)
+# ** test: TestClassName                ← harness test class (PascalCase)
+# ** test: <snake_case_name>            ← standalone test function
+```
+
+Standard preamble groups follow general styling rules and appear before `fixtures` and `tests`:
 
 ```
 # *** imports
@@ -21,21 +32,14 @@ Harness-based test modules follow standard artifact comments:
 
 # *** constants                         ← shared sample data and normalizers
 # ** constant: <snake_case_name>
-
-# *** fixtures                          ← module-level pytest fixtures
-# ** fixture: <snake_case_name>
-
-# *** tests                             ← test classes or standalone tests
-# ** test: TestClassName                ← harness test class (PascalCase)
-# ** test: <snake_case_name>            ← standalone test function
 ```
 
 Inside harness test classes:
 
 ```
-# * attribute: <name>                   ← harness class configuration attrs
-# * fixture: <name>                     ← fixture overrides
-# * method: <name>                      ← custom test methods
+# * attribute: <name>                   ← artifact member: harness class configuration attrs
+# * fixture: <name>                     ← artifact member: fixture overrides
+# * method: <name>                      ← artifact member: custom test methods
 ```
 
 Repository integration tests use `# ** test_int: <name>`.

--- a/docs/collab/agents/skills/tiferet-code-testing/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-testing/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: tiferet-code-testing
+description: Apply Tiferet test harness conventions when writing or extending tests in a Tiferet-family repo. Covers MapperAssertions, AggregateTestBase, TransferObjectTestBase, DomainEventTestBase, ServiceEventTestBase, and conftest hook registration.
+---
+
+# Testing Harness Code Style – Tiferet
+
+## When to use
+- When adding or modifying tests for Aggregates, TransferObjects (ConfigObjects), or DomainEvents.
+- When migrating standalone tests to the shared harnesses in `tiferet.testing`.
+- When adding `conftest.py` hook registrations for mapper or event test parametrization.
+- Pair with the relevant component skill (`tiferet-code-events`, `tiferet-code-mappers`, etc.) for the production artifact conventions.
+
+## Artifact comment structure
+
+Harness-based test modules follow standard artifact comments:
+
+```
+# *** imports
+# ** core / # ** infra / # ** app
+
+# *** constants                         ← shared sample data and normalizers
+# ** constant: <snake_case_name>
+
+# *** fixtures                          ← module-level pytest fixtures
+# ** fixture: <snake_case_name>
+
+# *** tests                             ← test classes or standalone tests
+# ** test: TestClassName                ← harness test class (PascalCase)
+# ** test: <snake_case_name>            ← standalone test function
+```
+
+Inside harness test classes:
+
+```
+# * attribute: <name>                   ← harness class configuration attrs
+# * fixture: <name>                     ← fixture overrides
+# * method: <name>                      ← custom test methods
+```
+
+Repository integration tests use `# ** test_int: <name>`.
+
+## Key conventions
+
+**Mapper harnesses** (`tiferet.testing`):
+- `MapperAssertions` — shared comparison helpers.
+- `AggregateTestBase` — required attrs: `aggregate_cls`, `sample_data`, `equality_fields`, `set_attribute_params`; optional `field_normalizers`.
+- `TransferObjectTestBase` — required attrs: `transfer_cls`, `aggregate_cls`, `sample_data`, `aggregate_sample_data`, `equality_fields`; optional `field_normalizers`, `map_kwargs`.
+- Put reusable dicts and normalizer functions under `# *** constants`.
+- For nested collections, define normalizer functions that accept dicts or domain objects and return comparable tuples.
+
+**Event harnesses** (`tiferet.testing`):
+- `DomainEventTestBase` — required attrs: `event_cls`, `dependencies`, `sample_kwargs`, `required_params`.
+- `ServiceEventTestBase` — adds `service_attr`, `not_found_error_code`, `not_found_kwargs`.
+- Override `mock_dependencies` as a `# * fixture:` when service mocks need preconfigured behavior.
+- Use `self.handle(mock_dependencies, **overrides)` to invoke `DomainEvent.handle`.
+
+**Hook registration** in `conftest.py`:
+- `register_mapper_hooks(metafunc)` — parametrizes `AggregateTestBase.test_set_attribute`.
+- `register_event_hooks(metafunc)` — parametrizes `DomainEventTestBase.test_missing_required_params`.
+
+**General:**
+- Tests use `pytest`.
+- Keep docstrings RST-style and keep one blank line after docstrings.
+- Use mocks for event/unit tests; use real temp files (`tmp_path`) for repository integration tests.
+
+## Example
+
+```python
+"""Tiferet Error Mapper Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from tiferet.events import a
+from tiferet.mappers.error import ErrorAggregate, ErrorConfigObject
+from tiferet.testing import AggregateTestBase, TransferObjectTestBase
+
+# *** constants
+
+# ** constant: error_sample_data
+ERROR_SAMPLE_DATA = {
+    'id': 'TEST_ERROR',
+    'name': 'Test Error',
+    'error_code': 'TEST_ERROR',
+    'message': [{'lang': 'en_US', 'text': 'Test error message.'}],
+}
+
+# ** constant: equality_fields
+EQUALITY_FIELDS = ['id', 'name', 'error_code']
+
+# ** constant: message_tuple
+def MESSAGE_TUPLE(message):
+    '''
+    Normalize an error message dict or domain object into a comparable tuple.
+
+    :param message: The message dict or domain object.
+    :type message: dict | object
+    :return: A comparable message tuple.
+    :rtype: tuple
+    '''
+
+    # Normalize dict input.
+    if isinstance(message, dict):
+        return (message['lang'], message['text'])
+
+    # Normalize domain object input.
+    return (message.lang, message.text)
+
+# ** constant: field_normalizers
+FIELD_NORMALIZERS = {
+    'message': lambda messages: tuple(
+        sorted(MESSAGE_TUPLE(m) for m in (messages or []))
+    ),
+}
+
+# *** tests
+
+# ** test: TestErrorAggregate
+class TestErrorAggregate(AggregateTestBase):
+    '''
+    Tests for ErrorAggregate using the mapper harness.
+    '''
+
+    # * attribute: aggregate_cls
+    aggregate_cls = ErrorAggregate
+
+    # * attribute: sample_data
+    sample_data = ERROR_SAMPLE_DATA
+
+    # * attribute: equality_fields
+    equality_fields = EQUALITY_FIELDS
+
+    # * attribute: field_normalizers
+    field_normalizers = FIELD_NORMALIZERS
+
+    # * attribute: set_attribute_params
+    set_attribute_params = [
+        ('name', 'Updated Error', None),
+        ('invalid_attribute', 'value', a.const.INVALID_MODEL_ATTRIBUTE_ID),
+    ]
+
+    # * method: test_rename
+    def test_rename(self, aggregate):
+        '''
+        Test the domain-specific rename mutation.
+
+        :param aggregate: The harness-created ErrorAggregate fixture.
+        :type aggregate: ErrorAggregate
+        '''
+
+        # Rename the aggregate.
+        aggregate.rename('Renamed Error')
+
+        # Assert the mutation was applied.
+        assert aggregate.name == 'Renamed Error'
+
+
+# ** test: TestErrorConfigObject
+class TestErrorConfigObject(TransferObjectTestBase):
+    '''
+    Tests for ErrorConfigObject using the transfer object harness.
+    '''
+
+    # * attribute: transfer_cls
+    transfer_cls = ErrorConfigObject
+
+    # * attribute: aggregate_cls
+    aggregate_cls = ErrorAggregate
+
+    # * attribute: sample_data
+    sample_data = ERROR_SAMPLE_DATA
+
+    # * attribute: aggregate_sample_data
+    aggregate_sample_data = ERROR_SAMPLE_DATA
+
+    # * attribute: equality_fields
+    equality_fields = EQUALITY_FIELDS
+
+    # * attribute: field_normalizers
+    field_normalizers = FIELD_NORMALIZERS
+```
+
+`conftest.py` hook registration:
+
+```python
+# *** imports
+
+# ** app
+from tiferet.testing import register_mapper_hooks, register_event_hooks
+
+# *** functions
+
+# ** function: pytest_generate_tests
+def pytest_generate_tests(metafunc):
+    '''
+    Register Tiferet harness parametrization hooks.
+
+    :param metafunc: The pytest metafunc object.
+    :type metafunc: object
+    '''
+
+    # Register mapper harness parametrization.
+    register_mapper_hooks(metafunc)
+
+    # Register domain event harness parametrization.
+    register_event_hooks(metafunc)
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/testing.md

--- a/docs/collab/agents/skills/tiferet-code-utils/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-utils/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: tiferet-code-utils
+description: Apply utility conventions when adding or modifying infrastructure utilities in a Tiferet-family repo. Covers the FileLoader base, context manager protocol, static one-shot helpers, exported aliases, and computational vs physical infrastructure.
+---
+
+# Utilities Code Style – Tiferet
+
+## When to use
+- When adding a new utility class or modifying an existing one in `tiferet/utils/`.
+- When implementing physical infrastructure (file I/O, database, network) or computational infrastructure (algorithms, ML inference, transformations) behind a Service contract.
+- When extending `FileLoader` for a new file format (e.g. TOML, XML).
+
+## Artifact comment structure
+
+```
+# *** utils                             ← top-level
+# ** util: <snake_case_name>            ← individual utility class
+# * attribute: <name>                   ← instance attributes
+# * init                                ← constructor
+# * method: <name>                      ← instance methods
+# * method: <name> (static)             ← static one-shot helpers
+```
+
+## Key conventions
+
+- Utilities implement a **Service** contract from `tiferet/interfaces/` (e.g. `FileLoader` implements `FileService`, `SqliteClient` implements `SqliteService`).
+- Use `RaiseError.execute(error_code, ...)` from `tiferet/events/static.py` for all error paths — never raise raw exceptions from utilities.
+- **Resource-owning utilities** implement the context manager protocol: `__enter__` (open/connect) and `__exit__` (close/disconnect; commit or rollback on error).
+- **Static one-shot helpers** on utilities (e.g. `CsvLoader.load_rows(path)`) provide a convenience API that opens, reads, closes in a single call.
+- Export from `tiferet/utils/__init__.py` with both the full class name and a short alias (e.g. `FileLoader` / `File`, `YamlLoader` / `Yaml`).
+- Stateless computational utilities (algorithms, inference) do NOT need context managers.
+
+**Current utility aliases:**
+
+| Full name | Alias | Service |
+|---|---|---|
+| `FileLoader` | `File` | `FileService` |
+| `YamlLoader` | `Yaml` | (via `FileLoader`) |
+| `JsonLoader` | `Json` | (via `FileLoader`) |
+| `CsvLoader` | `Csv` | (via `FileLoader`) |
+| `CsvDictLoader` | `CsvDict` | (via `FileLoader`) |
+| `SqliteClient` | `Sqlite` | `SqliteService`, `FileService` |
+
+## Example
+
+```python
+# *** imports
+
+# ** core
+import tomllib
+from pathlib import Path
+
+# ** app
+from .file import FileLoader
+from ..events.static import RaiseError
+from .. import assets as a
+
+# *** utils
+
+# ** util: toml_loader
+class TomlLoader(FileLoader):
+    '''
+    Utility for loading TOML configuration files.
+
+    Implements FileService via FileLoader. Context manager opens the
+    file stream; load() parses and transforms the content.
+    '''
+
+    # * init
+    def __init__(self, path, mode: str = 'rb', **kwargs):
+        '''
+        Initialize the TOML loader.
+
+        :param path: Path to the TOML file.
+        :type path: str | Path
+        :param mode: File open mode (default 'rb' for TOML).
+        :type mode: str
+        :param kwargs: Additional kwargs forwarded to FileLoader.
+        :type kwargs: dict
+        '''
+
+        # Initialize the file loader base.
+        super().__init__(path=path, mode=mode, **kwargs)
+
+    # * method: load
+    def load(self,
+            start_node=lambda x: x,
+            data_factory=lambda x: x):
+        '''
+        Load and parse the TOML file content.
+
+        :param start_node: Function to navigate to a sub-node of the parsed data.
+        :type start_node: Callable
+        :param data_factory: Function to transform the navigated data.
+        :type data_factory: Callable
+        :return: The loaded and transformed data.
+        :rtype: Any
+        '''
+
+        # Open, parse, transform, and return the TOML data.
+        with self:
+            try:
+                data = tomllib.load(self.file)
+            except tomllib.TOMLDecodeError as e:
+                RaiseError.execute(
+                    error_code=a.const.INVALID_TOML_FILE_ID,
+                    message=str(e),
+                    path=str(self.path),
+                )
+
+        # Apply the start_node navigation and data_factory transform.
+        return data_factory(start_node(data))
+
+    # * method: load_toml (static)
+    @staticmethod
+    def load_toml(path, start_node=lambda x: x, data_factory=lambda x: x):
+        '''
+        One-shot static helper: open, parse, close, and return.
+
+        :param path: Path to the TOML file.
+        :type path: str | Path
+        :param start_node: Sub-node navigation function.
+        :type start_node: Callable
+        :param data_factory: Data transformation function.
+        :type data_factory: Callable
+        :return: The loaded and transformed data.
+        :rtype: Any
+        '''
+
+        # Delegate to an instance with managed lifecycle.
+        return TomlLoader(path).load(start_node=start_node, data_factory=data_factory)
+```
+
+## Canonical source
+https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md

--- a/docs/collab/agents/skills/tiferet-code-utils/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-utils/SKILL.md
@@ -12,18 +12,30 @@ description: Apply utility conventions when adding or modifying infrastructure u
 
 ## Artifact comment structure
 
+Module skeleton (any module):
 ```
-# *** utils                             ← top-level
-# ** util: <snake_case_name>            ← individual utility class
-# * attribute: <name>                   ← instance attributes
-# * init                                ← constructor
-# * method: <name>                      ← instance methods
-# * method: <name> (static)             ← static one-shot helpers
+# *** imports
+# *** constants          ← optional
+# *** functions          ← optional; side-effect-free module helpers
+# *** classes            ← base classes only (core.py modules)
+# *** utils              ← construct group for this skill
+# *** exports            ← __init__.py only
+```
+
+Util-specific labels:
+```
+# *** utils                             ← artifact section
+# ** util: <snake_case_name>            ← artifact
+# * attribute: <name>                   ← artifact member: instance attributes
+# * init                                ← artifact member: constructor
+# * method: <name>                      ← artifact member: instance methods
+# * method: <name> (static)             ← artifact member: static one-shot helpers
 ```
 
 ## Key conventions
 
-- Utilities implement a **Service** contract from `tiferet/interfaces/` (e.g. `FileLoader` implements `FileService`, `SqliteClient` implements `SqliteService`).
+- **Layer boundary — valid `# ** app` imports:** `interfaces` (to implement a Service contract), `events` (`RaiseError`, `a`). Never import from `domain`, `mappers`, `repos`, `di`, `contexts`, or `blueprints`.
+- Implementing a **Service** contract from `tiferet/interfaces/` is **optional** — required only when the utility needs to be DI-injectable (resolved from the container). Utilities called statically or directly do not need a Service interface.
 - Use `RaiseError.execute(error_code, ...)` from `tiferet/events/static.py` for all error paths — never raise raw exceptions from utilities.
 - **Resource-owning utilities** implement the context manager protocol: `__enter__` (open/connect) and `__exit__` (close/disconnect; commit or rollback on error).
 - **Static one-shot helpers** on utilities (e.g. `CsvLoader.load_rows(path)`) provide a convenience API that opens, reads, closes in a single call.
@@ -32,14 +44,18 @@ description: Apply utility conventions when adding or modifying infrastructure u
 
 **Current utility aliases:**
 
-| Full name | Alias | Service |
+| Full name | Alias | Service contract |
 |---|---|---|
 | `FileLoader` | `File` | `FileService` |
 | `YamlLoader` | `Yaml` | (via `FileLoader`) |
 | `JsonLoader` | `Json` | (via `FileLoader`) |
+| `TomlLoader` | `Toml` | (via `FileLoader`) |
 | `CsvLoader` | `Csv` | (via `FileLoader`) |
 | `CsvDictLoader` | `CsvDict` | (via `FileLoader`) |
 | `SqliteClient` | `Sqlite` | `SqliteService`, `FileService` |
+| `LoggingMiddleware` | — | `MiddlewareService` |
+| `TimingMiddleware` | — | `MiddlewareService` |
+| `CacheMiddleware` | — | `MiddlewareService` |
 
 ## Example
 


### PR DESCRIPTION
## Problem

`main` had no first-class skills for implementation work. The six existing skills cover collaboration workflows (TRDs, milestones, PRs, reports) but leave implementation agents without offline-capable, self-contained guidance on Tiferet's code style. The only reference was a set of `blob/main` URLs in TRDs — usable when online, but not embedded in any agent-discoverable artifact.

## Changes

### Design decision: self-contained distillations, not URL wrappers

Each skill embeds the key artifact comment labels, spacing rules, naming conventions, and a minimal working example directly in the `SKILL.md` file. An implementation agent can apply the conventions without fetching any external URL. The `## Canonical source` section at the end of each skill provides the full `docs/core/<file>.md` URL as a fallback for deeper reference.

### 12 new skills under `docs/collab/agents/skills/`

| Skill | What it covers |
|---|---|
| `tiferet-code-style` | Foundational artifact comment hierarchy, spacing, docstrings, annotation artifacts — read at the start of every session |
| `tiferet-code-domain` | `DomainObject` base, Pydantic field declarations, `@model_validator` derivation, read-only design |
| `tiferet-code-events` | Per-module base events, `@parameters_required` decorator, `verify`/`raise_error` pattern |
| `tiferet-code-mappers` | `Aggregate` (mutation) and `TransferObject`/`ConfigObject` (`_ROLES`, `map`, `from_model`) with naming conventions |
| `tiferet-code-interfaces` | `Service` ABC, `@abstractmethod`, `MiddlewareService` contract |
| `tiferet-code-repos` | `ConfigurationRepository` base, `<domain>_config` constructor convention, read/write/delete patterns |
| `tiferet-code-contexts` | `BaseContext` registry, `AppSessionContext` hub, `domain_type`, `from_domain` construction |
| `tiferet-code-assets` | Five permitted artifact kinds, `SCREAMING_SNAKE_CASE` constants, factory functions, exports pattern |
| `tiferet-code-blueprints` | `build_app` composition chain, thin entrypoint design, `# *** functions` vs `# *** blueprints` split |
| `tiferet-code-utils` | `FileLoader` base, context manager protocol, static one-shot helpers, exported aliases |
| `tiferet-code-di` | Event-free/asset-free constraint, `injectable_parameter_names`, Factory vs Singleton scope |
| `tiferet-code-testing` | `AggregateTestBase`, `TransferObjectTestBase`, `DomainEventTestBase`, `ServiceEventTestBase`, conftest hooks |

All content targets v2.0.0. All GitHub links target `main`. Naming uses corrected v2.0.0 vocabulary throughout (`AppSession`, `AppSessionContext`, `*ConfigObject`, `ServiceRegistration`, `EventFeatureStep`).

### README restructured

`docs/collab/agents/skills/README.md` — "Skills in this folder" replaced with two sections: **Collaboration skills** (the existing six) and **Code style skills** (the new twelve, with a trigger-condition table). The verify section updated to reflect the full set.

## What was intentionally left unchanged

- The six existing collaboration skills are not touched.
- `AGENTS.md`, `CONTRIBUTING.md`, and `tiferet-author-trd` wiring of these skills into the TRD workflow are deferred to Phase 3.

---

_Generated with [Oz](https://app.warp.dev/conversation/1bbc97c1-7289-41a4-9416-262b6747a3e5)_

Co-Authored-By: Oz <oz-agent@warp.dev>