### PR TITLE
Docs/Collab – Integrate tiferet-code-* skills into TRD workflow and onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,30 @@ grep -rn "# ++\|# --" tiferet/
 
 Full grammar and resolution expectations: [`docs/core/code_style.md § Annotation Artifacts`](docs/core/code_style.md).
 
+### Code Style Skills
+
+The `tiferet-code-*` skill suite provides self-contained, offline-capable style guidance for each component layer. Skills embed key conventions and a working example — no external URLs required. Install them from `docs/collab/agents/skills/` (see that folder's README for activation instructions).
+
+**Read `tiferet-code-style` at the start of every implementation session** (same standing as `tiferet-annotation-artifacts`). **Read `tiferet-code-architecture` before any multi-component implementation.**
+
+| Skill | When to use |
+|---|---|
+| **`tiferet-code-architecture`** | Any multi-component task — layer graph, import rules, runtime flow |
+| **`tiferet-code-style`** | Every implementation session — read first |
+| **`tiferet-code-domain`** | Adding or modifying domain objects |
+| **`tiferet-code-events`** | Adding or modifying domain events |
+| **`tiferet-code-mappers`** | Adding or modifying aggregates or transfer objects |
+| **`tiferet-code-interfaces`** | Adding or modifying service interfaces |
+| **`tiferet-code-contexts`** | Adding or modifying contexts |
+| **`tiferet-code-repos`** | Adding or modifying repositories |
+| **`tiferet-code-assets`** | Adding or modifying assets constants, errors, or exceptions |
+| **`tiferet-code-blueprints`** | Adding or modifying blueprints |
+| **`tiferet-code-utils`** | Adding or modifying utilities |
+| **`tiferet-code-di`** | Adding or modifying DI layer classes or functions |
+| **`tiferet-code-testing`** | Writing or extending tests using the harness |
+
+**Fallback rule:** if a skill is not installed, read `docs/core/<component>.md` directly — the full-detail guides are the canonical source of truth.
+
 ## Domain Events
 
 Domain events are the primary operational units. Key patterns:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,15 +48,8 @@ Key points:
 
 ### Implement
 
-- Follow the [Structured Code Style](docs/core/code_style.md) — artifact comments, spacing rules, RST docstrings, and snippet conventions are enforced across the codebase.
-- Consult the component-specific guides in `docs/core/` for the layers you're working in:
-  - [domain.md](docs/core/domain.md) — Domain objects
-  - [events.md](docs/core/events.md) — Domain events
-  - [mappers.md](docs/core/mappers.md) — Aggregates and transfer objects
-  - [interfaces.md](docs/core/interfaces.md) — Service interfaces
-  - [contexts.md](docs/core/contexts.md) — Application contexts
-  - [repos.md](docs/core/repos.md) — Repositories
-  - [utils.md](docs/core/utils.md) — Utilities
+- Read **`tiferet-code-style`** before writing any code — artifact comments, spacing rules, RST docstrings, and snippet conventions are enforced across the codebase. If the skill is not installed, use [docs/core/code_style.md](docs/core/code_style.md) directly.
+- Read the **`tiferet-code-<component>`** skill for each layer you’re modifying (see the Code Style Skills list in **Working with AI Agents** above). If the skill is not installed, use the corresponding `docs/core/<component>.md` guide directly.
 - Write tests using `pytest`.
 
 ### Commit Hygiene
@@ -89,7 +82,9 @@ See the full report format guide:
 
 ## Working with AI Agents
 
-Warp/AI agents contributing to Tiferet follow the same conventions described above and in the [`docs/collab/`](docs/collab/) stream guides. The most common workflows are also packaged as reusable agent **skills** so they're applied consistently across all Tiferet-family repositories:
+Warp/AI agents contributing to Tiferet follow the same conventions described above and in the [`docs/collab/`](docs/collab/) stream guides. All common workflows and code style conventions are packaged as reusable agent **skills** so they're applied consistently across all Tiferet-family repositories.
+
+**Collaboration skills** handle process workflows:
 
 - **`tiferet-create-milestone`** — create or format a GitHub milestone (title and description conventions).
 - **`tiferet-author-trd`** — author a TRD in the standard structure ([tech_requirements.md](docs/collab/tech_requirements.md)).
@@ -97,9 +92,25 @@ Warp/AI agents contributing to Tiferet follow the same conventions described abo
 - **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop ([main.md](docs/collab/main.md)).
 - **`tiferet-pr-code-review`** — review a PR by comparing its feature branch against a prototype source of truth and posting only actionable comments ([code_review.md](docs/collab/code_review.md)).
 
+**Code style skills** (`tiferet-code-*`) handle implementation conventions — read `tiferet-code-style` at the start of every implementation session, then the component skill(s) for what you’re modifying:
+
+- **`tiferet-code-architecture`** — layer graph, import rules, runtime flow; read for any multi-component task.
+- **`tiferet-code-style`** — artifact comment hierarchy, spacing, docstrings, annotation artifacts; read every session.
+- **`tiferet-code-domain`** — domain object conventions ([domain.md](docs/core/domain.md)).
+- **`tiferet-code-events`** — domain event conventions ([events.md](docs/core/events.md)).
+- **`tiferet-code-mappers`** — aggregate and transfer object conventions ([mappers.md](docs/core/mappers.md)).
+- **`tiferet-code-interfaces`** — service interface conventions ([interfaces.md](docs/core/interfaces.md)).
+- **`tiferet-code-contexts`** — context conventions ([contexts.md](docs/core/contexts.md)).
+- **`tiferet-code-repos`** — repository conventions ([repos.md](docs/core/repos.md)).
+- **`tiferet-code-assets`** — assets constants, errors, and exceptions ([assets.md](docs/core/assets.md)).
+- **`tiferet-code-blueprints`** — blueprint orchestration conventions ([blueprints.md](docs/core/blueprints.md)).
+- **`tiferet-code-utils`** — utility and infrastructure conventions ([utils.md](docs/core/utils.md)).
+- **`tiferet-code-di`** — DI layer conventions ([di.md](docs/core/di.md)).
+- **`tiferet-code-testing`** — test harness conventions ([testing.md](docs/core/testing.md)).
+
 A ready-to-apply **global agent rule** is preserved at [docs/collab/agent_rule.md](docs/collab/agent_rule.md) — copy it into your agent's global/user rules to apply these standards across every Tiferet repo.
 
-These skills and any AI rules treat `docs/collab/` and the [code style guides](docs/core/) as the **single source of truth** — they reference these documents rather than copying them, so the docs stay authoritative. The skills' canonical copies live in [docs/collab/agents/skills/](docs/collab/agents/skills/); follow that folder's README to copy them into `~/.agents/skills/` (global) or a repo's `.agents/skills/` (project) so your agent auto-discovers them.
+Skills and AI rules treat `docs/collab/` and the [code style guides](docs/core/) as the **single source of truth** — they reference these documents rather than copying them. The skills' canonical copies live in [docs/collab/agents/skills/](docs/collab/agents/skills/); follow that folder's README to copy them into `~/.agents/skills/` (global) or a repo's `.agents/skills/` (project) so your agent auto-discovers them.
 
 ## Code Style
 

--- a/docs/collab/agent_rule.md
+++ b/docs/collab/agent_rule.md
@@ -19,14 +19,23 @@ Applies to all Tiferet-family repositories (greatstrength/tiferet, and any tifer
 
 Source of truth (read when relevant): start at CONTRIBUTING.md, which indexes docs/collab/ (stream guides) and docs/core/ (code style). Inside the tiferet repo use those local paths; from any other repo use the GitHub URLs under https://github.com/greatstrength/tiferet/blob/main/.
 
-For these workflows, use the matching skill (each carries the detailed conventions): tiferet-create-milestone (GitHub milestones), tiferet-author-trd (TRDs), tiferet-collab-report (completion reports), tiferet-milestone-session (per-issue release loop), tiferet-pr-code-review (PR review against a source of truth).
+Navigation by task type:
+- Implementation work: orient with AGENTS.md (architecture, key concepts, code style) → read tiferet-code-style (mandatory every implementation session) → read the component skill(s) matching what you are modifying.
+- Multi-component implementation: also read tiferet-code-architecture before writing code.
+- Collaboration/process work (milestones, TRDs, PRs, reports): orient with CONTRIBUTING.md → Working with AI Agents → use the matching collaboration skill.
+
+For collaboration workflows, use the matching skill: tiferet-create-milestone (GitHub milestones), tiferet-author-trd (TRDs), tiferet-collab-report (completion reports), tiferet-milestone-session (per-issue release loop), tiferet-pr-code-review (PR review against a source of truth).
+
+For implementation sessions, read tiferet-code-style first, then the component skill(s) for what you are modifying: tiferet-code-domain (domain objects), tiferet-code-events (domain events), tiferet-code-mappers (aggregates/transfer objects), tiferet-code-interfaces (service interfaces), tiferet-code-contexts (contexts), tiferet-code-repos (repositories), tiferet-code-assets (constants/errors), tiferet-code-blueprints (blueprints), tiferet-code-utils (utilities), tiferet-code-di (DI layer), tiferet-code-testing (test harness). If a skill is not installed, read docs/core/<component>.md directly.
 
 Always: tie work to a GitHub issue; write a TRD before non-trivial changes; follow the structured code style (artifact comments, RST docstrings, spacing); keep functional vs docs/config commits separate; add a Co-Authored-By line when an AI agent collaborates; never commit or merge unless asked.
 ```
 
 ## Companion skills
 
-The workflows named in the rule are packaged as agent skills, with canonical copies kept in [agents/skills/](agents/skills/) (see that folder's README to activate them via `~/.agents/skills/` for global use, or a repo's `.agents/skills/` for one project):
+All skills have canonical copies in [agents/skills/](agents/skills/) (see that folder's README to activate them via `~/.agents/skills/` for global use, or a repo's `.agents/skills/` for one project).
+
+**Collaboration skills:**
 
 - `tiferet-create-milestone`
 - `tiferet-author-trd`
@@ -34,4 +43,20 @@ The workflows named in the rule are packaged as agent skills, with canonical cop
 - `tiferet-milestone-session`
 - `tiferet-pr-code-review`
 
-See the **Working with AI Agents** section of [CONTRIBUTING.md](../../CONTRIBUTING.md) for the overview.
+**Code style skills** (read `tiferet-code-style` every implementation session; read others as needed):
+
+- `tiferet-code-architecture` — layer graph, import rules, runtime flow
+- `tiferet-code-style` — artifact comments, spacing, docstrings (mandatory every session)
+- `tiferet-code-domain` — domain objects
+- `tiferet-code-events` — domain events
+- `tiferet-code-mappers` — aggregates and transfer objects
+- `tiferet-code-interfaces` — service interfaces
+- `tiferet-code-contexts` — contexts
+- `tiferet-code-repos` — repositories
+- `tiferet-code-assets` — constants, errors, exceptions
+- `tiferet-code-blueprints` — blueprints
+- `tiferet-code-utils` — utilities
+- `tiferet-code-di` — DI layer
+- `tiferet-code-testing` — test harness
+
+See the **Working with AI Agents** section of [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full overview.

--- a/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
@@ -50,7 +50,9 @@ Follow this exact structure (pure Markdown — headers, tables, code blocks):
 |------------|-------------|
 
 ## 8. Related Code Style Documentation
-- Always link code_style.md; add component guides only for components actually touched.
+- `tiferet-code-style` — required for every story.
+- `tiferet-code-<component>` — include only for components this story modifies (domain, events, mappers, interfaces, contexts, repos, assets, blueprints, utils, di, testing). For multi-component stories, also include `tiferet-code-architecture`.
+- **Fallback** (if skills not installed): link to `docs/core/<component>.md` directly.
 ```
 
 ## Key rules
@@ -60,7 +62,7 @@ Follow this exact structure (pure Markdown — headers, tables, code blocks):
   - **Main stream:** the milestone version. For a no-version domain-scoped parity milestone, use the milestone's descriptive name, e.g. `Core DDD Parity I — Domain Infrastructure (tracking milestone)`.
   - **RFP stream:** `Request for Prototype`.
   - **Doc stream:** the latest released version.
-- **Related Code Style Documentation** (section 8) is mandatory: always include `code_style.md`; include a component guide only when the story modifies that component. Link to `https://github.com/greatstrength/tiferet/blob/main/docs/core/<file>` — available guides: `code_style.md`, `domain.md`, `events.md`, `mappers.md`, `interfaces.md`, `contexts.md`, `repos.md`, `utils.md`.
+- **Related Code Style Documentation** (section 8) is mandatory: always include `tiferet-code-style`; include a `tiferet-code-<component>` skill for each component the story modifies. For multi-component stories, also include `tiferet-code-architecture`. If skills are not installed, fall back to repo-relative paths — available guides: `docs/core/code_style.md`, `docs/core/domain.md`, `docs/core/events.md`, `docs/core/mappers.md`, `docs/core/interfaces.md`, `docs/core/contexts.md`, `docs/core/repos.md`, `docs/core/assets.md`, `docs/core/blueprints.md`, `docs/core/utils.md`, `docs/core/di.md`, `docs/core/testing.md`.
 
 ## Artifact-based requirements
 Specify work as artifacts to **Add / Update / Remove** — modules, classes, `# * method:` / `# ** <component>:` labels / `# *** <section>` headers per the structured code style — not prose or "copy from X". In §3 give each module an artifact-action summary; in §4 enumerate the named artifacts, using a `From (current)` → `To (target)` delta table for renames/migrations with an Add/Update/Remove legend (factor the shared pattern once, list per-module exceptions). In §5 assert target artifacts exist and retired ones are gone. Make cross-layer prerequisites, artifact-label corrections, and behavioral shifts explicit.

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -433,14 +433,16 @@ These practices ensure Tiferet code remains consistent, maintainable, and AI-fri
 
 The Tiferet framework maintains a suite of focused documentation in `docs/core/` to guide consistent implementation across different component types. These documents complement the main **Structured Code Style** guidelines and provide domain-specific conventions.
 
-- **[assets.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md)** – Assets layer conventions (imports, constants, functions, standalone classes, exports).
-- **[blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md)** – Blueprint orchestration conventions.
-- **[contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md)** – Context conventions (high-level and low-level runtime shape).
-- **[di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md)** – Dependency injection layer conventions.
-- **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain object conventions (dual role, factory methods, read-only design).
-- **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event conventions (dependency injection, validation, test harness).
-- **[interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md)** – Service interface conventions.
-- **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.
-- **[repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md)** – Repository implementation conventions.
-- **[testing.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/testing.md)** – Testing harness conventions (AggregateTestBase, TransferObjectTestBase, DomainEventTestBase).
-- **[utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md)** – Utility and infrastructure conventions.
+For implementation agents, the **`tiferet-code-<component>` skills** (see `docs/collab/agents/skills/`) are the preferred access path — they embed key conventions and a working example offline. Each entry below lists the companion skill alongside the full doc as the authoritative fallback.
+
+- **`tiferet-code-assets`** / **[assets.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md)** – Assets layer conventions (imports, constants, functions, standalone classes, exports).
+- **`tiferet-code-blueprints`** / **[blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md)** – Blueprint orchestration conventions.
+- **`tiferet-code-contexts`** / **[contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md)** – Context conventions (high-level and low-level runtime shape).
+- **`tiferet-code-di`** / **[di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md)** – Dependency injection layer conventions.
+- **`tiferet-code-domain`** / **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain object conventions (dual role, factory methods, read-only design).
+- **`tiferet-code-events`** / **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event conventions (dependency injection, validation, test harness).
+- **`tiferet-code-interfaces`** / **[interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md)** – Service interface conventions.
+- **`tiferet-code-mappers`** / **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Aggregate and TransferObject conventions.
+- **`tiferet-code-repos`** / **[repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md)** – Repository implementation conventions.
+- **`tiferet-code-testing`** / **[testing.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/testing.md)** – Testing harness conventions (AggregateTestBase, TransferObjectTestBase, DomainEventTestBase).
+- **`tiferet-code-utils`** / **[utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md)** – Utility and infrastructure conventions.


### PR DESCRIPTION
## Problem

`main` had no onboarding path that connected the new `tiferet-code-*` skill suite (landed in #893) to the three entry points agents actually read: the TRD authoring skill, `AGENTS.md`, and `CONTRIBUTING.md`. The global agent rule (`docs/collab/agent_rule.md`) also only covered collaboration workflows and gave no direction for implementation sessions.

## Changes

### `AGENTS.md` — Code Style Skills subsection

Added a **Code Style Skills** subsection directly under the Structured Code Style section (after Annotation Artifacts). It contains the 13-skill table with trigger conditions, the mandates that `tiferet-code-style` is read every implementation session and `tiferet-code-architecture` before multi-component work, and the fallback rule pointing to `docs/core/<component>.md` when a skill is not installed.

### `CONTRIBUTING.md` — Working with AI Agents + Implement sections

- **Working with AI Agents**: restructured into two named groups — Collaboration skills (unchanged 5) and Code Style skills (13 new `tiferet-code-*` entries with doc links). The global-rule pointer and activation instructions are preserved.
- **Implement**: replaced the raw seven-item `docs/core/` link list with skill-first guidance (`tiferet-code-style` first, then component skills) and fallback paths for when skills are not installed.

### `docs/core/code_style.md` — Additional Linked Code Style Documents footer

Added a `tiferet-code-<component>` skill name alongside each of the 11 doc entries and a note at the top of the section that skills are the preferred access path for implementation agents, with the full doc as the authoritative fallback.

### `docs/collab/agents/skills/tiferet-author-trd/SKILL.md` — Section 8

- **Template block**: replaced the single-line placeholder with a three-bullet structure: `tiferet-code-style` always required, component skills conditionally (with `tiferet-code-architecture` for multi-component stories), and a fallback note for uninstalled skills.
- **Key rules**: updated the Section 8 rule to reference skills first and list all 12 fallback repo-relative paths (completing the set from the previous 8).

### `docs/collab/agent_rule.md` — Global agent rule

Extended the rule text with:
- A **Navigation by task type** block giving agents a concrete starting point based on whether they're doing implementation, multi-component implementation, or collaboration/process work.
- An **implementation sessions** paragraph listing all 11 component skills, the mandatory `tiferet-code-style` mandate, and the fallback rule.

The Companion skills section was split into Collaboration and Code Style skills lists.

## What was intentionally left unchanged

The collaboration skills (`tiferet-create-milestone`, `tiferet-author-trd`, `tiferet-collab-report`, `tiferet-milestone-session`, `tiferet-pr-code-review`) and their existing descriptions are preserved verbatim. The `docs/collab/` stream guides are not touched. The `tiferet-annotation-artifacts` skill's standing as a mandatory session-start read is preserved and referenced alongside `tiferet-code-style`.

Co-Authored-By: Oz <oz-agent@warp.dev>
