### PR TITLE
Docs – TRD lifecycle, super-TRD format, issue creation workflow, and status conventions

### DIFF
--- a/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
@@ -79,3 +79,65 @@ For parity/migration work sourced from a prototype branch, keep the dev-facing T
 Verify: all sections present, tables well-formed, code blocks carry a language hint, acceptance criteria are verifiable, and no placeholder text remains. Keep it to ~1-3 pages.
 
 The TRD also feeds the issue's project fields: Components Affected, Acceptance Criteria, and Prerequisites drive **Size**/**Estimate**, and the Prerequisites table drives **Priority** — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md).
+
+## Super-TRDs and file naming
+
+**When to use a super-TRD:** any story sized XL (8 pts) or above with a natural seam (by layer, concern, or parallelizability). If no seam exists, proceed as a single XL issue.
+
+**Sizing session:** before creating GitHub issues for a milestone, size all TRDs using [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md), identify XL/XXL candidates, split into super-TRDs, encode field values in filenames, then create issues.
+
+**Super-TRD parent structure:**
+- H1 prefix: `Super-TRD: <Story Title>`
+- Header addition: `**Type:** Super-TRD | N child TRDs`
+- §3 → "Child Stories" (table: TRD filename, Size, Est, Prereqs, sequencing note)
+- §4 → "Story Sequencing" (ASCII dependency diagram)
+- §5 → "Combined Acceptance Criteria" (union of all child ACs)
+- §6–8: standard NFR, Prerequisites, Related Code Style Documentation
+
+**Child TRD addition:** `**Parent:** \`<parent-filename>\` (Child N of M)` in the header.
+
+**Child priority rule:** a child that is a prerequisite for sibling children → P0; all other children → parent's priority.
+
+**Super-TRD closing:** parent issue closes when all child sub-issues close. Rename parent TRD file to `.complete.md` and close the parent GitHub issue.
+
+**TRD file naming (save to `.trd/`):**
+```
+Draft (no issue):           <kebab-title>__<Size>_<Est>_<Priority>.md
+Active (issue, milestone):  m<milestone>_<issue>_<kebab-title>[_N]__<Size>_<Est>_<Priority>.md
+Active (issue, no m/s):     <issue>_<kebab-title>__<Size>_<Est>_<Priority>.md
+Complete:                   [m<N>_]<issue>_<kebab-title>[_N]__<Size>_<Est>_<Priority>.complete.md
+```
+
+`m<N>_` and the issue number are acquired simultaneously — a TRD cannot be assigned to a milestone without an issue. `.complete.md` is the only explicit state marker.
+
+## Creating GitHub issues
+
+**`gh issue create --milestone` silently fails** for milestones with en-dashes. Use the REST API:
+```bash
+gh api repos/greatstrength/tiferet/issues \
+  -f title="<Story title>" \
+  -f body="$(cat .trd/<filename>.md)" \
+  -F milestone=<integer-number> \
+  --jq '{number, node_id, html_url}'
+```
+
+After creating the issue, rename the TRD file to insert the issue number and `m<N>_` prefix.
+
+**Set project fields** via two-step GraphQL (`gh project item-add` does not return item ID):
+```bash
+ITEM_ID=$(gh api graphql -f query="mutation { addProjectV2ItemById(input: {projectId: \"PVT_kwDOCKXjws4A7Y85\", contentId: \"<node-id>\"}) { item { id } } }" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"PVT_kwDOCKXjws4A7Y85\", itemId: \"$ITEM_ID\", fieldId: \"<field-id>\", value: {singleSelectOptionId: \"<option-id>\"} }) { projectV2Item { id } } }"
+```
+Set **Status=Ready** for all new issues. See [tech_requirements.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/tech_requirements.md) for stable project field IDs.
+
+**Wire blocked-by** (requires `gh` v2.94.0+):
+```bash
+gh issue edit <blocked> --add-blocked-by <blocker> --repo greatstrength/tiferet
+# Multiple blockers: --add-blocked-by 905,906,907
+```
+
+**Link super-TRD sub-issues:**
+```bash
+CHILD_ID=$(gh api repos/greatstrength/tiferet/issues/<child> --jq '.id')
+gh api repos/greatstrength/tiferet/issues/<parent>/sub_issues -X POST -F sub_issue_id=$CHILD_ID
+```

--- a/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-milestone-session/SKILL.md
@@ -13,21 +13,30 @@ Canonical sources of truth:
 - https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md (Status Workflow, Priority/Size/Estimate fields, Start/End dates)
 
 ## Project status states (project #2)
-`Backlog → Ready → In Progress → In Review → Done`. Move each issue's status as it progresses.
+`Ready → In Progress → In Review → Done`. All new issues start at **Ready** — do not use Backlog. Blocked-by relationships communicate dependency ordering; Status does not reflect blocked state.
 
-At triage (Backlog → Ready) set the **Priority**, **Size**, and **Estimate** fields; set the **Start date** when work begins (In Progress) and the **End date** when the issue is Done — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md).
+Set **Priority**, **Size**, and **Estimate** at issue creation; set the **Start date** when work begins (In Progress) and the **End date** when the issue is Done — see [project_fields.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/project_fields.md).
+
+## Before starting: confirm issue setup
+
+Before beginning implementation, verify that all issues in the milestone:
+- Exist on GitHub with Status=Ready, Priority, Size, Estimate, and milestone set.
+- Have blocked-by relationships wired (`gh issue edit <n> --add-blocked-by <blocker>`).
+- Super-TRD children are linked to their parent via the sub_issues API.
+
+If any issues still need to be created or wired, follow the GitHub Issue Creation workflow in [tech_requirements.md](https://github.com/greatstrength/tiferet/blob/main/docs/collab/tech_requirements.md) before starting the per-issue loop.
 
 ## Per-issue loop
 For each issue in the milestone, in dependency-aware order:
 1. **Create a feature branch** from `main`: `<issue-number>-<lowercase-hyphenated-title>`.
 2. **Link** the branch to the issue, set the project status to **In Progress**, and set the **Start date**.
-3. **Implement and test** following the structured code style; write/port tests with `pytest`.
+3. **Read code-style skills, then implement and test.** Before writing any code, read `tiferet-code-style` (mandatory every session) and the `tiferet-code-<component>` skill(s) for the layers this issue touches; for multi-component issues, also read `tiferet-code-architecture`. Then implement following the structured code style; write/port tests with `pytest`.
 4. **Open a PR** targeting `main`, set status to **In Review**, and return the PR URL to the user.
 5. **If PR comments arrive:** set status back to **In Progress**, address the feedback, re-push, then set back to **In Review**.
 6. The **user squash-merges** the PR.
 7. **Post a Collaboration Report** as a comment on the issue (use the `tiferet-collab-report` skill).
 8. **Local cleanup:** check out `main`, pull latest, confirm the merge landed, delete the local feature branch.
-9. **Mark Done:** set the project status to **Done**, set the **End date**, **close the issue**, then repeat for the next one.
+9. **Mark Done:** set the project status to **Done**, set the **End date**, and close the issue. If the project has a `.trd/` folder containing a file matching `[m<N>_]<issue>_*.md`, rename it to `[m<N>_]<issue>_*.complete.md`. For child TRDs of a super-TRD parent: if all sibling children are now `.complete.md`, also rename the parent's TRD file and close the parent GitHub issue. Then repeat for the next issue.
 
 ## Guardrails
 - Never commit or merge unless the user asks — branch/PR work is yours; merging is the user's.

--- a/docs/collab/project_fields.md
+++ b/docs/collab/project_fields.md
@@ -11,7 +11,7 @@ This document defines the canonical GitHub Project field set used across all Tif
 
 ### Triage fields (set at triage / during the workflow)
 
-- **Status** — workflow state: Backlog → Ready → In progress → In review → Done (see [main.md](main.md)).
+- **Status** — workflow state: Ready → In progress → In review → Done (see [main.md](main.md)). All new issues start at **Ready**; use blocked-by relationships for dependency ordering rather than Backlog.
 - **Priority** — `P0`/`P1`/`P2`; sequence and criticality.
 - **Size** — `XS`–`XL`; fast t-shirt judgment.
 - **Estimate** — numeric story points on a Fibonacci scale; the additive rollup/velocity metric. Kept under GitHub's built-in **Estimate** field name (it stores the point value).
@@ -29,13 +29,12 @@ Milestone, Labels, Repository, Linked pull requests, Assignees, Reviewers, Creat
 
 Status tracks each issue through its lifecycle. Transitions are driven by branch, PR, and merge events and mirror the Per-Issue Workflow in [main.md](main.md):
 
-1. **Backlog** — issue created, not yet scheduled.
-2. **Ready** — triaged and ready to pick up. Assign **Priority**, **Size**, and **Estimate** (see below) before promoting to Ready.
-3. **In progress** — work has started / the feature branch is cut. Set the **Start date**.
-4. **In review** — the PR is opened (targeting `main`). If review comments arrive, move back to **In progress**, address them, then return to **In review**.
-5. **Done** — the PR is merged. Set the **End date** and **close the issue**.
+1. **Ready** — issue created and ready to implement. Set **Priority**, **Size**, and **Estimate** at creation.
+2. **In progress** — work has started / the feature branch is cut. Set the **Start date**.
+3. **In review** — the PR is opened (targeting `main`). If review comments arrive, move back to **In progress**, address them, then return to **In review**.
+4. **Done** — the PR is merged. Set the **End date** and **close the issue**.
 
-In short: starting an issue → **In progress**; PR opened → **In review**; PR merged → **Done** + issue closed. Triage (Backlog → Ready) is where the Priority/Size/Estimate fields below are assigned.
+In short: all new issues start at **Ready**; starting an issue → **In progress**; PR opened → **In review**; PR merged → **Done** + issue closed. **Backlog** is available but not used for new issues — blocked-by relationships communicate dependency ordering without reflecting it in Status.
 
 ## Priority
 

--- a/docs/collab/tech_requirements.md
+++ b/docs/collab/tech_requirements.md
@@ -89,6 +89,37 @@ When a story moves work toward a prototype or other source branch (e.g., a parit
 - Record not-yet-satisfied cross-layer dependencies in **Prerequisites (§7)** with their current status in `main`.
 - The prototype/source-of-truth branch is reserved for the **review/reconciliation** step, handled separately by the [`tiferet-pr-code-review`](agents/skills/tiferet-pr-code-review/SKILL.md) skill — not the authoring or implementation step.
 
+## Super-TRD Format
+
+A **super-TRD** is required when a story is sized XL (8 points) or above and has a natural decomposition seam (by layer, concern, or parallelizability). If no seam exists, proceed as a single XL issue with clear acceptance criteria.
+
+**Sizing session:** Before creating GitHub issues for a milestone, run a sizing pass on all TRDs using the rubric in [project_fields.md](project_fields.md). Identify XL/XXL candidates and split them into super-TRDs. Encode field values in filenames before beginning issue creation.
+
+### Super-TRD document structure
+
+The super-TRD parent is both a local planning artifact and a GitHub issue (children are linked as GitHub sub-issues). Use the following structure:
+
+- **H1 prefix:** `Super-TRD: <Story Title>`
+- **Header addition:** `**Type:** Super-TRD | N child TRDs`
+- **§3 — Child Stories:** replaces Components Affected — a table with TRD filename, Size, Estimate, Prerequisites, and sequencing note.
+- **§4 — Story Sequencing:** replaces Detailed Requirements — an ASCII dependency diagram.
+- **§5 — Combined Acceptance Criteria:** union of all child ACs.
+- **§6–8:** standard Non-Functional Requirements, Prerequisites, Related Code Style Documentation.
+
+### Child TRD structure
+
+Each child TRD is a standard 8-section TRD with one header addition:
+
+- `**Parent:** \`<parent-filename>\` (Child N of M)`
+
+### Child priority rule
+
+A child that is a prerequisite for one or more sibling children carries **P0**. All other children carry the parent story's priority.
+
+### Super-TRD closing
+
+The parent issue closes when all child sub-issues are closed. When the last child's issue is closed, also rename the parent's TRD file to `.complete.md` and close the parent GitHub issue.
+
 ## Review Checklist
 Before finalizing:
 - [ ] All sections present.
@@ -103,22 +134,174 @@ These instructions ensure all TRDs remain uniform, readable, and actionable acro
 
 ## Related Code Style Documentation
 
-Every TRD must include a **"Related Code Style Documentation"** section at the end. This section provides targeted links to component-specific style guides based on the primary artifacts being modified in the story.
+Every TRD must include a **"Related Code Style Documentation"** section (§8) listing the code-style skills the implementation agent must read before starting work.
 
 **Rule for inclusion:**
-- Always include the general `code_style.md`.
-- Include a component-specific guide **only if the story directly adds, modifies, or refactors code in that component type**.
-- Do not include unrelated guides to avoid clutter.
+- `tiferet-code-style` — always required for every story.
+- `tiferet-code-<component>` — include for each component the story modifies.
+- `tiferet-code-architecture` — include for any story that modifies more than one component.
+- **Fallback** (if skills not installed): link to `docs/core/<component>.md` directly.
 
-Current available guides (located in `docs/core/` on the `main` branch):
-- **[code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md)** – General structured code style (artifact comments, spacing, docstrings, snippets).
-- **[domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md)** – Domain model and aggregate conventions.
-- **[events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md)** – Domain event patterns and usage.
-- **[mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md)** – Data mapping, DTOs, and transformation conventions.
-- **[contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md)** – Context-specific conventions (injection patterns, lifecycle methods, execution flow).
-- **[interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md)** – Interface / contract / service conventions.
+Available skills and their fallback docs:
+- **`tiferet-code-style`** / [code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — general structured code style (artifact comments, spacing, docstrings, snippets).
+- **`tiferet-code-domain`** / [domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — domain object and aggregate conventions.
+- **`tiferet-code-events`** / [events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — domain event patterns.
+- **`tiferet-code-mappers`** / [mappers.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/mappers.md) — aggregate and transfer object conventions.
+- **`tiferet-code-interfaces`** / [interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — service interface conventions.
+- **`tiferet-code-contexts`** / [contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md) — context conventions.
+- **`tiferet-code-repos`** / [repos.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/repos.md) — repository conventions.
+- **`tiferet-code-assets`** / [assets.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/assets.md) — constants, exceptions, and bootstrap defaults.
+- **`tiferet-code-blueprints`** / [blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md) — blueprint orchestration functions.
+- **`tiferet-code-utils`** / [utils.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/utils.md) — infrastructure utility conventions.
+- **`tiferet-code-di`** / [di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md) — dependency injection layer.
+- **`tiferet-code-testing`** / [testing.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/testing.md) — test harness conventions.
 
-Additional component-specific style guides will be added as the framework evolves. Always consult the relevant documents when implementing or extending components.
+## TRD File Lifecycle and Naming
+
+All TRDs are stored locally in `.trd/` (git-ignored). Milestone description payloads are stored in `.milestones/` (git-ignored). Neither folder is committed to the repository.
+
+### `.trd/` — flat file structure
+
+All TRDs live in `.trd/` as a flat list. The filename encodes milestone, issue number, state, and project field values.
+
+**Naming convention:**
+```
+[m<milestone>_]<issue>_<kebab-title>[_N]__<Size>_<Est>_<Priority>[.complete].md
+```
+
+- `m<milestone>_` — present when the issue is assigned to a milestone (e.g. `m30_`). Requires an issue number — never appears without one.
+- `<issue>_` — GitHub issue number (e.g. `895_`). Presence signals the TRD is active.
+- `<kebab-title>` — lowercase-hyphenated story title.
+- `[_N]` — child number for super-TRD children (e.g. `_1`, `_2`); omitted for standalone TRDs and super-TRD parents.
+- `__<Size>_<Est>_<Priority>` — project field suffix (e.g. `__L_5_P0`); omitted for unscoped RFP TRDs.
+- `.complete` — appended when the issue is closed and work is done; the only explicit state marker.
+
+**Lifecycle states (determined by filename structure):**
+
+| State | Filename shape | Rule |
+|-------|---------------|------|
+| Draft | `<kebab-title>__<fields>.md` | No issue number |
+| Active (no milestone) | `<issue>_<kebab-title>__<fields>.md` | Issue exists, no milestone |
+| Active (with milestone) | `m<N>_<issue>_<kebab-title>__<fields>.md` | Issue + milestone acquired together |
+| Complete | `[m<N>_]<issue>_<kebab-title>__<fields>.complete.md` | PR merged, issue closed |
+
+**Invariants:**
+- No issue number → draft. `m<N>_` always requires an issue number — both are added simultaneously when the GitHub issue is created and assigned to a milestone.
+- `.complete.md` requires an issue number; milestone is optional.
+
+**Transition: draft → active** — when the GitHub issue is created and assigned to a milestone:
+```bash
+mv .trd/assets-error-catalog-extraction__L_5_P0.md \
+   .trd/m30_895_assets-error-catalog-extraction__L_5_P0.md
+```
+
+**Transition: active → complete** — when the PR is merged and the issue is closed:
+```bash
+mv .trd/m30_895_assets-error-catalog-extraction__L_5_P0.md \
+   .trd/m30_895_assets-error-catalog-extraction__L_5_P0.complete.md
+```
+
+For **super-TRD parents**: when the last child issue closes, check if all sibling children are `.complete.md`; if so, also rename the parent and close the parent GitHub issue.
+
+### `.milestones/` — milestone description payloads
+
+`.milestones/` stores Markdown files used as `gh api` description payloads. The milestone number prefix is required:
+
+```
+m<milestone-number>_<kebab-milestone-title>.md
+```
+
+```bash
+# Create milestone
+gh api repos/greatstrength/tiferet/milestones \
+  -f title='<Title>' \
+  -F description=@.milestones/m<N>_<kebab-title>.md \
+  --jq '{number, title, state, html_url}'
+
+# PATCH to backfill issue numbers:
+gh api repos/greatstrength/tiferet/milestones/<number> \
+  -X PATCH \
+  -F description=@.milestones/m<N>_<kebab-title>.md
+```
+
+## GitHub Issue Creation
+
+### Creating an issue
+
+The `--milestone` flag on `gh issue create` silently fails for milestones with en-dashes or when an integer is passed. Use the REST API directly:
+
+```bash
+gh api repos/greatstrength/tiferet/issues \
+  -f title="<Story title>" \
+  -f body="$(cat .trd/<filename>.md)" \
+  -F milestone=<integer-number> \
+  --jq '{number, node_id, html_url}'
+```
+
+`gh api` does not support `--json` output — use `--jq` with a projection. After creating the issue, rename the TRD file to insert the issue number and `m<N>_` prefix (see TRD File Lifecycle above).
+
+### Setting project fields
+
+Use the two-step GraphQL pattern — `gh project item-add` does not return the item ID in machine-readable form:
+
+**Step 1 — Add to project:**
+```bash
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {projectId: \"PVT_kwDOCKXjws4A7Y85\", contentId: \"<issue-node-id>\"}) {
+    item { id }
+  }
+}" --jq '.data.addProjectV2ItemById.item.id')
+```
+
+**Step 2 — Set a field (repeat per field):**
+```bash
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOCKXjws4A7Y85\",
+    itemId: \"$ITEM_ID\",
+    fieldId: \"<field-node-id>\",
+    value: {singleSelectOptionId: \"<option-id>\"}
+  }) { projectV2Item { id } }
+}"
+```
+
+**Tiferet Framework project (#2) stable IDs:**
+- Project: `PVT_kwDOCKXjws4A7Y85`
+- Status (`PVTSSF_lADOCKXjws4A7Y85zgvs_j4`): Ready=`08afe404`, In Progress=`47fc9ee4`, In Review=`4cc61d42`, Done=`98236657`
+- Priority (`PVTSSF_lADOCKXjws4A7Y85zgvs_no`): P0=`79628723`, P1=`0a877460`, P2=`da944a9c`
+- Size (`PVTSSF_lADOCKXjws4A7Y85zgvs_ns`): XS=`eff732af`, S=`9592a5a3`, M=`9728cbdc`, L=`c53df028`, XL=`7b141a16`
+- Estimate (`PVTF_lADOCKXjws4A7Y85zgvs_nw`): number field — use `value: {number: N}`
+
+Set **Status=Ready** for all new issues. Blocked-by relationships communicate dependency ordering — do not use Backlog for blocked issues.
+
+### Wiring blocked-by dependencies
+
+Requires `gh` v2.94.0+:
+```bash
+# Single blocker
+gh issue edit <blocked-number> --add-blocked-by <blocker-number> --repo greatstrength/tiferet
+
+# Multiple blockers (comma-separated)
+gh issue edit <n> --add-blocked-by 905,906,907 --repo greatstrength/tiferet
+```
+
+REST fallback (gh < v2.94.0):
+```bash
+BLOCKER_ID=$(gh api repos/greatstrength/tiferet/issues/<N> --jq '.id')
+gh api repos/greatstrength/tiferet/issues/<blocked>/dependencies/blocked_by \
+  -X POST -f issue_id=$BLOCKER_ID
+```
+
+### Linking super-TRD sub-issues
+
+After creating parent and child issues, link each child as a GitHub sub-issue:
+```bash
+CHILD_ID=$(gh api repos/greatstrength/tiferet/issues/<child-number> --jq '.id')
+gh api repos/greatstrength/tiferet/issues/<parent-number>/sub_issues \
+  -X POST -F sub_issue_id=$CHILD_ID
+```
+
+`sub_issue_id` uses the integer `id` field (not the display number).
 
 ## Branch Naming and Workflow Conventions
 


### PR DESCRIPTION
## Overview

This PR extends the TRD authoring and milestone workflow documentation with four areas of new guidance: a formalized super-TRD format, a TRD file lifecycle and naming convention, a GitHub issue creation workflow, and a simplified status model for new issues.

## Changes

### `docs/collab/tech_requirements.md`
- **Super-TRD Format** — defines when to split an XL+ story into a parent/child super-TRD, the required document structure for parent and child TRDs, the child priority rule (P0 for prerequisite children), and the closing rule (parent closes when all children close, triggering a `.complete.md` rename).
- **Related Code Style Documentation** — replaces the previous section with a skill-first inclusion rule: always require `tiferet-code-style`; add `tiferet-code-<component>` for each modified component; add `tiferet-code-architecture` for multi-component stories. Lists all 12 available skills with their `docs/core/` fallback paths.
- **TRD File Lifecycle and Naming** — formalizes the `.trd/` flat-file structure, the filename encoding convention (`[m<N>_]<issue>_<kebab-title>[_N]__<Size>_<Est>_<Priority>[.complete].md`), lifecycle state table, transition commands, and the companion `.milestones/` payload folder.
- **GitHub Issue Creation** — documents the REST API workaround for `gh issue create --milestone` silent failures, the two-step GraphQL pattern for setting project fields (with stable Tiferet project #2 field/option IDs), the `gh issue edit --add-blocked-by` workflow for wiring dependencies (requires gh ≥ v2.94.0), and the sub-issues API for linking super-TRD children.

### `docs/collab/project_fields.md`
- Status workflow updated: all new issues start at **Ready** — Backlog is no longer the default start state. Blocked-by relationships communicate dependency ordering; Status does not reflect blocked state.

### `docs/collab/agents/skills/tiferet-author-trd/SKILL.md`
- Adds a **Super-TRDs and file naming** section covering the sizing session, parent/child document structure, filename convention, and lifecycle state transitions.
- Adds a **Creating GitHub issues** section with the full `gh` CLI patterns for issue creation (REST API), project field assignment (GraphQL), blocked-by wiring, and sub-issue linking.

### `docs/collab/agents/skills/tiferet-milestone-session/SKILL.md`
- Status flow simplified: **Ready → In Progress → In Review → Done**; Backlog removed as a start state.
- Adds a **Before starting: confirm issue setup** section requiring all issues to have Status=Ready, blocked-by relationships wired, and super-TRD children linked before the per-issue loop begins.
- Step 3 now explicitly requires reading `tiferet-code-style` and the relevant component skill(s) before writing any code.
- Step 9 (mark Done) includes the conditional `.complete.md` rename for TRD files and the super-TRD parent cascade rule.

Co-Authored-By: Oz <oz-agent@warp.dev>