### PR TITLE
Docs – Align non-guide docs to v2.0.0 semantics and module layout

### DIFF
--- a/docs/collab/agents/skills/tiferet-annotation-artifacts/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-annotation-artifacts/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: tiferet-annotation-artifacts
+description: Manage annotation artifacts (# ++ todo: and # -- obsolete:) in any Tiferet-family repo. Use this when the user asks to scan, add, or resolve annotation artifacts, or when a milestone session, TRD, or code review session needs a pre-implementation annotation inventory. Covers the formal syntax, when to add each type, the pre-session scan procedure, resolution procedure, and collaboration report integration.
+---
+
+# Manage Tiferet Annotation Artifacts
+
+## When to use
+Use this when:
+- Starting any implementation or code review session in a Tiferet-family repo — run the scan procedure before touching affected files.
+- Adding a `# ++ todo:` or `# -- obsolete:` annotation during implementation.
+- Resolving (removing) an annotation after the described work is complete.
+- Including annotation status in a Collaboration Report.
+
+Canonical source of truth:
+https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md#annotation-artifacts
+
+---
+
+## Annotation types
+
+### `# ++ todo: <message>`
+- **Meaning**: deferred work attached to a specific artifact. `++` = *something to add or grow here*.
+- **Remove when**: the described work is done. Never leave a `# ++ todo:` after the work it describes is complete.
+- **Issue reference**: when the work is tracked in GitHub, include the issue number: `# ++ todo: #123 — remove attribute_id once tests are migrated`.
+
+### `# -- obsolete: <reason or target version>`
+- **Meaning**: the annotated artifact is deprecated and slated for removal. `--` = *something to reduce or remove*.
+- **Remove when**: the artifact itself is deleted. Verify no callers remain before deletion.
+- **Shorthand**: the `(obsolete)` parenthetical suffix on a `# *` or `# **` label is valid shorthand when no reason is needed. When a reason or target version is meaningful, add `# -- obsolete:` on its own line immediately after the label.
+
+---
+
+## Placement grammar
+
+Annotations appear **immediately after** the structural comment they annotate, on their own line, before the code body:
+
+```python
+# * method: remove_service
+# ++ todo: remove attribute_id parameter once the dependency with the app event tests has been resolved
+def remove_service(self, service_id: str | None = None, attribute_id: str | None = None):
+    ...
+
+# * attribute: return_to_data (obsolete)
+# -- obsolete: superseded by data_key; remove when callers are fully migrated
+return_to_data: bool = Field(default=False, ...)
+```
+
+Annotations may appear below `# **` or `# ***` comments when they apply to an entire section or class. Inside method bodies, `# ++ todo:` follows inline-before-snippet placement like any other snippet comment.
+
+---
+
+## Pre-session scan procedure
+
+**Before beginning any implementation session**, run this scan in the repository root and review the results:
+
+```bash
+grep -rn "# ++\|# --" tiferet/
+```
+
+For a Tiferet-family repo (not the canonical repo), substitute the package directory accordingly.
+
+Review each open annotation and decide:
+- Is it in scope for this session? If so, plan to resolve it.
+- Is it out of scope? Note it so the Collaboration Report reflects its status.
+
+Include the scan results (or a summary) when authoring a TRD to ensure the scope section accounts for any open annotations that the new work would touch.
+
+---
+
+## Resolution procedure
+
+### Resolving `# ++ todo:`
+1. Complete the described work.
+2. Remove the `# ++ todo:` line from the source file.
+3. If the annotation referenced a GitHub issue, confirm the issue is closed or the sub-task is complete.
+4. Note the resolution in the Collaboration Report.
+
+### Retiring `# -- obsolete:` with its artifact
+1. Verify no callers reference the annotated artifact (search the codebase).
+2. Delete the artifact and its `# -- obsolete:` annotation line together.
+3. If the `(obsolete)` parenthetical shorthand was used on the `# *` label, remove that too.
+4. Note the retirement in the Collaboration Report.
+
+---
+
+## Collaboration report integration
+
+In the Collaboration Report (Section 2 — Code Components Touched or Section 3 — Deviations), note:
+
+- Any `# ++ todo:` annotations introduced during the session (with the artifact and message).
+- Any `# ++ todo:` annotations resolved (with the artifact and what was done).
+- Any `# -- obsolete:` annotations introduced or retired (with the artifact and reason).
+
+Example log entry:
+> **AI** — Resolved `# ++ todo:` on `AppSessionAggregate.remove_service`: removed `attribute_id` parameter and updated all callers.
+> **AI** — Retired `# -- obsolete:` on `AppSessionAggregate.return_to_data`: deleted attribute, updated `AppSessionConfigObject` mapper, confirmed no remaining callers.
+
+---
+
+## Quick reference
+
+| Task | Action |
+|---|---|
+| Scan for open annotations | `grep -rn "# ++\|# --" tiferet/` |
+| Add deferred-work note | `# ++ todo: <message>` after the `# *` label |
+| Add obsolete marker with reason | `# -- obsolete: <reason>` after the `# *` label |
+| Shorthand obsolete (no reason) | `# * method: foo (obsolete)` on the label line |
+| Resolve a todo | Delete the `# ++ todo:` line; note in collab report |
+| Retire an obsolete artifact | Delete artifact + annotation; verify no callers; note in collab report |

--- a/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-repos/SKILL.md
@@ -50,7 +50,7 @@ def __init__(self, error_config: str, encoding: str = 'utf-8') -> None:
     ConfigurationRepository.__init__(self, config_file=error_config, encoding=encoding)
 ```
 
-**`ConfigurationRepository` base** (inherited from `tiferet/repos/settings.py`):
+**`ConfigurationRepository` base** (inherited from `tiferet/repos/core.py`):
 - `config_file`, `encoding`, `default_role` (fixed to `'to_data'`)
 - `_load(start_node=..., data_factory=...)` — format-dispatched read (YAML or JSON based on file extension)
 - `_save(data)` — format-dispatched write

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -214,7 +214,7 @@ This gives an immediate picture of outstanding technical debt and deprecated cod
 # *** imports
 
 # ** app
-from .settings import DomainEvent, a
+from .core import DomainEvent, a
 from ..interfaces import FeatureService
 from ..domain import Feature
 
@@ -275,7 +275,7 @@ import pytest
 from unittest import mock
 
 # ** app
-from tiferet.events.settings import DomainEvent
+from tiferet.events.core import DomainEvent
 from tiferet.events.feature import GetFeature
 from tiferet.interfaces import FeatureService
 from tiferet.domain import Feature

--- a/docs/core/contexts.md
+++ b/docs/core/contexts.md
@@ -7,7 +7,7 @@ Contexts are a core component of the Tiferet framework, representing the structu
 A Context in Tiferet is a class that encapsulates a specific aspect of an application’s runtime behavior, such as user-facing interactions (e.g., CLI, web), feature execution, dependency injection, error handling, caching, or logging. Contexts form a graph-like structure during execution, defining how the application processes inputs, executes domain logic, and returns outputs. They align with Domain-Driven Design (DDD) principles, isolating concerns to ensure modularity and extensibility.
 
 ### Types of Contexts
-All contexts extend `BaseContext` (`tiferet/contexts/settings.py`), which provides a shared `services` slot and a `ContextMeta` registry mapping a domain object type (`domain_type`) to its context class. `BaseContext.for_domain(DomainType)` resolves the registered class, and `BaseContext.from_domain(domain_obj, **kwargs)` constructs a context bound to a loaded domain object (exposed as `ctx.domain`). Caching is not part of the base; contexts that need a `CacheContext` (e.g., `AppSessionContext`, `FeatureContext`) declare and wire it themselves.
+All contexts extend `BaseContext` (`tiferet/contexts/core.py`), which provides a `ContextMeta` registry mapping a domain object type (`domain_type`) to its context class. `BaseContext.for_domain(DomainType)` resolves the registered class, and `BaseContext.from_domain(domain_obj, **kwargs)` constructs a context bound to a loaded domain object (exposed as `ctx.domain`). Caching is not part of the base; contexts that need a `CacheContext` (e.g., `AppSessionContext`, `FeatureContext`) declare and wire it themselves.
 
 Tiferet recognizes two broad categories:
 
@@ -40,7 +40,7 @@ Contexts are organized under the `# *** contexts` top-level comment, with indivi
 # *** imports
 
 # ** app
-from .settings import BaseContext
+from .core import BaseContext
 from .cache import CacheContext
 from .feature import FeatureContext
 from .error import ErrorContext
@@ -49,26 +49,30 @@ from ..domain import AppSession
 
 # *** contexts
 
-# ** context: app_interface_context
+# ** context: app_session_context
 class AppSessionContext(BaseContext):
 
     # * attribute: domain_type
     domain_type = AppSession
 
     # * init
-    def __init__(self, get_feature_evt, get_error_evt, logging_list_all_evt,
-                 get_dependency, cache=None,
-                 default_features=None, default_commands=None):
+    def __init__(self,
+                 get_dependency,
+                 logging_context=None,
+                 cache=None,
+                 execute_feature_handler=None,
+                 create_request_handler=None,
+                 raise_error_handler=None,
+                 response_handler=None):
         '''
         Initialize the hub. The loaded AppSession is bound via from_domain as
-        self.domain, supplying the interface id and logger id on demand.
+        self.domain, supplying the session id and logger id on demand.
         '''
         super().__init__()
         self.cache = cache if cache is not None else CacheContext()
-        self.get_feature_evt = get_feature_evt
-        # ... store the remaining events and the injected get_dependency
-        # service-resolution handler, plus validated bootstrap defaults;
-        # sub-contexts are created lazily on first use ...
+        self.get_dependency = get_dependency
+        # ... store the injected handler callables and logging context;
+        # sub-contexts are built on demand via BaseContext.for_domain ...
 
     # * method: run
     def run(self, feature_id, headers=None, data=None, **kwargs):
@@ -152,31 +156,26 @@ Tests use `pytest` with `unittest.mock`, organized under `# *** fixtures` and `#
 ```python
 # *** fixtures
 
-# ** fixture: app_interface_context
+# ** fixture: app_session_context
 @pytest.fixture
-def app_interface_context(app_interface, feature_context, error_context, logging_context):
-    # Build the hub declaratively from a loaded interface with mock events.
+def app_session_context(app_session, logging_context):
+    # Build the hub declaratively from a loaded app session via from_domain.
     context = AppSessionContext.from_domain(
-        app_interface,
-        get_feature_evt=mock.Mock(),
-        get_error_evt=mock.Mock(),
-        logging_list_all_evt=mock.Mock(),
+        app_session,
         get_dependency=mock.Mock(),
+        logging_context=logging_context,
     )
-    # Inject the mock logging context via its cache; feature and error contexts
-    # are built on demand, so patch BaseContext.for_domain to return the mocks.
-    context._logging = logging_context
     return context
 
 # *** tests
 
-# ** test: app_interface_context_run_success
-def test_app_interface_context_run_success(app_interface_context, logging_context):
+# ** test: app_session_context_run_success
+def test_app_session_context_run_success(app_session_context, logging_context):
     # Arrange the logger.
     logging_context.build_logger.return_value = mock.Mock()
 
     # Act.
-    result = app_interface_context.run('calc.add', data={'a': 1, 'b': 2})
+    result = app_session_context.run('calc.add', data={'a': 1, 'b': 2})
 
     # The feature context is built on demand inside execute_feature; assert the
     # run completed and produced a response.

--- a/docs/core/di.md
+++ b/docs/core/di.md
@@ -308,7 +308,7 @@ The older declarative-wiring path (`wire_services`, `load_app_instance`, `Create
 
 ## Structured Code Design
 
-The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consistent with other `settings.py` modules in the framework (e.g., `contexts/settings.py`).
+The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consistent with other `core.py` modules in the framework (e.g., `contexts/core.py`).
 
 ### Artifact Comments
 
@@ -328,10 +328,10 @@ The `di/` package uses `# *** classes` / `# ** class:` artifact comments, consis
 When a class type is registered via `add_service()`, it is wrapped in a `providers.Factory`. Each resolution creates a new instance with constructor kwargs wired to sibling providers:
 
 ```python
-container.add_constants({'feature_config': 'app/configs/feature.yml'})
+container.add_constants({'feature_config': 'config.yml'})
 container.add_service('feature_service', FeatureConfigRepository)
 
-# FeatureConfigRepository(feature_config='app/configs/feature.yml') is resolved:
+# FeatureConfigRepository(feature_config='config.yml') is resolved:
 repo = container.get_service('feature_service')  # ✓ new instance each time
 ```
 
@@ -340,10 +340,10 @@ repo = container.get_service('feature_service')  # ✓ new instance each time
 Non-type values registered via `add_services()` or `add_constants()` are wrapped in `providers.Object`. Each resolution returns the same value:
 
 ```python
-container.add_constants({'app_config': 'app/configs/app.yml'})
+container.add_constants({'app_config': 'config.yml'})
 
 # Direct scalar resolution works:
-path = container.get_service('app_config')  # ✓ returns 'app/configs/app.yml'
+path = container.get_service('app_config')  # ✓ returns 'config.yml'
 ```
 
 ## Customizing Parameter Parsing

--- a/docs/core/domain.md
+++ b/docs/core/domain.md
@@ -27,9 +27,9 @@ This duality ensures a single source of truth for domain structure and behavior,
 - **Runtime Use** (`ErrorContext`):
   ```python
   # The hub loads the Error; the context formats the response from it.
-  error_message = error.format_message(lang, **getattr(exception, 'kwargs', {}))
+  error_message = error.format_message(lang, **exception.kwargs)
   ```
-  The `Error` domain object is retrieved via the hub's `load_error_domain` and used by `ErrorContext.format_response` to assemble the structured response.
+  The `Error` domain object is retrieved via the hub's `get_error` (cache-first) and used by `ErrorContext.format_response` to assemble the structured response.
 
 - **Mapper Layer Use** (`ErrorAggregate`, `ErrorConfigObject`):
   ```python
@@ -41,7 +41,7 @@ This duality ensures a single source of truth for domain structure and behavior,
       # Inherits fields/validation from Error
       # Adds serialization roles and mapping logic
   ```
-  Configuration (`error.yml`) maps through `ErrorConfigObject` to `ErrorAggregate`, which converts to/from the runtime `Error`.
+  Configuration (`config.yml` errors section) maps through `ErrorConfigObject` to `ErrorAggregate`, which converts to/from the runtime `Error`.
 
 ## The DomainObject Base Class
 
@@ -96,7 +96,7 @@ Domain objects follow a strict artifact comment structure for consistency and AI
 - Extend `DomainObject` from `tiferet.domain.core`.
 - Declare fields with Pydantic `Field(...)` annotations.
 - Instantiate directly via the constructor or `model_validate()`.
-- Use `@model_validator(mode='before')` for derivation logic that was previously in custom `new()` factories.
+- Use `@model_validator(mode='before')` for domain-specific derivation logic.
 
 **Example** – `CalculatorResult`:
 ```python

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Domain events are the operational core of the Tiferet framework. Every focused domain action — validation, service interaction, computation, or orchestration — is expressed as a class extending `DomainEvent` from `tiferet.events.settings`.
+Domain events are the operational core of the Tiferet framework. Every focused domain action — validation, service interaction, computation, or orchestration — is expressed as a class extending `DomainEvent` from `tiferet/events/core.py`.
 
 `DomainEvent` provides:
 - Core orchestration (`execute`, `handle`)
@@ -20,7 +20,7 @@ This class serves as the base for all domain event implementations. It centraliz
 `DomainEvent` extends `object` and provides the foundational methods for all domain operations:
 
 ```python
-# tiferet/events/settings.py
+# tiferet/events/core.py
 
 class DomainEvent(object):
     '''
@@ -129,7 +129,7 @@ The static utility events (`ParseParameter`, `ImportDependency`, `RaiseError` in
 
 Domain events follow the standard Tiferet artifact comment structure:
 
-- `# *** events` – top-level section (use `# *** classes` in `settings.py`).
+- `# *** events` – top-level section (use `# *** classes` in `core.py`).
 - `# ** event: <name>` – individual domain event (snake_case).
 - `# * attribute: <name>` – injected dependencies.
 - `# * init` – constructor.
@@ -152,7 +152,7 @@ Domain events follow the standard Tiferet artifact comment structure:
 # *** imports
 
 # ** app
-from .settings import DomainEvent, a
+from .core import DomainEvent, a
 from ..domain import Error
 from ..mappers import ErrorAggregate
 
@@ -232,7 +232,7 @@ Tests validate input validation, service interactions, and error handling using 
 
 ### Test Harness
 
-The domain event test harness (`tiferet/events/tests/settings.py`) provides two base classes that eliminate boilerplate and enforce consistency across all event test modules.
+The domain event test harness (`tiferet/testing/`) provides two base classes that eliminate boilerplate and enforce consistency across all event test modules.
 
 #### DomainEventTestBase
 
@@ -403,7 +403,7 @@ For built-in middleware, the `MiddlewareService` interface, ordering, `config.ym
 
 Domain events are defined in `tiferet/events/`:
 
-- `settings.py` – `DomainEvent` base class, `@parameters_required` decorator.
+- `core.py` – `DomainEvent` base class, `@parameters_required` decorator.
 - `static.py` – Static utility events (`ParseParameter`, `ImportDependency`, `RaiseError`).
 - `app.py` – `AppEvent` base + app interface management events.
 - `cli.py` – `CliEvent` base + CLI command management events.
@@ -414,11 +414,12 @@ Domain events are defined in `tiferet/events/`:
 - `sqlite.py` – `SqliteEvent` base + SQLite management events.
 - `__init__.py` – Public exports (`DomainEvent`, `TiferetError`, `a`).
 
-Tests live in `tiferet/events/tests/`:
+The test harness lives in `tiferet/testing/`:
 
-- `settings.py` – Test harness (`DomainEventTestBase`, `ServiceEventTestBase`).
-- `conftest.py` – `pytest_generate_tests` hook for auto-parametrization.
-- `test_app.py`, `test_cli.py`, `test_container.py`, etc. – Per-module test suites.
+- `tiferet/testing/mappers.py` – `AggregateTestBase`, `TransferObjectTestBase`, `MapperAssertions`.
+- `tiferet/testing/domain.py` – `DomainEventTestBase`, `ServiceEventTestBase`.
+- `tiferet/testing/hooks.py` – `register_mapper_hooks`, `register_event_hooks`.
+- Per-module test suites live in `tiferet/events/tests/` (e.g., `test_app.py`, `test_cli.py`, etc.).
 
 ## Conclusion
 

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -19,7 +19,7 @@ The mappers layer (`tiferet.mappers`) provides the bridge between persistent con
    - Provides `to_primitive(role)`, `map(target)`, and `from_model` classmethod for mapping and transformation.
    - Concrete transfer objects combine a domain object with `TransferObject` to add serialization roles (e.g., `ErrorConfigObject(Error, TransferObject)`).
 
-Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`) with a clearer separation of mutation (Aggregate) and serialization (TransferObject) concerns.
+Together, these classes provide a clear separation of mutation (Aggregate) and serialization (TransferObject) concerns.
 
 ### Example: Error Domain
 
@@ -42,7 +42,7 @@ Together, these classes replace the legacy `DataObject` (`tiferet.data.settings`
 `Aggregate` extends `DomainObject` and provides mutation-safe attribute updates:
 
 ```python
-# tiferet/mappers/settings.py
+# tiferet/mappers/core.py
 
 class Aggregate(DomainObject):
     '''
@@ -90,7 +90,7 @@ class ErrorConfigObject(Error, TransferObject):
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'message'}},
-        'to_data.yaml': {'by_alias': True, 'exclude': {'id'}},
+        'to_data': {'by_alias': True, 'exclude': {'id'}},
     }
 ```
 
@@ -114,7 +114,7 @@ Mapper classes follow the standard Tiferet artifact comment structure:
 - `# * attribute: <name>` — instance attributes (Pydantic `Field(...)` annotations or `ClassVar`).
 - `# * method: <name>` — instance or class methods.
 
-Use `# *** classes` in `settings.py` for the base classes themselves.
+Use `# *** classes` in `core.py` for the base classes themselves.
 
 **Spacing rules:**
 - One empty line between `# *** mappers` and first `# ** mapper`.
@@ -157,13 +157,13 @@ class FeatureAggregate(Feature, Aggregate):
 # ** mapper: feature_config_object
 class FeatureConfigObject(Feature, TransferObject):
     '''
-    YAML transfer object for the Feature domain object.
+    Configuration data representation of the Feature domain object.
     '''
 
     # * attribute: _ROLES
     _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
         'to_model': {'exclude': {'steps'}},
-        'to_data.yaml': {
+        'to_data': {
             'by_alias': True,
             'exclude': {'feature_key', 'group_id', 'id'},
         },
@@ -219,7 +219,7 @@ Repositories use transfer objects to load from configuration and map to aggregat
 ### Best Practices
 - Use artifact comments consistently (`# *** mappers`, `# ** mapper:`, `# *`).
 - Keep aggregates focused on mutation; keep transfer objects focused on serialization.
-- Instantiate aggregates directly via the Pydantic constructor — there is no `Aggregate.new()` factory.
+- Instantiate aggregates directly via the Pydantic constructor.
 - Use `set_attribute` for validated mutations with unknown-field checking.
 - Define `_ROLES` ClassVar on all transfer objects for role-based serialization.
 - Use `model_dump` kwargs (`exclude`, `by_alias`, `include`) in `_ROLES` definitions.
@@ -298,9 +298,9 @@ Harness-based test files follow this structure:
 import pytest
 
 # ** app
-from ..settings import TransferObject
+from ..core import TransferObject
 from ..<domain> import SomeAggregate, SomeConfigObject
-from .settings import AggregateTestBase, TransferObjectTestBase
+from tiferet.testing import AggregateTestBase, TransferObjectTestBase
 
 
 # *** constants
@@ -414,7 +414,7 @@ Small leaf-level mappers without mutation logic (e.g., `ErrorMessageConfigObject
 
 Mappers are defined in `tiferet/mappers/`:
 
-- `settings.py` — `Aggregate` and `TransferObject` base classes + constants.
+- `core.py` — `Aggregate` and `TransferObject` base classes + constants.
 - `app.py` — `AppSessionAggregate`, `AppSessionConfigObject`.
 - `cli.py` — `CliArgumentAggregate`, `CliCommandAggregate`, `CliCommandConfigObject`.
 - `di.py` — `ServiceRegistrationAggregate`, `ServiceRegistrationConfigObject`.

--- a/docs/core/repos.md
+++ b/docs/core/repos.md
@@ -26,7 +26,7 @@ class ErrorConfigRepository(ErrorService, ConfigurationRepository):
 
 ## The ConfigurationRepository Base
 
-All concrete repositories inherit the shared `ConfigurationRepository` base (`tiferet/repos/settings.py`), which makes persistence format-agnostic. The base dispatches to a format-specific loader by the configuration file extension:
+All concrete repositories inherit the shared `ConfigurationRepository` base (`tiferet/repos/core.py`), which makes persistence format-agnostic. The base dispatches to a format-specific loader by the configuration file extension:
 
 - `.yaml` / `.yml` → `YamlLoader`
 - `.json` → `JsonLoader`
@@ -35,7 +35,7 @@ All concrete repositories inherit the shared `ConfigurationRepository` base (`ti
 It supplies three inherited attributes — `config_file`, `encoding`, and `default_role` (fixed to `'to_data'`) — and the inherited `_load` / `_save` helpers that concrete repositories call instead of instantiating a loader directly:
 
 ```python
-# tiferet/repos/settings.py
+# tiferet/repos/core.py
 
 # ** class: configuration_repository
 class ConfigurationRepository:
@@ -91,7 +91,7 @@ from ..mappers import (
     ErrorAggregate,
     ErrorConfigObject,
 )
-from .settings import ConfigurationRepository
+from .core import ConfigurationRepository
 
 # *** repos
 
@@ -167,7 +167,7 @@ from ..mappers import (                          # Transfer objects and aggregat
     ErrorAggregate,
     ErrorConfigObject,
 )
-from .settings import ConfigurationRepository    # Shared configuration base
+from .core import ConfigurationRepository    # Shared configuration base
 ```
 
 The `# ** app` section imports three categories:
@@ -276,7 +276,7 @@ from ..mappers.calculator import (
     CalculatorResultAggregate,
     CalculatorResultConfigObject,
 )
-from .settings import ConfigurationRepository
+from .core import ConfigurationRepository
 
 # *** repos
 
@@ -383,7 +383,7 @@ Standard test cases cover:
 Repositories are defined in `tiferet/repos/`:
 
 - `__init__.py` — Empty exports (repositories are never exported).
-- `settings.py` — `ConfigurationRepository` (shared format-dispatch base).
+- `core.py` — `ConfigurationRepository` (shared format-dispatch base).
 - `app.py` — `AppConfigRepository`.
 - `cli.py` — `CliConfigRepository`.
 - `di.py` — `DIConfigRepository`.

--- a/docs/tutorial/basic_calculator/01-setup-and-entry-points.md
+++ b/docs/tutorial/basic_calculator/01-setup-and-entry-points.md
@@ -37,7 +37,7 @@ basic-calculator/
         ├── __init__.py
         └── calc.py
 ```
-In Tiferet v2.0, configuration is consolidated into a single root `config.yml` file, which replaces the older split `app/configs/*.yml` layout.
+In Tiferet v2.0.0, configuration is consolidated into a single root `config.yml` file, which replaces the older split `app/configs/*.yml` layout.
 
 Don't worry about filling everything yet — we'll get there step by step.
 
@@ -50,7 +50,7 @@ These are the files people will actually use. Let's look at them now so you know
 ```python
 from tiferet import App, TiferetError
 
-app = App().load_app_service(app_config="config.yml")
+app = App('basic_calc', app_config='config.yml')
 
 # Some fun test cases
 tests = [
@@ -68,7 +68,7 @@ print("Running calculator tests...\n")
 
 for feature_id, data, fmt in tests:
     try:
-        result = app.run("basic_calc", feature_id, data=data)
+        result = app.run(feature_id, data=data)
         if "b" in data:
             print(fmt.format(data["a"], data["b"], result))
         else:
@@ -95,13 +95,10 @@ Error: Invalid number: 'hello'
 **calc_cli.py** — the interactive command-line version
 
 ```python
-from tiferet import App
-
-app = App().load_app_service(app_config="config.yml")
-cli = app.load_interface("calc_cli")   # reads the CLI settings from root config.yml
+from tiferet import CLI
 
 if __name__ == "__main__":
-    cli.run()
+    CLI('calc_cli', app_config='config.yml')
 ```
 
 **What using it feels like** (once everything's wired):

--- a/docs/tutorial/basic_calculator/04-configurations.md
+++ b/docs/tutorial/basic_calculator/04-configurations.md
@@ -1,7 +1,7 @@
 # Step 4: Configurations
 
 We've got the math events and a nice validation utility — now it's time to make everything come alive through configuration.  
-In Tiferet v2.0, everything is consolidated into a single root `config.yml` file. This one file defines interfaces, dependency mappings, features, and errors.
+In Tiferet v2.0.0, everything is consolidated into a single root `config.yml` file. This one file defines interfaces, dependency mappings, features, and errors.
 
 ### 4.1 config.yml – The complete wiring diagram
 
@@ -18,7 +18,7 @@ interfaces:
 
 # Dependency injection mappings
 # These map friendly names (used in features) to actual Python classes
-attrs:
+services:
   add_event:
     module_path: app.events.calc
     class_name: AddNumber
@@ -42,37 +42,37 @@ features:
       name: Addition
       description: Add two numbers
       steps:
-        - attribute_id: add_event
+        - service_id: add_event
 
     subtract:
       name: Subtraction
       description: Subtract second number from first
       steps:
-        - attribute_id: subtract_event
+        - service_id: subtract_event
 
     multiply:
       name: Multiplication
       description: Multiply two numbers
       steps:
-        - attribute_id: multiply_event
+        - service_id: multiply_event
 
     divide:
       name: Division
       description: Divide first number by second
       steps:
-        - attribute_id: divide_event
+        - service_id: divide_event
 
     exp:
       name: Exponentiation
       description: Raise first number to the power of second
       steps:
-        - attribute_id: exp_event
+        - service_id: exp_event
 
     sqrt:
       name: Square Root
       description: Calculates the square root of a number
       steps:
-        - attribute_id: exp_event
+        - service_id: exp_event
           params:
             b: 0.5    # fixed exponent for square root (a^(1/2))
 
@@ -80,7 +80,7 @@ features:
       name: Safe Divide
       description: Divides only when denominator is non-zero
       steps:
-        - attribute_id: divide_event
+        - service_id: divide_event
           condition: '$r.b != 0'    # skip when b is zero instead of raising
 
 # Structured error messages
@@ -103,7 +103,7 @@ errors:
 - **Simpler structure** — No more hunting through multiple files.
 - **Easier to manage** — Everything related to how the app behaves is in one place.
 - **Still fully flexible** — You can define multiple interfaces, complex features, and rich error handling.
-- Tiferet automatically loads `config.yml` from the project root when you create `App()`.
+- Pass `app_config='config.yml'` when calling `App('basic_calc', app_config='config.yml')`.
 
 ### 4.3 Conditional steps
 
@@ -116,12 +116,12 @@ Conditions support `$r.<key>` references for any value in the request data and s
 In this single `config.yml` file we defined:
 
 - **Interfaces** (`basic_calc`) — the entry point for our script runner
-- **Dependency mappings** (`attrs`) — links friendly names like `add_event` to the actual Python classes in `app/events/calc.py`
+- **Services** (`services`) — links friendly names like `add_event` to the actual Python classes in `app/events/calc.py`
 - **Features** (`calc.add`, `calc.sqrt`, `calc.safe_divide`, etc.) — defines the workflows and which event to run for each operation
 - **Conditional steps** — declarative `condition` expressions on feature steps for runtime branching
 - **Errors** — user-friendly, structured error messages with support for multiple languages
 
-When you run `app = App()`, Tiferet reads this `config.yml` and wires everything together automatically.
+When you run `app = App('basic_calc', app_config='config.yml')`, Tiferet reads this file and wires everything together automatically.
 
 No code changes needed here — just this one YAML file.
 

--- a/docs/tutorial/basic_calculator/05-running-the-script.md
+++ b/docs/tutorial/basic_calculator/05-running-the-script.md
@@ -12,7 +12,7 @@ This is the simple test runner we looked at way back in Step 1 — now it should
 ```python
 from tiferet import App, TiferetError
 
-app = App()  # loads everything from app/configs/
+app = App('basic_calc', app_config='config.yml')
 
 # Some fun test cases
 tests = [
@@ -30,7 +30,7 @@ print("Running calculator tests...\n")
 
 for feature_id, data, fmt in tests:
     try:
-        result = app.run("basic_calc", feature_id, data=data)
+        result = app.run(feature_id, data=data)
         if "b" in data:
             print(fmt.format(data["a"], data["b"], result))
         else:
@@ -71,8 +71,8 @@ Error: Invalid number: 'hello'
 
 ### 5.4 Quick troubleshooting tips
 
-- Error "No such feature" → double-check `feature.yml` keys match the `feature_id` in tests
-- Import error → make sure paths in `container.yml` point to `app.events.calc`
+- Error "No such feature" → double-check `features:` keys in `config.yml` match the `feature_id` in tests
+- Import error → make sure paths in `services:` section of `config.yml` point to `app.events.calc`
 - Validation not working → confirm `app/utils/calc.py` is importable (check the `__init__.py` files)
 
 If you see the output above (or very close), congratulations — your core calculator is fully functional!

--- a/docs/tutorial/basic_calculator/07-persisting-recent-formulas.md
+++ b/docs/tutorial/basic_calculator/07-persisting-recent-formulas.md
@@ -120,7 +120,7 @@ Finally, add a feature to read the history back:
           name: List recent calculations
 ```
 
-> **Tip:** `params_schema` (added in v2.0.0b12) validates and coerces request data before any step runs — that's why `a` and `b` arrive as real numbers.
+> **Tip:** `params_schema` validates and coerces request data before any step runs — that's why `a` and `b` arrive as real numbers.
 
 ### 7.4 Add a CLI command (optional)
 

--- a/docs/tutorial/basic_calculator/08-saving-and-variablizing-formulas.md
+++ b/docs/tutorial/basic_calculator/08-saving-and-variablizing-formulas.md
@@ -59,7 +59,7 @@ class Formula(DomainObject):
 
 ### 8.2 The mappers
 
-Domain objects are read-only. Mutation lives in an **Aggregate**, and serialization lives in a **ConfigObject** (this is the v2.0.0b13 naming — earlier betas called these `*YamlObject`).
+Domain objects are read-only. Mutation lives in an **Aggregate**, and serialization lives in a **ConfigObject**.
 
 **app/mappers/formula.py**
 
@@ -135,7 +135,7 @@ class FormulaService(Service):
 from pathlib import Path
 from typing import List
 
-from tiferet.repos.settings import ConfigurationRepository
+from tiferet.repos.core import ConfigurationRepository
 from ..interfaces.formula import FormulaService
 from ..mappers.formula import FormulaAggregate, FormulaConfigObject
 
@@ -178,7 +178,7 @@ formulas: {}
 
 ### 8.5 The events
 
-Each single-service event module defines a small **base event** that holds the shared service (this is the v2.0.0b13 per-module base-event pattern). Concrete events extend it and define only `execute`.
+Each single-service event module defines a small **base event** that holds the shared service. Concrete events extend it and define only `execute`.
 
 **app/events/formula.py** (highlights)
 


### PR DESCRIPTION
## Overview

This PR brings all non-guide documentation — core component guides, the basic calculator tutorial, and two agent skills — into alignment with the v2.0.0 architecture and API. It corrects import paths, constructor signatures, YAML config keys, App/CLI usage patterns, the test harness location, and lingering beta-version references across 14 files.

## Changes by area

### `docs/core/` — Component guides

**`events.md`**
- Module reference updated from `tiferet/events/settings.py` to `tiferet/events/core.py` (file was renamed in v2.0.0).
- Import example corrected: `from .settings import DomainEvent, a` → `from .core import DomainEvent, a`.
- Test harness location updated from the old `tiferet/events/tests/settings.py` path to the dedicated `tiferet/testing/` package (`domain.py`, `mappers.py`, `hooks.py`).
- Package layout section updated accordingly.

**`mappers.md`**
- Module reference updated from `tiferet/mappers/settings.py` → `tiferet/mappers/core.py`.
- Test file import corrected from `from .settings import AggregateTestBase, TransferObjectTestBase` to `from tiferet.testing import AggregateTestBase, TransferObjectTestBase`.

**`contexts.md`**
- Module reference updated from `tiferet/contexts/settings.py` → `tiferet/contexts/core.py`.
- `AppSessionContext` constructor example replaced: removed the stale event-collaborator signature (`get_feature_evt`, `get_error_evt`, `logging_list_all_evt`) and substituted the current handler-callable signature (`get_dependency`, `execute_feature_handler`, `create_request_handler`, `raise_error_handler`, `response_handler`).
- Test fixture updated to use `app_session` (was `app_interface`) and the handler-callable constructor kwargs.

**`repos.md`**
- All three `from .settings import ConfigurationRepository` imports updated to `from .core import ConfigurationRepository`.
- Description prose and package layout updated from `tiferet/repos/settings.py` → `tiferet/repos/core.py`.

**`code_style.md`**
- Both import examples corrected: `from .settings import DomainEvent` → `from .core import DomainEvent`; `from tiferet.events.settings import DomainEvent` → `from tiferet.events.core import DomainEvent`.

**`di.md`**
- Reference to `contexts/settings.py` in the code-style note updated to `contexts/core.py`.
- Provider example constants updated from stale `app/configs/feature.yml` / `app/configs/app.yml` paths to `config.yml` (the consolidated v2.0.0 config layout).

**`domain.md`**
- Example reference updated from `error.yml` to `config.yml` (errors section), reflecting the consolidated config file.

### `docs/tutorial/basic_calculator/` — Calculator tutorial

**Steps 1 and 4 (`01-setup-and-entry-points.md`, `04-configurations.md`)**
- Version string updated: `Tiferet v2.0` → `Tiferet v2.0.0`.
- `App().load_app_service(app_config='config.yml')` → `App('basic_calc', app_config='config.yml')` (the v2.0.0 single-call constructor).
- YAML config section key `attrs:` → `services:` throughout step 4.
- YAML feature step key `attribute_id:` → `service_id:` for all six feature definitions.
- Inaccurate auto-load claim removed; caller is responsible for passing `app_config`.
- Recap text updated: "Dependency mappings (`attrs`)" → "Services (`services`)".

**Step 5 (`05-running-the-script.md`)**
- Entry point updated from `app = App()  # loads everything from app/configs/` to `App('basic_calc', app_config='config.yml')`.
- Two-argument `app.run('basic_calc', feature_id, ...)` → `app.run(feature_id, ...)`.
- Troubleshooting tips updated from `feature.yml` / `container.yml` references to `config.yml`.

**Step 1 CLI pattern (`01-setup-and-entry-points.md`)**
- Old `app.load_interface('calc_cli') / cli.run()` pattern replaced with the `CLI` blueprint: `CLI('calc_cli', app_config='config.yml')`.

**Steps 7 and 8 (`07-persisting-recent-formulas.md`, `08-saving-and-variablizing-formulas.md`)**
- Beta-version parentheticals removed: `params_schema (added in v2.0.0b12)` → `params_schema`; `v2.0.0b13 naming` / `v2.0.0b13 per-module base-event pattern` parentheticals dropped.
- Step 8 repository import corrected: `from tiferet.repos.settings import ConfigurationRepository` → `from tiferet.repos.core import ConfigurationRepository`.

### `docs/collab/agents/skills/` — Agent skills

**`tiferet-code-repos/SKILL.md`**
- `ConfigurationRepository` base reference updated from `tiferet/repos/settings.py` → `tiferet/repos/core.py`.

**`tiferet-annotation-artifacts/SKILL.md`** *(new to main)*
- Adds the annotation artifacts management skill, which covers the `# ++ todo:` and `# -- obsolete:` syntax, pre-session scan procedure, resolution procedure, and collaboration report integration.
- Collaboration report examples updated: `AppInterfaceAggregate` → `AppSessionAggregate` (reflecting the `AppInterface` → `AppSession` domain rename).

Co-Authored-By: Oz <oz-agent@warp.dev>