### PR TITLE
Assets - Extract default error catalog, normalize constants (#895)

### DIFF
--- a/tests/assets/__init__.py
+++ b/tests/assets/__init__.py
@@ -1,0 +1,1 @@
+"""Tiferet Assets Tests"""

--- a/tests/assets/test_constants.py
+++ b/tests/assets/test_constants.py
@@ -1,0 +1,71 @@
+"""Tests for tiferet.assets.constants"""
+
+# *** imports
+
+# ** app
+from tiferet.assets.constants import EN_US, create_default_error
+
+# *** tests
+
+# ** test: en_us_constant
+def test_en_us_constant():
+    '''Verify that EN_US equals the expected locale string.'''
+
+    # Assert the expected value.
+    assert EN_US == 'en_US'
+
+
+# ** test: create_default_error_single_message
+def test_create_default_error_single_message():
+    '''Verify create_default_error returns the expected structure for a single message pair.'''
+
+    # Build a default error with one message.
+    result = create_default_error(
+        'TEST_ERROR',
+        'Test Error',
+        [(EN_US, 'Something went wrong: {detail}.')],
+    )
+
+    # Assert the top-level fields.
+    assert result['id'] == 'TEST_ERROR'
+    assert result['name'] == 'Test Error'
+
+    # Assert the message list shape.
+    assert len(result['message']) == 1
+    assert result['message'][0] == {'lang': 'en_US', 'text': 'Something went wrong: {detail}.'}
+
+
+# ** test: create_default_error_preserves_message_order
+def test_create_default_error_preserves_message_order():
+    '''Verify create_default_error preserves the order of multiple message pairs.'''
+
+    # Define ordered message pairs.
+    messages = [
+        ('en_US', 'First message.'),
+        ('fr_FR', 'Deuxième message.'),
+        ('de_DE', 'Dritte Nachricht.'),
+    ]
+
+    # Build the error.
+    result = create_default_error('MULTI_LANG', 'Multi-Language Error', messages)
+
+    # Assert the messages are emitted in the supplied order.
+    assert len(result['message']) == 3
+    assert result['message'][0] == {'lang': 'en_US', 'text': 'First message.'}
+    assert result['message'][1] == {'lang': 'fr_FR', 'text': 'Deuxième message.'}
+    assert result['message'][2] == {'lang': 'de_DE', 'text': 'Dritte Nachricht.'}
+
+
+# ** test: create_default_error_empty_messages
+def test_create_default_error_empty_messages():
+    '''Verify create_default_error yields an empty message list when no pairs are supplied.'''
+
+    # Build an error with no messages.
+    result = create_default_error('EMPTY_ERROR', 'Empty Error', [])
+
+    # Assert id and name are retained.
+    assert result['id'] == 'EMPTY_ERROR'
+    assert result['name'] == 'Empty Error'
+
+    # Assert the message list is empty.
+    assert result['message'] == []

--- a/tiferet/assets/__init__.py
+++ b/tiferet/assets/__init__.py
@@ -4,9 +4,7 @@
 
 # ** app
 from .exceptions import TiferetError, TiferetAPIError
-from .constants import (
-    ERROR_NOT_FOUND_ID,
-    DEFAULT_ERRORS,
-)
+from .constants import ERROR_NOT_FOUND_ID
+from .error import DEFAULT_ERRORS
 from . import constants as const
 from . import blueprints as bps

--- a/tiferet/assets/constants.py
+++ b/tiferet/assets/constants.py
@@ -1,8 +1,16 @@
-"""Tiferet Connstants (Assets)"""
+"""Tiferet Constants (Assets)"""
 
 # *** imports
 
-# *** constants (errors)
+# ** core
+from typing import Any, Dict, List, Tuple
+
+# *** constants
+
+# ** constant: en_us
+EN_US = 'en_US'
+
+# *** constants (error)
 
 # ** constant: command_parameter_required_id
 COMMAND_PARAMETER_REQUIRED_ID = 'COMMAND_PARAMETER_REQUIRED'
@@ -12,54 +20,6 @@ ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
 
 # ** constant: error_already_exists_id
 ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
-
-# ** constant: feature_name_required_id
-FEATURE_NAME_REQUIRED_ID = 'FEATURE_NAME_REQUIRED'
-
-# ** constant: invalid_feature_attribute_id
-INVALID_FEATURE_ATTRIBUTE_ID = 'INVALID_FEATURE_ATTRIBUTE'
-
-# ** constant: invalid_feature_command_attribute_id
-INVALID_FEATURE_COMMAND_ATTRIBUTE_ID = 'INVALID_FEATURE_COMMAND_ATTRIBUTE'
-
-# ** constant: no_error_messages_id
-NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
-
-# ** constant: parameter_parsing_failed_id
-PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
-
-# ** constant: import_dependency_failed_id
-IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
-
-# ** constant: feature_command_loading_failed_id
-FEATURE_COMMAND_LOADING_FAILED_ID = 'FEATURE_COMMAND_LOADING_FAILED'
-
-# ** constant: middleware_loading_failed_id
-MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
-
-# ** constant: app_repository_import_failed_id
-APP_REPOSITORY_IMPORT_FAILED_ID = 'APP_REPOSITORY_IMPORT_FAILED'
-
-# ** constant: app_service_import_failed_id
-APP_SERVICE_IMPORT_FAILED_ID = 'APP_SERVICE_IMPORT_FAILED'
-
-# ** constant: app_service_not_loaded_id
-APP_SERVICE_NOT_LOADED_ID = 'APP_SERVICE_NOT_LOADED'
-
-# ** constant: di_service_not_configured_id
-DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
-
-# ** constant: dependency_type_not_found_id
-DEPENDENCY_TYPE_NOT_FOUND_ID = 'DEPENDENCY_TYPE_NOT_FOUND'
-
-# ** constant: request_not_found_id
-REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
-
-# ** constant: parameter_not_found_id
-PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
-
-# ** constant: request_validation_failed_id
-REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
 
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
@@ -73,17 +33,104 @@ FEATURE_NAME_REQUIRED_ID = 'FEATURE_NAME_REQUIRED'
 # ** constant: invalid_feature_attribute_id
 INVALID_FEATURE_ATTRIBUTE_ID = 'INVALID_FEATURE_ATTRIBUTE'
 
+# ** constant: invalid_feature_command_attribute_id
+INVALID_FEATURE_COMMAND_ATTRIBUTE_ID = 'INVALID_FEATURE_COMMAND_ATTRIBUTE'
+
+# ** constant: feature_command_not_found_id
+FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
+
+# ** constant: feature_command_loading_failed_id
+FEATURE_COMMAND_LOADING_FAILED_ID = 'FEATURE_COMMAND_LOADING_FAILED'
+
 # ** constant: invalid_model_attribute_id
 INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
 
 # ** constant: invalid_app_interface_type_id
 INVALID_APP_INTERFACE_TYPE_ID = 'INVALID_APP_INTERFACE_TYPE'
 
-# ** constant: feature_command_not_found_id
-FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
+# ** constant: attribute_already_exists_id
+ATTRIBUTE_ALREADY_EXISTS_ID = 'ATTRIBUTE_ALREADY_EXISTS'
 
-# ** constant: invalid_feature_command_attribute_id
-INVALID_FEATURE_COMMAND_ATTRIBUTE_ID = 'INVALID_FEATURE_COMMAND_ATTRIBUTE'
+# ** constant: di_service_not_configured_id
+DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
+
+# ** constant: dependency_type_not_found_id
+DEPENDENCY_TYPE_NOT_FOUND_ID = 'DEPENDENCY_TYPE_NOT_FOUND'
+
+# ** constant: invalid_service_registration_id
+INVALID_SERVICE_REGISTRATION_ID = 'INVALID_SERVICE_REGISTRATION'
+
+# ** constant: service_registration_not_found_id
+SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
+
+# ** constant: service_registration_already_exists_id
+SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
+
+# ** constant: invalid_flagged_dependency_id
+INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
+
+# ** constant: invalid_dependency_error_id
+INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
+
+# ** constant: parameter_parsing_failed_id
+PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
+
+# ** constant: parameter_not_found_id
+PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
+
+# ** constant: import_dependency_failed_id
+IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
+
+# ** constant: request_not_found_id
+REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
+
+# ** constant: request_validation_failed_id
+REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
+
+# ** constant: no_error_messages_id
+NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
+
+# ** constant: middleware_loading_failed_id
+MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
+
+# ** constant: app_repository_import_failed_id
+APP_REPOSITORY_IMPORT_FAILED_ID = 'APP_REPOSITORY_IMPORT_FAILED'
+
+# ** constant: app_service_import_failed_id
+APP_SERVICE_IMPORT_FAILED_ID = 'APP_SERVICE_IMPORT_FAILED'
+
+# ** constant: app_service_not_loaded_id
+APP_SERVICE_NOT_LOADED_ID = 'APP_SERVICE_NOT_LOADED'
+
+# ** constant: app_interface_not_found_id
+APP_INTERFACE_NOT_FOUND_ID = 'APP_INTERFACE_NOT_FOUND'
+
+# ** constant: app_error_id
+APP_ERROR_ID = 'APP_ERROR'
+
+# ** constant: config_file_not_found_id
+CONFIG_FILE_NOT_FOUND_ID = 'CONFIG_FILE_NOT_FOUND'
+
+# ** constant: app_config_loading_failed_id
+APP_CONFIG_LOADING_FAILED_ID = 'APP_CONFIG_LOADING_FAILED'
+
+# ** constant: container_config_loading_failed_id
+CONTAINER_CONFIG_LOADING_FAILED_ID = 'CONTAINER_CONFIG_LOADING_FAILED'
+
+# ** constant: feature_config_loading_failed_id
+FEATURE_CONFIG_LOADING_FAILED_ID = 'FEATURE_CONFIG_LOADING_FAILED'
+
+# ** constant: error_config_loading_failed_id
+ERROR_CONFIG_LOADING_FAILED_ID = 'ERROR_CONFIG_LOADING_FAILED'
+
+# ** constant: cli_config_loading_failed_id
+CLI_CONFIG_LOADING_FAILED_ID = 'CLI_CONFIG_LOADING_FAILED'
+
+# ** constant: cli_command_not_found_id
+CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
+
+# ** constant: cli_command_already_exists_id
+CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
 
 # ** constant: logging_config_failed_id
 LOGGING_CONFIG_FAILED_ID = 'LOGGING_CONFIG_FAILED'
@@ -115,38 +162,53 @@ INVALID_YAML_FILE_ID = 'INVALID_YAML_FILE'
 # ** constant: unsupported_config_file_type_id
 UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
 
-# ** constant: app_interface_not_found_id
-APP_INTERFACE_NOT_FOUND_ID = 'APP_INTERFACE_NOT_FOUND'
+# ** constant: yaml_file_not_found_id
+YAML_FILE_NOT_FOUND_ID = 'YAML_FILE_NOT_FOUND'
 
-# ** constant: cli_command_not_found_id
-CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
+# ** constant: yaml_file_load_error_id
+YAML_FILE_LOAD_ERROR_ID = 'YAML_FILE_LOAD_ERROR'
 
-# ** constant: cli_command_already_exists_id
-CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
+# ** constant: yaml_file_save_error_id
+YAML_FILE_SAVE_ERROR_ID = 'YAML_FILE_SAVE_ERROR'
 
-# ** constant: invalid_service_registration_id
-INVALID_SERVICE_REGISTRATION_ID = 'INVALID_SERVICE_REGISTRATION'
+# ** constant: json_file_not_found_id
+JSON_FILE_NOT_FOUND_ID = 'JSON_FILE_NOT_FOUND'
 
-# ** constant: attribute_already_exists_id
-ATTRIBUTE_ALREADY_EXISTS_ID = 'ATTRIBUTE_ALREADY_EXISTS'
+# ** constant: json_file_load_error_id
+JSON_FILE_LOAD_ERROR_ID = 'JSON_FILE_LOAD_ERROR'
 
-# ** constant: service_registration_not_found_id
-SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
+# ** constant: json_file_save_error_id
+JSON_FILE_SAVE_ERROR_ID = 'JSON_FILE_SAVE_ERROR'
 
-# ** constant: invalid_flagged_dependency_id
-INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
+# ** constant: invalid_json_path_id
+INVALID_JSON_PATH_ID = 'INVALID_JSON_PATH'
 
-# ** constant: service_registration_already_exists_id
-SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
+# ** constant: csv_invalid_mode_id
+CSV_INVALID_MODE_ID = 'CSV_INVALID_MODE'
 
-# ** constant: invalid_dependency_error_id
-INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
+# ** constant: csv_handle_not_initialized_id
+CSV_HANDLE_NOT_INITIALIZED_ID = 'CSV_HANDLE_NOT_INITIALIZED'
 
-# ** constant: invalid_model_attribute_id
-INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
+# ** constant: csv_invalid_read_mode_id
+CSV_INVALID_READ_MODE_ID = 'CSV_INVALID_READ_MODE'
 
-# ** constant: invalid_app_interface_type_id
-INVALID_APP_INTERFACE_TYPE_ID = 'INVALID_APP_INTERFACE_TYPE'
+# ** constant: csv_invalid_write_mode_id
+CSV_INVALID_WRITE_MODE_ID = 'CSV_INVALID_WRITE_MODE'
+
+# ** constant: csv_fieldnames_required_id
+CSV_FIELDNAMES_REQUIRED_ID = 'CSV_FIELDNAMES_REQUIRED'
+
+# ** constant: csv_dict_no_header_id
+CSV_DICT_NO_HEADER_ID = 'CSV_DICT_NO_HEADER'
+
+# ** constant: toml_file_not_found_id
+TOML_FILE_NOT_FOUND_ID = 'TOML_FILE_NOT_FOUND'
+
+# ** constant: toml_file_load_error_id
+TOML_FILE_LOAD_ERROR_ID = 'TOML_FILE_LOAD_ERROR'
+
+# ** constant: invalid_toml_file_id
+INVALID_TOML_FILE_ID = 'INVALID_TOML_FILE'
 
 # ** constant: sqlite_conn_already_open_id
 SQLITE_CONN_ALREADY_OPEN_ID = 'SQLITE_CONN_ALREADY_OPEN'
@@ -163,773 +225,34 @@ SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
 # ** constant: sqlite_backup_failed_id
 SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
 
-# ** constant: SQLITE_CONN_NOT_INITIALIZED_id
+# ** constant: sqlite_conn_not_initialized_id
 SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
 
-# ** constants: utils_errors
-
-YAML_FILE_NOT_FOUND_ID          = 'YAML_FILE_NOT_FOUND'
-YAML_FILE_LOAD_ERROR_ID         = 'YAML_FILE_LOAD_ERROR'
-YAML_FILE_SAVE_ERROR_ID         = 'YAML_FILE_SAVE_ERROR'
-
-JSON_FILE_NOT_FOUND_ID          = 'JSON_FILE_NOT_FOUND'
-JSON_FILE_LOAD_ERROR_ID         = 'JSON_FILE_LOAD_ERROR'
-JSON_FILE_SAVE_ERROR_ID         = 'JSON_FILE_SAVE_ERROR'
-INVALID_JSON_PATH_ID            = 'INVALID_JSON_PATH'
-
-CSV_INVALID_MODE_ID             = 'CSV_INVALID_MODE'
-CSV_HANDLE_NOT_INITIALIZED_ID   = 'CSV_HANDLE_NOT_INITIALIZED'
-CSV_INVALID_READ_MODE_ID        = 'CSV_INVALID_READ_MODE'
-CSV_INVALID_WRITE_MODE_ID       = 'CSV_INVALID_WRITE_MODE'
-CSV_FIELDNAMES_REQUIRED_ID      = 'CSV_FIELDNAMES_REQUIRED'
-CSV_DICT_NO_HEADER_ID           = 'CSV_DICT_NO_HEADER'
-
-TOML_FILE_NOT_FOUND_ID          = 'TOML_FILE_NOT_FOUND'
-TOML_FILE_LOAD_ERROR_ID         = 'TOML_FILE_LOAD_ERROR'
-INVALID_TOML_FILE_ID            = 'INVALID_TOML_FILE'
-
-# ** constant: default_errors
-DEFAULT_ERRORS = {
-
-    # * error: COMMAND_PARAMETER_REQUIRED
-    COMMAND_PARAMETER_REQUIRED_ID: {
-        'id': COMMAND_PARAMETER_REQUIRED_ID,
-        'name': 'Command Parameter Required',
-        'message': [
-            {'lang': 'en_US', 'text': 'The required parameter {parameter} for command {command} is missing.'}
-        ]
-    },
-
-    # * error: ERROR_NOT_FOUND
-    ERROR_NOT_FOUND_ID: {
-        'id': ERROR_NOT_FOUND_ID,
-        'name': 'Error Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Error not found: {id}.'}
-        ]
-    },
-
-    # * error: ERROR_ALREADY_EXISTS
-    ERROR_ALREADY_EXISTS_ID: {
-        'id': ERROR_ALREADY_EXISTS_ID,
-        'name': 'Error Already Exists',
-        'message': [
-            {'lang': 'en_US', 'text': 'An error with ID {id} already exists.'}
-        ]
-    },
-
-    # * error: FEATURE_NAME_REQUIRED
-    FEATURE_NAME_REQUIRED_ID: {
-        'id': FEATURE_NAME_REQUIRED_ID,
-        'name': 'Feature Name Required',
-        'message': [
-            {'lang': 'en_US', 'text': 'A feature name is required when updating the name attribute.'}
-        ]
-    },
-
-    # * error: INVALID_FEATURE_ATTRIBUTE
-    INVALID_FEATURE_ATTRIBUTE_ID: {
-        'id': INVALID_FEATURE_ATTRIBUTE_ID,
-        'name': 'Invalid Feature Attribute',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid feature attribute: {attribute}. Supported attributes are name and description.'}
-        ]
-    },
-
-    # * error: INVALID_FEATURE_COMMAND_ATTRIBUTE
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: {
-        'id': INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
-        'name': 'Invalid Feature Command Attribute',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Invalid feature command attribute: {attribute}. Supported attributes are name, attribute_id, data_key, pass_on_error, and parameters.',
-            }
-        ],
-    },
-
-    # * error: NO_ERROR_MESSAGES
-    NO_ERROR_MESSAGES_ID: {
-        'id': NO_ERROR_MESSAGES_ID,
-        'name': 'No Error Messages',
-        'message': [
-            {'lang': 'en_US', 'text': 'No error messages are defined for error ID {id}.'}
-        ]
-    },
-
-    # * error: PARAMETER_PARSING_FAILED
-    PARAMETER_PARSING_FAILED_ID: {
-        'id': PARAMETER_PARSING_FAILED_ID,
-        'name': 'Parameter Parsing Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to parse parameter: {parameter}. Error: {exception}.'}
-        ]
-    },
-
-    # * error: IMPORT_DEPENDENCY_FAILED
-    IMPORT_DEPENDENCY_FAILED_ID: {
-        'id': IMPORT_DEPENDENCY_FAILED_ID,
-        'name': 'Import Dependency Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to import {class_name} from {module_path}. Error: {exception}.'}
-        ]
-    },
-
-    # * error: FEATURE_COMMAND_LOADING_FAILED
-    FEATURE_COMMAND_LOADING_FAILED_ID: {
-        'id': FEATURE_COMMAND_LOADING_FAILED_ID,
-        'name': 'Feature Command Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to load feature command attribute: {attribute_id}. Error: {exception}.'}
-        ]
-    },
-
-    # * error: MIDDLEWARE_LOADING_FAILED
-    MIDDLEWARE_LOADING_FAILED_ID: {
-        'id': MIDDLEWARE_LOADING_FAILED_ID,
-        'name': 'Middleware Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to load middleware: {service_id}. Error: {exception}.'}
-        ]
-    },
-
-    # * error: APP_REPOSITORY_IMPORT_FAILED
-    APP_REPOSITORY_IMPORT_FAILED_ID: {
-        'id': APP_REPOSITORY_IMPORT_FAILED_ID,
-        'name': 'App Repository Import Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to import app repository: {exception}.'}
-        ]
-    },
-
-    # * error: APP_SERVICE_IMPORT_FAILED
-    APP_SERVICE_IMPORT_FAILED_ID: {
-        'id': APP_SERVICE_IMPORT_FAILED_ID,
-        'name': 'App Service Import Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to import app service dependencies: {exception}.'}
-        ]
-    },
-
-    # * error: APP_SERVICE_NOT_LOADED
-    APP_SERVICE_NOT_LOADED_ID: {
-        'id': APP_SERVICE_NOT_LOADED_ID,
-        'name': 'App Service Not Loaded',
-        'message': [
-            {'lang': 'en_US', 'text': 'App service must be loaded before loading interface {interface_id}.'}
-        ]
-    },
-
-    # * error: DI_SERVICE_NOT_CONFIGURED
-    DI_SERVICE_NOT_CONFIGURED_ID: {
-        'id': DI_SERVICE_NOT_CONFIGURED_ID,
-        'name': 'DI Service Not Configured',
-        'message': [
-            {'lang': 'en_US', 'text': 'No di_service dependency is configured for interface {interface_id}.'}
-        ]
-    },
-
-    # * error: DEPENDENCY_TYPE_NOT_FOUND
-    DEPENDENCY_TYPE_NOT_FOUND_ID: {
-        'id': DEPENDENCY_TYPE_NOT_FOUND_ID,
-        'name': 'Dependency Type Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'No dependency type found for attribute {attribute_id} with flags {flags}.'}
-        ]
-    },
-
-    # * error: REQUEST_NOT_FOUND
-    REQUEST_NOT_FOUND_ID: {
-        'id': REQUEST_NOT_FOUND_ID,
-        'name': 'Request Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Request data is not available for parameter parsing.'}
-        ]
-    },
-
-    # * error: PARAMETER_NOT_FOUND
-    PARAMETER_NOT_FOUND_ID: {
-        'id': PARAMETER_NOT_FOUND_ID,
-        'name': 'Parameter Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Parameter {parameter} not found in request data.'}
-        ]
-    },
-
-    # * error: REQUEST_VALIDATION_FAILED
-    REQUEST_VALIDATION_FAILED_ID: {
-        'id': REQUEST_VALIDATION_FAILED_ID,
-        'name': 'Request Validation Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Request validation failed for feature {feature_id}: {violations}.'}
-        ]
-    },
-
-    # * error: FEATURE_NOT_FOUND
-    FEATURE_NOT_FOUND_ID: {
-        'id': FEATURE_NOT_FOUND_ID,
-        'name': 'Feature Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Feature not found: {feature_id}.'}
-        ]
-    },
-
-    # * error: FEATURE_ALREADY_EXISTS
-    FEATURE_ALREADY_EXISTS_ID: {
-        'id': FEATURE_ALREADY_EXISTS_ID,
-        'name': 'Feature Already Exists',
-        'message': [
-            {'lang': 'en_US', 'text': 'Feature with ID {id} already exists.'}
-        ]
-    },
-
-    # * error: FEATURE_NAME_REQUIRED
-    FEATURE_NAME_REQUIRED_ID: {
-        'id': FEATURE_NAME_REQUIRED_ID,
-        'name': 'Feature Name Required',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'A feature name is required when updating the name attribute.',
-            },
-        ],
-    },
-
-    # * error: INVALID_FEATURE_ATTRIBUTE
-    INVALID_FEATURE_ATTRIBUTE_ID: {
-        'id': INVALID_FEATURE_ATTRIBUTE_ID,
-        'name': 'Invalid Feature Attribute',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Invalid feature attribute: {attribute}',
-            },
-        ],
-    },
-
-    # * error: FEATURE_COMMAND_NOT_FOUND
-    FEATURE_COMMAND_NOT_FOUND_ID: {
-        'id': FEATURE_COMMAND_NOT_FOUND_ID,
-        'name': 'Feature Command Not Found',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Feature command not found for feature {feature_id} at position {position}.',
-            },
-        ],
-    },
-
-    # * error: INVALID_FEATURE_COMMAND_ATTRIBUTE
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: {
-        'id': INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
-        'name': 'Invalid Feature Command Attribute',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': (
-                    'Invalid feature command attribute: {attribute}. Supported attributes are '
-                    'name, attribute_id, data_key, pass_on_error, and parameters.'
-                ),
-            },
-        ],
-    },
-
-    # * error: LOGGING_CONFIG_FAILED
-    LOGGING_CONFIG_FAILED_ID: {
-        'id': LOGGING_CONFIG_FAILED_ID,
-        'name': 'Logging Configuration Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to configure logging: {exception}.'}
-        ]
-    },
-
-    # * error: LOGGER_CREATION_FAILED
-    LOGGER_CREATION_FAILED_ID: {
-        'id': LOGGER_CREATION_FAILED_ID,
-        'name': 'Logger Creation Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to create logger with ID {logger_id}: {exception}.'}
-        ]
-    },
-
-    # * error: FILE_NOT_FOUND
-    FILE_NOT_FOUND_ID: {
-        'id': FILE_NOT_FOUND_ID,
-        'name': 'File Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'File not found: {path}.'}
-        ]
-    },
-
-    # * error: INVALID_FILE
-    INVALID_FILE_ID: {
-        'id': INVALID_FILE_ID,
-        'name': 'Invalid File',
-        'message': [
-            {'lang': 'en_US', 'text': 'Path is not a file: {path}.'}
-        ]
-    },
-
-    # * error: FILE_ALREADY_OPEN
-    FILE_ALREADY_OPEN_ID: {
-        'id': FILE_ALREADY_OPEN_ID,
-        'name': 'File Already Open',
-        'message': [
-            {'lang': 'en_US', 'text': 'File is already open: {path}.'}
-        ]
-    },
-
-    # * error: INVALID_FILE_MODE
-    INVALID_FILE_MODE_ID: {
-        'id': INVALID_FILE_MODE_ID,
-        'name': 'Invalid File Mode',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid file mode: {mode}. Valid modes include {modes}'}
-        ]
-    },
-
-    # * error: INVALID_ENCODING
-    INVALID_ENCODING_ID: {
-        'id': INVALID_ENCODING_ID,
-        'name': 'Invalid Encoding',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid encoding: {encoding}. Supported encodings are: utf-8, ascii, latin-1.'}
-        ]
-    },
-
-    # * error: INVALID_JSON_FILE
-    INVALID_JSON_FILE_ID: {
-        'id': INVALID_JSON_FILE_ID,
-        'name': 'Invalid JSON File',
-        'message': [
-            {'lang': 'en_US', 'text': 'File is not a valid JSON file: {path}.'}
-        ]
-    },
-
-    # * error: INVALID_YAML_FILE
-    INVALID_YAML_FILE_ID: {
-        'id': INVALID_YAML_FILE_ID,
-        'name': 'Invalid YAML File',
-        'message': [
-            {'lang': 'en_US', 'text': 'File is not a valid YAML file: {path}.'}
-        ]
-    },
-
-    # * error: UNSUPPORTED_CONFIG_FILE_TYPE
-    UNSUPPORTED_CONFIG_FILE_TYPE_ID: {
-        'id': UNSUPPORTED_CONFIG_FILE_TYPE_ID,
-        'name': 'Unsupported Configuration File Type',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unsupported configuration file type: {file_extension}.'}
-        ]
-    },
-
-
-    # * error: APP_INTERFACE_NOT_FOUND
-    APP_INTERFACE_NOT_FOUND_ID: {
-        'id': APP_INTERFACE_NOT_FOUND_ID,
-        'name': 'App Interface Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'App interface with ID {interface_id} not found.'}
-        ]
-    },
-
-    # * error: INVALID_SERVICE_REGISTRATION
-    INVALID_SERVICE_REGISTRATION_ID: {
-        'id': INVALID_SERVICE_REGISTRATION_ID,
-        'name': 'Invalid Service Registration',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': (
-                    'A service registration must define either a default type '
-                    '(module_path/class_name) or at least one flagged dependency.'
-                ),
-            }
-        ],
-    },
-
-    # * error: ATTRIBUTE_ALREADY_EXISTS
-    ATTRIBUTE_ALREADY_EXISTS_ID: {
-        'id': ATTRIBUTE_ALREADY_EXISTS_ID,
-        'name': 'Attribute Already Exists',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'A container attribute with ID {id} already exists.',
-            }
-        ],
-    },
-
-    # * error: SERVICE_REGISTRATION_NOT_FOUND
-    SERVICE_REGISTRATION_NOT_FOUND_ID: {
-        'id': SERVICE_REGISTRATION_NOT_FOUND_ID,
-        'name': 'Service Registration Not Found',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Service registration with ID {id} not found.',
-            }
-        ],
-    },
-
-    # * error: INVALID_FLAGGED_DEPENDENCY
-    INVALID_FLAGGED_DEPENDENCY_ID: {
-        'id': INVALID_FLAGGED_DEPENDENCY_ID,
-        'name': 'Invalid Flagged Dependency',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'A flagged dependency must define both module_path and class_name.',
-            }
-        ],
-    },
-
-    # * error: SERVICE_REGISTRATION_ALREADY_EXISTS
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: {
-        'id': SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
-        'name': 'Service Registration Already Exists',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'A service registration with ID {id} already exists.',
-            }
-        ],
-    },
-
-    # * error: INVALID_MODEL_ATTRIBUTE
-    INVALID_MODEL_ATTRIBUTE_ID: {
-        'id': INVALID_MODEL_ATTRIBUTE_ID,
-        'name': 'Invalid Model Attribute',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Invalid attribute: {attribute}. Supported attributes are {supported}.',
-            }
-        ],
-    },
-
-    # * error: INVALID_APP_INTERFACE_TYPE
-    INVALID_APP_INTERFACE_TYPE_ID: {
-        'id': INVALID_APP_INTERFACE_TYPE_ID,
-        'name': 'Invalid App Interface Type',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': '{attribute} must be a non-empty string.',
-            }
-        ],
-    },
-
-    # * error: SQLITE_CONN_ALREADY_OPEN
-    SQLITE_CONN_ALREADY_OPEN_ID: {
-        'id': SQLITE_CONN_ALREADY_OPEN_ID,
-        'name': 'SQLite Connection Already Open',
-        'message': [
-            {'lang': 'en_US', 'text': 'Connection already open for path: {path}.'}
-        ]
-    },
-
-    # * error: SQLITE_INVALID_MODE
-    SQLITE_INVALID_MODE_ID: {
-        'id': SQLITE_INVALID_MODE_ID,
-        'name': 'Invalid SQLite Mode',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).'}
-        ]
-    },
-
-    # * error: SQLITE_FILE_NOT_FOUND_OR_READONLY
-    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: {
-        'id': SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
-        'name': 'SQLite File Not Found or Read-Only',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to open SQLite database at {path}: {original_error}. Check path exists and is writable (use mode=rwc to create).'}
-        ]
-    },
-
-    # * error: SQLITE_CONN_FAILED
-    SQLITE_CONN_FAILED_ID: {
-        'id': SQLITE_CONN_FAILED_ID,
-        'name': 'SQLite Connection Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to connect to SQLite database at {path}: {original_error}'}
-        ]
-    },
-
-    # * error: SQLITE_BACKUP_FAILED
-    SQLITE_BACKUP_FAILED_ID: {
-        'id': SQLITE_BACKUP_FAILED_ID,
-        'name': 'SQLite Backup Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Backup to {target_path} failed: {original_error}'}
-        ]
-    },
-    
-    # * error: SQLITE_CONN_NOT_INITIALIZED
-    SQLITE_CONN_NOT_INITIALIZED_ID: {
-        'id': SQLITE_CONN_NOT_INITIALIZED_ID,
-        'name': 'SQLite Connection Not Initialized',
-        'message': [
-            {'lang': 'en_US', 'text': 'SQLite connection not initialized. Must be used within a "with" block.'}
-        ]
-    },
-    
-    # * error: INVALID_DEPENDENCY_ERROR
-    INVALID_DEPENDENCY_ERROR_ID: {
-        'id': INVALID_DEPENDENCY_ERROR_ID,
-        'name': 'Invalid Dependency Error',
-        'message': [
-            {'lang': 'en_US', 'text': 'Dependency {dependency} could not be resolved: {reason}.'}
-        ]
-    },
-
-    # * error: APP_ERROR
-    'APP_ERROR': {
-        'id': 'APP_ERROR',
-        'name': 'App Error',
-        'message': [
-            {'lang': 'en_US', 'text': 'An error occurred in the app: {error_message}.'}
-        ]
-    },
-
-    # * error: CONFIG_FILE_NOT_FOUND
-    'CONFIG_FILE_NOT_FOUND': {
-        'id': 'CONFIG_FILE_NOT_FOUND',
-        'name': 'Configuration File Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'Configuration file {file_path} not found.'}
-        ]
-    },
-
-    # * error: APP_CONFIG_LOADING_FAILED
-    'APP_CONFIG_LOADING_FAILED': {
-        'id': 'APP_CONFIG_LOADING_FAILED',
-        'name': 'App Configuration Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to load app configuration file {file_path}: {exception}.'}
-        ]
-    },
-
-    # * error: CONTAINER_CONFIG_LOADING_FAILED
-    'CONTAINER_CONFIG_LOADING_FAILED': {
-        'id': 'CONTAINER_CONFIG_LOADING_FAILED',
-        'name': 'Container Configuration Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to load container configuration file {file_path}: {exception}.'}
-        ]
-    },
-
-    # * error: FEATURE_CONFIG_LOADING_FAILED
-    'FEATURE_CONFIG_LOADING_FAILED': {
-        'id': 'FEATURE_CONFIG_LOADING_FAILED',
-        'name': 'Feature Configuration Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to load feature configuration file {file_path}: {exception}.'}
-        ]
-    },
-
-    # * error: ERROR_CONFIG_LOADING_FAILED
-    'ERROR_CONFIG_LOADING_FAILED': {
-        'id': 'ERROR_CONFIG_LOADING_FAILED',
-        'name': 'Error Configuration Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to load error configuration file {file_path}: {exception}.'}
-        ]
-    },
-
-    # * error: CLI_CONFIG_LOADING_FAILED
-    'CLI_CONFIG_LOADING_FAILED': {
-        'id': 'CLI_CONFIG_LOADING_FAILED',
-        'name': 'CLI Configuration Loading Failed',
-        'message': [
-            {'lang': 'en_US', 'text': 'Unable to load CLI configuration file {file_path}: {exception}.'}
-        ]
-    },
-
-    # * error: CLI_COMMAND_NOT_FOUND
-    CLI_COMMAND_NOT_FOUND_ID: {
-        'id': CLI_COMMAND_NOT_FOUND_ID,
-        'name': 'CLI Command Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'CLI command {command_id} not found.'}
-        ]
-    },
-
-    # * error: CLI_COMMAND_ALREADY_EXISTS
-    CLI_COMMAND_ALREADY_EXISTS_ID: {
-        'id': CLI_COMMAND_ALREADY_EXISTS_ID,
-        'name': 'CLI Command Already Exists',
-        'message': [
-            {'lang': 'en_US', 'text': 'CLI command with ID {id} already exists.'}
-        ]
-    },
-
-    # * error: INVALID_MODEL_ATTRIBUTE
-    INVALID_MODEL_ATTRIBUTE_ID: {
-        'id': INVALID_MODEL_ATTRIBUTE_ID,
-        'name': 'Invalid Model Attribute',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': 'Invalid attribute: {attribute}. Supported attributes are {supported}.',
-            },
-        ],
-    },
-
-    # * error: INVALID_APP_INTERFACE_TYPE
-    INVALID_APP_INTERFACE_TYPE_ID: {
-        'id': INVALID_APP_INTERFACE_TYPE_ID,
-        'name': 'Invalid App Interface Type',
-        'message': [
-            {
-                'lang': 'en_US',
-                'text': '{attribute} must be a non-empty string.',
-            },
-        ],
-    },
-
-    # * error: YAML_FILE_NOT_FOUND
-    YAML_FILE_NOT_FOUND_ID: {
-        'id': YAML_FILE_NOT_FOUND_ID,
-        'name': 'YAML File Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'The specified YAML file could not be found at {path}.'}
-        ]
-    },
-
-    # * error: YAML_FILE_LOAD_ERROR
-    YAML_FILE_LOAD_ERROR_ID: {
-        'id': YAML_FILE_LOAD_ERROR_ID,
-        'name': 'YAML Load Failure',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to parse YAML file: {error}. Path: {path}.'}
-        ]
-    },
-
-    # * error: YAML_FILE_SAVE_ERROR
-    YAML_FILE_SAVE_ERROR_ID: {
-        'id': YAML_FILE_SAVE_ERROR_ID,
-        'name': 'YAML Save Failure',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to write YAML file: {error}. Path: {path}.'}
-        ]
-    },
-
-    # * error: JSON_FILE_NOT_FOUND
-    JSON_FILE_NOT_FOUND_ID: {
-        'id': JSON_FILE_NOT_FOUND_ID,
-        'name': 'JSON File Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'The specified JSON file could not be found at {path}.'}
-        ]
-    },
-
-    # * error: JSON_FILE_LOAD_ERROR
-    JSON_FILE_LOAD_ERROR_ID: {
-        'id': JSON_FILE_LOAD_ERROR_ID,
-        'name': 'JSON Load Failure',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to parse JSON: {error}. Path: {path}.'}
-        ]
-    },
-
-    # * error: JSON_FILE_SAVE_ERROR
-    JSON_FILE_SAVE_ERROR_ID: {
-        'id': JSON_FILE_SAVE_ERROR_ID,
-        'name': 'JSON Save Failure',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to serialize/write JSON: {error}. Path: {path}.'}
-        ]
-    },
-
-    # * error: INVALID_JSON_PATH
-    INVALID_JSON_PATH_ID: {
-        'id': INVALID_JSON_PATH_ID,
-        'name': 'Invalid JSON Path',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid JSON path: {path}. Failed at segment: {part}.'}
-        ]
-    },
-
-    # * error: CSV_INVALID_MODE
-    CSV_INVALID_MODE_ID: {
-        'id': CSV_INVALID_MODE_ID,
-        'name': 'Invalid CSV Mode',
-        'message': [
-            {'lang': 'en_US', 'text': 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.'}
-        ]
-    },
-
-    # * error: CSV_HANDLE_NOT_INITIALIZED
-    CSV_HANDLE_NOT_INITIALIZED_ID: {
-        'id': CSV_HANDLE_NOT_INITIALIZED_ID,
-        'name': 'CSV Handle Not Initialized',
-        'message': [
-            {'lang': 'en_US', 'text': 'CSV file must be opened before reading/writing.'}
-        ]
-    },
-
-    # * error: CSV_INVALID_READ_MODE
-    CSV_INVALID_READ_MODE_ID: {
-        'id': CSV_INVALID_READ_MODE_ID,
-        'name': 'Invalid CSV Read Mode',
-        'message': [
-            {'lang': 'en_US', 'text': 'File not opened in readable mode for CSV reading.'}
-        ]
-    },
-
-    # * error: CSV_INVALID_WRITE_MODE
-    CSV_INVALID_WRITE_MODE_ID: {
-        'id': CSV_INVALID_WRITE_MODE_ID,
-        'name': 'Invalid CSV Write Mode',
-        'message': [
-            {'lang': 'en_US', 'text': 'File not opened in writable mode for CSV writing.'}
-        ]
-    },
-
-    # * error: CSV_FIELDNAMES_REQUIRED
-    CSV_FIELDNAMES_REQUIRED_ID: {
-        'id': CSV_FIELDNAMES_REQUIRED_ID,
-        'name': 'CSV Fieldnames Required',
-        'message': [
-            {'lang': 'en_US', 'text': 'Fieldnames must be provided when writing dict-based CSV rows.'}
-        ]
-    },
-
-    # * error: CSV_DICT_NO_HEADER
-    CSV_DICT_NO_HEADER_ID: {
-        'id': CSV_DICT_NO_HEADER_ID,
-        'name': 'CSV Dict Reader Without Header',
-        'message': [
-            {'lang': 'en_US', 'text': 'Dict reader expects header row; file appears to lack one or was not read correctly.'}
-        ]
-    },
-
-    # * error: TOML_FILE_NOT_FOUND
-    TOML_FILE_NOT_FOUND_ID: {
-        'id': TOML_FILE_NOT_FOUND_ID,
-        'name': 'TOML File Not Found',
-        'message': [
-            {'lang': 'en_US', 'text': 'The specified TOML file could not be found at {path}.'}
-        ]
-    },
-
-    # * error: TOML_FILE_LOAD_ERROR
-    TOML_FILE_LOAD_ERROR_ID: {
-        'id': TOML_FILE_LOAD_ERROR_ID,
-        'name': 'TOML Load Failure',
-        'message': [
-            {'lang': 'en_US', 'text': 'Failed to parse TOML file: {error}. Path: {path}.'}
-        ]
-    },
-
-    # * error: INVALID_TOML_FILE
-    INVALID_TOML_FILE_ID: {
-        'id': INVALID_TOML_FILE_ID,
-        'name': 'Invalid TOML File',
-        'message': [
-            {'lang': 'en_US', 'text': 'File is not a valid TOML file: {path}.'}
-        ]
-    },
-}
+# ** constant: context_not_found_id
+CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
+
+# *** functions
+
+# ** function: create_default_error
+def create_default_error(id: str,
+        name: str,
+        messages: List[Tuple[str, str]]) -> Dict[str, Any]:
+    '''
+    Build a default error definition dictionary.
+
+    :param id: The unique identifier of the error.
+    :type id: str
+    :param name: The human-readable error name.
+    :type name: str
+    :param messages: Ordered (lang, text) message pairs.
+    :type messages: List[Tuple[str, str]]
+    :return: The default error definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the default error definition dictionary.
+    return {
+        'id': id,
+        'name': name,
+        'message': [{'lang': lang, 'text': text} for lang, text in messages],
+    }

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -602,7 +602,7 @@ SQLITE_CONN_NOT_INITIALIZED = create_default_error(
 CONTEXT_NOT_FOUND = create_default_error(
     CONTEXT_NOT_FOUND_ID,
     'Context Not Found',
-    [(EN_US, 'No context registered for domain type {domain_type}.')],
+    [(EN_US, 'No context registered for domain type: {domain_type}.')],
 )
 
 # *** constants (groups)

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -1,0 +1,685 @@
+"""Tiferet Error Catalog (Assets)
+
+Default error catalog mapping each error-code constant to its name and
+multilingual message templates, consumed by ErrorContext and the error
+domain events when not overridden by consumer configuration.
+"""
+
+# *** imports
+
+# ** app
+from .constants import (
+    APP_CONFIG_LOADING_FAILED_ID,
+    APP_ERROR_ID,
+    APP_INTERFACE_NOT_FOUND_ID,
+    APP_REPOSITORY_IMPORT_FAILED_ID,
+    APP_SERVICE_IMPORT_FAILED_ID,
+    APP_SERVICE_NOT_LOADED_ID,
+    ATTRIBUTE_ALREADY_EXISTS_ID,
+    CLI_COMMAND_ALREADY_EXISTS_ID,
+    CLI_COMMAND_NOT_FOUND_ID,
+    CLI_CONFIG_LOADING_FAILED_ID,
+    COMMAND_PARAMETER_REQUIRED_ID,
+    CONFIG_FILE_NOT_FOUND_ID,
+    CONTAINER_CONFIG_LOADING_FAILED_ID,
+    CONTEXT_NOT_FOUND_ID,
+    CSV_DICT_NO_HEADER_ID,
+    CSV_FIELDNAMES_REQUIRED_ID,
+    CSV_HANDLE_NOT_INITIALIZED_ID,
+    CSV_INVALID_MODE_ID,
+    CSV_INVALID_READ_MODE_ID,
+    CSV_INVALID_WRITE_MODE_ID,
+    DEPENDENCY_TYPE_NOT_FOUND_ID,
+    DI_SERVICE_NOT_CONFIGURED_ID,
+    EN_US,
+    ERROR_ALREADY_EXISTS_ID,
+    ERROR_CONFIG_LOADING_FAILED_ID,
+    ERROR_NOT_FOUND_ID,
+    FEATURE_ALREADY_EXISTS_ID,
+    FEATURE_COMMAND_LOADING_FAILED_ID,
+    FEATURE_COMMAND_NOT_FOUND_ID,
+    FEATURE_CONFIG_LOADING_FAILED_ID,
+    FEATURE_NAME_REQUIRED_ID,
+    FEATURE_NOT_FOUND_ID,
+    FILE_ALREADY_OPEN_ID,
+    FILE_NOT_FOUND_ID,
+    IMPORT_DEPENDENCY_FAILED_ID,
+    INVALID_APP_INTERFACE_TYPE_ID,
+    INVALID_DEPENDENCY_ERROR_ID,
+    INVALID_ENCODING_ID,
+    INVALID_FEATURE_ATTRIBUTE_ID,
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+    INVALID_FILE_ID,
+    INVALID_FILE_MODE_ID,
+    INVALID_FLAGGED_DEPENDENCY_ID,
+    INVALID_JSON_FILE_ID,
+    INVALID_JSON_PATH_ID,
+    INVALID_MODEL_ATTRIBUTE_ID,
+    INVALID_SERVICE_REGISTRATION_ID,
+    INVALID_TOML_FILE_ID,
+    INVALID_YAML_FILE_ID,
+    JSON_FILE_LOAD_ERROR_ID,
+    JSON_FILE_NOT_FOUND_ID,
+    JSON_FILE_SAVE_ERROR_ID,
+    LOGGER_CREATION_FAILED_ID,
+    LOGGING_CONFIG_FAILED_ID,
+    MIDDLEWARE_LOADING_FAILED_ID,
+    NO_ERROR_MESSAGES_ID,
+    PARAMETER_NOT_FOUND_ID,
+    PARAMETER_PARSING_FAILED_ID,
+    REQUEST_NOT_FOUND_ID,
+    REQUEST_VALIDATION_FAILED_ID,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+    SERVICE_REGISTRATION_NOT_FOUND_ID,
+    SQLITE_BACKUP_FAILED_ID,
+    SQLITE_CONN_ALREADY_OPEN_ID,
+    SQLITE_CONN_FAILED_ID,
+    SQLITE_CONN_NOT_INITIALIZED_ID,
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
+    SQLITE_INVALID_MODE_ID,
+    TOML_FILE_LOAD_ERROR_ID,
+    TOML_FILE_NOT_FOUND_ID,
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
+    YAML_FILE_LOAD_ERROR_ID,
+    YAML_FILE_NOT_FOUND_ID,
+    YAML_FILE_SAVE_ERROR_ID,
+    create_default_error,
+)
+
+# *** constants (errors)
+
+# ** constant: command_parameter_required
+COMMAND_PARAMETER_REQUIRED = create_default_error(
+    COMMAND_PARAMETER_REQUIRED_ID,
+    'Command Parameter Required',
+    [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
+)
+
+# ** constant: error_not_found
+ERROR_NOT_FOUND = create_default_error(
+    ERROR_NOT_FOUND_ID,
+    'Error Not Found',
+    [(EN_US, 'Error not found: {id}.')],
+)
+
+# ** constant: error_already_exists
+ERROR_ALREADY_EXISTS = create_default_error(
+    ERROR_ALREADY_EXISTS_ID,
+    'Error Already Exists',
+    [(EN_US, 'An error with ID {id} already exists.')],
+)
+
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = create_default_error(
+    FEATURE_NOT_FOUND_ID,
+    'Feature Not Found',
+    [(EN_US, 'Feature not found: {feature_id}.')],
+)
+
+# ** constant: feature_already_exists
+FEATURE_ALREADY_EXISTS = create_default_error(
+    FEATURE_ALREADY_EXISTS_ID,
+    'Feature Already Exists',
+    [(EN_US, 'Feature with ID {id} already exists.')],
+)
+
+# ** constant: feature_name_required
+FEATURE_NAME_REQUIRED = create_default_error(
+    FEATURE_NAME_REQUIRED_ID,
+    'Feature Name Required',
+    [(EN_US, 'A feature name is required when updating the name attribute.')],
+)
+
+# ** constant: invalid_feature_attribute
+INVALID_FEATURE_ATTRIBUTE = create_default_error(
+    INVALID_FEATURE_ATTRIBUTE_ID,
+    'Invalid Feature Attribute',
+    [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
+)
+
+# ** constant: invalid_feature_command_attribute
+INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+    'Invalid Feature Command Attribute',
+    [(EN_US,
+      'Invalid feature command attribute: {attribute}. Supported attributes are '
+      'name, attribute_id, data_key, pass_on_error, and parameters.')],
+)
+
+# ** constant: feature_command_not_found
+FEATURE_COMMAND_NOT_FOUND = create_default_error(
+    FEATURE_COMMAND_NOT_FOUND_ID,
+    'Feature Command Not Found',
+    [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
+)
+
+# ** constant: feature_command_loading_failed
+FEATURE_COMMAND_LOADING_FAILED = create_default_error(
+    FEATURE_COMMAND_LOADING_FAILED_ID,
+    'Feature Command Loading Failed',
+    [(EN_US, 'Failed to load feature command attribute: {service_id}. Error: {exception}.')],
+)
+
+# ** constant: invalid_model_attribute
+INVALID_MODEL_ATTRIBUTE = create_default_error(
+    INVALID_MODEL_ATTRIBUTE_ID,
+    'Invalid Model Attribute',
+    [(EN_US, 'Invalid attribute: {attribute}. Supported attributes are {supported}.')],
+)
+
+# ** constant: invalid_app_interface_type
+INVALID_APP_INTERFACE_TYPE = create_default_error(
+    INVALID_APP_INTERFACE_TYPE_ID,
+    'Invalid App Interface Type',
+    [(EN_US, '{attribute} must be a non-empty string.')],
+)
+
+# ** constant: attribute_already_exists
+ATTRIBUTE_ALREADY_EXISTS = create_default_error(
+    ATTRIBUTE_ALREADY_EXISTS_ID,
+    'Attribute Already Exists',
+    [(EN_US, 'A container attribute with ID {id} already exists.')],
+)
+
+# ** constant: di_service_not_configured
+DI_SERVICE_NOT_CONFIGURED = create_default_error(
+    DI_SERVICE_NOT_CONFIGURED_ID,
+    'DI Service Not Configured',
+    [(EN_US, 'No di_service dependency is configured for interface {interface_id}.')],
+)
+
+# ** constant: dependency_type_not_found
+DEPENDENCY_TYPE_NOT_FOUND = create_default_error(
+    DEPENDENCY_TYPE_NOT_FOUND_ID,
+    'Dependency Type Not Found',
+    [(EN_US, 'No dependency type found for service configuration {configuration_id} with flags {flags}.')],
+)
+
+# ** constant: invalid_service_registration
+INVALID_SERVICE_REGISTRATION = create_default_error(
+    INVALID_SERVICE_REGISTRATION_ID,
+    'Invalid Service Registration',
+    [(EN_US,
+      'A service registration must define either a default type '
+      '(module_path/class_name) or at least one flagged dependency.')],
+)
+
+# ** constant: service_registration_not_found
+SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
+    SERVICE_REGISTRATION_NOT_FOUND_ID,
+    'Service Registration Not Found',
+    [(EN_US, 'Service registration with ID {id} not found.')],
+)
+
+# ** constant: service_registration_already_exists
+SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+    'Service Registration Already Exists',
+    [(EN_US, 'A service registration with ID {id} already exists.')],
+)
+
+# ** constant: invalid_flagged_dependency
+INVALID_FLAGGED_DEPENDENCY = create_default_error(
+    INVALID_FLAGGED_DEPENDENCY_ID,
+    'Invalid Flagged Dependency',
+    [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
+)
+
+# ** constant: invalid_dependency_error
+INVALID_DEPENDENCY_ERROR = create_default_error(
+    INVALID_DEPENDENCY_ERROR_ID,
+    'Invalid Dependency Error',
+    [(EN_US, 'Dependency {dependency} could not be resolved: {reason}.')],
+)
+
+# ** constant: parameter_parsing_failed
+PARAMETER_PARSING_FAILED = create_default_error(
+    PARAMETER_PARSING_FAILED_ID,
+    'Parameter Parsing Failed',
+    [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
+)
+
+# ** constant: parameter_not_found
+PARAMETER_NOT_FOUND = create_default_error(
+    PARAMETER_NOT_FOUND_ID,
+    'Parameter Not Found',
+    [(EN_US, 'Parameter {parameter} not found in request data.')],
+)
+
+# ** constant: import_dependency_failed
+IMPORT_DEPENDENCY_FAILED = create_default_error(
+    IMPORT_DEPENDENCY_FAILED_ID,
+    'Import Dependency Failed',
+    [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
+)
+
+# ** constant: request_not_found
+REQUEST_NOT_FOUND = create_default_error(
+    REQUEST_NOT_FOUND_ID,
+    'Request Not Found',
+    [(EN_US, 'Request data is not available for parameter parsing.')],
+)
+
+# ** constant: request_validation_failed
+REQUEST_VALIDATION_FAILED = create_default_error(
+    REQUEST_VALIDATION_FAILED_ID,
+    'Request Validation Failed',
+    [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
+)
+
+# ** constant: no_error_messages
+NO_ERROR_MESSAGES = create_default_error(
+    NO_ERROR_MESSAGES_ID,
+    'No Error Messages',
+    [(EN_US, 'No error messages are defined for error ID {id}.')],
+)
+
+# ** constant: middleware_loading_failed
+MIDDLEWARE_LOADING_FAILED = create_default_error(
+    MIDDLEWARE_LOADING_FAILED_ID,
+    'Middleware Loading Failed',
+    [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
+)
+
+# ** constant: app_repository_import_failed
+APP_REPOSITORY_IMPORT_FAILED = create_default_error(
+    APP_REPOSITORY_IMPORT_FAILED_ID,
+    'App Repository Import Failed',
+    [(EN_US, 'Failed to import app repository: {exception}.')],
+)
+
+# ** constant: app_service_import_failed
+APP_SERVICE_IMPORT_FAILED = create_default_error(
+    APP_SERVICE_IMPORT_FAILED_ID,
+    'App Service Import Failed',
+    [(EN_US, 'Failed to import app service dependencies: {exception}.')],
+)
+
+# ** constant: app_service_not_loaded
+APP_SERVICE_NOT_LOADED = create_default_error(
+    APP_SERVICE_NOT_LOADED_ID,
+    'App Service Not Loaded',
+    [(EN_US, 'App service must be loaded before loading interface {interface_id}.')],
+)
+
+# ** constant: app_interface_not_found
+APP_INTERFACE_NOT_FOUND = create_default_error(
+    APP_INTERFACE_NOT_FOUND_ID,
+    'App Interface Not Found',
+    [(EN_US, 'App interface with ID {interface_id} not found.')],
+)
+
+# ** constant: app_error
+APP_ERROR = create_default_error(
+    APP_ERROR_ID,
+    'App Error',
+    [(EN_US, 'An error occurred in the app: {error_message}.')],
+)
+
+# ** constant: config_file_not_found
+CONFIG_FILE_NOT_FOUND = create_default_error(
+    CONFIG_FILE_NOT_FOUND_ID,
+    'Configuration File Not Found',
+    [(EN_US, 'Configuration file {file_path} not found.')],
+)
+
+# ** constant: app_config_loading_failed
+APP_CONFIG_LOADING_FAILED = create_default_error(
+    APP_CONFIG_LOADING_FAILED_ID,
+    'App Configuration Loading Failed',
+    [(EN_US, 'Unable to load app configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: container_config_loading_failed
+CONTAINER_CONFIG_LOADING_FAILED = create_default_error(
+    CONTAINER_CONFIG_LOADING_FAILED_ID,
+    'Container Configuration Loading Failed',
+    [(EN_US, 'Unable to load container configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: feature_config_loading_failed
+FEATURE_CONFIG_LOADING_FAILED = create_default_error(
+    FEATURE_CONFIG_LOADING_FAILED_ID,
+    'Feature Configuration Loading Failed',
+    [(EN_US, 'Unable to load feature configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: error_config_loading_failed
+ERROR_CONFIG_LOADING_FAILED = create_default_error(
+    ERROR_CONFIG_LOADING_FAILED_ID,
+    'Error Configuration Loading Failed',
+    [(EN_US, 'Unable to load error configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: cli_config_loading_failed
+CLI_CONFIG_LOADING_FAILED = create_default_error(
+    CLI_CONFIG_LOADING_FAILED_ID,
+    'CLI Configuration Loading Failed',
+    [(EN_US, 'Unable to load CLI configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: cli_command_not_found
+CLI_COMMAND_NOT_FOUND = create_default_error(
+    CLI_COMMAND_NOT_FOUND_ID,
+    'CLI Command Not Found',
+    [(EN_US, 'CLI command {command_id} not found.')],
+)
+
+# ** constant: cli_command_already_exists
+CLI_COMMAND_ALREADY_EXISTS = create_default_error(
+    CLI_COMMAND_ALREADY_EXISTS_ID,
+    'CLI Command Already Exists',
+    [(EN_US, 'CLI command with ID {id} already exists.')],
+)
+
+# ** constant: logging_config_failed
+LOGGING_CONFIG_FAILED = create_default_error(
+    LOGGING_CONFIG_FAILED_ID,
+    'Logging Configuration Failed',
+    [(EN_US, 'Failed to configure logging: {exception}.')],
+)
+
+# ** constant: logger_creation_failed
+LOGGER_CREATION_FAILED = create_default_error(
+    LOGGER_CREATION_FAILED_ID,
+    'Logger Creation Failed',
+    [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
+)
+
+# ** constant: file_not_found
+FILE_NOT_FOUND = create_default_error(
+    FILE_NOT_FOUND_ID,
+    'File Not Found',
+    [(EN_US, 'File not found: {path}.')],
+)
+
+# ** constant: invalid_file
+INVALID_FILE = create_default_error(
+    INVALID_FILE_ID,
+    'Invalid File',
+    [(EN_US, 'Path is not a file: {path}.')],
+)
+
+# ** constant: file_already_open
+FILE_ALREADY_OPEN = create_default_error(
+    FILE_ALREADY_OPEN_ID,
+    'File Already Open',
+    [(EN_US, 'File is already open: {path}.')],
+)
+
+# ** constant: invalid_file_mode
+INVALID_FILE_MODE = create_default_error(
+    INVALID_FILE_MODE_ID,
+    'Invalid File Mode',
+    [(EN_US, 'Invalid file mode: {mode}. Valid modes include {modes}')],
+)
+
+# ** constant: invalid_encoding
+INVALID_ENCODING = create_default_error(
+    INVALID_ENCODING_ID,
+    'Invalid Encoding',
+    [(EN_US, 'Invalid encoding: {encoding}. Supported encodings are: utf-8, ascii, latin-1.')],
+)
+
+# ** constant: invalid_json_file
+INVALID_JSON_FILE = create_default_error(
+    INVALID_JSON_FILE_ID,
+    'Invalid JSON File',
+    [(EN_US, 'File is not a valid JSON file: {path}.')],
+)
+
+# ** constant: invalid_yaml_file
+INVALID_YAML_FILE = create_default_error(
+    INVALID_YAML_FILE_ID,
+    'Invalid YAML File',
+    [(EN_US, 'File is not a valid YAML file: {path}.')],
+)
+
+# ** constant: unsupported_config_file_type
+UNSUPPORTED_CONFIG_FILE_TYPE = create_default_error(
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
+    'Unsupported Configuration File Type',
+    [(EN_US, 'Unsupported configuration file type: {file_extension}.')],
+)
+
+# ** constant: yaml_file_not_found
+YAML_FILE_NOT_FOUND = create_default_error(
+    YAML_FILE_NOT_FOUND_ID,
+    'YAML File Not Found',
+    [(EN_US, 'The specified YAML file could not be found at {path}.')],
+)
+
+# ** constant: yaml_file_load_error
+YAML_FILE_LOAD_ERROR = create_default_error(
+    YAML_FILE_LOAD_ERROR_ID,
+    'YAML Load Failure',
+    [(EN_US, 'Failed to parse YAML file: {error}. Path: {path}.')],
+)
+
+# ** constant: yaml_file_save_error
+YAML_FILE_SAVE_ERROR = create_default_error(
+    YAML_FILE_SAVE_ERROR_ID,
+    'YAML Save Failure',
+    [(EN_US, 'Failed to write YAML file: {error}. Path: {path}.')],
+)
+
+# ** constant: json_file_not_found
+JSON_FILE_NOT_FOUND = create_default_error(
+    JSON_FILE_NOT_FOUND_ID,
+    'JSON File Not Found',
+    [(EN_US, 'The specified JSON file could not be found at {path}.')],
+)
+
+# ** constant: json_file_load_error
+JSON_FILE_LOAD_ERROR = create_default_error(
+    JSON_FILE_LOAD_ERROR_ID,
+    'JSON Load Failure',
+    [(EN_US, 'Failed to parse JSON: {error}. Path: {path}.')],
+)
+
+# ** constant: json_file_save_error
+JSON_FILE_SAVE_ERROR = create_default_error(
+    JSON_FILE_SAVE_ERROR_ID,
+    'JSON Save Failure',
+    [(EN_US, 'Failed to serialize/write JSON: {error}. Path: {path}.')],
+)
+
+# ** constant: invalid_json_path
+INVALID_JSON_PATH = create_default_error(
+    INVALID_JSON_PATH_ID,
+    'Invalid JSON Path',
+    [(EN_US, 'Invalid JSON path: {path}. Failed at segment: {part}.')],
+)
+
+# ** constant: csv_invalid_mode
+CSV_INVALID_MODE = create_default_error(
+    CSV_INVALID_MODE_ID,
+    'Invalid CSV Mode',
+    [(EN_US, 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.')],
+)
+
+# ** constant: csv_handle_not_initialized
+CSV_HANDLE_NOT_INITIALIZED = create_default_error(
+    CSV_HANDLE_NOT_INITIALIZED_ID,
+    'CSV Handle Not Initialized',
+    [(EN_US, 'CSV file must be opened before reading/writing.')],
+)
+
+# ** constant: csv_invalid_read_mode
+CSV_INVALID_READ_MODE = create_default_error(
+    CSV_INVALID_READ_MODE_ID,
+    'Invalid CSV Read Mode',
+    [(EN_US, 'File not opened in readable mode for CSV reading.')],
+)
+
+# ** constant: csv_invalid_write_mode
+CSV_INVALID_WRITE_MODE = create_default_error(
+    CSV_INVALID_WRITE_MODE_ID,
+    'Invalid CSV Write Mode',
+    [(EN_US, 'File not opened in writable mode for CSV writing.')],
+)
+
+# ** constant: csv_fieldnames_required
+CSV_FIELDNAMES_REQUIRED = create_default_error(
+    CSV_FIELDNAMES_REQUIRED_ID,
+    'CSV Fieldnames Required',
+    [(EN_US, 'Fieldnames must be provided when writing dict-based CSV rows.')],
+)
+
+# ** constant: csv_dict_no_header
+CSV_DICT_NO_HEADER = create_default_error(
+    CSV_DICT_NO_HEADER_ID,
+    'CSV Dict Reader Without Header',
+    [(EN_US, 'Dict reader expects header row; file appears to lack one or was not read correctly.')],
+)
+
+# ** constant: toml_file_not_found
+TOML_FILE_NOT_FOUND = create_default_error(
+    TOML_FILE_NOT_FOUND_ID,
+    'TOML File Not Found',
+    [(EN_US, 'The specified TOML file could not be found at {path}.')],
+)
+
+# ** constant: toml_file_load_error
+TOML_FILE_LOAD_ERROR = create_default_error(
+    TOML_FILE_LOAD_ERROR_ID,
+    'TOML Load Failure',
+    [(EN_US, 'Failed to parse TOML file: {error}. Path: {path}.')],
+)
+
+# ** constant: invalid_toml_file
+INVALID_TOML_FILE = create_default_error(
+    INVALID_TOML_FILE_ID,
+    'Invalid TOML File',
+    [(EN_US, 'File is not a valid TOML file: {path}.')],
+)
+
+# ** constant: sqlite_conn_already_open
+SQLITE_CONN_ALREADY_OPEN = create_default_error(
+    SQLITE_CONN_ALREADY_OPEN_ID,
+    'SQLite Connection Already Open',
+    [(EN_US, 'Connection already open for path: {path}.')],
+)
+
+# ** constant: sqlite_invalid_mode
+SQLITE_INVALID_MODE = create_default_error(
+    SQLITE_INVALID_MODE_ID,
+    'Invalid SQLite Mode',
+    [(EN_US, 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).')],
+)
+
+# ** constant: sqlite_file_not_found_or_readonly
+SQLITE_FILE_NOT_FOUND_OR_READONLY = create_default_error(
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
+    'SQLite File Not Found or Read-Only',
+    [(EN_US,
+      'Unable to open SQLite database at {path}: {original_error}. '
+      'Check path exists and is writable (use mode=rwc to create).')],
+)
+
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect to SQLite database at {path}: {original_error}')],
+)
+
+# ** constant: sqlite_backup_failed
+SQLITE_BACKUP_FAILED = create_default_error(
+    SQLITE_BACKUP_FAILED_ID,
+    'SQLite Backup Failed',
+    [(EN_US, 'Backup to {target_path} failed: {original_error}')],
+)
+
+# ** constant: sqlite_conn_not_initialized
+SQLITE_CONN_NOT_INITIALIZED = create_default_error(
+    SQLITE_CONN_NOT_INITIALIZED_ID,
+    'SQLite Connection Not Initialized',
+    [(EN_US, 'SQLite connection not initialized. Must be used within a "with" block.')],
+)
+
+# ** constant: context_not_found
+CONTEXT_NOT_FOUND = create_default_error(
+    CONTEXT_NOT_FOUND_ID,
+    'Context Not Found',
+    [(EN_US, 'No context registered for domain type {domain_type}.')],
+)
+
+# *** constants (groups)
+
+# ** constant: default_errors
+DEFAULT_ERRORS = {
+    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
+    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
+    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
+    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
+    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
+    FEATURE_COMMAND_LOADING_FAILED_ID: FEATURE_COMMAND_LOADING_FAILED,
+    INVALID_MODEL_ATTRIBUTE_ID: INVALID_MODEL_ATTRIBUTE,
+    INVALID_APP_INTERFACE_TYPE_ID: INVALID_APP_INTERFACE_TYPE,
+    ATTRIBUTE_ALREADY_EXISTS_ID: ATTRIBUTE_ALREADY_EXISTS,
+    DI_SERVICE_NOT_CONFIGURED_ID: DI_SERVICE_NOT_CONFIGURED,
+    DEPENDENCY_TYPE_NOT_FOUND_ID: DEPENDENCY_TYPE_NOT_FOUND,
+    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
+    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
+    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
+    INVALID_DEPENDENCY_ERROR_ID: INVALID_DEPENDENCY_ERROR,
+    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
+    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
+    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
+    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
+    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
+    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
+    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
+    APP_REPOSITORY_IMPORT_FAILED_ID: APP_REPOSITORY_IMPORT_FAILED,
+    APP_SERVICE_IMPORT_FAILED_ID: APP_SERVICE_IMPORT_FAILED,
+    APP_SERVICE_NOT_LOADED_ID: APP_SERVICE_NOT_LOADED,
+    APP_INTERFACE_NOT_FOUND_ID: APP_INTERFACE_NOT_FOUND,
+    APP_ERROR_ID: APP_ERROR,
+    CONFIG_FILE_NOT_FOUND_ID: CONFIG_FILE_NOT_FOUND,
+    APP_CONFIG_LOADING_FAILED_ID: APP_CONFIG_LOADING_FAILED,
+    CONTAINER_CONFIG_LOADING_FAILED_ID: CONTAINER_CONFIG_LOADING_FAILED,
+    FEATURE_CONFIG_LOADING_FAILED_ID: FEATURE_CONFIG_LOADING_FAILED,
+    ERROR_CONFIG_LOADING_FAILED_ID: ERROR_CONFIG_LOADING_FAILED,
+    CLI_CONFIG_LOADING_FAILED_ID: CLI_CONFIG_LOADING_FAILED,
+    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
+    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
+    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
+    FILE_NOT_FOUND_ID: FILE_NOT_FOUND,
+    INVALID_FILE_ID: INVALID_FILE,
+    FILE_ALREADY_OPEN_ID: FILE_ALREADY_OPEN,
+    INVALID_FILE_MODE_ID: INVALID_FILE_MODE,
+    INVALID_ENCODING_ID: INVALID_ENCODING,
+    INVALID_JSON_FILE_ID: INVALID_JSON_FILE,
+    INVALID_YAML_FILE_ID: INVALID_YAML_FILE,
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID: UNSUPPORTED_CONFIG_FILE_TYPE,
+    YAML_FILE_NOT_FOUND_ID: YAML_FILE_NOT_FOUND,
+    YAML_FILE_LOAD_ERROR_ID: YAML_FILE_LOAD_ERROR,
+    YAML_FILE_SAVE_ERROR_ID: YAML_FILE_SAVE_ERROR,
+    JSON_FILE_NOT_FOUND_ID: JSON_FILE_NOT_FOUND,
+    JSON_FILE_LOAD_ERROR_ID: JSON_FILE_LOAD_ERROR,
+    JSON_FILE_SAVE_ERROR_ID: JSON_FILE_SAVE_ERROR,
+    INVALID_JSON_PATH_ID: INVALID_JSON_PATH,
+    CSV_INVALID_MODE_ID: CSV_INVALID_MODE,
+    CSV_HANDLE_NOT_INITIALIZED_ID: CSV_HANDLE_NOT_INITIALIZED,
+    CSV_INVALID_READ_MODE_ID: CSV_INVALID_READ_MODE,
+    CSV_INVALID_WRITE_MODE_ID: CSV_INVALID_WRITE_MODE,
+    CSV_FIELDNAMES_REQUIRED_ID: CSV_FIELDNAMES_REQUIRED,
+    CSV_DICT_NO_HEADER_ID: CSV_DICT_NO_HEADER,
+    TOML_FILE_NOT_FOUND_ID: TOML_FILE_NOT_FOUND,
+    TOML_FILE_LOAD_ERROR_ID: TOML_FILE_LOAD_ERROR,
+    INVALID_TOML_FILE_ID: INVALID_TOML_FILE,
+    SQLITE_CONN_ALREADY_OPEN_ID: SQLITE_CONN_ALREADY_OPEN,
+    SQLITE_INVALID_MODE_ID: SQLITE_INVALID_MODE,
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: SQLITE_FILE_NOT_FOUND_OR_READONLY,
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+    SQLITE_BACKUP_FAILED_ID: SQLITE_BACKUP_FAILED,
+    SQLITE_CONN_NOT_INITIALIZED_ID: SQLITE_CONN_NOT_INITIALIZED,
+    CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND,
+}


### PR DESCRIPTION
## Summary

Resolves #895 — Assets: Default Error Catalog Extraction and Constants Normalization (Parity III Story 1, P0).

Separates two concerns that were conflated in `tiferet/assets/constants.py`: error-code identifier constants (which stay in `constants.py`) and the default error catalog (which moves to a new `tiferet/assets/error.py`). Also normalizes all identifier constants and adds the first unit test coverage for the assets layer.

## Changes

### `tiferet/assets/constants.py`
- Fixed module docstring typo (`Connstants` → `Constants`)
- Added `# *** imports` section with `typing` imports required by the factory
- Added `EN_US = 'en_US'` locale constant under `# *** constants`
- Deduplicated and normalized all 73 error-code identifier constants under a single `# *** constants (error)` section; each has its own `# ** constant:` artifact comment
- Added 8 new named `*_ID` constants for previously raw-string catalog keys: `APP_ERROR_ID`, `CONFIG_FILE_NOT_FOUND_ID`, `APP_CONFIG_LOADING_FAILED_ID`, `CONTAINER_CONFIG_LOADING_FAILED_ID`, `FEATURE_CONFIG_LOADING_FAILED_ID`, `ERROR_CONFIG_LOADING_FAILED_ID`, `CLI_CONFIG_LOADING_FAILED_ID`
- Added `CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'`
- Added `create_default_error` factory function under `# *** functions`
- Removed the inline `DEFAULT_ERRORS` dictionary

### `tiferet/assets/error.py` (new)
- Imports all 73 `*_ID` constants, `EN_US`, and `create_default_error` from `.constants` (alphabetically ordered)
- Defines one named constant per error (e.g., `FEATURE_NOT_FOUND`) built via `create_default_error`
- Assembles `DEFAULT_ERRORS` dict with 73 entries keyed by `*_ID` constants

### `tiferet/assets/__init__.py`
- Re-points `DEFAULT_ERRORS` import from `.constants` to `.error`; public API preserved

### `tests/assets/` (new)
- `__init__.py` package marker
- `test_constants.py`: 4 unit tests covering `EN_US`, single-message factory output, message-order preservation, and empty-messages edge case

## Test Results
- 4 new tests: all pass
- 760 existing tests: all pass, 11 skipped (pre-existing skips)
- The 8 pre-existing import errors in `tiferet/contexts/tests/` and `tiferet/blueprints/tests/` are unrelated to this story (missing `ServiceConfiguration` and `App` exports targeted by Parity III Stories 4–6)

## Warp Conversation
https://app.warp.dev/conversation/045df0b1-0c0c-42fc-be5d-1acdd2fba698

Co-Authored-By: Oz <oz-agent@warp.dev>