### PR TITLE
feat(domain): App Session rename and ServiceRegistration finalization (Story 5a, #900)

### DIFF
--- a/tests/domain/test_app.py
+++ b/tests/domain/test_app.py
@@ -4,12 +4,18 @@
 
 # ** infra
 import pytest
+from pydantic import ValidationError
 
 # ** app
-from tiferet.domain.core import DomainObject
+from tiferet.domain.core import DomainObject, ServiceDependency
 from tiferet.domain.app import (
     AppInterface,
     AppServiceDependency,
+    AppSession,
+)
+from tiferet.domain.di import (
+    FlaggedDependency,
+    ServiceRegistration,
 )
 
 # *** fixtures
@@ -152,6 +158,155 @@ def test_app_interface_apply_defaults_merges_missing_only(app_interface: AppInte
     assert result.get_service('new_service').module_path == 'new.module'
     assert result.constants['di_config'] == 'custom.yml'
     assert result.constants['feature_config'] == 'config.yml'
+
+# ** test: app_service_dependency_inherits_service_dependency
+def test_app_service_dependency_inherits_service_dependency() -> None:
+    '''
+    Test that AppServiceDependency is a subclass of ServiceDependency.
+    '''
+
+    # Assert the inheritance relationship.
+    assert issubclass(AppServiceDependency, ServiceDependency)
+
+
+# ** test: app_service_dependency_requires_service_id
+def test_app_service_dependency_requires_service_id() -> None:
+    '''
+    Test that AppServiceDependency raises ValidationError when service_id is missing.
+    '''
+
+    # Attempt to create an AppServiceDependency without service_id.
+    with pytest.raises(ValidationError):
+        AppServiceDependency(
+            module_path='some.module',
+            class_name='SomeClass',
+        )
+
+
+# ** test: app_service_dependency_no_direct_module_path
+def test_app_service_dependency_no_direct_module_path() -> None:
+    '''
+    Test that AppServiceDependency has no directly-declared module_path field.
+    '''
+
+    # Assert module_path is not declared directly on AppServiceDependency.
+    assert 'module_path' not in AppServiceDependency.__annotations__
+
+
+# ** test: app_session_flags_default
+def test_app_session_flags_default() -> None:
+    '''
+    Test that AppSession.flags defaults to ["default"] when not provided.
+    '''
+
+    # Create an AppSession with only required fields.
+    session = AppSession(id='x', name='x')
+
+    # Assert the default flags list.
+    assert session.flags == ['default']
+
+
+# ** test: app_session_get_service_found
+def test_app_session_get_service_found(app_dependency: AppServiceDependency) -> None:
+    '''
+    Test that AppSession.get_service returns the matching dependency by service_id.
+
+    :param app_dependency: The AppServiceDependency fixture.
+    :type app_dependency: AppServiceDependency
+    '''
+
+    # Create an AppSession with the fixture dependency.
+    session = AppSession(id='test', name='Test', services=[app_dependency])
+
+    # Retrieve the service by its id.
+    result = session.get_service('test_service')
+
+    # Assert the correct dependency is returned.
+    assert result is not None
+    assert result.service_id == 'test_service'
+
+
+# ** test: app_session_get_service_not_found
+def test_app_session_get_service_not_found() -> None:
+    '''
+    Test that AppSession.get_service returns None for an unknown service_id.
+    '''
+
+    # Create an AppSession with no services.
+    session = AppSession(id='test', name='Test')
+
+    # Assert None is returned for a non-existent service id.
+    assert session.get_service('unknown') is None
+
+
+# ** test: service_registration_resolve_service_flagged
+def test_service_registration_resolve_service_flagged() -> None:
+    '''
+    Test that resolve_service returns a ServiceDependency matching the flagged override.
+    '''
+
+    # Build a ServiceRegistration with one flagged dependency.
+    flagged = FlaggedDependency(
+        flag='test',
+        module_path='tiferet.domain.app',
+        class_name='AppSession',
+    )
+    registration = ServiceRegistration(
+        id='svc',
+        module_path='tiferet.domain.app',
+        class_name='AppInterface',
+        dependencies=[flagged],
+    )
+
+    # Resolve the service for the matching flag.
+    result = registration.resolve_service('test')
+
+    # Assert the returned dependency has the flagged module/class.
+    assert result is not None
+    assert isinstance(result, ServiceDependency)
+    assert result.module_path == 'tiferet.domain.app'
+    assert result.class_name == 'AppSession'
+
+
+# ** test: service_registration_resolve_service_default
+def test_service_registration_resolve_service_default() -> None:
+    '''
+    Test that resolve_service falls back to the default definition when no flag matches.
+    '''
+
+    # Build a ServiceRegistration with no matching flagged dependency.
+    registration = ServiceRegistration(
+        id='svc',
+        module_path='tiferet.domain.app',
+        class_name='AppInterface',
+    )
+
+    # Resolve with a flag that has no override.
+    result = registration.resolve_service('no_match')
+
+    # Assert the default module/class is returned.
+    assert result is not None
+    assert isinstance(result, ServiceDependency)
+    assert result.module_path == 'tiferet.domain.app'
+    assert result.class_name == 'AppInterface'
+
+
+# ** test: service_registration_resolve_service_none
+def test_service_registration_resolve_service_none() -> None:
+    '''
+    Test that resolve_service returns None when neither a flag override
+    nor a default definition is available.
+    '''
+
+    # Build a ServiceRegistration with no default type.
+    registration = ServiceRegistration(
+        id='svc_no_type',
+        dependencies=[],
+    )
+
+    # Assert None is returned.
+    assert registration.resolve_service('any_flag') is None
+
 
 # ** test: app_interface_apply_defaults_non_mutating
 def test_app_interface_apply_defaults_non_mutating(app_interface: AppInterface) -> None:

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -228,6 +228,9 @@ SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
 # ** constant: sqlite_conn_not_initialized_id
 SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
 
+# ** constant: app_session_not_found_id
+APP_SESSION_NOT_FOUND_ID = 'APP_SESSION_NOT_FOUND'
+
 # ** constant: context_not_found_id
 CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
 

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -15,6 +15,7 @@ from .core import (
     APP_REPOSITORY_IMPORT_FAILED_ID,
     APP_SERVICE_IMPORT_FAILED_ID,
     APP_SERVICE_NOT_LOADED_ID,
+    APP_SESSION_NOT_FOUND_ID,
     ATTRIBUTE_ALREADY_EXISTS_ID,
     CLI_COMMAND_ALREADY_EXISTS_ID,
     CLI_COMMAND_NOT_FOUND_ID,
@@ -300,6 +301,13 @@ APP_SERVICE_NOT_LOADED = create_default_error(
     APP_SERVICE_NOT_LOADED_ID,
     'App Service Not Loaded',
     [(EN_US, 'App service must be loaded before loading interface {interface_id}.')],
+)
+
+# ** constant: app_session_not_found
+APP_SESSION_NOT_FOUND = create_default_error(
+    APP_SESSION_NOT_FOUND_ID,
+    'App Session Not Found',
+    [(EN_US, 'App session with ID {interface_id} not found.')],
 )
 
 # ** constant: app_interface_not_found
@@ -639,6 +647,7 @@ DEFAULT_ERRORS = {
     APP_REPOSITORY_IMPORT_FAILED_ID: APP_REPOSITORY_IMPORT_FAILED,
     APP_SERVICE_IMPORT_FAILED_ID: APP_SERVICE_IMPORT_FAILED,
     APP_SERVICE_NOT_LOADED_ID: APP_SERVICE_NOT_LOADED,
+    APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND,
     APP_INTERFACE_NOT_FOUND_ID: APP_INTERFACE_NOT_FOUND,
     APP_ERROR_ID: APP_ERROR,
     CONFIG_FILE_NOT_FOUND_ID: CONFIG_FILE_NOT_FOUND,

--- a/tiferet/domain/__init__.py
+++ b/tiferet/domain/__init__.py
@@ -7,6 +7,7 @@ from .core import DomainObject, ServiceDependency
 from .app import (
     AppInterface,
     AppServiceDependency,
+    AppSession,
 )
 from .di import (
     FlaggedDependency,
@@ -44,6 +45,7 @@ __all__ = [
     'ServiceDependency',
     'AppInterface',
     'AppServiceDependency',
+    'AppSession',
     'FlaggedDependency',
     'ServiceRegistration',
     'CliArgument',

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -3,21 +3,21 @@
 # *** imports
 
 # ** core
-from importlib import import_module
 from typing import Dict, List
 
 # ** infra
 from pydantic import Field
 
 # ** app
-from .core import DomainObject
+from .core import DomainObject, ServiceDependency
 
 # *** models
 
 # ** model: app_service_dependency
-class AppServiceDependency(DomainObject):
+class AppServiceDependency(ServiceDependency):
     '''
-    An app service dependency that defines the service configuration for an app interface.
+    An app service dependency that defines the service configuration
+    for an app session.
     '''
 
     # * attribute: service_id
@@ -26,94 +26,52 @@ class AppServiceDependency(DomainObject):
         description='The service id for the application dependency.',
     )
 
-    # * attribute: module_path
-    module_path: str = Field(
-        ...,
-        description='The module path for the app dependency.',
-    )
-
-    # * attribute: class_name
-    class_name: str = Field(
-        ...,
-        description='The class name for the app dependency.',
-    )
-
-    # * attribute: parameters
-    parameters: Dict[str, str] = Field(
-        default_factory=dict,
-        description='The parameters for the application dependency.',
-    )
-
-    # * method: get_service_type
-    def get_service_type(self) -> type:
-        '''
-        Get the service type for this app service dependency.
-
-        :return: The service type.
-        :rtype: type
-        '''
-
-        # Import and return the service class type.
-        return getattr(import_module(self.module_path), self.class_name)
-
-# ** model: app_interface
-class AppInterface(DomainObject):
+# ** model: app_session
+class AppSession(DomainObject):
     '''
-    The base application interface object.
+    The base application session object.
     '''
 
     # * attribute: id
     id: str = Field(
         ...,
-        description='The unique identifier for the application interface.',
+        description='The unique identifier for the application session.',
     )
 
     # * attribute: name
     name: str = Field(
         ...,
-        description='The name of the application interface.',
+        description='The name of the application session.',
     )
 
     # * attribute: description
     description: str | None = Field(
         default=None,
-        description='The description of the application interface.',
-    )
-
-    # * attribute: module_path
-    module_path: str = Field(
-        ...,
-        description='The module path for the application instance context.',
-    )
-
-    # * attribute: class_name
-    class_name: str = Field(
-        ...,
-        description='The class name for the application instance context.',
+        description='The description of the application session.',
     )
 
     # * attribute: logger_id
     logger_id: str = Field(
         default='default',
-        description='The logger ID for the application instance.',
+        description='The logger ID for the application session.',
     )
 
     # * attribute: flags
     flags: List[str] = Field(
         default_factory=lambda: ['default'],
-        description='The flags for the application interface.',
+        description='The DI flags for the application session.',
     )
 
     # * attribute: services
     services: List[AppServiceDependency] = Field(
         default_factory=list,
-        description='The application instance service dependencies.',
+        description='The application session service dependencies.',
     )
 
     # * attribute: constants
     constants: Dict[str, str] = Field(
         default_factory=dict,
-        description='The application dependency constants.',
+        description='The application session dependency constants.',
     )
 
     # * method: get_service
@@ -127,10 +85,36 @@ class AppInterface(DomainObject):
         :rtype: AppServiceDependency | None
         '''
 
-        # Get the service dependency by service id.
+        # Return the first matching service dependency, or None.
         return next((dep for dep in self.services if dep.service_id == service_id), None)
 
+# ** model: app_interface
+# -- obsolete: AppInterface is superseded by AppSession. Retire in Parity V Story 13.
+class AppInterface(AppSession):
+    '''
+    Application interface definition.
+
+    .. deprecated::
+        Superseded by :class:`AppSession`. Retire in Parity V Story 13 when
+        contexts and blueprints are updated to consume AppSession directly.
+    '''
+
+    # * attribute: module_path
+    # -- obsolete: Context class location moved to runtime resolution. Retire in Parity V Story 13.
+    module_path: str | None = Field(
+        default=None,
+        description='The module path for the application interface context class. Obsolete.',
+    )
+
+    # * attribute: class_name
+    # -- obsolete: Context class name moved to runtime resolution. Retire in Parity V Story 13.
+    class_name: str | None = Field(
+        default=None,
+        description='The class name for the application interface context class. Obsolete.',
+    )
+
     # * method: apply_defaults
+    # -- obsolete: Default merging moved to blueprint layer. Retire in Parity V Story 17.
     def apply_defaults(self,
             default_services: List[AppServiceDependency] = None,
             default_constants: Dict[str, str] = None,

--- a/tiferet/domain/di.py
+++ b/tiferet/domain/di.py
@@ -3,45 +3,26 @@
 # *** imports
 
 # ** core
-from importlib import import_module
 from typing import Dict, List
 
 # ** infra
 from pydantic import Field
 
 # ** app
-from .core import DomainObject
+from .core import DomainObject, ServiceDependency
 
 # *** models
 
 # ** model: flagged_dependency
-class FlaggedDependency(DomainObject):
+class FlaggedDependency(ServiceDependency):
     '''
     A flagged container dependency object.
     '''
-
-    # * attribute: module_path
-    module_path: str = Field(
-        ...,
-        description='The module path.',
-    )
-
-    # * attribute: class_name
-    class_name: str = Field(
-        ...,
-        description='The class name.',
-    )
 
     # * attribute: flag
     flag: str = Field(
         ...,
         description='The flag for the container dependency.',
-    )
-
-    # * attribute: parameters
-    parameters: Dict[str, str] = Field(
-        default_factory=dict,
-        description='The container dependency parameters.',
     )
 
 # ** model: service_registration
@@ -115,8 +96,9 @@ class ServiceRegistration(DomainObject):
         '''
         Gets the service type based on the provided flags.
 
-        Checks flagged dependencies first (in flag priority order), then
-        falls back to the registration's default module_path/class_name.
+        Delegates to :meth:`resolve_service` so the flagged-override
+        → default precedence lives in exactly one place, then imports
+        the effective service type.
 
         :param flags: The flags for the flagged dependency.
         :type flags: Tuple[str, ...]
@@ -124,15 +106,41 @@ class ServiceRegistration(DomainObject):
         :rtype: type | None
         '''
 
-        # Check the flagged dependencies for the type first.
-        for flag in flags:
-            dependency = self.get_dependency(flag)
-            if dependency:
-                return getattr(import_module(dependency.module_path), dependency.class_name)
+        # Resolve the effective dependency for these flags, then import its type.
+        dependency = self.resolve_service(*flags)
+        return dependency.get_service_type() if dependency else None
 
-        # Otherwise defer to an available default type.
+    # * method: resolve_service
+    def resolve_service(self, *flags) -> ServiceDependency | None:
+        '''
+        Resolve the effective core service dependency for the given flags.
+
+        Prefers a matching flagged override (in flag priority order), then
+        falls back to the registration's own default definition, and returns
+        ``None`` when no service is defined.
+
+        :param flags: The flags to match against flagged dependencies.
+        :type flags: Tuple[str, ...]
+        :return: The effective core service dependency, or None.
+        :rtype: ServiceDependency | None
+        '''
+
+        # Prefer a flagged override when one matches (flag priority order).
+        dependency = self.get_dependency(*flags)
+        if dependency:
+            return ServiceDependency(
+                module_path=dependency.module_path,
+                class_name=dependency.class_name,
+                parameters=dependency.parameters,
+            )
+
+        # Fall back to the registration's default definition when fully specified.
         if self.module_path and self.class_name:
-            return getattr(import_module(self.module_path), self.class_name)
+            return ServiceDependency(
+                module_path=self.module_path,
+                class_name=self.class_name,
+                parameters=self.parameters,
+            )
 
-        # Return None if no type is found.
+        # Return None when no service is defined for these flags.
         return None


### PR DESCRIPTION
## Summary

Implements Parity III Story 5a (Child 1 of 2) — domain-layer half of the App Session and ServiceRegistration finalization.

## Changes

- **`domain/di.py`**: `FlaggedDependency` now extends `ServiceDependency` (removes duplicate `module_path`/`class_name`/`parameters` fields); adds `ServiceRegistration.resolve_service()` centralizing the flagged-override → default → `None` precedence; refactors `get_service_type()` to delegate.
- **`domain/app.py`**: `AppServiceDependency` now extends `ServiceDependency` (removes duplicate fields and `get_service_type()`); adds `AppSession` model (`id`, `name`, `description`, `logger_id`, `flags`, `services`, `constants`, `get_service()`); `AppInterface(AppSession)` with `module_path`/`class_name` marked `# -- obsolete:` (optional, Parity V Story 13) and `apply_defaults` marked `# -- obsolete:` (Parity V Story 17).
- **`assets/constants.py`**: adds `APP_SESSION_NOT_FOUND_ID` constant.
- **`assets/error.py`**: adds `APP_SESSION_NOT_FOUND` catalog entry and `DEFAULT_ERRORS` entry.
- **`domain/__init__.py`**: exports `AppSession`.
- **`tests/domain/test_app.py`**: 9 new tests covering `AppServiceDependency` inheritance, `AppSession` defaults/`get_service`, and `ServiceRegistration.resolve_service` (flagged/default/none cases).

## Tests

783 passed, 11 skipped — no regressions.

Closes #900

---
Warp conversation: https://app.warp.dev/conversation/019f913c-48b9-75b1-8717-e51f4922d227