### PR TITLE
feat(di): DI Abstract Contract Layer — di/core.py ABCs and Pure Functions (#905)

### DIFF
--- a/tests/di/test_core.py
+++ b/tests/di/test_core.py
@@ -1,4 +1,4 @@
-"""Tests for tiferet.di.core — ABCs and pure DI helper functions."""
+"""Tiferet DI Core Tests"""
 
 # *** imports
 
@@ -62,6 +62,18 @@ def test_injectable_parameter_names_uninspectable():
     result = injectable_parameter_names(int)
 
     # Result should be an empty list, not an exception.
+    assert result == []
+
+# ** test: normalize_flags_empty
+def test_normalize_flags_empty():
+    '''
+    normalize_flags returns an empty list when called with no arguments.
+    '''
+
+    # Call with no arguments.
+    result = normalize_flags()
+
+    # Result should be an empty list.
     assert result == []
 
 # ** test: normalize_flags_strings

--- a/tests/di/test_core.py
+++ b/tests/di/test_core.py
@@ -1,0 +1,196 @@
+"""Tests for tiferet.di.core — ABCs and pure DI helper functions."""
+
+# *** imports
+
+# ** core
+import pytest
+from typing import List
+
+# ** app
+from tiferet.di.core import (
+    ServiceContainer,
+    ServiceResolver,
+    injectable_parameter_names,
+    normalize_flags,
+)
+
+# *** tests
+
+# ** test: injectable_parameter_names_basic
+def test_injectable_parameter_names_basic():
+    '''
+    injectable_parameter_names returns the correct parameter names for a
+    simple __init__ with named parameters.
+    '''
+
+    # Define a simple service class with two named parameters.
+    class MyService:
+        def __init__(self, dep_a, dep_b):
+            pass
+
+    # Verify both parameter names are returned.
+    assert injectable_parameter_names(MyService) == ['dep_a', 'dep_b']
+
+# ** test: injectable_parameter_names_skips_self_and_variadics
+def test_injectable_parameter_names_skips_self_and_variadics():
+    '''
+    injectable_parameter_names excludes self, *args, and **kwargs from
+    the returned parameter list.
+    '''
+
+    # Define a class whose __init__ includes variadic parameters.
+    class MyService:
+        def __init__(self, dep_a, *args, dep_b=None, **kwargs):
+            pass
+
+    # Only named parameters (excluding self and variadics) should be returned.
+    result = injectable_parameter_names(MyService)
+    assert 'self' not in result
+    assert 'args' not in result
+    assert 'kwargs' not in result
+    assert 'dep_a' in result
+    assert 'dep_b' in result
+
+# ** test: injectable_parameter_names_uninspectable
+def test_injectable_parameter_names_uninspectable():
+    '''
+    injectable_parameter_names returns an empty list for types whose
+    constructor cannot be inspected (e.g. built-in C-extension types).
+    '''
+
+    # int.__init__ is a C-extension; inspect.signature raises TypeError.
+    result = injectable_parameter_names(int)
+
+    # Result should be an empty list, not an exception.
+    assert result == []
+
+# ** test: normalize_flags_strings
+def test_normalize_flags_strings():
+    '''
+    normalize_flags returns a flat list of strings unchanged when all
+    flags are already strings.
+    '''
+
+    # Pass three string flags.
+    result = normalize_flags('a', 'b', 'c')
+
+    # Result should equal the original strings in order.
+    assert result == ['a', 'b', 'c']
+
+# ** test: normalize_flags_expands_list
+def test_normalize_flags_expands_list():
+    '''
+    normalize_flags flattens a list argument into the result, expanding
+    its members alongside any surrounding scalar flags.
+    '''
+
+    # Mix a list with a trailing scalar.
+    result = normalize_flags(['a', 'b'], 'c')
+
+    # The list should be expanded into the flat result.
+    assert result == ['a', 'b', 'c']
+
+# ** test: normalize_flags_coerces_to_str
+def test_normalize_flags_coerces_to_str():
+    '''
+    normalize_flags coerces non-string scalars and list members to strings.
+    '''
+
+    # Mix integer scalars and a list of integers.
+    result = normalize_flags(['a', 'b'], 'c', 42)
+
+    # All elements should be strings.
+    assert result == ['a', 'b', 'c', '42']
+
+# ** test: service_container_is_abstract
+def test_service_container_is_abstract():
+    '''
+    ServiceContainer cannot be instantiated directly; it raises TypeError
+    because abstract methods are left unimplemented.
+    '''
+
+    # Attempt to instantiate the ABC directly.
+    with pytest.raises(TypeError):
+        ServiceContainer()
+
+# ** test: service_resolver_is_abstract
+def test_service_resolver_is_abstract():
+    '''
+    ServiceResolver cannot be instantiated directly; it raises TypeError
+    because build_container is left unimplemented.
+    '''
+
+    # Attempt to instantiate the ABC directly.
+    with pytest.raises(TypeError):
+        ServiceResolver()
+
+# ** test: service_resolver_add_and_get_container
+def test_service_resolver_add_and_get_container():
+    '''
+    add_container stores a container under the normalized flag tuple and
+    get_container retrieves it using the same flags.
+    '''
+
+    # Build a minimal concrete resolver with a stub build_container.
+    class ConcreteResolver(ServiceResolver):
+        def build_container(self, flags: List[str]):
+            raise NotImplementedError('not needed for this test')
+
+    # Build a minimal concrete container stub.
+    class ConcreteContainer(ServiceContainer):
+        def add_service(self, service_id, service): pass
+        def add_constant(self, constant_id, value): pass
+        def get_dependency(self, dependency_id): pass
+        def has_dependency(self, dependency_id): return False
+        def remove_dependency(self, dependency_id): pass
+        def load_container(self, services=None, constants=None): pass
+
+    resolver = ConcreteResolver()
+    container = ConcreteContainer()
+
+    # Store the container under a set of flags.
+    resolver.add_container(container, 'flag_a', 'flag_b')
+
+    # Retrieve the container using the same flags.
+    retrieved = resolver.get_container('flag_a', 'flag_b')
+    assert retrieved is container
+
+    # A different flag combination should return None.
+    assert resolver.get_container('flag_c') is None
+
+# ** test: service_resolver_get_dependency_calls_build_on_miss
+def test_service_resolver_get_dependency_calls_build_on_miss():
+    '''
+    get_dependency calls build_container when no cached container exists
+    for the given flags, then caches and uses the result.
+    '''
+
+    # Track how many times build_container is called.
+    build_calls = []
+
+    class ConcreteContainer(ServiceContainer):
+        def __init__(self, value):
+            self._value = value
+        def add_service(self, service_id, service): pass
+        def add_constant(self, constant_id, value): pass
+        def get_dependency(self, dependency_id): return self._value
+        def has_dependency(self, dependency_id): return True
+        def remove_dependency(self, dependency_id): pass
+        def load_container(self, services=None, constants=None): pass
+
+    class ConcreteResolver(ServiceResolver):
+        def build_container(self, flags: List[str]) -> ServiceContainer:
+            build_calls.append(flags)
+            return ConcreteContainer('resolved_value')
+
+    resolver = ConcreteResolver()
+
+    # First call triggers build_container.
+    result = resolver.get_dependency('my_service', 'flag_x')
+    assert result == 'resolved_value'
+    assert len(build_calls) == 1
+
+    # Second call with same flags reuses the cached container.
+    result = resolver.get_dependency('my_service', 'flag_x')
+    assert result == 'resolved_value'
+    assert len(build_calls) == 1

--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -15,10 +15,6 @@ __all__ = [
 # ** app
 from .settings import (
     ServiceProvider,
-    ServiceContainer,
-    ServiceResolver,
-    injectable_parameter_names,
-    normalize_flags,
     create_cache_key,
     merge_settings,
 )

--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -23,6 +23,12 @@ from .settings import (
     merge_settings,
 )
 from .dynamic import DynamicServiceProvider
+from .core import (
+    ServiceContainer,
+    ServiceResolver,
+    injectable_parameter_names,
+    normalize_flags,
+)
 
 # Backward-compatible alias: downstream consumers importing
 # DependenciesServiceProvider will receive DynamicServiceProvider.

--- a/tiferet/di/core.py
+++ b/tiferet/di/core.py
@@ -1,0 +1,277 @@
+"""Tiferet DI Core"""
+
+# *** imports
+
+# ** core
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Tuple
+import inspect
+
+# ** app
+from ..domain import ServiceDependency
+
+# *** functions
+
+# ** function: injectable_parameter_names
+def injectable_parameter_names(service_type: type) -> List[str]:
+    '''
+    Return the injectable constructor parameter names for a service type.
+
+    Excludes ``self`` and variadic (``*args`` / ``**kwargs``) parameters.
+    Types whose constructor cannot be inspected are treated as no-arg.
+
+    :param service_type: The service class to inspect.
+    :type service_type: type
+    :return: The list of injectable constructor parameter names.
+    :rtype: List[str]
+    '''
+
+    # Inspect the constructor signature; treat uninspectable types as no-arg.
+    try:
+        signature = inspect.signature(service_type.__init__)
+    except (ValueError, TypeError):
+        return []
+
+    # Collect parameter names, skipping self and variadic parameters.
+    names = []
+    for name, parameter in signature.parameters.items():
+
+        # Skip the bound self parameter.
+        if name == 'self':
+            continue
+
+        # Skip variadic positional and keyword parameters.
+        if parameter.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+
+        # Record the injectable parameter name.
+        names.append(name)
+
+    # Return the collected parameter names.
+    return names
+
+# ** function: normalize_flags
+def normalize_flags(*flags) -> List[str]:
+    '''
+    Flatten a mixed sequence of strings, lists, and tuples into a flat list of strings.
+
+    :param flags: The flags to normalize (strings, lists, or tuples).
+    :type flags: Tuple[Any, ...]
+    :return: A flat list of flag strings.
+    :rtype: List[str]
+    '''
+
+    # Flatten one level of lists/tuples into a single flag list, stringifying every flag.
+    normalized = []
+    for flag in flags:
+
+        # Expand nested list/tuple flag groups, coercing each member to a string.
+        if isinstance(flag, (list, tuple)):
+            normalized.extend(str(f) for f in flag)
+
+        # Append scalar flags coerced to strings.
+        else:
+            normalized.append(str(flag))
+
+    # Return the flattened flag list.
+    return normalized
+
+# *** classes
+
+# ** class: service_container
+class ServiceContainer(ABC):
+    '''
+    Abstract DI container contract for the Tiferet framework.
+
+    Defines the typed registration and resolution interface that all concrete
+    DI container implementations must satisfy. The ``add_service`` method accepts
+    a ``ServiceDependency`` domain object; concrete implementations are responsible
+    for importing the service class from its ``module_path`` and ``class_name``.
+
+    Event-free: raw exceptions surface; callers with event access convert them to
+    structured errors.
+    '''
+
+    # * method: add_service
+    @abstractmethod
+    def add_service(self, service_id: str, service: ServiceDependency):
+        '''
+        Register a service dependency in the container.
+
+        :param service_id: The service identifier.
+        :type service_id: str
+        :param service: The core service dependency.
+        :type service: ServiceDependency
+        '''
+
+        raise NotImplementedError()
+
+    # * method: add_constant
+    @abstractmethod
+    def add_constant(self, constant_id: str, value: Any):
+        '''
+        Register a constant value in the container.
+
+        :param constant_id: The constant identifier.
+        :type constant_id: str
+        :param value: The constant value.
+        :type value: Any
+        '''
+
+        raise NotImplementedError()
+
+    # * method: get_dependency
+    @abstractmethod
+    def get_dependency(self, dependency_id: str) -> Any:
+        '''
+        Resolve a registered dependency by identifier.
+
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        :return: The resolved instance or value.
+        :rtype: Any
+        '''
+
+        raise NotImplementedError()
+
+    # * method: has_dependency
+    @abstractmethod
+    def has_dependency(self, dependency_id: str) -> bool:
+        '''
+        Return True when a dependency is registered under the given identifier.
+
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        :return: True when registered, False otherwise.
+        :rtype: bool
+        '''
+
+        raise NotImplementedError()
+
+    # * method: remove_dependency
+    @abstractmethod
+    def remove_dependency(self, dependency_id: str):
+        '''
+        Remove a registered dependency from the container. Idempotent.
+
+        :param dependency_id: The dependency identifier.
+        :type dependency_id: str
+        '''
+
+        raise NotImplementedError()
+
+    # * method: load_container
+    @abstractmethod
+    def load_container(self,
+            services: Dict[str, ServiceDependency] = None,
+            constants: Dict[str, Any] = None,
+        ):
+        '''
+        Bulk-load the container from service dependencies and constants.
+
+        Implementations must register constants before services so that scalar
+        parameter values are available when factory kwargs are wired.
+
+        :param services: A mapping of service id to core service dependency.
+        :type services: Dict[str, ServiceDependency] | None
+        :param constants: A mapping of constant id to value.
+        :type constants: Dict[str, Any] | None
+        '''
+
+        raise NotImplementedError()
+
+# ** class: service_resolver
+class ServiceResolver(ABC):
+    '''
+    Abstract service resolver for the Tiferet framework.
+
+    Manages a per-flag-tuple cache of ``ServiceContainer`` instances and provides
+    a template-method ``get_dependency`` that builds and caches a container on a
+    cache miss. Subclasses implement ``build_container`` to construct a concrete
+    ``ServiceContainer`` for a given flag set.
+    '''
+
+    # * attribute: _containers
+    _containers: Dict[Tuple[str, ...], ServiceContainer]
+
+    # * init
+    def __init__(self):
+        '''
+        Initialize the service resolver with an empty container cache.
+        '''
+
+        # Initialize the per-flag container cache.
+        self._containers = {}
+
+    # * method: add_container
+    def add_container(self, container: ServiceContainer, *flags) -> ServiceContainer:
+        '''
+        Cache a service container under the normalized flag tuple.
+
+        :param container: The service container to cache.
+        :type container: ServiceContainer
+        :param flags: The flags identifying this container.
+        :type flags: Tuple[Any, ...]
+        :return: The cached service container.
+        :rtype: ServiceContainer
+        '''
+
+        # Cache the container under the normalized flag key.
+        key = tuple(normalize_flags(*flags))
+        self._containers[key] = container
+
+        # Return the cached container.
+        return container
+
+    # * method: get_container
+    def get_container(self, *flags) -> ServiceContainer:
+        '''
+        Return the cached container for the given flags, or None on a miss.
+
+        :param flags: The flags identifying the desired container.
+        :type flags: Tuple[Any, ...]
+        :return: The cached service container, or None.
+        :rtype: ServiceContainer | None
+        '''
+
+        # Look up the container by normalized flag key.
+        return self._containers.get(tuple(normalize_flags(*flags)))
+
+    # * method: build_container
+    @abstractmethod
+    def build_container(self, flags: List[str]) -> ServiceContainer:
+        '''
+        Build a new service container for the given normalized flag list.
+
+        :param flags: The normalized flag list for this container.
+        :type flags: List[str]
+        :return: A new service container instance.
+        :rtype: ServiceContainer
+        '''
+
+        raise NotImplementedError()
+
+    # * method: get_dependency
+    def get_dependency(self, service_id: str, *flags) -> Any:
+        '''
+        Resolve a service dependency by ID, building and caching a container on a miss.
+
+        :param service_id: The service registration identifier.
+        :type service_id: str
+        :param flags: The feature or data flags to use.
+        :type flags: Tuple[Any, ...]
+        :return: The resolved service instance.
+        :rtype: Any
+        '''
+
+        # Normalize the provided flags.
+        normalized = normalize_flags(*flags)
+
+        # Retrieve the cached container, or build and cache one on a miss.
+        container = self.get_container(*normalized)
+        if container is None:
+            container = self.build_container(normalized)
+            self.add_container(container, *normalized)
+
+        # Return the resolved dependency from the container.
+        return container.get_dependency(service_id)


### PR DESCRIPTION
## Summary

Implements Parity IV Story 7 — introduces `tiferet/di/core.py` as the abstract DI contract layer.

## Changes

**`tiferet/di/core.py`** (new)
- `injectable_parameter_names` — pure function; returns injectable constructor parameter names (excludes `self` / variadics; treats uninspectable types as no-arg)
- `normalize_flags` — pure function; flattens mixed string/list/tuple flag inputs into a flat `List[str]`
- `ServiceContainer` ABC — 6 abstract methods: `add_service`, `add_constant`, `get_dependency`, `has_dependency`, `remove_dependency`, `load_container`
- `ServiceResolver` ABC — template-method `get_dependency` (builds+caches container on miss); abstract `build_container`; concrete `add_container` / `get_container` helpers with tuple-keyed per-flag cache
- Domain-only: no `dependency-injector` import, no assets import

**`tiferet/di/__init__.py`** (updated)
- Re-exports `ServiceContainer`, `ServiceResolver`, `injectable_parameter_names`, `normalize_flags` from `.core` (shadows the legacy `settings.py` names; backward compat preserved)

**`tests/di/test_core.py`** (new)
- 10 test cases covering all ACs from TRD §4.7

## Test Results

- 60 di tests pass (10 new + 50 existing)
- 46 domain/events/mappers/repos/assets/interfaces tests pass — no regressions

## Conversation

https://app.warp.dev/conversation/4f6586cd-8d6d-46eb-9e19-a253e2edb78f

Closes #905