### PR TITLE
docs: sync .gitignore with v2.x-proto housekeeping entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,5 +166,14 @@ test.py
 # VS Code
 .vscode/
 
+# TRD local copies
+.trd/
+
+# Milestone planning artifacts (local, do not commit)
+.milestones/
+
+# Handoff documents (local, do not commit)
+.handoff/
+
 # pytest
 pytest.ini


### PR DESCRIPTION
## Summary

Ports the local artifact ignore rules from `v2.x-proto` into `main`, completing the `.gitignore` housekeeping pass.

## Changes

- Added `.trd/` — TRD local copies (do not commit)
- Added `.milestones/` — milestone planning artifacts (do not commit)
- Added `.handoff/` — handoff documents (do not commit)

## Notes

`.eloha/` was present on `v2.x-proto` but intentionally omitted here. The `.eloha` directory has been migrated to `tiferet-ccc` and added to that repo's `.gitignore` instead.

---

[Warp conversation](https://app.warp.dev/conversation/356f3402-41d6-4012-8a99-6b119a97feaa)

Co-Authored-By: Oz <oz-agent@warp.dev>