### PR TITLE
feat(assets): App Service Catalog — assets/app.py with CORE_DEFAULT_SERVICES and CORE_DEFAULT_CONSTANTS (#903)

### DIFF
--- a/tests/assets/test_app.py
+++ b/tests/assets/test_app.py
@@ -1,0 +1,101 @@
+"""Tiferet App Assets Tests"""
+
+# *** imports
+
+# ** app
+from tiferet.assets import app
+from tiferet.assets.core import create_app_service_dependency
+
+# *** tests
+
+# ** test: create_app_service_dependency_structure
+def test_create_app_service_dependency_structure():
+    '''
+    Verify create_app_service_dependency returns a dict with the expected keys.
+    '''
+
+    # Create a test service dependency.
+    result = create_app_service_dependency(
+        'test_service',
+        'tiferet.repos.test',
+        'TestRepository',
+    )
+
+    # Verify the result has all expected keys.
+    assert 'service_id' in result
+    assert 'module_path' in result
+    assert 'class_name' in result
+    assert 'parameters' in result
+
+
+# ** test: create_app_service_dependency_default_parameters
+def test_create_app_service_dependency_default_parameters():
+    '''
+    Verify omitting parameters yields an empty dict.
+    '''
+
+    # Create a dependency without explicit parameters.
+    result = create_app_service_dependency(
+        'test_service',
+        'tiferet.repos.test',
+        'TestRepository',
+    )
+
+    # Verify parameters defaults to an empty dict.
+    assert result['parameters'] == {}
+
+
+# ** test: core_default_services_keys
+def test_core_default_services_keys():
+    '''
+    Verify CORE_DEFAULT_SERVICES contains all expected service ID keys.
+    '''
+
+    # Define the expected service IDs.
+    expected_ids = [
+        app.DI_SERVICE_ID,
+        app.ERROR_SERVICE_ID,
+        app.LOGGING_SERVICE_ID,
+        app.FEATURE_SERVICE_ID,
+        app.GET_ERROR_EVT_ID,
+        app.GET_FEATURE_EVT_ID,
+        app.LOGGING_LIST_ALL_EVT_ID,
+        app.CLI_SERVICE_ID,
+        app.LIST_COMMANDS_EVT_ID,
+        app.GET_PARENT_ARGS_EVT_ID,
+        app.DI_LIST_ALL_CONFIGS_EVT_ID,
+    ]
+
+    # Verify all expected service IDs are present in CORE_DEFAULT_SERVICES.
+    for service_id in expected_ids:
+        assert service_id in app.CORE_DEFAULT_SERVICES
+
+
+# ** test: core_default_constants_config_ids
+def test_core_default_constants_config_ids():
+    '''
+    Verify CORE_DEFAULT_CONSTANTS maps each config ID to 'config.yml'.
+    '''
+
+    # Define the expected config IDs.
+    expected_config_ids = [
+        app.CLI_CONFIG_ID,
+        app.DI_CONFIG_ID,
+        app.ERROR_CONFIG_ID,
+        app.LOGGING_CONFIG_ID,
+        app.FEATURE_CONFIG_ID,
+    ]
+
+    # Verify each config ID maps to 'config.yml'.
+    for config_id in expected_config_ids:
+        assert app.CORE_DEFAULT_CONSTANTS[config_id] == 'config.yml'
+
+
+# ** test: default_app_service_class_name
+def test_default_app_service_class_name():
+    '''
+    Verify DEFAULT_APP_SERVICE_CLASS_NAME is 'AppConfigRepository'.
+    '''
+
+    # Verify the class name.
+    assert app.DEFAULT_APP_SERVICE_CLASS_NAME == 'AppConfigRepository'

--- a/tiferet/assets/__init__.py
+++ b/tiferet/assets/__init__.py
@@ -5,6 +5,7 @@
 # ** app
 from .exceptions import TiferetError, TiferetAPIError, RaiseError
 from .error import ERROR_NOT_FOUND_ID, DEFAULT_ERRORS
+from . import app
 from . import core
 from . import error
 from . import logging

--- a/tiferet/assets/__init__.py
+++ b/tiferet/assets/__init__.py
@@ -5,8 +5,8 @@
 # ** app
 from .exceptions import TiferetError, TiferetAPIError, RaiseError
 from .error import ERROR_NOT_FOUND_ID, DEFAULT_ERRORS
-from . import app
 from . import core
+from . import app
 from . import error
 from . import logging
 

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -1,0 +1,179 @@
+"""Tiferet App Assets
+
+App service ID constants, default app service data, and the CORE_DEFAULT_SERVICES /
+CORE_DEFAULT_CONSTANTS bootstrap catalogs consumed by the blueprint layer during
+cache seeding for application bootstrapping.
+"""
+
+# *** imports
+
+# ** core
+from typing import Any, Dict
+
+# ** app
+from .core import create_app_service_dependency
+
+# *** constants (ids)
+
+# ** constant: di_service_id
+DI_SERVICE_ID = 'di_service'
+
+# ** constant: error_service_id
+ERROR_SERVICE_ID = 'error_service'
+
+# ** constant: logging_service_id
+LOGGING_SERVICE_ID = 'logging_service'
+
+# ** constant: feature_service_id
+FEATURE_SERVICE_ID = 'feature_service'
+
+# ** constant: get_error_evt_id
+GET_ERROR_EVT_ID = 'get_error_evt'
+
+# ** constant: get_feature_evt_id
+GET_FEATURE_EVT_ID = 'get_feature_evt'
+
+# ** constant: logging_list_all_evt_id
+LOGGING_LIST_ALL_EVT_ID = 'logging_list_all_evt'
+
+# ** constant: cli_service_id
+CLI_SERVICE_ID = 'cli_service'
+
+# ** constant: list_commands_evt_id
+LIST_COMMANDS_EVT_ID = 'list_commands_evt'
+
+# ** constant: get_parent_args_evt_id
+GET_PARENT_ARGS_EVT_ID = 'get_parent_args_evt'
+
+# ** constant: di_list_all_configs_evt_id
+DI_LIST_ALL_CONFIGS_EVT_ID = 'di_list_all_configs_evt'
+
+# ** constant: cli_config_id
+CLI_CONFIG_ID = 'cli_config'
+
+# ** constant: di_config_id
+DI_CONFIG_ID = 'di_config'
+
+# ** constant: error_config_id
+ERROR_CONFIG_ID = 'error_config'
+
+# ** constant: logging_config_id
+LOGGING_CONFIG_ID = 'logging_config'
+
+# ** constant: feature_config_id
+FEATURE_CONFIG_ID = 'feature_config'
+
+# *** constants (models)
+
+# ** constant: default_config_file
+DEFAULT_CONFIG_FILE = 'config.yml'
+
+# ** constant: default_app_service_module_path
+DEFAULT_APP_SERVICE_MODULE_PATH = 'tiferet.repos.app'
+
+# ** constant: default_app_service_class_name
+DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
+
+# ** constant: default_app_service_parameters
+DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_CONFIG_FILE}
+
+# ** constant: di_service
+DI_SERVICE = create_app_service_dependency(
+    DI_SERVICE_ID,
+    'tiferet.repos.di',
+    'DIConfigRepository',
+)
+
+# ** constant: error_service
+ERROR_SERVICE = create_app_service_dependency(
+    ERROR_SERVICE_ID,
+    'tiferet.repos.error',
+    'ErrorConfigRepository',
+)
+
+# ** constant: logging_service
+LOGGING_SERVICE = create_app_service_dependency(
+    LOGGING_SERVICE_ID,
+    'tiferet.repos.logging',
+    'LoggingConfigRepository',
+)
+
+# ** constant: feature_service
+FEATURE_SERVICE = create_app_service_dependency(
+    FEATURE_SERVICE_ID,
+    'tiferet.repos.feature',
+    'FeatureConfigRepository',
+)
+
+# ** constant: get_error_evt
+GET_ERROR_EVT = create_app_service_dependency(
+    GET_ERROR_EVT_ID,
+    'tiferet.events.error',
+    'GetError',
+)
+
+# ** constant: get_feature_evt
+GET_FEATURE_EVT = create_app_service_dependency(
+    GET_FEATURE_EVT_ID,
+    'tiferet.events.feature',
+    'GetFeature',
+)
+
+# ** constant: logging_list_all_evt
+LOGGING_LIST_ALL_EVT = create_app_service_dependency(
+    LOGGING_LIST_ALL_EVT_ID,
+    'tiferet.events.logging',
+    'ListAllLoggingConfigs',
+)
+
+# ** constant: cli_service
+CLI_SERVICE = create_app_service_dependency(
+    CLI_SERVICE_ID,
+    'tiferet.repos.cli',
+    'CliConfigRepository',
+)
+
+# ** constant: list_commands_evt
+LIST_COMMANDS_EVT = create_app_service_dependency(
+    LIST_COMMANDS_EVT_ID,
+    'tiferet.events.cli',
+    'ListCliCommands',
+)
+
+# ** constant: get_parent_args_evt
+GET_PARENT_ARGS_EVT = create_app_service_dependency(
+    GET_PARENT_ARGS_EVT_ID,
+    'tiferet.events.cli',
+    'GetParentArguments',
+)
+
+# ** constant: di_list_all_configs_evt
+DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
+    DI_LIST_ALL_CONFIGS_EVT_ID,
+    'tiferet.events.di',
+    'ListAllSettings',
+)
+
+# ** constant: core_default_services
+CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
+    DI_SERVICE_ID: DI_SERVICE,
+    ERROR_SERVICE_ID: ERROR_SERVICE,
+    LOGGING_SERVICE_ID: LOGGING_SERVICE,
+    FEATURE_SERVICE_ID: FEATURE_SERVICE,
+    GET_ERROR_EVT_ID: GET_ERROR_EVT,
+    GET_FEATURE_EVT_ID: GET_FEATURE_EVT,
+    LOGGING_LIST_ALL_EVT_ID: LOGGING_LIST_ALL_EVT,
+    CLI_SERVICE_ID: CLI_SERVICE,
+    LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT,
+    GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT,
+    DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT,
+}
+
+# ** constant: core_default_constants
+CORE_DEFAULT_CONSTANTS: Dict[str, str] = {
+    CLI_CONFIG_ID: DEFAULT_CONFIG_FILE,
+    DI_CONFIG_ID: DEFAULT_CONFIG_FILE,
+    ERROR_CONFIG_ID: DEFAULT_CONFIG_FILE,
+    LOGGING_CONFIG_ID: DEFAULT_CONFIG_FILE,
+    FEATURE_CONFIG_ID: DEFAULT_CONFIG_FILE,
+}

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -243,7 +243,6 @@ DEFAULT_APP_SERVICE_MODULE_PATH: str = 'tiferet.repos.app'
 DEFAULT_APP_SERVICE_CLASS_NAME: str = 'AppYamlRepository'
 
 # ** constant: default_constants
-# ++ todo: Parity III Story 6b — move to assets/app.py as CORE_DEFAULT_CONSTANTS
 DEFAULT_CONSTANTS: Dict[str, str] = {
     'cli_yaml_file': 'config.yml',
     'di_yaml_file': 'config.yml',
@@ -253,7 +252,6 @@ DEFAULT_CONSTANTS: Dict[str, str] = {
 }
 
 # ** constant: default_services
-# ++ todo: Parity III Story 6b — move to assets/app.py as CORE_DEFAULT_SERVICES
 DEFAULT_SERVICES: List[Tuple[str, str, str, Dict[str, Any] | None]] = [
     ('di_service', 'tiferet.repos.di', 'DIYamlRepository', None),
     ('error_service', 'tiferet.repos.error', 'ErrorYamlRepository', None),


### PR DESCRIPTION
## Summary

Implements [#903](https://github.com/greatstrength/tiferet/issues/903) — Story 6b: Assets – App Service Catalog.

Introduces `tiferet/assets/app.py`, the id-keyed catalog of default app service dependencies and configuration constants that the blueprint layer will use for cache seeding during application bootstrapping.

## Changes

- **`tiferet/assets/app.py`** (new): 11 service-ID string constants, 5 config-ID string constants, `DEFAULT_APP_SERVICE_*` bootstrap values, 11 service model constants built via `create_app_service_dependency` (using updated `*ConfigRepository` class names from the b7 rename), `CORE_DEFAULT_SERVICES` dict keyed by service ID, `CORE_DEFAULT_CONSTANTS` dict keyed by config ID.
- **`tiferet/assets/__init__.py`**: Added `from . import app` to expose `a.app`.
- **`tiferet/assets/core.py`**: Removed resolved `# ++ todo: Parity III Story 6b` annotations (deliverables now in `app.py`; backward-compat shims `DEFAULT_SERVICES`/`DEFAULT_CONSTANTS` remain for existing consumers).
- **`tests/assets/test_app.py`** (new): 5 test functions covering `create_app_service_dependency` structure, default parameters, `CORE_DEFAULT_SERVICES` keys, `CORE_DEFAULT_CONSTANTS` config IDs, and `DEFAULT_APP_SERVICE_CLASS_NAME`.

## Test Results

799 tests pass, 11 skipped. The 2 pre-existing failures in `tests/events/test_blueprint.py` (introduced by #905 — `ServiceResolver` ABC / `build_container` not yet implemented in `settings.py`) are unrelated to this PR and will be resolved by #907.

## Warp Conversation

https://app.warp.dev/conversation/019f944d-951a-7d1a-bbcc-e48ea1e7e50f