### PR TITLE
feat(assets): standardize domain catalog modules to three-section pattern

### DIFF
--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -1,0 +1,225 @@
+"""Tests for tiferet.assets.core"""
+
+# *** imports
+
+# ** app
+from tiferet.assets.core import (
+    create_service_dependency,
+    create_app_service_dependency,
+    create_service_registration,
+    create_default_feature,
+    create_default_app_session,
+)
+
+# *** tests
+
+# ** test: create_service_dependency_returns_expected_shape
+def test_create_service_dependency_returns_expected_shape() -> None:
+    '''
+    Test that create_service_dependency returns a dict with the three base keys.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the dependency dict.
+    result = create_service_dependency('tiferet.repos.app', 'AppConfigRepository')
+
+    # Assert the shape and values.
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
+    assert result['module_path'] == 'tiferet.repos.app'
+    assert result['class_name'] == 'AppConfigRepository'
+    assert result['parameters'] == {}
+
+# ** test: create_service_dependency_with_parameters
+def test_create_service_dependency_with_parameters() -> None:
+    '''
+    Test that create_service_dependency passes through explicit parameters.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with explicit parameters.
+    params = {'config_file': 'config.yml'}
+    result = create_service_dependency('tiferet.repos.app', 'AppConfigRepository', params)
+
+    # Assert parameters are preserved.
+    assert result['parameters'] == params
+
+# ** test: create_app_service_dependency_returns_expected_shape
+def test_create_app_service_dependency_returns_expected_shape() -> None:
+    '''
+    Test that create_app_service_dependency returns a dict with the four
+    dependency keys and that service_id matches the first argument.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the app service dependency dict.
+    result = create_app_service_dependency(
+        'error_service',
+        'tiferet.repos.error',
+        'ErrorConfigRepository',
+    )
+
+    # Assert the shape and values.
+    assert set(result.keys()) == {'service_id', 'module_path', 'class_name', 'parameters'}
+    assert result['service_id'] == 'error_service'
+    assert result['module_path'] == 'tiferet.repos.error'
+    assert result['class_name'] == 'ErrorConfigRepository'
+    assert result['parameters'] == {}
+
+# ** test: create_app_service_dependency_omitting_parameters_yields_empty_dict
+def test_create_app_service_dependency_omitting_parameters_yields_empty_dict() -> None:
+    '''
+    Test that omitting parameters in create_app_service_dependency yields an
+    empty dict rather than None.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build without explicit parameters.
+    result = create_app_service_dependency('svc', 'tiferet.mod', 'Cls')
+
+    # Assert parameters default to an empty dict.
+    assert result['parameters'] == {}
+
+# ** test: create_service_registration_returns_expected_shape
+def test_create_service_registration_returns_expected_shape() -> None:
+    '''
+    Test that create_service_registration returns a dict with the four
+    registration keys and that id matches the first argument.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the service registration dict.
+    result = create_service_registration(
+        'add_feature_evt',
+        'tiferet.events.feature',
+        'AddFeature',
+    )
+
+    # Assert the shape and values.
+    assert set(result.keys()) == {'id', 'module_path', 'class_name', 'parameters'}
+    assert result['id'] == 'add_feature_evt'
+    assert result['module_path'] == 'tiferet.events.feature'
+    assert result['class_name'] == 'AddFeature'
+    assert result['parameters'] == {}
+
+# ** test: create_service_registration_omitting_parameters_yields_empty_dict
+def test_create_service_registration_omitting_parameters_yields_empty_dict() -> None:
+    '''
+    Test that omitting parameters in create_service_registration yields an
+    empty dict rather than None.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build without explicit parameters.
+    result = create_service_registration('svc', 'tiferet.mod', 'Cls')
+
+    # Assert parameters default to an empty dict.
+    assert result['parameters'] == {}
+
+# ** test: create_default_feature_returns_required_fields
+def test_create_default_feature_returns_required_fields() -> None:
+    '''
+    Test that create_default_feature returns a dict with all five required
+    fields populated and no optional fields when omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal feature with no optional arguments.
+    steps = [{'service_id': 'get_feature_evt', 'name': 'Get feature'}]
+    result = create_default_feature(
+        'feature.get',
+        'Get Feature',
+        'feature',
+        'get',
+        steps,
+    )
+
+    # Assert required fields are present.
+    assert result['id'] == 'feature.get'
+    assert result['name'] == 'Get Feature'
+    assert result['group_id'] == 'feature'
+    assert result['feature_key'] == 'get'
+    assert result['steps'] == steps
+
+    # Assert optional fields are absent when not provided.
+    assert 'description' not in result
+    assert 'params_schema' not in result
+
+# ** test: create_default_feature_includes_optional_fields_when_provided
+def test_create_default_feature_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_feature includes description and params_schema
+    when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with optional arguments.
+    schema = {'id': 'str'}
+    result = create_default_feature(
+        'feature.get',
+        'Get Feature',
+        'feature',
+        'get',
+        [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
+        description='Retrieve a feature by ID.',
+        params_schema=schema,
+    )
+
+    # Assert optional fields are included.
+    assert result['description'] == 'Retrieve a feature by ID.'
+    assert result['params_schema'] == schema
+
+# ** test: create_default_app_session_returns_required_fields
+def test_create_default_app_session_returns_required_fields() -> None:
+    '''
+    Test that create_default_app_session returns a dict with id and name and
+    no description field when omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal session with no optional arguments.
+    result = create_default_app_session('admin', 'Admin App')
+
+    # Assert required fields are present.
+    assert result['id'] == 'admin'
+    assert result['name'] == 'Admin App'
+
+    # Assert optional description is absent when not provided.
+    assert 'description' not in result
+
+# ** test: create_default_app_session_includes_description_when_provided
+def test_create_default_app_session_includes_description_when_provided() -> None:
+    '''
+    Test that create_default_app_session includes the description field when
+    it is supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with an optional description.
+    result = create_default_app_session(
+        'admin_cli',
+        'Admin CLI',
+        description='Built-in CLI for managing Tiferet application configurations',
+    )
+
+    # Assert the description is included.
+    assert result['description'] == 'Built-in CLI for managing Tiferet application configurations'

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -1,4 +1,4 @@
-"""Tests for tiferet.assets.core"""
+"""Tests for Core Assets"""
 
 # *** imports
 
@@ -7,11 +7,45 @@ from tiferet.assets.core import (
     create_service_dependency,
     create_app_service_dependency,
     create_service_registration,
+    create_service_module_path,
     create_default_feature,
     create_default_app_session,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    FEATURE_DOMAIN_PATH,
 )
 
 # *** tests
+
+# ** test: create_service_module_path_returns_dotted_path
+def test_create_service_module_path_returns_dotted_path() -> None:
+    '''
+    Test that create_service_module_path joins base and domain with a dot.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the module path.
+    result = create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH)
+
+    # Assert the joined path is correct.
+    assert result == 'tiferet.events.feature'
+
+# ** test: create_service_module_path_repos_path
+def test_create_service_module_path_repos_path() -> None:
+    '''
+    Test that create_service_module_path works correctly for a repos base path.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a repos module path.
+    result = create_service_module_path(TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH)
+
+    # Assert the joined path is correct.
+    assert result == 'tiferet.repos.feature'
 
 # ** test: create_service_dependency_returns_expected_shape
 def test_create_service_dependency_returns_expected_shape() -> None:

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -10,6 +10,8 @@ from tiferet.assets.core import (
     create_service_module_path,
     create_default_feature,
     create_default_app_session,
+    create_params_schema,
+    TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
     FEATURE_DOMAIN_PATH,
@@ -27,7 +29,7 @@ def test_create_service_module_path_returns_dotted_path() -> None:
     '''
 
     # Build the module path.
-    result = create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH)
+    result = create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH)
 
     # Assert the joined path is correct.
     assert result == 'tiferet.events.feature'
@@ -42,7 +44,7 @@ def test_create_service_module_path_repos_path() -> None:
     '''
 
     # Build a repos module path.
-    result = create_service_module_path(TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH)
+    result = create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH)
 
     # Assert the joined path is correct.
     assert result == 'tiferet.repos.feature'
@@ -237,6 +239,31 @@ def test_create_default_app_session_returns_required_fields() -> None:
 
     # Assert optional description is absent when not provided.
     assert 'description' not in result
+
+# ** test: create_params_schema_returns_expected_dict
+def test_create_params_schema_returns_expected_dict() -> None:
+    '''
+    Test that create_params_schema assembles a parameter schema dict from
+    keyword arguments, supporting both shorthand type strings and expanded
+    spec dicts.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a schema with a mix of shorthand and expanded entries.
+    result = create_params_schema(
+        id='str',
+        name='str',
+        description={'type': 'str', 'required': False},
+    )
+
+    # Assert the schema contains all provided parameters.
+    assert result == {
+        'id': 'str',
+        'name': 'str',
+        'description': {'type': 'str', 'required': False},
+    }
 
 # ** test: create_default_app_session_includes_description_when_provided
 def test_create_default_app_session_includes_description_when_provided() -> None:

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -11,6 +11,11 @@ from tiferet.assets.core import (
     create_default_feature,
     create_default_app_session,
     create_params_schema,
+    create_default_formatter,
+    create_default_handler,
+    create_default_logger,
+    create_default_cli_argument,
+    create_default_cli_command,
     TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
@@ -284,3 +289,268 @@ def test_create_default_app_session_includes_description_when_provided() -> None
 
     # Assert the description is included.
     assert result['description'] == 'Built-in CLI for managing Tiferet application configurations'
+
+# ** test: create_default_formatter_returns_required_fields
+def test_create_default_formatter_returns_required_fields() -> None:
+    '''
+    Test that create_default_formatter returns a dict with the three required
+    fields and no optional fields when they are omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal formatter with no optional arguments.
+    result = create_default_formatter(
+        'default',
+        'Default Formatter',
+        '%(asctime)s - %(levelname)s - %(message)s',
+    )
+
+    # Assert required fields are present.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Formatter'
+    assert result['format'] == '%(asctime)s - %(levelname)s - %(message)s'
+
+    # Assert optional fields are absent when not provided.
+    assert 'description' not in result
+    assert 'datefmt' not in result
+
+# ** test: create_default_formatter_includes_optional_fields_when_provided
+def test_create_default_formatter_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_formatter includes description and datefmt when
+    they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with optional arguments.
+    result = create_default_formatter(
+        'default',
+        'Default Formatter',
+        '%(asctime)s - %(levelname)s - %(message)s',
+        description='The default logging formatter.',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+
+    # Assert optional fields are included.
+    assert result['description'] == 'The default logging formatter.'
+    assert result['datefmt'] == '%Y-%m-%d %H:%M:%S'
+
+# ** test: create_default_handler_returns_required_fields
+def test_create_default_handler_returns_required_fields() -> None:
+    '''
+    Test that create_default_handler returns a dict with the six required
+    fields and no optional fields when they are omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal handler with no optional arguments.
+    result = create_default_handler(
+        'default',
+        'Default Handler',
+        'logging',
+        'StreamHandler',
+        'INFO',
+        'default',
+    )
+
+    # Assert required fields are present.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Handler'
+    assert result['module_path'] == 'logging'
+    assert result['class_name'] == 'StreamHandler'
+    assert result['level'] == 'INFO'
+    assert result['formatter'] == 'default'
+
+    # Assert optional fields are absent when not provided.
+    assert 'description' not in result
+    assert 'stream' not in result
+    assert 'filename' not in result
+
+# ** test: create_default_handler_includes_optional_fields_when_provided
+def test_create_default_handler_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_handler includes description, stream, and
+    filename when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with optional arguments.
+    result = create_default_handler(
+        'default',
+        'Default Handler',
+        'logging',
+        'StreamHandler',
+        'INFO',
+        'default',
+        description='The default logging handler.',
+        stream='ext://sys.stdout',
+        filename='app.log',
+    )
+
+    # Assert optional fields are included.
+    assert result['description'] == 'The default logging handler.'
+    assert result['stream'] == 'ext://sys.stdout'
+    assert result['filename'] == 'app.log'
+
+# ** test: create_default_logger_returns_required_fields
+def test_create_default_logger_returns_required_fields() -> None:
+    '''
+    Test that create_default_logger returns a dict with all required fields
+    and that propagate/is_root default to False.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal logger with no optional arguments.
+    result = create_default_logger(
+        'default',
+        'Default Logger',
+        'INFO',
+        ['default'],
+    )
+
+    # Assert required fields are present.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Logger'
+    assert result['level'] == 'INFO'
+    assert result['handlers'] == ['default']
+    assert result['propagate'] is False
+    assert result['is_root'] is False
+
+    # Assert optional description is absent when not provided.
+    assert 'description' not in result
+
+# ** test: create_default_logger_includes_optional_fields_when_provided
+def test_create_default_logger_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_logger includes description and respects explicit
+    propagate and is_root values when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with optional and overridden arguments.
+    result = create_default_logger(
+        'root',
+        'Root Logger',
+        'WARNING',
+        ['default_root'],
+        propagate=False,
+        is_root=True,
+        description='The root logger.',
+    )
+
+    # Assert overridden booleans and optional description are included.
+    assert result['propagate'] is False
+    assert result['is_root'] is True
+    assert result['description'] == 'The root logger.'
+
+# ** test: create_default_cli_argument_returns_required_field
+def test_create_default_cli_argument_returns_required_field() -> None:
+    '''
+    Test that create_default_cli_argument returns a dict with only
+    name_or_flags when all optional arguments are omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal argument with no optional fields.
+    result = create_default_cli_argument(['--flag'])
+
+    # Assert the only key present is name_or_flags.
+    assert result == {'name_or_flags': ['--flag']}
+
+# ** test: create_default_cli_argument_includes_optional_fields_when_provided
+def test_create_default_cli_argument_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_cli_argument includes all optional fields when
+    they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with all optional fields supplied.
+    result = create_default_cli_argument(
+        ['level'],
+        'Logging level.',
+        type='str',
+        default='INFO',
+        required=True,
+        nargs='?',
+        choices=['DEBUG', 'INFO', 'WARNING'],
+        action='store',
+    )
+
+    # Assert all optional fields are present with correct values.
+    assert result['description'] == 'Logging level.'
+    assert result['type'] == 'str'
+    assert result['default'] == 'INFO'
+    assert result['required'] is True
+    assert result['nargs'] == '?'
+    assert result['choices'] == ['DEBUG', 'INFO', 'WARNING']
+    assert result['action'] == 'store'
+
+# ** test: create_default_cli_command_returns_required_fields
+def test_create_default_cli_command_returns_required_fields() -> None:
+    '''
+    Test that create_default_cli_command returns a dict with the four required
+    fields and no optional fields when they are omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a minimal command with no optional arguments.
+    result = create_default_cli_command(
+        'feature.list',
+        'list',
+        'feature',
+        'List Features',
+    )
+
+    # Assert required fields are present.
+    assert result['id'] == 'feature.list'
+    assert result['key'] == 'list'
+    assert result['group_key'] == 'feature'
+    assert result['name'] == 'List Features'
+
+    # Assert optional fields are absent when not provided.
+    assert 'description' not in result
+    assert 'arguments' not in result
+
+# ** test: create_default_cli_command_includes_optional_fields_when_provided
+def test_create_default_cli_command_includes_optional_fields_when_provided() -> None:
+    '''
+    Test that create_default_cli_command includes description and arguments
+    when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build with optional arguments.
+    args = [create_default_cli_argument(['id'], 'The feature identifier.')]
+    result = create_default_cli_command(
+        'feature.get',
+        'get',
+        'feature',
+        'Get Feature',
+        description='Retrieve a feature by ID.',
+        arguments=args,
+    )
+
+    # Assert optional fields are included.
+    assert result['description'] == 'Retrieve a feature by ID.'
+    assert result['arguments'] == args

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -13,8 +13,8 @@ application bootstrapping and cache seeding.
 # *** imports
 
 # ** app
-from .core import create_app_service_dependency
-from .di import DEFAULT_TIFERET_CLI_SERVICES as _CLI_SERVICES_LIST
+from .core import create_app_service_dependency, create_default_app_session
+from .di import DEFAULT_TIFERET_CLI_SERVICES
 
 # *** constants (ids)
 
@@ -60,6 +60,12 @@ TIMING_MIDDLEWARE_ID = 'timing_middleware'
 # ** constant: cache_middleware_id
 CACHE_MIDDLEWARE_ID = 'cache_middleware'
 
+# ** constant: tiferet_admin_id
+TIFERET_ADMIN_ID = 'admin'
+
+# ** constant: tiferet_admin_cli_id
+TIFERET_ADMIN_CLI_ID = 'admin_cli'
+
 # ** constant: cli_config_id
 CLI_CONFIG_ID = 'cli_config'
 
@@ -78,18 +84,18 @@ FEATURE_CONFIG_ID = 'feature_config'
 # *** constants (models)
 
 # ** constant: default_admin_app_session
-DEFAULT_ADMIN_APP_SESSION = {
-    'id': 'tiferet_app',
-    'name': 'Admin App',
-    'description': 'Default built-in admin application session',
-}
+DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
+    TIFERET_ADMIN_ID,
+    'Admin App',
+    description='Default built-in admin application session',
+)
 
 # ** constant: default_admin_cli_session
-DEFAULT_ADMIN_CLI_SESSION = {
-    'id': 'tiferet_cli',
-    'name': 'Admin CLI',
-    'description': 'Built-in CLI for managing Tiferet application configurations',
-}
+DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
+    TIFERET_ADMIN_CLI_ID,
+    'Admin CLI',
+    description='Built-in CLI for managing Tiferet application configurations',
+)
 
 # ** constant: default_config_file
 DEFAULT_CONFIG_FILE = 'config.yml'
@@ -207,15 +213,16 @@ CORE_DEFAULT_CONSTANTS = {
 
 # ** constant: admin_default_services
 # Full service catalog for the admin layer: all core services plus admin domain
-# events (derived from the CLI services list) and the AppConfigRepository.
+# events (from the CLI services catalog) as app service dependencies.
 ADMIN_DEFAULT_SERVICES = {
     **CORE_DEFAULT_SERVICES,
-    'app_service': create_app_service_dependency(
-        'app_service', 'tiferet.repos.app', 'AppConfigRepository',
-    ),
     **{
-        sid: create_app_service_dependency(sid, mp, cn)
-        for sid, mp, cn, _p in _CLI_SERVICES_LIST
+        svc_id: create_app_service_dependency(
+            svc_id,
+            svc['module_path'],
+            svc['class_name'],
+        )
+        for svc_id, svc in DEFAULT_TIFERET_CLI_SERVICES.items()
     },
 }
 
@@ -230,6 +237,6 @@ ADMIN_DEFAULT_CONSTANTS = {
 # Built-in session definitions seeded into the cache by build_cache so the admin
 # paths can resolve them without a config-file entry or a separate fallback.
 CORE_DEFAULT_APP_SESSIONS = {
-    DEFAULT_ADMIN_APP_SESSION['id']: DEFAULT_ADMIN_APP_SESSION,
-    DEFAULT_ADMIN_CLI_SESSION['id']: DEFAULT_ADMIN_CLI_SESSION,
+    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION,
+    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION,
 }

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -17,14 +17,17 @@ from .core import (
     create_app_service_dependency,
     create_default_app_session,
     create_service_module_path,
+    TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
+    TIFERET_UTILS_PATH,
     FEATURE_DOMAIN_PATH,
     ERROR_DOMAIN_PATH,
     DI_DOMAIN_PATH,
     APP_DOMAIN_PATH,
     LOGGING_DOMAIN_PATH,
     CLI_DOMAIN_PATH,
+    MIDDLEWARE_DOMAIN_PATH,
 )
 
 # *** constants (ids)
@@ -92,117 +95,6 @@ LOGGING_CONFIG_ID = 'logging_config'
 # ** constant: feature_config_id
 FEATURE_CONFIG_ID = 'feature_config'
 
-# ** constant: app_service_id
-APP_SERVICE_ID = 'app_service'
-
-# ** constant: add_feature_evt_id
-ADD_FEATURE_EVT_ID = 'add_feature_evt'
-
-# ** constant: list_features_evt_id
-LIST_FEATURES_EVT_ID = 'list_features_evt'
-
-# ** constant: remove_feature_evt_id
-REMOVE_FEATURE_EVT_ID = 'remove_feature_evt'
-
-# ** constant: update_feature_evt_id
-UPDATE_FEATURE_EVT_ID = 'update_feature_evt'
-
-# ** constant: add_feature_step_evt_id
-ADD_FEATURE_STEP_EVT_ID = 'add_feature_step_evt'
-
-# ** constant: update_feature_step_evt_id
-UPDATE_FEATURE_STEP_EVT_ID = 'update_feature_step_evt'
-
-# ** constant: remove_feature_step_evt_id
-REMOVE_FEATURE_STEP_EVT_ID = 'remove_feature_step_evt'
-
-# ** constant: reorder_feature_step_evt_id
-REORDER_FEATURE_STEP_EVT_ID = 'reorder_feature_step_evt'
-
-# ** constant: add_error_evt_id
-ADD_ERROR_EVT_ID = 'add_error_evt'
-
-# ** constant: list_errors_evt_id
-LIST_ERRORS_EVT_ID = 'list_errors_evt'
-
-# ** constant: rename_error_evt_id
-RENAME_ERROR_EVT_ID = 'rename_error_evt'
-
-# ** constant: set_error_message_evt_id
-SET_ERROR_MESSAGE_EVT_ID = 'set_error_message_evt'
-
-# ** constant: remove_error_message_evt_id
-REMOVE_ERROR_MESSAGE_EVT_ID = 'remove_error_message_evt'
-
-# ** constant: remove_error_evt_id
-REMOVE_ERROR_EVT_ID = 'remove_error_evt'
-
-# ** constant: add_service_registration_evt_id
-ADD_SERVICE_REGISTRATION_EVT_ID = 'add_service_registration_evt'
-
-# ** constant: set_default_service_registration_evt_id
-SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID = 'set_default_service_registration_evt'
-
-# ** constant: set_di_service_dependency_evt_id
-SET_DI_SERVICE_DEPENDENCY_EVT_ID = 'set_di_service_dependency_evt'
-
-# ** constant: remove_di_service_dependency_evt_id
-REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID = 'remove_di_service_dependency_evt'
-
-# ** constant: remove_service_registration_evt_id
-REMOVE_SERVICE_REGISTRATION_EVT_ID = 'remove_service_registration_evt'
-
-# ** constant: set_service_constants_evt_id
-SET_SERVICE_CONSTANTS_EVT_ID = 'set_service_constants_evt'
-
-# ** constant: add_app_session_evt_id
-ADD_APP_SESSION_EVT_ID = 'add_app_session_evt'
-
-# ** constant: get_app_session_evt_id
-GET_APP_SESSION_EVT_ID = 'get_app_session_evt'
-
-# ** constant: update_app_session_evt_id
-UPDATE_APP_SESSION_EVT_ID = 'update_app_session_evt'
-
-# ** constant: set_app_constants_evt_id
-SET_APP_CONSTANTS_EVT_ID = 'set_app_constants_evt'
-
-# ** constant: list_app_sessions_evt_id
-LIST_APP_SESSIONS_EVT_ID = 'list_app_sessions_evt'
-
-# ** constant: set_app_service_dependency_evt_id
-SET_APP_SERVICE_DEPENDENCY_EVT_ID = 'set_app_service_dependency_evt'
-
-# ** constant: remove_app_service_dependency_evt_id
-REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID = 'remove_app_service_dependency_evt'
-
-# ** constant: remove_app_session_evt_id
-REMOVE_APP_SESSION_EVT_ID = 'remove_app_session_evt'
-
-# ** constant: add_cli_command_evt_id
-ADD_CLI_COMMAND_EVT_ID = 'add_cli_command_evt'
-
-# ** constant: add_cli_argument_evt_id
-ADD_CLI_ARGUMENT_EVT_ID = 'add_cli_argument_evt'
-
-# ** constant: add_formatter_evt_id
-ADD_FORMATTER_EVT_ID = 'add_formatter_evt'
-
-# ** constant: remove_formatter_evt_id
-REMOVE_FORMATTER_EVT_ID = 'remove_formatter_evt'
-
-# ** constant: add_handler_evt_id
-ADD_HANDLER_EVT_ID = 'add_handler_evt'
-
-# ** constant: remove_handler_evt_id
-REMOVE_HANDLER_EVT_ID = 'remove_handler_evt'
-
-# ** constant: add_logger_evt_id
-ADD_LOGGER_EVT_ID = 'add_logger_evt'
-
-# ** constant: remove_logger_evt_id
-REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
-
 # *** constants (models)
 
 # ** constant: default_admin_app_session
@@ -226,7 +118,7 @@ DEFAULT_CONFIG_FILE = 'config.yml'
 DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
 
 # ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH)
+DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH)
 
 # ** constant: default_app_service_class_name
 DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
@@ -237,352 +129,99 @@ DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
 # ** constant: di_service
 DI_SERVICE = create_app_service_dependency(
     DI_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
     'DIConfigRepository',
 )
 
 # ** constant: error_service
 ERROR_SERVICE = create_app_service_dependency(
     ERROR_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
     'ErrorConfigRepository',
 )
 
 # ** constant: logging_service
 LOGGING_SERVICE = create_app_service_dependency(
     LOGGING_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
     'LoggingConfigRepository',
 )
 
 # ** constant: feature_service
 FEATURE_SERVICE = create_app_service_dependency(
     FEATURE_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
     'FeatureConfigRepository',
 )
 
 # ** constant: get_error_evt
 GET_ERROR_EVT = create_app_service_dependency(
     GET_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'GetError',
 )
 
 # ** constant: get_feature_evt
 GET_FEATURE_EVT = create_app_service_dependency(
     GET_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'GetFeature',
 )
 
 # ** constant: logging_list_all_evt
 LOGGING_LIST_ALL_EVT = create_app_service_dependency(
     LOGGING_LIST_ALL_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'ListAllLoggingConfigs',
 )
 
 # ** constant: cli_service
 CLI_SERVICE = create_app_service_dependency(
     CLI_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
     'CliConfigRepository',
 )
 
 # ** constant: list_commands_evt
 LIST_COMMANDS_EVT = create_app_service_dependency(
     LIST_COMMANDS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'ListCliCommands',
 )
 
 # ** constant: get_parent_args_evt
 GET_PARENT_ARGS_EVT = create_app_service_dependency(
     GET_PARENT_ARGS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'GetParentArguments',
 )
 
 # ** constant: di_list_all_configs_evt
 DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
     DI_LIST_ALL_CONFIGS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'ListAllSettings',
 )
 
 # ** constant: logging_middleware
 LOGGING_MIDDLEWARE = create_app_service_dependency(
-    LOGGING_MIDDLEWARE_ID, 'tiferet.utils.middleware', 'LoggingMiddleware',
+    LOGGING_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'LoggingMiddleware',
 )
 
 # ** constant: timing_middleware
 TIMING_MIDDLEWARE = create_app_service_dependency(
-    TIMING_MIDDLEWARE_ID, 'tiferet.utils.middleware', 'TimingMiddleware',
+    TIMING_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'TimingMiddleware',
 )
 
 # ** constant: cache_middleware
 CACHE_MIDDLEWARE = create_app_service_dependency(
-    CACHE_MIDDLEWARE_ID, 'tiferet.utils.middleware', 'CacheMiddleware',
-)
-
-# ** constant: app_service
-APP_SERVICE = create_app_service_dependency(
-    APP_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
-    'AppConfigRepository',
-)
-
-# ** constant: add_feature_evt
-ADD_FEATURE_EVT = create_app_service_dependency(
-    ADD_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'AddFeature',
-)
-
-# ** constant: list_features_evt
-LIST_FEATURES_EVT = create_app_service_dependency(
-    LIST_FEATURES_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'ListFeatures',
-)
-
-# ** constant: remove_feature_evt
-REMOVE_FEATURE_EVT = create_app_service_dependency(
-    REMOVE_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'RemoveFeature',
-)
-
-# ** constant: update_feature_evt
-UPDATE_FEATURE_EVT = create_app_service_dependency(
-    UPDATE_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'UpdateFeature',
-)
-
-# ** constant: add_feature_step_evt
-ADD_FEATURE_STEP_EVT = create_app_service_dependency(
-    ADD_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'AddFeatureStep',
-)
-
-# ** constant: update_feature_step_evt
-UPDATE_FEATURE_STEP_EVT = create_app_service_dependency(
-    UPDATE_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'UpdateFeatureStep',
-)
-
-# ** constant: remove_feature_step_evt
-REMOVE_FEATURE_STEP_EVT = create_app_service_dependency(
-    REMOVE_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'RemoveFeatureStep',
-)
-
-# ** constant: reorder_feature_step_evt
-REORDER_FEATURE_STEP_EVT = create_app_service_dependency(
-    REORDER_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
-    'ReorderFeatureStep',
-)
-
-# ** constant: add_error_evt
-ADD_ERROR_EVT = create_app_service_dependency(
-    ADD_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'AddError',
-)
-
-# ** constant: list_errors_evt
-LIST_ERRORS_EVT = create_app_service_dependency(
-    LIST_ERRORS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'ListErrors',
-)
-
-# ** constant: rename_error_evt
-RENAME_ERROR_EVT = create_app_service_dependency(
-    RENAME_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'RenameError',
-)
-
-# ** constant: set_error_message_evt
-SET_ERROR_MESSAGE_EVT = create_app_service_dependency(
-    SET_ERROR_MESSAGE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'SetErrorMessage',
-)
-
-# ** constant: remove_error_message_evt
-REMOVE_ERROR_MESSAGE_EVT = create_app_service_dependency(
-    REMOVE_ERROR_MESSAGE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'RemoveErrorMessage',
-)
-
-# ** constant: remove_error_evt
-REMOVE_ERROR_EVT = create_app_service_dependency(
-    REMOVE_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
-    'RemoveError',
-)
-
-# ** constant: add_service_registration_evt
-ADD_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
-    ADD_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'AddServiceRegistration',
-)
-
-# ** constant: set_default_service_registration_evt
-SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'SetDefaultServiceRegistration',
-)
-
-# ** constant: set_di_service_dependency_evt
-SET_DI_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'SetServiceDependency',
-)
-
-# ** constant: remove_di_service_dependency_evt
-REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'RemoveServiceDependency',
-)
-
-# ** constant: remove_service_registration_evt
-REMOVE_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
-    REMOVE_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'RemoveServiceRegistration',
-)
-
-# ** constant: set_service_constants_evt
-SET_SERVICE_CONSTANTS_EVT = create_app_service_dependency(
-    SET_SERVICE_CONSTANTS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
-    'SetServiceConstants',
-)
-
-# ** constant: add_app_session_evt
-ADD_APP_SESSION_EVT = create_app_service_dependency(
-    ADD_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'AddAppSession',
-)
-
-# ** constant: get_app_session_evt
-GET_APP_SESSION_EVT = create_app_service_dependency(
-    GET_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'GetAppSession',
-)
-
-# ** constant: update_app_session_evt
-UPDATE_APP_SESSION_EVT = create_app_service_dependency(
-    UPDATE_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'UpdateAppSession',
-)
-
-# ** constant: set_app_constants_evt
-SET_APP_CONSTANTS_EVT = create_app_service_dependency(
-    SET_APP_CONSTANTS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'SetAppConstants',
-)
-
-# ** constant: list_app_sessions_evt
-LIST_APP_SESSIONS_EVT = create_app_service_dependency(
-    LIST_APP_SESSIONS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'ListAppSessions',
-)
-
-# ** constant: set_app_service_dependency_evt
-SET_APP_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'SetServiceDependency',
-)
-
-# ** constant: remove_app_service_dependency_evt
-REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'RemoveServiceDependency',
-)
-
-# ** constant: remove_app_session_evt
-REMOVE_APP_SESSION_EVT = create_app_service_dependency(
-    REMOVE_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
-    'RemoveAppSession',
-)
-
-# ** constant: add_cli_command_evt
-ADD_CLI_COMMAND_EVT = create_app_service_dependency(
-    ADD_CLI_COMMAND_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
-    'AddCliCommand',
-)
-
-# ** constant: add_cli_argument_evt
-ADD_CLI_ARGUMENT_EVT = create_app_service_dependency(
-    ADD_CLI_ARGUMENT_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
-    'AddCliArgument',
-)
-
-# ** constant: add_formatter_evt
-ADD_FORMATTER_EVT = create_app_service_dependency(
-    ADD_FORMATTER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'AddFormatter',
-)
-
-# ** constant: remove_formatter_evt
-REMOVE_FORMATTER_EVT = create_app_service_dependency(
-    REMOVE_FORMATTER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'RemoveFormatter',
-)
-
-# ** constant: add_handler_evt
-ADD_HANDLER_EVT = create_app_service_dependency(
-    ADD_HANDLER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'AddHandler',
-)
-
-# ** constant: remove_handler_evt
-REMOVE_HANDLER_EVT = create_app_service_dependency(
-    REMOVE_HANDLER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'RemoveHandler',
-)
-
-# ** constant: add_logger_evt
-ADD_LOGGER_EVT = create_app_service_dependency(
-    ADD_LOGGER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'AddLogger',
-)
-
-# ** constant: remove_logger_evt
-REMOVE_LOGGER_EVT = create_app_service_dependency(
-    REMOVE_LOGGER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
-    'RemoveLogger',
+    CACHE_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'CacheMiddleware',
 )
 
 # *** constants (groups)
@@ -614,51 +253,9 @@ CORE_DEFAULT_CONSTANTS = {
     FEATURE_CONFIG_ID: DEFAULT_CONFIG_FILE,
 }
 
-# ** constant: default_admin_cli_services
-DEFAULT_ADMIN_CLI_SERVICES = {
-    APP_SERVICE_ID: APP_SERVICE,
-    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
-    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
-    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
-    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
-    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
-    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
-    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
-    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
-    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
-    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
-    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
-    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
-    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
-    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
-    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
-    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
-    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
-    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
-    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
-    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
-    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
-    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
-    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
-    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
-    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
-    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
-    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
-}
-
 # ** constant: admin_default_services
 ADMIN_DEFAULT_SERVICES = {
     **CORE_DEFAULT_SERVICES,
-    **DEFAULT_ADMIN_CLI_SERVICES,
 }
 
 # ** constant: admin_default_constants

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -13,8 +13,19 @@ application bootstrapping and cache seeding.
 # *** imports
 
 # ** app
-from .core import create_app_service_dependency, create_default_app_session
-from .di import DEFAULT_TIFERET_CLI_SERVICES
+from .core import (
+    create_app_service_dependency,
+    create_default_app_session,
+    create_service_module_path,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    FEATURE_DOMAIN_PATH,
+    ERROR_DOMAIN_PATH,
+    DI_DOMAIN_PATH,
+    APP_DOMAIN_PATH,
+    LOGGING_DOMAIN_PATH,
+    CLI_DOMAIN_PATH,
+)
 
 # *** constants (ids)
 
@@ -81,6 +92,117 @@ LOGGING_CONFIG_ID = 'logging_config'
 # ** constant: feature_config_id
 FEATURE_CONFIG_ID = 'feature_config'
 
+# ** constant: app_service_id
+APP_SERVICE_ID = 'app_service'
+
+# ** constant: add_feature_evt_id
+ADD_FEATURE_EVT_ID = 'add_feature_evt'
+
+# ** constant: list_features_evt_id
+LIST_FEATURES_EVT_ID = 'list_features_evt'
+
+# ** constant: remove_feature_evt_id
+REMOVE_FEATURE_EVT_ID = 'remove_feature_evt'
+
+# ** constant: update_feature_evt_id
+UPDATE_FEATURE_EVT_ID = 'update_feature_evt'
+
+# ** constant: add_feature_step_evt_id
+ADD_FEATURE_STEP_EVT_ID = 'add_feature_step_evt'
+
+# ** constant: update_feature_step_evt_id
+UPDATE_FEATURE_STEP_EVT_ID = 'update_feature_step_evt'
+
+# ** constant: remove_feature_step_evt_id
+REMOVE_FEATURE_STEP_EVT_ID = 'remove_feature_step_evt'
+
+# ** constant: reorder_feature_step_evt_id
+REORDER_FEATURE_STEP_EVT_ID = 'reorder_feature_step_evt'
+
+# ** constant: add_error_evt_id
+ADD_ERROR_EVT_ID = 'add_error_evt'
+
+# ** constant: list_errors_evt_id
+LIST_ERRORS_EVT_ID = 'list_errors_evt'
+
+# ** constant: rename_error_evt_id
+RENAME_ERROR_EVT_ID = 'rename_error_evt'
+
+# ** constant: set_error_message_evt_id
+SET_ERROR_MESSAGE_EVT_ID = 'set_error_message_evt'
+
+# ** constant: remove_error_message_evt_id
+REMOVE_ERROR_MESSAGE_EVT_ID = 'remove_error_message_evt'
+
+# ** constant: remove_error_evt_id
+REMOVE_ERROR_EVT_ID = 'remove_error_evt'
+
+# ** constant: add_service_registration_evt_id
+ADD_SERVICE_REGISTRATION_EVT_ID = 'add_service_registration_evt'
+
+# ** constant: set_default_service_registration_evt_id
+SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID = 'set_default_service_registration_evt'
+
+# ** constant: set_di_service_dependency_evt_id
+SET_DI_SERVICE_DEPENDENCY_EVT_ID = 'set_di_service_dependency_evt'
+
+# ** constant: remove_di_service_dependency_evt_id
+REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID = 'remove_di_service_dependency_evt'
+
+# ** constant: remove_service_registration_evt_id
+REMOVE_SERVICE_REGISTRATION_EVT_ID = 'remove_service_registration_evt'
+
+# ** constant: set_service_constants_evt_id
+SET_SERVICE_CONSTANTS_EVT_ID = 'set_service_constants_evt'
+
+# ** constant: add_app_session_evt_id
+ADD_APP_SESSION_EVT_ID = 'add_app_session_evt'
+
+# ** constant: get_app_session_evt_id
+GET_APP_SESSION_EVT_ID = 'get_app_session_evt'
+
+# ** constant: update_app_session_evt_id
+UPDATE_APP_SESSION_EVT_ID = 'update_app_session_evt'
+
+# ** constant: set_app_constants_evt_id
+SET_APP_CONSTANTS_EVT_ID = 'set_app_constants_evt'
+
+# ** constant: list_app_sessions_evt_id
+LIST_APP_SESSIONS_EVT_ID = 'list_app_sessions_evt'
+
+# ** constant: set_app_service_dependency_evt_id
+SET_APP_SERVICE_DEPENDENCY_EVT_ID = 'set_app_service_dependency_evt'
+
+# ** constant: remove_app_service_dependency_evt_id
+REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID = 'remove_app_service_dependency_evt'
+
+# ** constant: remove_app_session_evt_id
+REMOVE_APP_SESSION_EVT_ID = 'remove_app_session_evt'
+
+# ** constant: add_cli_command_evt_id
+ADD_CLI_COMMAND_EVT_ID = 'add_cli_command_evt'
+
+# ** constant: add_cli_argument_evt_id
+ADD_CLI_ARGUMENT_EVT_ID = 'add_cli_argument_evt'
+
+# ** constant: add_formatter_evt_id
+ADD_FORMATTER_EVT_ID = 'add_formatter_evt'
+
+# ** constant: remove_formatter_evt_id
+REMOVE_FORMATTER_EVT_ID = 'remove_formatter_evt'
+
+# ** constant: add_handler_evt_id
+ADD_HANDLER_EVT_ID = 'add_handler_evt'
+
+# ** constant: remove_handler_evt_id
+REMOVE_HANDLER_EVT_ID = 'remove_handler_evt'
+
+# ** constant: add_logger_evt_id
+ADD_LOGGER_EVT_ID = 'add_logger_evt'
+
+# ** constant: remove_logger_evt_id
+REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
+
 # *** constants (models)
 
 # ** constant: default_admin_app_session
@@ -104,7 +226,7 @@ DEFAULT_CONFIG_FILE = 'config.yml'
 DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
 
 # ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH = 'tiferet.repos.app'
+DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH)
 
 # ** constant: default_app_service_class_name
 DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
@@ -114,57 +236,79 @@ DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
 
 # ** constant: di_service
 DI_SERVICE = create_app_service_dependency(
-    DI_SERVICE_ID, 'tiferet.repos.di', 'DIConfigRepository',
+    DI_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
+    'DIConfigRepository',
 )
 
 # ** constant: error_service
 ERROR_SERVICE = create_app_service_dependency(
-    ERROR_SERVICE_ID, 'tiferet.repos.error', 'ErrorConfigRepository',
+    ERROR_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
+    'ErrorConfigRepository',
 )
 
 # ** constant: logging_service
 LOGGING_SERVICE = create_app_service_dependency(
-    LOGGING_SERVICE_ID, 'tiferet.repos.logging', 'LoggingConfigRepository',
+    LOGGING_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
+    'LoggingConfigRepository',
 )
 
 # ** constant: feature_service
 FEATURE_SERVICE = create_app_service_dependency(
-    FEATURE_SERVICE_ID, 'tiferet.repos.feature', 'FeatureConfigRepository',
+    FEATURE_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
+    'FeatureConfigRepository',
 )
 
 # ** constant: get_error_evt
 GET_ERROR_EVT = create_app_service_dependency(
-    GET_ERROR_EVT_ID, 'tiferet.events.error', 'GetError',
+    GET_ERROR_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'GetError',
 )
 
 # ** constant: get_feature_evt
 GET_FEATURE_EVT = create_app_service_dependency(
-    GET_FEATURE_EVT_ID, 'tiferet.events.feature', 'GetFeature',
+    GET_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'GetFeature',
 )
 
 # ** constant: logging_list_all_evt
 LOGGING_LIST_ALL_EVT = create_app_service_dependency(
-    LOGGING_LIST_ALL_EVT_ID, 'tiferet.events.logging', 'ListAllLoggingConfigs',
+    LOGGING_LIST_ALL_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'ListAllLoggingConfigs',
 )
 
 # ** constant: cli_service
 CLI_SERVICE = create_app_service_dependency(
-    CLI_SERVICE_ID, 'tiferet.repos.cli', 'CliConfigRepository',
+    CLI_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
+    'CliConfigRepository',
 )
 
 # ** constant: list_commands_evt
 LIST_COMMANDS_EVT = create_app_service_dependency(
-    LIST_COMMANDS_EVT_ID, 'tiferet.events.cli', 'ListCliCommands',
+    LIST_COMMANDS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'ListCliCommands',
 )
 
 # ** constant: get_parent_args_evt
 GET_PARENT_ARGS_EVT = create_app_service_dependency(
-    GET_PARENT_ARGS_EVT_ID, 'tiferet.events.cli', 'GetParentArguments',
+    GET_PARENT_ARGS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'GetParentArguments',
 )
 
 # ** constant: di_list_all_configs_evt
 DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
-    DI_LIST_ALL_CONFIGS_EVT_ID, 'tiferet.events.di', 'ListAllSettings',
+    DI_LIST_ALL_CONFIGS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'ListAllSettings',
 )
 
 # ** constant: logging_middleware
@@ -180,6 +324,265 @@ TIMING_MIDDLEWARE = create_app_service_dependency(
 # ** constant: cache_middleware
 CACHE_MIDDLEWARE = create_app_service_dependency(
     CACHE_MIDDLEWARE_ID, 'tiferet.utils.middleware', 'CacheMiddleware',
+)
+
+# ** constant: app_service
+APP_SERVICE = create_app_service_dependency(
+    APP_SERVICE_ID,
+    create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
+    'AppConfigRepository',
+)
+
+# ** constant: add_feature_evt
+ADD_FEATURE_EVT = create_app_service_dependency(
+    ADD_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'AddFeature',
+)
+
+# ** constant: list_features_evt
+LIST_FEATURES_EVT = create_app_service_dependency(
+    LIST_FEATURES_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'ListFeatures',
+)
+
+# ** constant: remove_feature_evt
+REMOVE_FEATURE_EVT = create_app_service_dependency(
+    REMOVE_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'RemoveFeature',
+)
+
+# ** constant: update_feature_evt
+UPDATE_FEATURE_EVT = create_app_service_dependency(
+    UPDATE_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'UpdateFeature',
+)
+
+# ** constant: add_feature_step_evt
+ADD_FEATURE_STEP_EVT = create_app_service_dependency(
+    ADD_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'AddFeatureStep',
+)
+
+# ** constant: update_feature_step_evt
+UPDATE_FEATURE_STEP_EVT = create_app_service_dependency(
+    UPDATE_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'UpdateFeatureStep',
+)
+
+# ** constant: remove_feature_step_evt
+REMOVE_FEATURE_STEP_EVT = create_app_service_dependency(
+    REMOVE_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'RemoveFeatureStep',
+)
+
+# ** constant: reorder_feature_step_evt
+REORDER_FEATURE_STEP_EVT = create_app_service_dependency(
+    REORDER_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'ReorderFeatureStep',
+)
+
+# ** constant: add_error_evt
+ADD_ERROR_EVT = create_app_service_dependency(
+    ADD_ERROR_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'AddError',
+)
+
+# ** constant: list_errors_evt
+LIST_ERRORS_EVT = create_app_service_dependency(
+    LIST_ERRORS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'ListErrors',
+)
+
+# ** constant: rename_error_evt
+RENAME_ERROR_EVT = create_app_service_dependency(
+    RENAME_ERROR_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RenameError',
+)
+
+# ** constant: set_error_message_evt
+SET_ERROR_MESSAGE_EVT = create_app_service_dependency(
+    SET_ERROR_MESSAGE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'SetErrorMessage',
+)
+
+# ** constant: remove_error_message_evt
+REMOVE_ERROR_MESSAGE_EVT = create_app_service_dependency(
+    REMOVE_ERROR_MESSAGE_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RemoveErrorMessage',
+)
+
+# ** constant: remove_error_evt
+REMOVE_ERROR_EVT = create_app_service_dependency(
+    REMOVE_ERROR_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RemoveError',
+)
+
+# ** constant: add_service_registration_evt
+ADD_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
+    ADD_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'AddServiceRegistration',
+)
+
+# ** constant: set_default_service_registration_evt
+SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetDefaultServiceRegistration',
+)
+
+# ** constant: set_di_service_dependency_evt
+SET_DI_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetServiceDependency',
+)
+
+# ** constant: remove_di_service_dependency_evt
+REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_service_registration_evt
+REMOVE_SERVICE_REGISTRATION_EVT = create_app_service_dependency(
+    REMOVE_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'RemoveServiceRegistration',
+)
+
+# ** constant: set_service_constants_evt
+SET_SERVICE_CONSTANTS_EVT = create_app_service_dependency(
+    SET_SERVICE_CONSTANTS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetServiceConstants',
+)
+
+# ** constant: add_app_session_evt
+ADD_APP_SESSION_EVT = create_app_service_dependency(
+    ADD_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'AddAppSession',
+)
+
+# ** constant: get_app_session_evt
+GET_APP_SESSION_EVT = create_app_service_dependency(
+    GET_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'GetAppSession',
+)
+
+# ** constant: update_app_session_evt
+UPDATE_APP_SESSION_EVT = create_app_service_dependency(
+    UPDATE_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'UpdateAppSession',
+)
+
+# ** constant: set_app_constants_evt
+SET_APP_CONSTANTS_EVT = create_app_service_dependency(
+    SET_APP_CONSTANTS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'SetAppConstants',
+)
+
+# ** constant: list_app_sessions_evt
+LIST_APP_SESSIONS_EVT = create_app_service_dependency(
+    LIST_APP_SESSIONS_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'ListAppSessions',
+)
+
+# ** constant: set_app_service_dependency_evt
+SET_APP_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'SetServiceDependency',
+)
+
+# ** constant: remove_app_service_dependency_evt
+REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_app_service_dependency(
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_app_session_evt
+REMOVE_APP_SESSION_EVT = create_app_service_dependency(
+    REMOVE_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'RemoveAppSession',
+)
+
+# ** constant: add_cli_command_evt
+ADD_CLI_COMMAND_EVT = create_app_service_dependency(
+    ADD_CLI_COMMAND_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'AddCliCommand',
+)
+
+# ** constant: add_cli_argument_evt
+ADD_CLI_ARGUMENT_EVT = create_app_service_dependency(
+    ADD_CLI_ARGUMENT_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'AddCliArgument',
+)
+
+# ** constant: add_formatter_evt
+ADD_FORMATTER_EVT = create_app_service_dependency(
+    ADD_FORMATTER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddFormatter',
+)
+
+# ** constant: remove_formatter_evt
+REMOVE_FORMATTER_EVT = create_app_service_dependency(
+    REMOVE_FORMATTER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveFormatter',
+)
+
+# ** constant: add_handler_evt
+ADD_HANDLER_EVT = create_app_service_dependency(
+    ADD_HANDLER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddHandler',
+)
+
+# ** constant: remove_handler_evt
+REMOVE_HANDLER_EVT = create_app_service_dependency(
+    REMOVE_HANDLER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveHandler',
+)
+
+# ** constant: add_logger_evt
+ADD_LOGGER_EVT = create_app_service_dependency(
+    ADD_LOGGER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddLogger',
+)
+
+# ** constant: remove_logger_evt
+REMOVE_LOGGER_EVT = create_app_service_dependency(
+    REMOVE_LOGGER_EVT_ID,
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveLogger',
 )
 
 # *** constants (groups)
@@ -211,19 +614,51 @@ CORE_DEFAULT_CONSTANTS = {
     FEATURE_CONFIG_ID: DEFAULT_CONFIG_FILE,
 }
 
+# ** constant: default_admin_cli_services
+DEFAULT_ADMIN_CLI_SERVICES = {
+    APP_SERVICE_ID: APP_SERVICE,
+    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
+    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
+    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
+    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
+    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
+    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
+    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
+    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
+    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
+    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
+    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
+    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
+    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
+    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
+    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
+    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
+    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
+    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
+    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
+    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
+    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
+    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
+    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
+    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
+    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
+    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
+    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
+}
+
 # ** constant: admin_default_services
-# Full service catalog for the admin layer: all core services plus admin domain
-# events (from the CLI services catalog) as app service dependencies.
 ADMIN_DEFAULT_SERVICES = {
     **CORE_DEFAULT_SERVICES,
-    **{
-        svc_id: create_app_service_dependency(
-            svc_id,
-            svc['module_path'],
-            svc['class_name'],
-        )
-        for svc_id, svc in DEFAULT_TIFERET_CLI_SERVICES.items()
-    },
+    **DEFAULT_ADMIN_CLI_SERVICES,
 }
 
 # ** constant: admin_default_constants

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -13,513 +13,748 @@ at startup — they are not loaded from the consumer's config file.
 # ** core
 from typing import Any, Dict, List
 
-# *** constants
+# ** app
+from .core import create_default_cli_argument, create_default_cli_command
 
-# ** constant: default_tiferet_cli_command_list
-# Each dict matches the CliCommand domain object constructor fields.
-# Arguments use CliArgument field names: name_or_flags, description, type, default, required, nargs, choices, action.
-_DEFAULT_TIFERET_CLI_COMMAND_LIST: List[Dict[str, Any]] = [
+# *** constants (ids)
 
-    # * commands: feature domain
+# ** constant: feature_add_command_id
+FEATURE_ADD_COMMAND_ID = 'feature.add'
 
-    {
-        'id': 'feature.add',
-        'key': 'add',
-        'group_key': 'feature',
-        'name': 'Add Feature',
-        'description': 'Add a new feature configuration.',
-        'arguments': [
-            {'name_or_flags': ['name'], 'description': 'The feature name.'},
-            {'name_or_flags': ['group_id'], 'description': 'The group identifier.'},
-            {'name_or_flags': ['--feature-key'], 'description': 'Optional explicit feature key.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional feature description.'},
-        ],
-    },
-    {
-        'id': 'feature.get',
-        'key': 'get',
-        'group_key': 'feature',
-        'name': 'Get Feature',
-        'description': 'Retrieve a feature by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier (e.g. calc.add).'},
-        ],
-    },
-    {
-        'id': 'feature.list',
-        'key': 'list',
-        'group_key': 'feature',
-        'name': 'List Features',
-        'description': 'List all features, optionally filtered by group.',
-        'arguments': [
-            {'name_or_flags': ['--group-id'], 'description': 'Optional group ID to filter results.'},
-        ],
-    },
-    {
-        'id': 'feature.remove',
-        'key': 'remove',
-        'group_key': 'feature',
-        'name': 'Remove Feature',
-        'description': 'Remove a feature configuration by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'feature.update',
-        'key': 'update',
-        'group_key': 'feature',
-        'name': 'Update Feature',
-        'description': 'Update a feature attribute (name or description).',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier.'},
-            {'name_or_flags': ['attribute'], 'description': 'The attribute to update.', 'choices': ['name', 'description']},
-            {'name_or_flags': ['value'], 'description': 'The new value for the attribute.'},
-        ],
-    },
-    {
-        'id': 'feature.add_step',
-        'key': 'add-step',
-        'group_key': 'feature',
-        'name': 'Add Feature Step',
-        'description': 'Add a step to an existing feature workflow.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier.'},
-            {'name_or_flags': ['name'], 'description': 'The step name.'},
-            {'name_or_flags': ['service_id'], 'description': 'The service configuration ID for the step.'},
-            {'name_or_flags': ['--parameters'], 'description': 'Optional step parameters as JSON string.'},
-            {'name_or_flags': ['--data-key'], 'description': 'Optional result data key.'},
-            {'name_or_flags': ['--position'], 'description': 'Insertion position (default: append).', 'type': 'int'},
-        ],
-    },
-    {
-        'id': 'feature.update_step',
-        'key': 'update-step',
-        'group_key': 'feature',
-        'name': 'Update Feature Step',
-        'description': 'Update an attribute on a feature step.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier.'},
-            {'name_or_flags': ['position'], 'description': 'Zero-based index of the step.', 'type': 'int'},
-            {'name_or_flags': ['attribute'], 'description': 'The attribute to update.', 'choices': ['name', 'service_id', 'data_key', 'pass_on_error', 'parameters']},
-            {'name_or_flags': ['value'], 'description': 'The new value for the attribute.'},
-        ],
-    },
-    {
-        'id': 'feature.remove_step',
-        'key': 'remove-step',
-        'group_key': 'feature',
-        'name': 'Remove Feature Step',
-        'description': 'Remove a step from a feature by position.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier.'},
-            {'name_or_flags': ['position'], 'description': 'The index of the step to remove.', 'type': 'int'},
-        ],
-    },
-    {
-        'id': 'feature.reorder_step',
-        'key': 'reorder-step',
-        'group_key': 'feature',
-        'name': 'Reorder Feature Step',
-        'description': 'Move a feature step from one position to another.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The feature identifier.'},
-            {'name_or_flags': ['start_position'], 'description': 'Current index of the step.', 'type': 'int'},
-            {'name_or_flags': ['end_position'], 'description': 'Desired new index.', 'type': 'int'},
-        ],
-    },
+# ** constant: feature_get_command_id
+FEATURE_GET_COMMAND_ID = 'feature.get'
 
-    # * commands: error domain
+# ** constant: feature_list_command_id
+FEATURE_LIST_COMMAND_ID = 'feature.list'
 
-    {
-        'id': 'error.add',
-        'key': 'add',
-        'group_key': 'error',
-        'name': 'Add Error',
-        'description': 'Add a new error definition.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The unique error identifier.'},
-            {'name_or_flags': ['name'], 'description': 'The error name.'},
-            {'name_or_flags': ['message'], 'description': 'The primary error message text.'},
-            {'name_or_flags': ['--lang'], 'description': 'Language code for the message (default: en_US).', 'default': 'en_US'},
-        ],
-    },
-    {
-        'id': 'error.get',
-        'key': 'get',
-        'group_key': 'error',
-        'name': 'Get Error',
-        'description': 'Retrieve an error by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The error identifier.'},
-        ],
-    },
-    {
-        'id': 'error.list',
-        'key': 'list',
-        'group_key': 'error',
-        'name': 'List Errors',
-        'description': 'List all error definitions.',
-        'arguments': [
-            {'name_or_flags': ['--include-defaults'], 'description': 'Include built-in default errors.', 'action': 'store_true'},
-        ],
-    },
-    {
-        'id': 'error.rename',
-        'key': 'rename',
-        'group_key': 'error',
-        'name': 'Rename Error',
-        'description': 'Rename an existing error.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The error identifier.'},
-            {'name_or_flags': ['new_name'], 'description': 'The new name for the error.'},
-        ],
-    },
-    {
-        'id': 'error.set_message',
-        'key': 'set-message',
-        'group_key': 'error',
-        'name': 'Set Error Message',
-        'description': 'Set or update an error message for a language.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The error identifier.'},
-            {'name_or_flags': ['message'], 'description': 'The message text.'},
-            {'name_or_flags': ['--lang'], 'description': 'Language code (default: en_US).', 'default': 'en_US'},
-        ],
-    },
-    {
-        'id': 'error.remove_message',
-        'key': 'remove-message',
-        'group_key': 'error',
-        'name': 'Remove Error Message',
-        'description': 'Remove an error message by language.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The error identifier.'},
-            {'name_or_flags': ['--lang'], 'description': 'Language code to remove (default: en_US).', 'default': 'en_US'},
-        ],
-    },
-    {
-        'id': 'error.remove',
-        'key': 'remove',
-        'group_key': 'error',
-        'name': 'Remove Error',
-        'description': 'Remove an error definition by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The error identifier to remove.'},
-        ],
-    },
+# ** constant: feature_remove_command_id
+FEATURE_REMOVE_COMMAND_ID = 'feature.remove'
 
-    # * commands: service (DI) domain
+# ** constant: feature_update_command_id
+FEATURE_UPDATE_COMMAND_ID = 'feature.update'
 
-    {
-        'id': 'service.add',
-        'key': 'add',
-        'group_key': 'service',
-        'name': 'Add Service Configuration',
-        'description': 'Add a new service configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The unique service configuration identifier.'},
-            {'name_or_flags': ['--module-path'], 'description': 'Default module path.'},
-            {'name_or_flags': ['--class-name'], 'description': 'Default class name.'},
-            {'name_or_flags': ['--parameters'], 'description': 'Configuration parameters as JSON string.'},
-            {'name_or_flags': ['--flagged-dependencies'], 'description': 'Flagged dependencies as JSON string.'},
-        ],
-    },
-    {
-        'id': 'service.list',
-        'key': 'list',
-        'group_key': 'service',
-        'name': 'List All Settings',
-        'description': 'List all service configurations and constants.',
-        'arguments': [],
-    },
-    {
-        'id': 'service.set_default',
-        'key': 'set-default',
-        'group_key': 'service',
-        'name': 'Set Default Service Configuration',
-        'description': 'Set or update the default type for a service configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The service configuration identifier.'},
-            {'name_or_flags': ['--module-path'], 'description': 'Default module path.'},
-            {'name_or_flags': ['--class-name'], 'description': 'Default class name.'},
-            {'name_or_flags': ['--parameters'], 'description': 'Parameters as JSON string.'},
-        ],
-    },
-    {
-        'id': 'service.set_dependency',
-        'key': 'set-dependency',
-        'group_key': 'service',
-        'name': 'Set Service Dependency',
-        'description': 'Set or update a flagged dependency on a service configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The service configuration identifier.'},
-            {'name_or_flags': ['flag'], 'description': 'The flag identifying the dependency.'},
-            {'name_or_flags': ['module_path'], 'description': 'Module path for the dependency.'},
-            {'name_or_flags': ['class_name'], 'description': 'Class name for the dependency.'},
-            {'name_or_flags': ['--parameters'], 'description': 'Parameters as JSON string.'},
-        ],
-    },
-    {
-        'id': 'service.remove_dependency',
-        'key': 'remove-dependency',
-        'group_key': 'service',
-        'name': 'Remove Service Dependency',
-        'description': 'Remove a flagged dependency from a service configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The service configuration identifier.'},
-            {'name_or_flags': ['flag'], 'description': 'The flag identifying the dependency to remove.'},
-        ],
-    },
-    {
-        'id': 'service.remove',
-        'key': 'remove',
-        'group_key': 'service',
-        'name': 'Remove Service Configuration',
-        'description': 'Remove a service configuration by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The service configuration identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'service.set_constants',
-        'key': 'set-constants',
-        'group_key': 'service',
-        'name': 'Set Service Constants',
-        'description': 'Set or clear service-level constants.',
-        'arguments': [
-            {'name_or_flags': ['--constants'], 'description': 'Constants as JSON string. Omit to clear all.'},
-        ],
-    },
+# ** constant: feature_add_step_command_id
+FEATURE_ADD_STEP_COMMAND_ID = 'feature.add_step'
 
-    # * commands: app interface domain
+# ** constant: feature_update_step_command_id
+FEATURE_UPDATE_STEP_COMMAND_ID = 'feature.update_step'
 
-    {
-        'id': 'app.add',
-        'key': 'add',
-        'group_key': 'app',
-        'name': 'Add App Interface',
-        'description': 'Add a new application interface configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique interface identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Interface name.'},
-            {'name_or_flags': ['module_path'], 'description': 'Python module path of the context class.'},
-            {'name_or_flags': ['class_name'], 'description': 'Name of the context class.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--logger-id'], 'description': 'Logger identifier (default: default).', 'default': 'default'},
-            {'name_or_flags': ['--services'], 'description': 'Service dependencies as JSON string.'},
-            {'name_or_flags': ['--constants'], 'description': 'Constants as JSON string.'},
-        ],
-    },
-    {
-        'id': 'app.get',
-        'key': 'get',
-        'group_key': 'app',
-        'name': 'Get App Interface',
-        'description': 'Retrieve an app interface by ID.',
-        'arguments': [
-            {'name_or_flags': ['interface_id'], 'description': 'The interface identifier.'},
-        ],
-    },
-    {
-        'id': 'app.list',
-        'key': 'list',
-        'group_key': 'app',
-        'name': 'List App Interfaces',
-        'description': 'List all configured app interfaces.',
-        'arguments': [],
-    },
-    {
-        'id': 'app.update',
-        'key': 'update',
-        'group_key': 'app',
-        'name': 'Update App Interface',
-        'description': 'Update a scalar attribute on an app interface.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The interface identifier.'},
-            {'name_or_flags': ['attribute'], 'description': 'The attribute to update.'},
-            {'name_or_flags': ['value'], 'description': 'The new value.'},
-        ],
-    },
-    {
-        'id': 'app.set_constants',
-        'key': 'set-constants',
-        'group_key': 'app',
-        'name': 'Set App Constants',
-        'description': 'Set or clear constants on an app interface.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The interface identifier.'},
-            {'name_or_flags': ['--constants'], 'description': 'Constants as JSON string. Omit to clear all.'},
-        ],
-    },
-    {
-        'id': 'app.set_service',
-        'key': 'set-service',
-        'group_key': 'app',
-        'name': 'Set App Service Dependency',
-        'description': 'Set or update a service dependency on an app interface.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The interface identifier.'},
-            {'name_or_flags': ['service_id'], 'description': 'The service dependency identifier.'},
-            {'name_or_flags': ['module_path'], 'description': 'Module path for the service.'},
-            {'name_or_flags': ['class_name'], 'description': 'Class name for the service.'},
-            {'name_or_flags': ['--parameters'], 'description': 'Parameters as JSON string.'},
-        ],
-    },
-    {
-        'id': 'app.remove_service',
-        'key': 'remove-service',
-        'group_key': 'app',
-        'name': 'Remove App Service Dependency',
-        'description': 'Remove a service dependency from an app interface.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The interface identifier.'},
-            {'name_or_flags': ['service_id'], 'description': 'The service dependency identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'app.remove',
-        'key': 'remove',
-        'group_key': 'app',
-        'name': 'Remove App Interface',
-        'description': 'Remove an app interface by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The interface identifier to remove.'},
-        ],
-    },
+# ** constant: feature_remove_step_command_id
+FEATURE_REMOVE_STEP_COMMAND_ID = 'feature.remove_step'
 
-    # * commands: cli domain
+# ** constant: feature_reorder_step_command_id
+FEATURE_REORDER_STEP_COMMAND_ID = 'feature.reorder_step'
 
-    {
-        'id': 'cli.add_command',
-        'key': 'add-command',
-        'group_key': 'cli',
-        'name': 'Add CLI Command',
-        'description': 'Add a new CLI command definition.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique command identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Command name.'},
-            {'name_or_flags': ['key'], 'description': 'Command key (used in CLI invocation).'},
-            {'name_or_flags': ['group_key'], 'description': 'Group key for the command.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional command description.'},
-        ],
-    },
-    {
-        'id': 'cli.list_commands',
-        'key': 'list-commands',
-        'group_key': 'cli',
-        'name': 'List CLI Commands',
-        'description': 'List all CLI command definitions.',
-        'arguments': [],
-    },
-    {
-        'id': 'cli.add_argument',
-        'key': 'add-argument',
-        'group_key': 'cli',
-        'name': 'Add CLI Argument',
-        'description': 'Add an argument to an existing CLI command.',
-        'arguments': [
-            {'name_or_flags': ['command_id'], 'description': 'The CLI command identifier.'},
-            {'name_or_flags': ['name_or_flags'], 'description': 'Argument name or flags (comma-separated for multiple flags).'},
-            {'name_or_flags': ['--description'], 'description': 'Optional argument description.'},
-        ],
-    },
+# ** constant: error_add_command_id
+ERROR_ADD_COMMAND_ID = 'error.add'
 
-    # * commands: logging domain
+# ** constant: error_get_command_id
+ERROR_GET_COMMAND_ID = 'error.get'
 
-    {
-        'id': 'logging.add_formatter',
-        'key': 'add-formatter',
-        'group_key': 'logging',
-        'name': 'Add Formatter',
-        'description': 'Add a new logging formatter configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique formatter identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Formatter name.'},
-            {'name_or_flags': ['format'], 'description': 'Format string for log messages.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--datefmt'], 'description': 'Optional date format string.'},
-        ],
-    },
-    {
-        'id': 'logging.remove_formatter',
-        'key': 'remove-formatter',
-        'group_key': 'logging',
-        'name': 'Remove Formatter',
-        'description': 'Remove a logging formatter by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The formatter identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'logging.add_handler',
-        'key': 'add-handler',
-        'group_key': 'logging',
-        'name': 'Add Handler',
-        'description': 'Add a new logging handler configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique handler identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Handler name.'},
-            {'name_or_flags': ['module_path'], 'description': 'Module path of the handler class.'},
-            {'name_or_flags': ['class_name'], 'description': 'Handler class name.'},
-            {'name_or_flags': ['level'], 'description': 'Logging level.', 'choices': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']},
-            {'name_or_flags': ['formatter'], 'description': 'Formatter ID to use.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--stream'], 'description': 'Optional stream specification.'},
-            {'name_or_flags': ['--filename'], 'description': 'Optional filename for FileHandler.'},
-        ],
-    },
-    {
-        'id': 'logging.remove_handler',
-        'key': 'remove-handler',
-        'group_key': 'logging',
-        'name': 'Remove Handler',
-        'description': 'Remove a logging handler by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The handler identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'logging.add_logger',
-        'key': 'add-logger',
-        'group_key': 'logging',
-        'name': 'Add Logger',
-        'description': 'Add a new logger configuration.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique logger identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Logger name.'},
-            {'name_or_flags': ['level'], 'description': 'Logging level.', 'choices': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']},
-            {'name_or_flags': ['handlers'], 'description': 'Comma-separated list of handler IDs.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--no-propagate'], 'description': 'Disable message propagation.', 'action': 'store_true'},
-        ],
-    },
-    {
-        'id': 'logging.remove_logger',
-        'key': 'remove-logger',
-        'group_key': 'logging',
-        'name': 'Remove Logger',
-        'description': 'Remove a logger by ID.',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The logger identifier to remove.'},
-        ],
-    },
-    {
-        'id': 'logging.list',
-        'key': 'list',
-        'group_key': 'logging',
-        'name': 'List Logging Configs',
-        'description': 'List all logging configurations (formatters, handlers, loggers).',
-        'arguments': [],
-    },
-]
+# ** constant: error_list_command_id
+ERROR_LIST_COMMAND_ID = 'error.list'
+
+# ** constant: error_rename_command_id
+ERROR_RENAME_COMMAND_ID = 'error.rename'
+
+# ** constant: error_set_message_command_id
+ERROR_SET_MESSAGE_COMMAND_ID = 'error.set_message'
+
+# ** constant: error_remove_message_command_id
+ERROR_REMOVE_MESSAGE_COMMAND_ID = 'error.remove_message'
+
+# ** constant: error_remove_command_id
+ERROR_REMOVE_COMMAND_ID = 'error.remove'
+
+# ** constant: service_add_command_id
+SERVICE_ADD_COMMAND_ID = 'service.add'
+
+# ** constant: service_list_command_id
+SERVICE_LIST_COMMAND_ID = 'service.list'
+
+# ** constant: service_set_default_command_id
+SERVICE_SET_DEFAULT_COMMAND_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_command_id
+SERVICE_SET_DEPENDENCY_COMMAND_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_command_id
+SERVICE_REMOVE_DEPENDENCY_COMMAND_ID = 'service.remove_dependency'
+
+# ** constant: service_remove_command_id
+SERVICE_REMOVE_COMMAND_ID = 'service.remove'
+
+# ** constant: service_set_constants_command_id
+SERVICE_SET_CONSTANTS_COMMAND_ID = 'service.set_constants'
+
+# ** constant: app_add_command_id
+APP_ADD_COMMAND_ID = 'app.add'
+
+# ** constant: app_get_command_id
+APP_GET_COMMAND_ID = 'app.get'
+
+# ** constant: app_list_command_id
+APP_LIST_COMMAND_ID = 'app.list'
+
+# ** constant: app_update_command_id
+APP_UPDATE_COMMAND_ID = 'app.update'
+
+# ** constant: app_set_constants_command_id
+APP_SET_CONSTANTS_COMMAND_ID = 'app.set_constants'
+
+# ** constant: app_set_service_command_id
+APP_SET_SERVICE_COMMAND_ID = 'app.set_service'
+
+# ** constant: app_remove_service_command_id
+APP_REMOVE_SERVICE_COMMAND_ID = 'app.remove_service'
+
+# ** constant: app_remove_command_id
+APP_REMOVE_COMMAND_ID = 'app.remove'
+
+# ** constant: cli_add_command_command_id
+CLI_ADD_COMMAND_COMMAND_ID = 'cli.add_command'
+
+# ** constant: cli_list_commands_command_id
+CLI_LIST_COMMANDS_COMMAND_ID = 'cli.list_commands'
+
+# ** constant: cli_add_argument_command_id
+CLI_ADD_ARGUMENT_COMMAND_ID = 'cli.add_argument'
+
+# ** constant: logging_add_formatter_command_id
+LOGGING_ADD_FORMATTER_COMMAND_ID = 'logging.add_formatter'
+
+# ** constant: logging_remove_formatter_command_id
+LOGGING_REMOVE_FORMATTER_COMMAND_ID = 'logging.remove_formatter'
+
+# ** constant: logging_add_handler_command_id
+LOGGING_ADD_HANDLER_COMMAND_ID = 'logging.add_handler'
+
+# ** constant: logging_remove_handler_command_id
+LOGGING_REMOVE_HANDLER_COMMAND_ID = 'logging.remove_handler'
+
+# ** constant: logging_add_logger_command_id
+LOGGING_ADD_LOGGER_COMMAND_ID = 'logging.add_logger'
+
+# ** constant: logging_remove_logger_command_id
+LOGGING_REMOVE_LOGGER_COMMAND_ID = 'logging.remove_logger'
+
+# ** constant: logging_list_command_id
+LOGGING_LIST_COMMAND_ID = 'logging.list'
+
+# *** constants (commands)
+
+# ** constant: feature_add_command
+FEATURE_ADD_COMMAND = create_default_cli_command(
+    FEATURE_ADD_COMMAND_ID,
+    'add',
+    'feature',
+    'Add Feature',
+    description='Add a new feature configuration.',
+    arguments=[
+        create_default_cli_argument(['name'], 'The feature name.'),
+        create_default_cli_argument(['group_id'], 'The group identifier.'),
+        create_default_cli_argument(['--feature-key'], 'Optional explicit feature key.'),
+        create_default_cli_argument(['--description'], 'Optional feature description.'),
+    ],
+)
+
+# ** constant: feature_get_command
+FEATURE_GET_COMMAND = create_default_cli_command(
+    FEATURE_GET_COMMAND_ID,
+    'get',
+    'feature',
+    'Get Feature',
+    description='Retrieve a feature by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier (e.g. calc.add).'),
+    ],
+)
+
+# ** constant: feature_list_command
+FEATURE_LIST_COMMAND = create_default_cli_command(
+    FEATURE_LIST_COMMAND_ID,
+    'list',
+    'feature',
+    'List Features',
+    description='List all features, optionally filtered by group.',
+    arguments=[
+        create_default_cli_argument(['--group-id'], 'Optional group ID to filter results.'),
+    ],
+)
+
+# ** constant: feature_remove_command
+FEATURE_REMOVE_COMMAND = create_default_cli_command(
+    FEATURE_REMOVE_COMMAND_ID,
+    'remove',
+    'feature',
+    'Remove Feature',
+    description='Remove a feature configuration by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier to remove.'),
+    ],
+)
+
+# ** constant: feature_update_command
+FEATURE_UPDATE_COMMAND = create_default_cli_command(
+    FEATURE_UPDATE_COMMAND_ID,
+    'update',
+    'feature',
+    'Update Feature',
+    description='Update a feature attribute (name or description).',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['attribute'], 'The attribute to update.', choices=['name', 'description']),
+        create_default_cli_argument(['value'], 'The new value for the attribute.'),
+    ],
+)
+
+# ** constant: feature_add_step_command
+FEATURE_ADD_STEP_COMMAND = create_default_cli_command(
+    FEATURE_ADD_STEP_COMMAND_ID,
+    'add-step',
+    'feature',
+    'Add Feature Step',
+    description='Add a step to an existing feature workflow.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['name'], 'The step name.'),
+        create_default_cli_argument(['service_id'], 'The service configuration ID for the step.'),
+        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.'),
+        create_default_cli_argument(['--data-key'], 'Optional result data key.'),
+        create_default_cli_argument(['--position'], 'Insertion position (default: append).', type='int'),
+    ],
+)
+
+# ** constant: feature_update_step_command
+FEATURE_UPDATE_STEP_COMMAND = create_default_cli_command(
+    FEATURE_UPDATE_STEP_COMMAND_ID,
+    'update-step',
+    'feature',
+    'Update Feature Step',
+    description='Update an attribute on a feature step.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['position'], 'Zero-based index of the step.', type='int'),
+        create_default_cli_argument(
+            ['attribute'],
+            'The attribute to update.',
+            choices=['name', 'service_id', 'data_key', 'pass_on_error', 'parameters'],
+        ),
+        create_default_cli_argument(['value'], 'The new value for the attribute.'),
+    ],
+)
+
+# ** constant: feature_remove_step_command
+FEATURE_REMOVE_STEP_COMMAND = create_default_cli_command(
+    FEATURE_REMOVE_STEP_COMMAND_ID,
+    'remove-step',
+    'feature',
+    'Remove Feature Step',
+    description='Remove a step from a feature by position.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['position'], 'The index of the step to remove.', type='int'),
+    ],
+)
+
+# ** constant: feature_reorder_step_command
+FEATURE_REORDER_STEP_COMMAND = create_default_cli_command(
+    FEATURE_REORDER_STEP_COMMAND_ID,
+    'reorder-step',
+    'feature',
+    'Reorder Feature Step',
+    description='Move a feature step from one position to another.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['start_position'], 'Current index of the step.', type='int'),
+        create_default_cli_argument(['end_position'], 'Desired new index.', type='int'),
+    ],
+)
+
+# ** constant: error_add_command
+ERROR_ADD_COMMAND = create_default_cli_command(
+    ERROR_ADD_COMMAND_ID,
+    'add',
+    'error',
+    'Add Error',
+    description='Add a new error definition.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The unique error identifier.'),
+        create_default_cli_argument(['name'], 'The error name.'),
+        create_default_cli_argument(['message'], 'The primary error message text.'),
+        create_default_cli_argument(['--lang'], 'Language code for the message (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_get_command
+ERROR_GET_COMMAND = create_default_cli_command(
+    ERROR_GET_COMMAND_ID,
+    'get',
+    'error',
+    'Get Error',
+    description='Retrieve an error by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+    ],
+)
+
+# ** constant: error_list_command
+ERROR_LIST_COMMAND = create_default_cli_command(
+    ERROR_LIST_COMMAND_ID,
+    'list',
+    'error',
+    'List Errors',
+    description='List all error definitions.',
+    arguments=[
+        create_default_cli_argument(['--include-defaults'], 'Include built-in default errors.', action='store_true'),
+    ],
+)
+
+# ** constant: error_rename_command
+ERROR_RENAME_COMMAND = create_default_cli_command(
+    ERROR_RENAME_COMMAND_ID,
+    'rename',
+    'error',
+    'Rename Error',
+    description='Rename an existing error.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['new_name'], 'The new name for the error.'),
+    ],
+)
+
+# ** constant: error_set_message_command
+ERROR_SET_MESSAGE_COMMAND = create_default_cli_command(
+    ERROR_SET_MESSAGE_COMMAND_ID,
+    'set-message',
+    'error',
+    'Set Error Message',
+    description='Set or update an error message for a language.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['message'], 'The message text.'),
+        create_default_cli_argument(['--lang'], 'Language code (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_remove_message_command
+ERROR_REMOVE_MESSAGE_COMMAND = create_default_cli_command(
+    ERROR_REMOVE_MESSAGE_COMMAND_ID,
+    'remove-message',
+    'error',
+    'Remove Error Message',
+    description='Remove an error message by language.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['--lang'], 'Language code to remove (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_remove_command
+ERROR_REMOVE_COMMAND = create_default_cli_command(
+    ERROR_REMOVE_COMMAND_ID,
+    'remove',
+    'error',
+    'Remove Error',
+    description='Remove an error definition by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier to remove.'),
+    ],
+)
+
+# ** constant: service_add_command
+SERVICE_ADD_COMMAND = create_default_cli_command(
+    SERVICE_ADD_COMMAND_ID,
+    'add',
+    'service',
+    'Add Service Configuration',
+    description='Add a new service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The unique service configuration identifier.'),
+        create_default_cli_argument(['--module-path'], 'Default module path.'),
+        create_default_cli_argument(['--class-name'], 'Default class name.'),
+        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.'),
+        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.'),
+    ],
+)
+
+# ** constant: service_list_command
+SERVICE_LIST_COMMAND = create_default_cli_command(
+    SERVICE_LIST_COMMAND_ID,
+    'list',
+    'service',
+    'List All Settings',
+    description='List all service configurations and constants.',
+)
+
+# ** constant: service_set_default_command
+SERVICE_SET_DEFAULT_COMMAND = create_default_cli_command(
+    SERVICE_SET_DEFAULT_COMMAND_ID,
+    'set-default',
+    'service',
+    'Set Default Service Configuration',
+    description='Set or update the default type for a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['--module-path'], 'Default module path.'),
+        create_default_cli_argument(['--class-name'], 'Default class name.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+    ],
+)
+
+# ** constant: service_set_dependency_command
+SERVICE_SET_DEPENDENCY_COMMAND = create_default_cli_command(
+    SERVICE_SET_DEPENDENCY_COMMAND_ID,
+    'set-dependency',
+    'service',
+    'Set Service Dependency',
+    description='Set or update a flagged dependency on a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['flag'], 'The flag identifying the dependency.'),
+        create_default_cli_argument(['module_path'], 'Module path for the dependency.'),
+        create_default_cli_argument(['class_name'], 'Class name for the dependency.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+    ],
+)
+
+# ** constant: service_remove_dependency_command
+SERVICE_REMOVE_DEPENDENCY_COMMAND = create_default_cli_command(
+    SERVICE_REMOVE_DEPENDENCY_COMMAND_ID,
+    'remove-dependency',
+    'service',
+    'Remove Service Dependency',
+    description='Remove a flagged dependency from a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['flag'], 'The flag identifying the dependency to remove.'),
+    ],
+)
+
+# ** constant: service_remove_command
+SERVICE_REMOVE_COMMAND = create_default_cli_command(
+    SERVICE_REMOVE_COMMAND_ID,
+    'remove',
+    'service',
+    'Remove Service Configuration',
+    description='Remove a service configuration by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier to remove.'),
+    ],
+)
+
+# ** constant: service_set_constants_command
+SERVICE_SET_CONSTANTS_COMMAND = create_default_cli_command(
+    SERVICE_SET_CONSTANTS_COMMAND_ID,
+    'set-constants',
+    'service',
+    'Set Service Constants',
+    description='Set or clear service-level constants.',
+    arguments=[
+        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
+    ],
+)
+
+# ** constant: app_add_command
+APP_ADD_COMMAND = create_default_cli_command(
+    APP_ADD_COMMAND_ID,
+    'add',
+    'app',
+    'Add App Interface',
+    description='Add a new application interface configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'Unique interface identifier.'),
+        create_default_cli_argument(['name'], 'Interface name.'),
+        create_default_cli_argument(['module_path'], 'Python module path of the context class.'),
+        create_default_cli_argument(['class_name'], 'Name of the context class.'),
+        create_default_cli_argument(['--description'], 'Optional description.'),
+        create_default_cli_argument(['--logger-id'], 'Logger identifier (default: default).', default='default'),
+        create_default_cli_argument(['--services'], 'Service dependencies as JSON string.'),
+        create_default_cli_argument(['--constants'], 'Constants as JSON string.'),
+    ],
+)
+
+# ** constant: app_get_command
+APP_GET_COMMAND = create_default_cli_command(
+    APP_GET_COMMAND_ID,
+    'get',
+    'app',
+    'Get App Interface',
+    description='Retrieve an app interface by ID.',
+    arguments=[
+        create_default_cli_argument(['interface_id'], 'The interface identifier.'),
+    ],
+)
+
+# ** constant: app_list_command
+APP_LIST_COMMAND = create_default_cli_command(
+    APP_LIST_COMMAND_ID,
+    'list',
+    'app',
+    'List App Interfaces',
+    description='List all configured app interfaces.',
+)
+
+# ** constant: app_update_command
+APP_UPDATE_COMMAND = create_default_cli_command(
+    APP_UPDATE_COMMAND_ID,
+    'update',
+    'app',
+    'Update App Interface',
+    description='Update a scalar attribute on an app interface.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The interface identifier.'),
+        create_default_cli_argument(['attribute'], 'The attribute to update.'),
+        create_default_cli_argument(['value'], 'The new value.'),
+    ],
+)
+
+# ** constant: app_set_constants_command
+APP_SET_CONSTANTS_COMMAND = create_default_cli_command(
+    APP_SET_CONSTANTS_COMMAND_ID,
+    'set-constants',
+    'app',
+    'Set App Constants',
+    description='Set or clear constants on an app interface.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The interface identifier.'),
+        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
+    ],
+)
+
+# ** constant: app_set_service_command
+APP_SET_SERVICE_COMMAND = create_default_cli_command(
+    APP_SET_SERVICE_COMMAND_ID,
+    'set-service',
+    'app',
+    'Set App Service Dependency',
+    description='Set or update a service dependency on an app interface.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The interface identifier.'),
+        create_default_cli_argument(['service_id'], 'The service dependency identifier.'),
+        create_default_cli_argument(['module_path'], 'Module path for the service.'),
+        create_default_cli_argument(['class_name'], 'Class name for the service.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+    ],
+)
+
+# ** constant: app_remove_service_command
+APP_REMOVE_SERVICE_COMMAND = create_default_cli_command(
+    APP_REMOVE_SERVICE_COMMAND_ID,
+    'remove-service',
+    'app',
+    'Remove App Service Dependency',
+    description='Remove a service dependency from an app interface.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The interface identifier.'),
+        create_default_cli_argument(['service_id'], 'The service dependency identifier to remove.'),
+    ],
+)
+
+# ** constant: app_remove_command
+APP_REMOVE_COMMAND = create_default_cli_command(
+    APP_REMOVE_COMMAND_ID,
+    'remove',
+    'app',
+    'Remove App Interface',
+    description='Remove an app interface by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The interface identifier to remove.'),
+    ],
+)
+
+# ** constant: cli_add_command_command
+CLI_ADD_COMMAND_COMMAND = create_default_cli_command(
+    CLI_ADD_COMMAND_COMMAND_ID,
+    'add-command',
+    'cli',
+    'Add CLI Command',
+    description='Add a new CLI command definition.',
+    arguments=[
+        create_default_cli_argument(['id'], 'Unique command identifier.'),
+        create_default_cli_argument(['name'], 'Command name.'),
+        create_default_cli_argument(['key'], 'Command key (used in CLI invocation).'),
+        create_default_cli_argument(['group_key'], 'Group key for the command.'),
+        create_default_cli_argument(['--description'], 'Optional command description.'),
+    ],
+)
+
+# ** constant: cli_list_commands_command
+CLI_LIST_COMMANDS_COMMAND = create_default_cli_command(
+    CLI_LIST_COMMANDS_COMMAND_ID,
+    'list-commands',
+    'cli',
+    'List CLI Commands',
+    description='List all CLI command definitions.',
+)
+
+# ** constant: cli_add_argument_command
+CLI_ADD_ARGUMENT_COMMAND = create_default_cli_command(
+    CLI_ADD_ARGUMENT_COMMAND_ID,
+    'add-argument',
+    'cli',
+    'Add CLI Argument',
+    description='Add an argument to an existing CLI command.',
+    arguments=[
+        create_default_cli_argument(['command_id'], 'The CLI command identifier.'),
+        create_default_cli_argument(
+            ['name_or_flags'],
+            'Argument name or flags (comma-separated for multiple flags).',
+        ),
+        create_default_cli_argument(['--description'], 'Optional argument description.'),
+    ],
+)
+
+# ** constant: logging_add_formatter_command
+LOGGING_ADD_FORMATTER_COMMAND = create_default_cli_command(
+    LOGGING_ADD_FORMATTER_COMMAND_ID,
+    'add-formatter',
+    'logging',
+    'Add Formatter',
+    description='Add a new logging formatter configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'Unique formatter identifier.'),
+        create_default_cli_argument(['name'], 'Formatter name.'),
+        create_default_cli_argument(['format'], 'Format string for log messages.'),
+        create_default_cli_argument(['--description'], 'Optional description.'),
+        create_default_cli_argument(['--datefmt'], 'Optional date format string.'),
+    ],
+)
+
+# ** constant: logging_remove_formatter_command
+LOGGING_REMOVE_FORMATTER_COMMAND = create_default_cli_command(
+    LOGGING_REMOVE_FORMATTER_COMMAND_ID,
+    'remove-formatter',
+    'logging',
+    'Remove Formatter',
+    description='Remove a logging formatter by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The formatter identifier to remove.'),
+    ],
+)
+
+# ** constant: logging_add_handler_command
+LOGGING_ADD_HANDLER_COMMAND = create_default_cli_command(
+    LOGGING_ADD_HANDLER_COMMAND_ID,
+    'add-handler',
+    'logging',
+    'Add Handler',
+    description='Add a new logging handler configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'Unique handler identifier.'),
+        create_default_cli_argument(['name'], 'Handler name.'),
+        create_default_cli_argument(['module_path'], 'Module path of the handler class.'),
+        create_default_cli_argument(['class_name'], 'Handler class name.'),
+        create_default_cli_argument(
+            ['level'],
+            'Logging level.',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        ),
+        create_default_cli_argument(['formatter'], 'Formatter ID to use.'),
+        create_default_cli_argument(['--description'], 'Optional description.'),
+        create_default_cli_argument(['--stream'], 'Optional stream specification.'),
+        create_default_cli_argument(['--filename'], 'Optional filename for FileHandler.'),
+    ],
+)
+
+# ** constant: logging_remove_handler_command
+LOGGING_REMOVE_HANDLER_COMMAND = create_default_cli_command(
+    LOGGING_REMOVE_HANDLER_COMMAND_ID,
+    'remove-handler',
+    'logging',
+    'Remove Handler',
+    description='Remove a logging handler by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The handler identifier to remove.'),
+    ],
+)
+
+# ** constant: logging_add_logger_command
+LOGGING_ADD_LOGGER_COMMAND = create_default_cli_command(
+    LOGGING_ADD_LOGGER_COMMAND_ID,
+    'add-logger',
+    'logging',
+    'Add Logger',
+    description='Add a new logger configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'Unique logger identifier.'),
+        create_default_cli_argument(['name'], 'Logger name.'),
+        create_default_cli_argument(
+            ['level'],
+            'Logging level.',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        ),
+        create_default_cli_argument(['handlers'], 'Comma-separated list of handler IDs.'),
+        create_default_cli_argument(['--description'], 'Optional description.'),
+        create_default_cli_argument(['--no-propagate'], 'Disable message propagation.', action='store_true'),
+    ],
+)
+
+# ** constant: logging_remove_logger_command
+LOGGING_REMOVE_LOGGER_COMMAND = create_default_cli_command(
+    LOGGING_REMOVE_LOGGER_COMMAND_ID,
+    'remove-logger',
+    'logging',
+    'Remove Logger',
+    description='Remove a logger by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The logger identifier to remove.'),
+    ],
+)
+
+# ** constant: logging_list_command
+LOGGING_LIST_COMMAND = create_default_cli_command(
+    LOGGING_LIST_COMMAND_ID,
+    'list',
+    'logging',
+    'List Logging Configs',
+    description='List all logging configurations (formatters, handlers, loggers).',
+)
+
+# *** constants (groups)
 
 # ** constant: admin_default_commands
-# Id-keyed mapping mirroring YAML shape: the key is the command id and the
-# value is the record minus id. The bootstrap builder in the orchestration
-# layer materializes each record into a typed CliCommand object.
 ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
-    entry['id']: {key: value for key, value in entry.items() if key != 'id'}
-    for entry in _DEFAULT_TIFERET_CLI_COMMAND_LIST
+    FEATURE_ADD_COMMAND_ID:           FEATURE_ADD_COMMAND,
+    FEATURE_GET_COMMAND_ID:           FEATURE_GET_COMMAND,
+    FEATURE_LIST_COMMAND_ID:          FEATURE_LIST_COMMAND,
+    FEATURE_REMOVE_COMMAND_ID:        FEATURE_REMOVE_COMMAND,
+    FEATURE_UPDATE_COMMAND_ID:        FEATURE_UPDATE_COMMAND,
+    FEATURE_ADD_STEP_COMMAND_ID:      FEATURE_ADD_STEP_COMMAND,
+    FEATURE_UPDATE_STEP_COMMAND_ID:   FEATURE_UPDATE_STEP_COMMAND,
+    FEATURE_REMOVE_STEP_COMMAND_ID:   FEATURE_REMOVE_STEP_COMMAND,
+    FEATURE_REORDER_STEP_COMMAND_ID:  FEATURE_REORDER_STEP_COMMAND,
+    ERROR_ADD_COMMAND_ID:             ERROR_ADD_COMMAND,
+    ERROR_GET_COMMAND_ID:             ERROR_GET_COMMAND,
+    ERROR_LIST_COMMAND_ID:            ERROR_LIST_COMMAND,
+    ERROR_RENAME_COMMAND_ID:          ERROR_RENAME_COMMAND,
+    ERROR_SET_MESSAGE_COMMAND_ID:     ERROR_SET_MESSAGE_COMMAND,
+    ERROR_REMOVE_MESSAGE_COMMAND_ID:  ERROR_REMOVE_MESSAGE_COMMAND,
+    ERROR_REMOVE_COMMAND_ID:          ERROR_REMOVE_COMMAND,
+    SERVICE_ADD_COMMAND_ID:           SERVICE_ADD_COMMAND,
+    SERVICE_LIST_COMMAND_ID:          SERVICE_LIST_COMMAND,
+    SERVICE_SET_DEFAULT_COMMAND_ID:   SERVICE_SET_DEFAULT_COMMAND,
+    SERVICE_SET_DEPENDENCY_COMMAND_ID: SERVICE_SET_DEPENDENCY_COMMAND,
+    SERVICE_REMOVE_DEPENDENCY_COMMAND_ID: SERVICE_REMOVE_DEPENDENCY_COMMAND,
+    SERVICE_REMOVE_COMMAND_ID:        SERVICE_REMOVE_COMMAND,
+    SERVICE_SET_CONSTANTS_COMMAND_ID: SERVICE_SET_CONSTANTS_COMMAND,
+    APP_ADD_COMMAND_ID:               APP_ADD_COMMAND,
+    APP_GET_COMMAND_ID:               APP_GET_COMMAND,
+    APP_LIST_COMMAND_ID:              APP_LIST_COMMAND,
+    APP_UPDATE_COMMAND_ID:            APP_UPDATE_COMMAND,
+    APP_SET_CONSTANTS_COMMAND_ID:     APP_SET_CONSTANTS_COMMAND,
+    APP_SET_SERVICE_COMMAND_ID:       APP_SET_SERVICE_COMMAND,
+    APP_REMOVE_SERVICE_COMMAND_ID:    APP_REMOVE_SERVICE_COMMAND,
+    APP_REMOVE_COMMAND_ID:            APP_REMOVE_COMMAND,
+    CLI_ADD_COMMAND_COMMAND_ID:       CLI_ADD_COMMAND_COMMAND,
+    CLI_LIST_COMMANDS_COMMAND_ID:     CLI_LIST_COMMANDS_COMMAND,
+    CLI_ADD_ARGUMENT_COMMAND_ID:      CLI_ADD_ARGUMENT_COMMAND,
+    LOGGING_ADD_FORMATTER_COMMAND_ID:    LOGGING_ADD_FORMATTER_COMMAND,
+    LOGGING_REMOVE_FORMATTER_COMMAND_ID: LOGGING_REMOVE_FORMATTER_COMMAND,
+    LOGGING_ADD_HANDLER_COMMAND_ID:      LOGGING_ADD_HANDLER_COMMAND,
+    LOGGING_REMOVE_HANDLER_COMMAND_ID:   LOGGING_REMOVE_HANDLER_COMMAND,
+    LOGGING_ADD_LOGGER_COMMAND_ID:       LOGGING_ADD_LOGGER_COMMAND,
+    LOGGING_REMOVE_LOGGER_COMMAND_ID:    LOGGING_REMOVE_LOGGER_COMMAND,
+    LOGGING_LIST_COMMAND_ID:             LOGGING_LIST_COMMAND,
 }
 

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -34,6 +34,32 @@ def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) ->
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
 
+# ** function: create_service_dependency
+def create_service_dependency(
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a base service dependency definition dictionary.
+
+    :param module_path: The module path of the service implementation.
+    :type module_path: str
+    :param class_name: The class name of the service implementation.
+    :type class_name: str
+    :param parameters: Optional DI parameters for the dependency.
+    :type parameters: Dict[str, Any]
+    :return: The base service dependency definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the base service dependency definition dictionary.
+    return {
+        'module_path': module_path,
+        'class_name': class_name,
+        'parameters': parameters or {},
+    }
+
 # ** function: create_app_service_dependency
 def create_app_service_dependency(
         service_id: str,
@@ -56,10 +82,117 @@ def create_app_service_dependency(
     :rtype: Dict[str, Any]
     '''
 
-    # Assemble and return the default app service dependency definition dictionary.
+    # Assemble and return the app service dependency definition dictionary.
     return {
         'service_id': service_id,
-        'module_path': module_path,
-        'class_name': class_name,
-        'parameters': parameters or {},
+        **create_service_dependency(module_path, class_name, parameters),
     }
+
+# ** function: create_service_registration
+def create_service_registration(
+        id: str,
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default service registration definition dictionary.
+
+    :param id: The unique service registration identifier.
+    :type id: str
+    :param module_path: The module path of the service implementation.
+    :type module_path: str
+    :param class_name: The class name of the service implementation.
+    :type class_name: str
+    :param parameters: Optional DI parameters for the registration.
+    :type parameters: Dict[str, Any]
+    :return: The default service registration definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the service registration definition dictionary.
+    return {
+        'id': id,
+        **create_service_dependency(module_path, class_name, parameters),
+    }
+
+# ** function: create_default_feature
+def create_default_feature(
+        id: str,
+        name: str,
+        group_id: str,
+        feature_key: str,
+        steps: List[Dict[str, Any]],
+        description: str = None,
+        params_schema: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default feature workflow definition dictionary.
+
+    :param id: The unique feature identifier (e.g. ``'feature.add'``).
+    :type id: str
+    :param name: The human-readable feature name.
+    :type name: str
+    :param group_id: The group this feature belongs to.
+    :type group_id: str
+    :param feature_key: The feature key within its group.
+    :type feature_key: str
+    :param steps: The ordered list of feature step dicts.
+    :type steps: List[Dict[str, Any]]
+    :param description: Optional feature description.
+    :type description: str
+    :param params_schema: Optional request parameter schema dict.
+    :type params_schema: Dict[str, Any]
+    :return: The default feature workflow definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base feature definition.
+    feature = {
+        'id': id,
+        'name': name,
+        'group_id': group_id,
+        'feature_key': feature_key,
+        'steps': steps,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        feature['description'] = description
+    if params_schema is not None:
+        feature['params_schema'] = params_schema
+
+    # Return the assembled feature definition.
+    return feature
+
+# ** function: create_default_app_session
+def create_default_app_session(
+        id: str,
+        name: str,
+        description: str = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default application session definition dictionary.
+
+    :param id: The unique session identifier.
+    :type id: str
+    :param name: The human-readable session name.
+    :type name: str
+    :param description: Optional session description.
+    :type description: str
+    :return: The default application session definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base session definition.
+    session = {
+        'id': id,
+        'name': name,
+    }
+
+    # Add the optional description when provided.
+    if description is not None:
+        session['description'] = description
+
+    # Return the assembled session definition.
+    return session

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -10,6 +10,32 @@ from typing import List, Tuple, Dict, Any
 # ** constant: en_us
 EN_US = 'en_US'
 
+# *** constants (paths)
+
+# ** constant: tiferet_events_path
+TIFERET_EVENTS_PATH = 'tiferet.events'
+
+# ** constant: tiferet_repos_path
+TIFERET_REPOS_PATH = 'tiferet.repos'
+
+# ** constant: feature_domain_path
+FEATURE_DOMAIN_PATH = 'feature'
+
+# ** constant: error_domain_path
+ERROR_DOMAIN_PATH = 'error'
+
+# ** constant: di_domain_path
+DI_DOMAIN_PATH = 'di'
+
+# ** constant: app_domain_path
+APP_DOMAIN_PATH = 'app'
+
+# ** constant: logging_domain_path
+LOGGING_DOMAIN_PATH = 'logging'
+
+# ** constant: cli_domain_path
+CLI_DOMAIN_PATH = 'cli'
+
 # *** functions
 
 # ** function: create_default_error
@@ -33,6 +59,23 @@ def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) ->
         'name': name,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
+
+# ** function: create_service_module_path
+def create_service_module_path(base_path: str, domain_path: str) -> str:
+    '''
+    Build a fully-qualified service module path from a base path and a domain
+    path segment.
+
+    :param base_path: The base module path (e.g. ``TIFERET_EVENTS_PATH``).
+    :type base_path: str
+    :param domain_path: The domain path segment (e.g. ``FEATURE_DOMAIN_PATH``).
+    :type domain_path: str
+    :return: The fully-qualified module path.
+    :rtype: str
+    '''
+
+    # Assemble and return the fully-qualified module path.
+    return f'{base_path}.{domain_path}'
 
 # ** function: create_service_dependency
 def create_service_dependency(

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -10,13 +10,21 @@ from typing import List, Tuple, Dict, Any
 # ** constant: en_us
 EN_US = 'en_US'
 
-# *** constants (paths)
+# ** constant: tiferet
+TIFERET = 'tiferet'
+
+# *** constants (paths): packages
 
 # ** constant: tiferet_events_path
-TIFERET_EVENTS_PATH = 'tiferet.events'
+TIFERET_EVENTS_PATH = 'events'
 
 # ** constant: tiferet_repos_path
-TIFERET_REPOS_PATH = 'tiferet.repos'
+TIFERET_REPOS_PATH = 'repos'
+
+# ** constant: tiferet_utils_path
+TIFERET_UTILS_PATH = 'utils'
+
+# *** constants (paths): domains
 
 # ** constant: feature_domain_path
 FEATURE_DOMAIN_PATH = 'feature'
@@ -35,6 +43,9 @@ LOGGING_DOMAIN_PATH = 'logging'
 
 # ** constant: cli_domain_path
 CLI_DOMAIN_PATH = 'cli'
+
+# ** constant: middleware_domain_path
+MIDDLEWARE_DOMAIN_PATH = 'middleware'
 
 # *** functions
 
@@ -61,21 +72,23 @@ def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) ->
     }
 
 # ** function: create_service_module_path
-def create_service_module_path(base_path: str, domain_path: str) -> str:
+def create_service_module_path(app_base_path: str, base_path: str, domain_path: str) -> str:
     '''
-    Build a fully-qualified service module path from a base path and a domain
-    path segment.
+    Build a fully-qualified service module path from an application base path,
+    a sub-package path, and a domain path segment.
 
-    :param base_path: The base module path (e.g. ``TIFERET_EVENTS_PATH``).
+    :param app_base_path: The application root path (e.g. ``TIFERET``).
+    :type app_base_path: str
+    :param base_path: The sub-package path segment (e.g. ``TIFERET_EVENTS_PATH``).
     :type base_path: str
-    :param domain_path: The domain path segment (e.g. ``FEATURE_DOMAIN_PATH``).
+    :param domain_path: The domain module path segment (e.g. ``FEATURE_DOMAIN_PATH``).
     :type domain_path: str
     :return: The fully-qualified module path.
     :rtype: str
     '''
 
     # Assemble and return the fully-qualified module path.
-    return f'{base_path}.{domain_path}'
+    return f'{app_base_path}.{base_path}.{domain_path}'
 
 # ** function: create_service_dependency
 def create_service_dependency(
@@ -207,6 +220,27 @@ def create_default_feature(
 
     # Return the assembled feature definition.
     return feature
+
+# ** function: create_params_schema
+def create_params_schema(**params: Any) -> Dict[str, Any]:
+    '''
+    Build a request parameter schema dict for use as ``params_schema`` in a
+    feature definition.
+
+    Each keyword argument names one expected request parameter. The value is
+    either a plain type string (``'str'``, ``'int'``, ``'bool'``, ``'float'``,
+    ``'list'``, ``'dict'``) for a required parameter, or a parameter-spec dict
+    with keys ``type``, ``required``, ``default``, and any additional
+    constraints recognised by ``RequestSpecification``.
+
+    :param params: Mapping of parameter names to type strings or spec dicts.
+    :type params: Any
+    :return: The assembled parameter schema dict.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Return the assembled parameter schema dict.
+    return dict(params)
 
 # ** function: create_default_app_session
 def create_default_app_session(

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -13,7 +13,7 @@ EN_US = 'en_US'
 # ** constant: tiferet
 TIFERET = 'tiferet'
 
-# *** constants (paths): packages
+# *** constants (paths_packages)
 
 # ** constant: tiferet_events_path
 TIFERET_EVENTS_PATH = 'events'
@@ -24,7 +24,7 @@ TIFERET_REPOS_PATH = 'repos'
 # ** constant: tiferet_utils_path
 TIFERET_UTILS_PATH = 'utils'
 
-# *** constants (paths): domains
+# *** constants (paths_domains)
 
 # ** constant: feature_domain_path
 FEATURE_DOMAIN_PATH = 'feature'

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -3,7 +3,7 @@
 # *** imports
 
 # ** core
-from typing import List, Tuple, Dict, Any
+from typing import Any, Dict, List, Tuple
 
 # *** constants
 
@@ -273,3 +273,251 @@ def create_default_app_session(
 
     # Return the assembled session definition.
     return session
+
+# ** function: create_default_formatter
+def create_default_formatter(
+        id: str,
+        name: str,
+        format: str,
+        description: str = None,
+        datefmt: str = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default logging formatter definition dictionary.
+
+    :param id: The unique identifier of the formatter.
+    :type id: str
+    :param name: The human-readable formatter name.
+    :type name: str
+    :param format: The format string for log messages.
+    :type format: str
+    :param description: Optional formatter description.
+    :type description: str
+    :param datefmt: Optional date format string.
+    :type datefmt: str
+    :return: The default formatter definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base formatter definition.
+    formatter = {
+        'id': id,
+        'name': name,
+        'format': format,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        formatter['description'] = description
+    if datefmt is not None:
+        formatter['datefmt'] = datefmt
+
+    # Return the assembled formatter definition.
+    return formatter
+
+# ** function: create_default_handler
+def create_default_handler(
+        id: str,
+        name: str,
+        module_path: str,
+        class_name: str,
+        level: str,
+        formatter: str,
+        description: str = None,
+        stream: str = None,
+        filename: str = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default logging handler definition dictionary.
+
+    :param id: The unique identifier of the handler.
+    :type id: str
+    :param name: The human-readable handler name.
+    :type name: str
+    :param module_path: The module path of the handler class.
+    :type module_path: str
+    :param class_name: The class name of the handler.
+    :type class_name: str
+    :param level: The logging level (e.g. ``'INFO'``, ``'DEBUG'``).
+    :type level: str
+    :param formatter: The id of the formatter to use.
+    :type formatter: str
+    :param description: Optional handler description.
+    :type description: str
+    :param stream: Optional stream specification (e.g. ``'ext://sys.stdout'``).
+    :type stream: str
+    :param filename: Optional file path for file-based handlers.
+    :type filename: str
+    :return: The default handler definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base handler definition.
+    handler = {
+        'id': id,
+        'name': name,
+        'module_path': module_path,
+        'class_name': class_name,
+        'level': level,
+        'formatter': formatter,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        handler['description'] = description
+    if stream is not None:
+        handler['stream'] = stream
+    if filename is not None:
+        handler['filename'] = filename
+
+    # Return the assembled handler definition.
+    return handler
+
+# ** function: create_default_logger
+def create_default_logger(
+        id: str,
+        name: str,
+        level: str,
+        handlers: List[str],
+        propagate: bool = False,
+        is_root: bool = False,
+        description: str = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default logger definition dictionary.
+
+    :param id: The unique identifier of the logger.
+    :type id: str
+    :param name: The human-readable logger name.
+    :type name: str
+    :param level: The logging level (e.g. ``'INFO'``, ``'WARNING'``).
+    :type level: str
+    :param handlers: The ordered list of handler ids for this logger.
+    :type handlers: List[str]
+    :param propagate: Whether to propagate messages to parent loggers.
+    :type propagate: bool
+    :param is_root: Whether this is the root logger.
+    :type is_root: bool
+    :param description: Optional logger description.
+    :type description: str
+    :return: The default logger definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base logger definition.
+    logger = {
+        'id': id,
+        'name': name,
+        'level': level,
+        'handlers': handlers,
+        'propagate': propagate,
+        'is_root': is_root,
+    }
+
+    # Add the optional description when provided.
+    if description is not None:
+        logger['description'] = description
+
+    # Return the assembled logger definition.
+    return logger
+
+# ** function: create_default_cli_argument
+def create_default_cli_argument(
+        name_or_flags: List[str],
+        description: str = None,
+        type: str = None,
+        default: Any = None,
+        required: bool = None,
+        nargs: str = None,
+        choices: List[str] = None,
+        action: str = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default CLI argument definition dictionary.
+
+    :param name_or_flags: The argument name or flags list (e.g. ``['--flag']``).
+    :type name_or_flags: List[str]
+    :param description: Optional argument description surfaced as help text.
+    :type description: str
+    :param type: Optional argument type string (``'str'``, ``'int'``, ``'float'``).
+    :type type: str
+    :param default: Optional default value when the argument is not provided.
+    :type default: Any
+    :param required: Optional flag indicating whether the argument is required.
+    :type required: bool
+    :param nargs: Optional argument count specifier (``'?'``, ``'*'``, ``'+'``).
+    :type nargs: str
+    :param choices: Optional list of allowed values for the argument.
+    :type choices: List[str]
+    :param action: Optional argparse action string (e.g. ``'store_true'``).
+    :type action: str
+    :return: The default CLI argument definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base argument definition.
+    argument: Dict[str, Any] = {'name_or_flags': name_or_flags}
+
+    # Add optional fields when provided.
+    if description is not None:
+        argument['description'] = description
+    if type is not None:
+        argument['type'] = type
+    if default is not None:
+        argument['default'] = default
+    if required is not None:
+        argument['required'] = required
+    if nargs is not None:
+        argument['nargs'] = nargs
+    if choices is not None:
+        argument['choices'] = choices
+    if action is not None:
+        argument['action'] = action
+
+    # Return the assembled argument definition.
+    return argument
+
+# ** function: create_default_cli_command
+def create_default_cli_command(
+        id: str,
+        key: str,
+        group_key: str,
+        name: str,
+        description: str = None,
+        arguments: List[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default CLI command definition dictionary.
+
+    :param id: The unique command identifier (e.g. ``'feature.add'``).
+    :type id: str
+    :param key: The command key used in CLI invocation.
+    :type key: str
+    :param group_key: The group key for the command.
+    :type group_key: str
+    :param name: The human-readable command name.
+    :type name: str
+    :param description: Optional command description.
+    :type description: str
+    :param arguments: Optional ordered list of argument definition dicts.
+    :type arguments: List[Dict[str, Any]]
+    :return: The default CLI command definition.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base command definition.
+    command = {
+        'id': id,
+        'key': key,
+        'group_key': group_key,
+        'name': name,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        command['description'] = description
+    if arguments:
+        command['arguments'] = arguments
+
+    # Return the assembled command definition.
+    return command

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -1,4 +1,4 @@
-"""Tiferet Assets Service
+"""Tiferet DI Assets
 
 Provides the default service registration catalog for the built-in Tiferet CLI
 management application. Each entry maps a service ID constant to a registration
@@ -15,7 +15,18 @@ Services already defined in ``app.CORE_DEFAULT_SERVICES`` (e.g.
 from typing import Any, Dict
 
 # ** app
-from .core import create_service_registration
+from .core import (
+    create_service_registration,
+    create_service_module_path,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    FEATURE_DOMAIN_PATH,
+    ERROR_DOMAIN_PATH,
+    DI_DOMAIN_PATH,
+    APP_DOMAIN_PATH,
+    LOGGING_DOMAIN_PATH,
+    CLI_DOMAIN_PATH,
+)
 
 # *** constants (ids)
 
@@ -135,259 +146,259 @@ REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
 # ** constant: app_service
 APP_SERVICE = create_service_registration(
     APP_SERVICE_ID,
-    'tiferet.repos.app',
+    create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
     'AppConfigRepository',
 )
 
 # ** constant: add_feature_evt
 ADD_FEATURE_EVT = create_service_registration(
     ADD_FEATURE_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeature',
 )
 
 # ** constant: list_features_evt
 LIST_FEATURES_EVT = create_service_registration(
     LIST_FEATURES_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ListFeatures',
 )
 
 # ** constant: remove_feature_evt
 REMOVE_FEATURE_EVT = create_service_registration(
     REMOVE_FEATURE_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeature',
 )
 
 # ** constant: update_feature_evt
 UPDATE_FEATURE_EVT = create_service_registration(
     UPDATE_FEATURE_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeature',
 )
 
 # ** constant: add_feature_step_evt
 ADD_FEATURE_STEP_EVT = create_service_registration(
     ADD_FEATURE_STEP_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeatureStep',
 )
 
 # ** constant: update_feature_step_evt
 UPDATE_FEATURE_STEP_EVT = create_service_registration(
     UPDATE_FEATURE_STEP_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeatureStep',
 )
 
 # ** constant: remove_feature_step_evt
 REMOVE_FEATURE_STEP_EVT = create_service_registration(
     REMOVE_FEATURE_STEP_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeatureStep',
 )
 
 # ** constant: reorder_feature_step_evt
 REORDER_FEATURE_STEP_EVT = create_service_registration(
     REORDER_FEATURE_STEP_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ReorderFeatureStep',
 )
 
 # ** constant: add_error_evt
 ADD_ERROR_EVT = create_service_registration(
     ADD_ERROR_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'AddError',
 )
 
 # ** constant: list_errors_evt
 LIST_ERRORS_EVT = create_service_registration(
     LIST_ERRORS_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'ListErrors',
 )
 
 # ** constant: rename_error_evt
 RENAME_ERROR_EVT = create_service_registration(
     RENAME_ERROR_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RenameError',
 )
 
 # ** constant: set_error_message_evt
 SET_ERROR_MESSAGE_EVT = create_service_registration(
     SET_ERROR_MESSAGE_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'SetErrorMessage',
 )
 
 # ** constant: remove_error_message_evt
 REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
     REMOVE_ERROR_MESSAGE_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveErrorMessage',
 )
 
 # ** constant: remove_error_evt
 REMOVE_ERROR_EVT = create_service_registration(
     REMOVE_ERROR_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveError',
 )
 
 # ** constant: add_service_registration_evt
 ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
     ADD_SERVICE_REGISTRATION_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'AddServiceRegistration',
 )
 
 # ** constant: set_default_service_registration_evt
 SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
     SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetDefaultServiceRegistration',
 )
 
 # ** constant: set_di_service_dependency_evt
 SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
     SET_DI_SERVICE_DEPENDENCY_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
 # ** constant: remove_di_service_dependency_evt
 REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
     REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
 # ** constant: remove_service_registration_evt
 REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
     REMOVE_SERVICE_REGISTRATION_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceRegistration',
 )
 
 # ** constant: set_service_constants_evt
 SET_SERVICE_CONSTANTS_EVT = create_service_registration(
     SET_SERVICE_CONSTANTS_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceConstants',
 )
 
 # ** constant: add_app_session_evt
 ADD_APP_SESSION_EVT = create_service_registration(
     ADD_APP_SESSION_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'AddAppSession',
 )
 
 # ** constant: get_app_session_evt
 GET_APP_SESSION_EVT = create_service_registration(
     GET_APP_SESSION_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'GetAppSession',
 )
 
 # ** constant: update_app_session_evt
 UPDATE_APP_SESSION_EVT = create_service_registration(
     UPDATE_APP_SESSION_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'UpdateAppSession',
 )
 
 # ** constant: set_app_constants_evt
 SET_APP_CONSTANTS_EVT = create_service_registration(
     SET_APP_CONSTANTS_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetAppConstants',
 )
 
 # ** constant: list_app_sessions_evt
 LIST_APP_SESSIONS_EVT = create_service_registration(
     LIST_APP_SESSIONS_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'ListAppSessions',
 )
 
 # ** constant: set_app_service_dependency_evt
 SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
     SET_APP_SERVICE_DEPENDENCY_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
 # ** constant: remove_app_service_dependency_evt
 REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
     REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
 # ** constant: remove_app_session_evt
 REMOVE_APP_SESSION_EVT = create_service_registration(
     REMOVE_APP_SESSION_EVT_ID,
-    'tiferet.events.app',
+    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveAppSession',
 )
 
 # ** constant: add_cli_command_evt
 ADD_CLI_COMMAND_EVT = create_service_registration(
     ADD_CLI_COMMAND_EVT_ID,
-    'tiferet.events.cli',
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliCommand',
 )
 
 # ** constant: add_cli_argument_evt
 ADD_CLI_ARGUMENT_EVT = create_service_registration(
     ADD_CLI_ARGUMENT_EVT_ID,
-    'tiferet.events.cli',
+    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliArgument',
 )
 
 # ** constant: add_formatter_evt
 ADD_FORMATTER_EVT = create_service_registration(
     ADD_FORMATTER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddFormatter',
 )
 
 # ** constant: remove_formatter_evt
 REMOVE_FORMATTER_EVT = create_service_registration(
     REMOVE_FORMATTER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveFormatter',
 )
 
 # ** constant: add_handler_evt
 ADD_HANDLER_EVT = create_service_registration(
     ADD_HANDLER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddHandler',
 )
 
 # ** constant: remove_handler_evt
 REMOVE_HANDLER_EVT = create_service_registration(
     REMOVE_HANDLER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveHandler',
 )
 
 # ** constant: add_logger_evt
 ADD_LOGGER_EVT = create_service_registration(
     ADD_LOGGER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddLogger',
 )
 
 # ** constant: remove_logger_evt
 REMOVE_LOGGER_EVT = create_service_registration(
     REMOVE_LOGGER_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveLogger',
 )
 

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -1,73 +1,435 @@
 """Tiferet Assets Service
 
-Provides the default service configurations for the built-in Tiferet CLI
-management application. These register domain events as injectable services
-for CLI feature workflows.
+Provides the default service registration catalog for the built-in Tiferet CLI
+management application. Each entry maps a service ID constant to a registration
+definition built via ``create_service_registration``.
 
 Services already defined in ``app.CORE_DEFAULT_SERVICES`` (e.g.
 ``get_error_evt``, ``get_feature_evt``, ``list_all_settings_evt``) are
-**not** duplicated here. The blueprint merges both lists at startup.
+**not** duplicated here. The blueprint merges both catalogs at startup.
 """
 
 # *** imports
 
 # ** core
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
-# *** constants
+# ** app
+from .core import create_service_registration
+
+# *** constants (ids)
+
+# ** constant: app_service_id
+APP_SERVICE_ID = 'app_service'
+
+# ** constant: add_feature_evt_id
+ADD_FEATURE_EVT_ID = 'add_feature_evt'
+
+# ** constant: list_features_evt_id
+LIST_FEATURES_EVT_ID = 'list_features_evt'
+
+# ** constant: remove_feature_evt_id
+REMOVE_FEATURE_EVT_ID = 'remove_feature_evt'
+
+# ** constant: update_feature_evt_id
+UPDATE_FEATURE_EVT_ID = 'update_feature_evt'
+
+# ** constant: add_feature_step_evt_id
+ADD_FEATURE_STEP_EVT_ID = 'add_feature_step_evt'
+
+# ** constant: update_feature_step_evt_id
+UPDATE_FEATURE_STEP_EVT_ID = 'update_feature_step_evt'
+
+# ** constant: remove_feature_step_evt_id
+REMOVE_FEATURE_STEP_EVT_ID = 'remove_feature_step_evt'
+
+# ** constant: reorder_feature_step_evt_id
+REORDER_FEATURE_STEP_EVT_ID = 'reorder_feature_step_evt'
+
+# ** constant: add_error_evt_id
+ADD_ERROR_EVT_ID = 'add_error_evt'
+
+# ** constant: list_errors_evt_id
+LIST_ERRORS_EVT_ID = 'list_errors_evt'
+
+# ** constant: rename_error_evt_id
+RENAME_ERROR_EVT_ID = 'rename_error_evt'
+
+# ** constant: set_error_message_evt_id
+SET_ERROR_MESSAGE_EVT_ID = 'set_error_message_evt'
+
+# ** constant: remove_error_message_evt_id
+REMOVE_ERROR_MESSAGE_EVT_ID = 'remove_error_message_evt'
+
+# ** constant: remove_error_evt_id
+REMOVE_ERROR_EVT_ID = 'remove_error_evt'
+
+# ** constant: add_service_registration_evt_id
+ADD_SERVICE_REGISTRATION_EVT_ID = 'add_service_registration_evt'
+
+# ** constant: set_default_service_registration_evt_id
+SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID = 'set_default_service_registration_evt'
+
+# ** constant: set_di_service_dependency_evt_id
+SET_DI_SERVICE_DEPENDENCY_EVT_ID = 'set_di_service_dependency_evt'
+
+# ** constant: remove_di_service_dependency_evt_id
+REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID = 'remove_di_service_dependency_evt'
+
+# ** constant: remove_service_registration_evt_id
+REMOVE_SERVICE_REGISTRATION_EVT_ID = 'remove_service_registration_evt'
+
+# ** constant: set_service_constants_evt_id
+SET_SERVICE_CONSTANTS_EVT_ID = 'set_service_constants_evt'
+
+# ** constant: add_app_session_evt_id
+ADD_APP_SESSION_EVT_ID = 'add_app_session_evt'
+
+# ** constant: get_app_session_evt_id
+GET_APP_SESSION_EVT_ID = 'get_app_session_evt'
+
+# ** constant: update_app_session_evt_id
+UPDATE_APP_SESSION_EVT_ID = 'update_app_session_evt'
+
+# ** constant: set_app_constants_evt_id
+SET_APP_CONSTANTS_EVT_ID = 'set_app_constants_evt'
+
+# ** constant: list_app_sessions_evt_id
+LIST_APP_SESSIONS_EVT_ID = 'list_app_sessions_evt'
+
+# ** constant: set_app_service_dependency_evt_id
+SET_APP_SERVICE_DEPENDENCY_EVT_ID = 'set_app_service_dependency_evt'
+
+# ** constant: remove_app_service_dependency_evt_id
+REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID = 'remove_app_service_dependency_evt'
+
+# ** constant: remove_app_session_evt_id
+REMOVE_APP_SESSION_EVT_ID = 'remove_app_session_evt'
+
+# ** constant: add_cli_command_evt_id
+ADD_CLI_COMMAND_EVT_ID = 'add_cli_command_evt'
+
+# ** constant: add_cli_argument_evt_id
+ADD_CLI_ARGUMENT_EVT_ID = 'add_cli_argument_evt'
+
+# ** constant: add_formatter_evt_id
+ADD_FORMATTER_EVT_ID = 'add_formatter_evt'
+
+# ** constant: remove_formatter_evt_id
+REMOVE_FORMATTER_EVT_ID = 'remove_formatter_evt'
+
+# ** constant: add_handler_evt_id
+ADD_HANDLER_EVT_ID = 'add_handler_evt'
+
+# ** constant: remove_handler_evt_id
+REMOVE_HANDLER_EVT_ID = 'remove_handler_evt'
+
+# ** constant: add_logger_evt_id
+ADD_LOGGER_EVT_ID = 'add_logger_evt'
+
+# ** constant: remove_logger_evt_id
+REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
+
+# *** constants (services)
+
+# ** constant: app_service
+APP_SERVICE = create_service_registration(
+    APP_SERVICE_ID,
+    'tiferet.repos.app',
+    'AppConfigRepository',
+)
+
+# ** constant: add_feature_evt
+ADD_FEATURE_EVT = create_service_registration(
+    ADD_FEATURE_EVT_ID,
+    'tiferet.events.feature',
+    'AddFeature',
+)
+
+# ** constant: list_features_evt
+LIST_FEATURES_EVT = create_service_registration(
+    LIST_FEATURES_EVT_ID,
+    'tiferet.events.feature',
+    'ListFeatures',
+)
+
+# ** constant: remove_feature_evt
+REMOVE_FEATURE_EVT = create_service_registration(
+    REMOVE_FEATURE_EVT_ID,
+    'tiferet.events.feature',
+    'RemoveFeature',
+)
+
+# ** constant: update_feature_evt
+UPDATE_FEATURE_EVT = create_service_registration(
+    UPDATE_FEATURE_EVT_ID,
+    'tiferet.events.feature',
+    'UpdateFeature',
+)
+
+# ** constant: add_feature_step_evt
+ADD_FEATURE_STEP_EVT = create_service_registration(
+    ADD_FEATURE_STEP_EVT_ID,
+    'tiferet.events.feature',
+    'AddFeatureStep',
+)
+
+# ** constant: update_feature_step_evt
+UPDATE_FEATURE_STEP_EVT = create_service_registration(
+    UPDATE_FEATURE_STEP_EVT_ID,
+    'tiferet.events.feature',
+    'UpdateFeatureStep',
+)
+
+# ** constant: remove_feature_step_evt
+REMOVE_FEATURE_STEP_EVT = create_service_registration(
+    REMOVE_FEATURE_STEP_EVT_ID,
+    'tiferet.events.feature',
+    'RemoveFeatureStep',
+)
+
+# ** constant: reorder_feature_step_evt
+REORDER_FEATURE_STEP_EVT = create_service_registration(
+    REORDER_FEATURE_STEP_EVT_ID,
+    'tiferet.events.feature',
+    'ReorderFeatureStep',
+)
+
+# ** constant: add_error_evt
+ADD_ERROR_EVT = create_service_registration(
+    ADD_ERROR_EVT_ID,
+    'tiferet.events.error',
+    'AddError',
+)
+
+# ** constant: list_errors_evt
+LIST_ERRORS_EVT = create_service_registration(
+    LIST_ERRORS_EVT_ID,
+    'tiferet.events.error',
+    'ListErrors',
+)
+
+# ** constant: rename_error_evt
+RENAME_ERROR_EVT = create_service_registration(
+    RENAME_ERROR_EVT_ID,
+    'tiferet.events.error',
+    'RenameError',
+)
+
+# ** constant: set_error_message_evt
+SET_ERROR_MESSAGE_EVT = create_service_registration(
+    SET_ERROR_MESSAGE_EVT_ID,
+    'tiferet.events.error',
+    'SetErrorMessage',
+)
+
+# ** constant: remove_error_message_evt
+REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
+    REMOVE_ERROR_MESSAGE_EVT_ID,
+    'tiferet.events.error',
+    'RemoveErrorMessage',
+)
+
+# ** constant: remove_error_evt
+REMOVE_ERROR_EVT = create_service_registration(
+    REMOVE_ERROR_EVT_ID,
+    'tiferet.events.error',
+    'RemoveError',
+)
+
+# ** constant: add_service_registration_evt
+ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
+    ADD_SERVICE_REGISTRATION_EVT_ID,
+    'tiferet.events.di',
+    'AddServiceRegistration',
+)
+
+# ** constant: set_default_service_registration_evt
+SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
+    'tiferet.events.di',
+    'SetDefaultServiceRegistration',
+)
+
+# ** constant: set_di_service_dependency_evt
+SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
+    'tiferet.events.di',
+    'SetServiceDependency',
+)
+
+# ** constant: remove_di_service_dependency_evt
+REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
+    'tiferet.events.di',
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_service_registration_evt
+REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
+    REMOVE_SERVICE_REGISTRATION_EVT_ID,
+    'tiferet.events.di',
+    'RemoveServiceRegistration',
+)
+
+# ** constant: set_service_constants_evt
+SET_SERVICE_CONSTANTS_EVT = create_service_registration(
+    SET_SERVICE_CONSTANTS_EVT_ID,
+    'tiferet.events.di',
+    'SetServiceConstants',
+)
+
+# ** constant: add_app_session_evt
+ADD_APP_SESSION_EVT = create_service_registration(
+    ADD_APP_SESSION_EVT_ID,
+    'tiferet.events.app',
+    'AddAppSession',
+)
+
+# ** constant: get_app_session_evt
+GET_APP_SESSION_EVT = create_service_registration(
+    GET_APP_SESSION_EVT_ID,
+    'tiferet.events.app',
+    'GetAppSession',
+)
+
+# ** constant: update_app_session_evt
+UPDATE_APP_SESSION_EVT = create_service_registration(
+    UPDATE_APP_SESSION_EVT_ID,
+    'tiferet.events.app',
+    'UpdateAppSession',
+)
+
+# ** constant: set_app_constants_evt
+SET_APP_CONSTANTS_EVT = create_service_registration(
+    SET_APP_CONSTANTS_EVT_ID,
+    'tiferet.events.app',
+    'SetAppConstants',
+)
+
+# ** constant: list_app_sessions_evt
+LIST_APP_SESSIONS_EVT = create_service_registration(
+    LIST_APP_SESSIONS_EVT_ID,
+    'tiferet.events.app',
+    'ListAppSessions',
+)
+
+# ** constant: set_app_service_dependency_evt
+SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
+    'tiferet.events.app',
+    'SetServiceDependency',
+)
+
+# ** constant: remove_app_service_dependency_evt
+REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
+    'tiferet.events.app',
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_app_session_evt
+REMOVE_APP_SESSION_EVT = create_service_registration(
+    REMOVE_APP_SESSION_EVT_ID,
+    'tiferet.events.app',
+    'RemoveAppSession',
+)
+
+# ** constant: add_cli_command_evt
+ADD_CLI_COMMAND_EVT = create_service_registration(
+    ADD_CLI_COMMAND_EVT_ID,
+    'tiferet.events.cli',
+    'AddCliCommand',
+)
+
+# ** constant: add_cli_argument_evt
+ADD_CLI_ARGUMENT_EVT = create_service_registration(
+    ADD_CLI_ARGUMENT_EVT_ID,
+    'tiferet.events.cli',
+    'AddCliArgument',
+)
+
+# ** constant: add_formatter_evt
+ADD_FORMATTER_EVT = create_service_registration(
+    ADD_FORMATTER_EVT_ID,
+    'tiferet.events.logging',
+    'AddFormatter',
+)
+
+# ** constant: remove_formatter_evt
+REMOVE_FORMATTER_EVT = create_service_registration(
+    REMOVE_FORMATTER_EVT_ID,
+    'tiferet.events.logging',
+    'RemoveFormatter',
+)
+
+# ** constant: add_handler_evt
+ADD_HANDLER_EVT = create_service_registration(
+    ADD_HANDLER_EVT_ID,
+    'tiferet.events.logging',
+    'AddHandler',
+)
+
+# ** constant: remove_handler_evt
+REMOVE_HANDLER_EVT = create_service_registration(
+    REMOVE_HANDLER_EVT_ID,
+    'tiferet.events.logging',
+    'RemoveHandler',
+)
+
+# ** constant: add_logger_evt
+ADD_LOGGER_EVT = create_service_registration(
+    ADD_LOGGER_EVT_ID,
+    'tiferet.events.logging',
+    'AddLogger',
+)
+
+# ** constant: remove_logger_evt
+REMOVE_LOGGER_EVT = create_service_registration(
+    REMOVE_LOGGER_EVT_ID,
+    'tiferet.events.logging',
+    'RemoveLogger',
+)
+
+# *** constants (groups)
 
 # ** constant: default_tiferet_cli_services
-# Each tuple: (service_id, module_path, class_name, parameters | None)
-DEFAULT_TIFERET_CLI_SERVICES: List[Tuple[str, str, str, Dict[str, Any] | None]] = [
-
-    # * services: app_service (repository — needed by app domain events)
-    ('app_service', 'tiferet.repos.app', 'AppConfigRepository', None),
-
-    # * services: feature domain events
-    ('add_feature_evt', 'tiferet.events.feature', 'AddFeature', None),
-    ('list_features_evt', 'tiferet.events.feature', 'ListFeatures', None),
-    ('remove_feature_evt', 'tiferet.events.feature', 'RemoveFeature', None),
-    ('update_feature_evt', 'tiferet.events.feature', 'UpdateFeature', None),
-    ('add_feature_step_evt', 'tiferet.events.feature', 'AddFeatureStep', None),
-    ('update_feature_step_evt', 'tiferet.events.feature', 'UpdateFeatureStep', None),
-    ('remove_feature_step_evt', 'tiferet.events.feature', 'RemoveFeatureStep', None),
-    ('reorder_feature_step_evt', 'tiferet.events.feature', 'ReorderFeatureStep', None),
-
-    # * services: error domain events
-    ('add_error_evt', 'tiferet.events.error', 'AddError', None),
-    ('list_errors_evt', 'tiferet.events.error', 'ListErrors', None),
-    ('rename_error_evt', 'tiferet.events.error', 'RenameError', None),
-    ('set_error_message_evt', 'tiferet.events.error', 'SetErrorMessage', None),
-    ('remove_error_message_evt', 'tiferet.events.error', 'RemoveErrorMessage', None),
-    ('remove_error_evt', 'tiferet.events.error', 'RemoveError', None),
-
-    # * services: di (service configuration) domain events
-    ('add_service_registration_evt', 'tiferet.events.di', 'AddServiceRegistration', None),
-    ('set_default_service_registration_evt', 'tiferet.events.di', 'SetDefaultServiceRegistration', None),
-    ('set_di_service_dependency_evt', 'tiferet.events.di', 'SetServiceDependency', None),
-    ('remove_di_service_dependency_evt', 'tiferet.events.di', 'RemoveServiceDependency', None),
-    ('remove_service_registration_evt', 'tiferet.events.di', 'RemoveServiceRegistration', None),
-    ('set_service_constants_evt', 'tiferet.events.di', 'SetServiceConstants', None),
-
-    # * services: app session domain events
-    ('add_app_session_evt', 'tiferet.events.app', 'AddAppSession', None),
-    ('get_app_session_evt', 'tiferet.events.app', 'GetAppSession', None),
-    ('update_app_session_evt', 'tiferet.events.app', 'UpdateAppSession', None),
-    ('set_app_constants_evt', 'tiferet.events.app', 'SetAppConstants', None),
-    ('list_app_sessions_evt', 'tiferet.events.app', 'ListAppSessions', None),
-    ('set_app_service_dependency_evt', 'tiferet.events.app', 'SetServiceDependency', None),
-    ('remove_app_service_dependency_evt', 'tiferet.events.app', 'RemoveServiceDependency', None),
-    ('remove_app_session_evt', 'tiferet.events.app', 'RemoveAppSession', None),
-
-    # * services: cli domain events
-    ('add_cli_command_evt', 'tiferet.events.cli', 'AddCliCommand', None),
-    ('add_cli_argument_evt', 'tiferet.events.cli', 'AddCliArgument', None),
-
-    # * services: logging domain events
-    ('add_formatter_evt', 'tiferet.events.logging', 'AddFormatter', None),
-    ('remove_formatter_evt', 'tiferet.events.logging', 'RemoveFormatter', None),
-    ('add_handler_evt', 'tiferet.events.logging', 'AddHandler', None),
-    ('remove_handler_evt', 'tiferet.events.logging', 'RemoveHandler', None),
-    ('add_logger_evt', 'tiferet.events.logging', 'AddLogger', None),
-    ('remove_logger_evt', 'tiferet.events.logging', 'RemoveLogger', None),
-]
+DEFAULT_TIFERET_CLI_SERVICES: Dict[str, Dict[str, Any]] = {
+    APP_SERVICE_ID: APP_SERVICE,
+    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
+    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
+    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
+    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
+    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
+    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
+    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
+    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
+    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
+    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
+    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
+    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
+    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
+    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
+    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
+    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
+    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
+    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
+    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
+    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
+    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
+    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
+    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
+    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
+    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
+    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
+    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
+}

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -18,6 +18,7 @@ from typing import Any, Dict
 from .core import (
     create_service_registration,
     create_service_module_path,
+    TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
     FEATURE_DOMAIN_PATH,
@@ -146,259 +147,259 @@ REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
 # ** constant: app_service
 APP_SERVICE = create_service_registration(
     APP_SERVICE_ID,
-    create_service_module_path(TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
     'AppConfigRepository',
 )
 
 # ** constant: add_feature_evt
 ADD_FEATURE_EVT = create_service_registration(
     ADD_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeature',
 )
 
 # ** constant: list_features_evt
 LIST_FEATURES_EVT = create_service_registration(
     LIST_FEATURES_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ListFeatures',
 )
 
 # ** constant: remove_feature_evt
 REMOVE_FEATURE_EVT = create_service_registration(
     REMOVE_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeature',
 )
 
 # ** constant: update_feature_evt
 UPDATE_FEATURE_EVT = create_service_registration(
     UPDATE_FEATURE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeature',
 )
 
 # ** constant: add_feature_step_evt
 ADD_FEATURE_STEP_EVT = create_service_registration(
     ADD_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeatureStep',
 )
 
 # ** constant: update_feature_step_evt
 UPDATE_FEATURE_STEP_EVT = create_service_registration(
     UPDATE_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeatureStep',
 )
 
 # ** constant: remove_feature_step_evt
 REMOVE_FEATURE_STEP_EVT = create_service_registration(
     REMOVE_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeatureStep',
 )
 
 # ** constant: reorder_feature_step_evt
 REORDER_FEATURE_STEP_EVT = create_service_registration(
     REORDER_FEATURE_STEP_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ReorderFeatureStep',
 )
 
 # ** constant: add_error_evt
 ADD_ERROR_EVT = create_service_registration(
     ADD_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'AddError',
 )
 
 # ** constant: list_errors_evt
 LIST_ERRORS_EVT = create_service_registration(
     LIST_ERRORS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'ListErrors',
 )
 
 # ** constant: rename_error_evt
 RENAME_ERROR_EVT = create_service_registration(
     RENAME_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RenameError',
 )
 
 # ** constant: set_error_message_evt
 SET_ERROR_MESSAGE_EVT = create_service_registration(
     SET_ERROR_MESSAGE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'SetErrorMessage',
 )
 
 # ** constant: remove_error_message_evt
 REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
     REMOVE_ERROR_MESSAGE_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveErrorMessage',
 )
 
 # ** constant: remove_error_evt
 REMOVE_ERROR_EVT = create_service_registration(
     REMOVE_ERROR_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveError',
 )
 
 # ** constant: add_service_registration_evt
 ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
     ADD_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'AddServiceRegistration',
 )
 
 # ** constant: set_default_service_registration_evt
 SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
     SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetDefaultServiceRegistration',
 )
 
 # ** constant: set_di_service_dependency_evt
 SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
     SET_DI_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
 # ** constant: remove_di_service_dependency_evt
 REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
     REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
 # ** constant: remove_service_registration_evt
 REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
     REMOVE_SERVICE_REGISTRATION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceRegistration',
 )
 
 # ** constant: set_service_constants_evt
 SET_SERVICE_CONSTANTS_EVT = create_service_registration(
     SET_SERVICE_CONSTANTS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceConstants',
 )
 
 # ** constant: add_app_session_evt
 ADD_APP_SESSION_EVT = create_service_registration(
     ADD_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'AddAppSession',
 )
 
 # ** constant: get_app_session_evt
 GET_APP_SESSION_EVT = create_service_registration(
     GET_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'GetAppSession',
 )
 
 # ** constant: update_app_session_evt
 UPDATE_APP_SESSION_EVT = create_service_registration(
     UPDATE_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'UpdateAppSession',
 )
 
 # ** constant: set_app_constants_evt
 SET_APP_CONSTANTS_EVT = create_service_registration(
     SET_APP_CONSTANTS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetAppConstants',
 )
 
 # ** constant: list_app_sessions_evt
 LIST_APP_SESSIONS_EVT = create_service_registration(
     LIST_APP_SESSIONS_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'ListAppSessions',
 )
 
 # ** constant: set_app_service_dependency_evt
 SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
     SET_APP_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
 # ** constant: remove_app_service_dependency_evt
 REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
     REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
 # ** constant: remove_app_session_evt
 REMOVE_APP_SESSION_EVT = create_service_registration(
     REMOVE_APP_SESSION_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveAppSession',
 )
 
 # ** constant: add_cli_command_evt
 ADD_CLI_COMMAND_EVT = create_service_registration(
     ADD_CLI_COMMAND_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliCommand',
 )
 
 # ** constant: add_cli_argument_evt
 ADD_CLI_ARGUMENT_EVT = create_service_registration(
     ADD_CLI_ARGUMENT_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliArgument',
 )
 
 # ** constant: add_formatter_evt
 ADD_FORMATTER_EVT = create_service_registration(
     ADD_FORMATTER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddFormatter',
 )
 
 # ** constant: remove_formatter_evt
 REMOVE_FORMATTER_EVT = create_service_registration(
     REMOVE_FORMATTER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveFormatter',
 )
 
 # ** constant: add_handler_evt
 ADD_HANDLER_EVT = create_service_registration(
     ADD_HANDLER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddHandler',
 )
 
 # ** constant: remove_handler_evt
 REMOVE_HANDLER_EVT = create_service_registration(
     REMOVE_HANDLER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveHandler',
 )
 
 # ** constant: add_logger_evt
 ADD_LOGGER_EVT = create_service_registration(
     ADD_LOGGER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddLogger',
 )
 
 # ** constant: remove_logger_evt
 REMOVE_LOGGER_EVT = create_service_registration(
     REMOVE_LOGGER_EVT_ID,
-    create_service_module_path(TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveLogger',
 )
 

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -11,557 +11,733 @@ at startup — they are not loaded from the consumer's config file.
 # *** imports
 
 # ** core
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-# *** constants
+# ** app
+from .core import create_default_feature
 
-# ** constant: default_tiferet_cli_feature_list
-# Each dict matches the Feature domain object constructor fields.
-# Steps use EventFeatureStep field names: service_id, name, parameters, data_key.
-# ``params_schema`` declares the feature-level request validation schema
-# (RFP #838) for each feature, mapping the underlying event's expected request
-# parameters to declared types and defaults. It uses the ergonomic keyed form:
-# the shorthand ``name: type`` for required parameters and the expanded form
-# ``name: {type, required, default}`` for optional parameters. Framework
-# context parameters (e.g. default_* fallbacks), free-form ``value`` arguments,
-# and comma-separated list arguments (handlers, name_or_flags) are intentionally
-# omitted so existing request behavior is preserved.
-_DEFAULT_TIFERET_CLI_FEATURE_LIST: List[Dict[str, Any]] = [
+# *** constants (ids)
 
-    # * features: feature domain
-    {
-        'id': 'feature.add',
-        'group_id': 'feature',
-        'feature_key': 'add',
-        'name': 'Add Feature',
-        'description': 'Add a new feature configuration.',
-        'params_schema': {
-            'name': 'str',
-            'group_id': 'str',
-            'feature_key': {'type': 'str', 'required': False},
-            'id': {'type': 'str', 'required': False},
-            'description': {'type': 'str', 'required': False},
-            'steps': {'type': 'list', 'required': False},
-            'log_params': {'type': 'dict', 'required': False},
-        },
-        'steps': [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
-    },
-    {
-        'id': 'feature.get',
-        'group_id': 'feature',
-        'feature_key': 'get',
-        'name': 'Get Feature',
-        'description': 'Retrieve a feature by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
-    },
-    {
-        'id': 'feature.list',
-        'group_id': 'feature',
-        'feature_key': 'list',
-        'name': 'List Features',
-        'description': 'List all features, optionally filtered by group.',
-        'params_schema': {
-            'group_id': {'type': 'str', 'required': False},
-        },
-        'steps': [{'service_id': 'list_features_evt', 'name': 'List features'}],
-    },
-    {
-        'id': 'feature.remove',
-        'group_id': 'feature',
-        'feature_key': 'remove',
-        'name': 'Remove Feature',
-        'description': 'Remove a feature configuration by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
-    },
-    {
-        'id': 'feature.update',
-        'group_id': 'feature',
-        'feature_key': 'update',
-        'name': 'Update Feature',
-        'description': 'Update a feature attribute (name or description).',
-        'params_schema': {
-            'id': 'str',
-            'attribute': 'str',
-        },
-        'steps': [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
-    },
-    {
-        'id': 'feature.add_step',
-        'group_id': 'feature',
-        'feature_key': 'add_step',
-        'name': 'Add Feature Step',
-        'description': 'Add a step to an existing feature workflow.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'service_id': 'str',
-            'parameters': {'type': 'dict', 'required': False},
-            'data_key': {'type': 'str', 'required': False},
-            'pass_on_error': {'type': 'bool', 'required': False, 'default': False},
-            'position': {'type': 'int', 'required': False},
-        },
-        'steps': [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
-    },
-    {
-        'id': 'feature.update_step',
-        'group_id': 'feature',
-        'feature_key': 'update_step',
-        'name': 'Update Feature Step',
-        'description': 'Update an attribute on a feature step.',
-        'params_schema': {
-            'id': 'str',
-            'position': 'int',
-            'attribute': 'str',
-        },
-        'steps': [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
-    },
-    {
-        'id': 'feature.remove_step',
-        'group_id': 'feature',
-        'feature_key': 'remove_step',
-        'name': 'Remove Feature Step',
-        'description': 'Remove a step from a feature by position.',
-        'params_schema': {
-            'id': 'str',
-            'position': 'int',
-        },
-        'steps': [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
-    },
-    {
-        'id': 'feature.reorder_step',
-        'group_id': 'feature',
-        'feature_key': 'reorder_step',
-        'name': 'Reorder Feature Step',
-        'description': 'Move a feature step from one position to another.',
-        'params_schema': {
-            'id': 'str',
-            'start_position': 'int',
-            'end_position': 'int',
-        },
-        'steps': [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
-    },
+# ** constant: feature_add_id
+FEATURE_ADD_ID = 'feature.add'
 
-    # * features: error domain
-    {
-        'id': 'error.add',
-        'group_id': 'error',
-        'feature_key': 'add',
-        'name': 'Add Error',
-        'description': 'Add a new error definition.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'message': 'str',
-            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-            'additional_messages': {'type': 'list', 'required': False, 'default': []},
-        },
-        'steps': [{'service_id': 'add_error_evt', 'name': 'Add error'}],
-    },
-    {
-        'id': 'error.get',
-        'group_id': 'error',
-        'feature_key': 'get',
-        'name': 'Get Error',
-        'description': 'Retrieve an error by ID.',
-        'params_schema': {
-            'id': 'str',
-            'include_defaults': {'type': 'bool', 'required': False, 'default': False},
-        },
-        'steps': [{'service_id': 'get_error_evt', 'name': 'Get error'}],
-    },
-    {
-        'id': 'error.list',
-        'group_id': 'error',
-        'feature_key': 'list',
-        'name': 'List Errors',
-        'description': 'List all error definitions.',
-        'params_schema': {
-            'include_defaults': {'type': 'bool', 'required': False, 'default': False},
-        },
-        'steps': [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
-    },
-    {
-        'id': 'error.rename',
-        'group_id': 'error',
-        'feature_key': 'rename',
-        'name': 'Rename Error',
-        'description': 'Rename an existing error.',
-        'params_schema': {
-            'id': 'str',
-            'new_name': 'str',
-        },
-        'steps': [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
-    },
-    {
-        'id': 'error.set_message',
-        'group_id': 'error',
-        'feature_key': 'set_message',
-        'name': 'Set Error Message',
-        'description': 'Set or update an error message for a language.',
-        'params_schema': {
-            'id': 'str',
-            'message': 'str',
-            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-        },
-        'steps': [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
-    },
-    {
-        'id': 'error.remove_message',
-        'group_id': 'error',
-        'feature_key': 'remove_message',
-        'name': 'Remove Error Message',
-        'description': 'Remove an error message by language.',
-        'params_schema': {
-            'id': 'str',
-            'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-        },
-        'steps': [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
-    },
-    {
-        'id': 'error.remove',
-        'group_id': 'error',
-        'feature_key': 'remove',
-        'name': 'Remove Error',
-        'description': 'Remove an error definition by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
-    },
+# ** constant: feature_get_id
+FEATURE_GET_ID = 'feature.get'
 
-    # * features: service (DI) domain
-    {
-        'id': 'service.add',
-        'group_id': 'service',
-        'feature_key': 'add',
-        'name': 'Add Service Configuration',
-        'description': 'Add a new service configuration.',
-        'params_schema': {
-            'id': 'str',
-            'module_path': {'type': 'str', 'required': False},
-            'class_name': {'type': 'str', 'required': False},
-            'parameters': {'type': 'dict', 'required': False, 'default': {}},
-            'flagged_dependencies': {'type': 'list', 'required': False, 'default': []},
-        },
-        'steps': [{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
-    },
-    {
-        'id': 'service.list',
-        'group_id': 'service',
-        'feature_key': 'list',
-        'name': 'List All Settings',
-        'description': 'List all service configurations and constants.',
-        'steps': [{'service_id': 'di_list_all_configs_evt', 'name': 'List all settings'}],
-    },
-    {
-        'id': 'service.set_default',
-        'group_id': 'service',
-        'feature_key': 'set_default',
-        'name': 'Set Default Service Configuration',
-        'description': 'Set or update the default type for a service configuration.',
-        'params_schema': {
-            'id': 'str',
-            'module_path': {'type': 'str', 'required': False},
-            'class_name': {'type': 'str', 'required': False},
-            'parameters': {'type': 'dict', 'required': False},
-        },
-        'steps': [{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
-    },
-    {
-        'id': 'service.set_dependency',
-        'group_id': 'service',
-        'feature_key': 'set_dependency',
-        'name': 'Set Service Dependency',
-        'description': 'Set or update a flagged dependency on a service configuration.',
-        'params_schema': {
-            'id': 'str',
-            'flag': 'str',
-            'module_path': 'str',
-            'class_name': 'str',
-            'parameters': {'type': 'dict', 'required': False, 'default': {}},
-        },
-        'steps': [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
-    },
-    {
-        'id': 'service.remove_dependency',
-        'group_id': 'service',
-        'feature_key': 'remove_dependency',
-        'name': 'Remove Service Dependency',
-        'description': 'Remove a flagged dependency from a service configuration.',
-        'params_schema': {
-            'id': 'str',
-            'flag': 'str',
-        },
-        'steps': [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
-    },
-    {
-        'id': 'service.remove',
-        'group_id': 'service',
-        'feature_key': 'remove',
-        'name': 'Remove Service Configuration',
-        'description': 'Remove a service configuration by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
-    },
-    {
-        'id': 'service.set_constants',
-        'group_id': 'service',
-        'feature_key': 'set_constants',
-        'name': 'Set Service Constants',
-        'description': 'Set or clear service-level constants.',
-        'params_schema': {
-            'constants': {'type': 'dict', 'required': False, 'default': {}},
-        },
-        'steps': [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
-    },
+# ** constant: feature_list_id
+FEATURE_LIST_ID = 'feature.list'
 
-    # * features: app session domain
-    {
-        'id': 'app.add',
-        'group_id': 'app',
-        'feature_key': 'add',
-        'name': 'Add App Session',
-        'description': 'Add a new application session configuration.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'module_path': 'str',
-            'class_name': 'str',
-            'description': {'type': 'str', 'required': False},
-            'logger_id': {'type': 'str', 'required': False, 'default': 'default'},
-            'flags': {'type': 'list', 'required': False, 'default': ['default']},
-            'services': {'type': 'list', 'required': False, 'default': []},
-            'constants': {'type': 'dict', 'required': False, 'default': {}},
-        },
-        'steps': [{'service_id': 'add_app_session_evt', 'name': 'Add app session'}],
-    },
-    {
-        'id': 'app.get',
-        'group_id': 'app',
-        'feature_key': 'get',
-        'name': 'Get App Session',
-        'description': 'Retrieve an app session by ID.',
-        'params_schema': {
-            'interface_id': 'str',
-        },
-        'steps': [{'service_id': 'get_app_session_evt', 'name': 'Get app session'}],
-    },
-    {
-        'id': 'app.list',
-        'group_id': 'app',
-        'feature_key': 'list',
-        'name': 'List App Sessions',
-        'description': 'List all configured app sessions.',
-        'steps': [{'service_id': 'list_app_sessions_evt', 'name': 'List app sessions'}],
-    },
-    {
-        'id': 'app.update',
-        'group_id': 'app',
-        'feature_key': 'update',
-        'name': 'Update App Session',
-        'description': 'Update a scalar attribute on an app session.',
-        'params_schema': {
-            'id': 'str',
-            'attribute': 'str',
-        },
-        'steps': [{'service_id': 'update_app_session_evt', 'name': 'Update app session'}],
-    },
-    {
-        'id': 'app.set_constants',
-        'group_id': 'app',
-        'feature_key': 'set_constants',
-        'name': 'Set App Constants',
-        'description': 'Set or clear constants on an app session.',
-        'params_schema': {
-            'id': 'str',
-            'constants': {'type': 'dict', 'required': False},
-        },
-        'steps': [{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
-    },
-    {
-        'id': 'app.set_service',
-        'group_id': 'app',
-        'feature_key': 'set_service',
-        'name': 'Set App Service Dependency',
-        'description': 'Set or update a service dependency on an app session.',
-        'params_schema': {
-            'id': 'str',
-            'service_id': 'str',
-            'module_path': 'str',
-            'class_name': 'str',
-            'parameters': {'type': 'dict', 'required': False},
-        },
-        'steps': [{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
-    },
-    {
-        'id': 'app.remove_service',
-        'group_id': 'app',
-        'feature_key': 'remove_service',
-        'name': 'Remove App Service Dependency',
-        'description': 'Remove a service dependency from an app session.',
-        'params_schema': {
-            'id': 'str',
-            'service_id': 'str',
-        },
-        'steps': [{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
-    },
-    {
-        'id': 'app.remove',
-        'group_id': 'app',
-        'feature_key': 'remove',
-        'name': 'Remove App Session',
-        'description': 'Remove an app session by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_app_session_evt', 'name': 'Remove app session'}],
-    },
+# ** constant: feature_remove_id
+FEATURE_REMOVE_ID = 'feature.remove'
 
-    # * features: cli domain
-    {
-        'id': 'cli.add_command',
-        'group_id': 'cli',
-        'feature_key': 'add_command',
-        'name': 'Add CLI Command',
-        'description': 'Add a new CLI command definition.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'key': 'str',
-            'group_key': 'str',
-            'description': {'type': 'str', 'required': False},
-            'arguments': {'type': 'list', 'required': False, 'default': []},
-        },
-        'steps': [{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
-    },
-    {
-        'id': 'cli.list_commands',
-        'group_id': 'cli',
-        'feature_key': 'list_commands',
-        'name': 'List CLI Commands',
-        'description': 'List all CLI command definitions.',
-        'steps': [{'service_id': 'list_commands_evt', 'name': 'List CLI commands'}],
-    },
-    {
-        'id': 'cli.add_argument',
-        'group_id': 'cli',
-        'feature_key': 'add_argument',
-        'name': 'Add CLI Argument',
-        'description': 'Add an argument to an existing CLI command.',
-        'params_schema': {
-            'command_id': 'str',
-            'description': {'type': 'str', 'required': False},
-        },
-        'steps': [{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
-    },
+# ** constant: feature_update_id
+FEATURE_UPDATE_ID = 'feature.update'
 
-    # * features: logging domain
-    {
-        'id': 'logging.add_formatter',
-        'group_id': 'logging',
-        'feature_key': 'add_formatter',
-        'name': 'Add Formatter',
-        'description': 'Add a new logging formatter configuration.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'format': 'str',
-            'description': {'type': 'str', 'required': False},
-            'datefmt': {'type': 'str', 'required': False},
-        },
-        'steps': [{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
-    },
-    {
-        'id': 'logging.remove_formatter',
-        'group_id': 'logging',
-        'feature_key': 'remove_formatter',
-        'name': 'Remove Formatter',
-        'description': 'Remove a logging formatter by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
-    },
-    {
-        'id': 'logging.add_handler',
-        'group_id': 'logging',
-        'feature_key': 'add_handler',
-        'name': 'Add Handler',
-        'description': 'Add a new logging handler configuration.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'module_path': 'str',
-            'class_name': 'str',
-            'level': 'str',
-            'formatter': 'str',
-            'description': {'type': 'str', 'required': False},
-            'stream': {'type': 'str', 'required': False},
-            'filename': {'type': 'str', 'required': False},
-        },
-        'steps': [{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
-    },
-    {
-        'id': 'logging.remove_handler',
-        'group_id': 'logging',
-        'feature_key': 'remove_handler',
-        'name': 'Remove Handler',
-        'description': 'Remove a logging handler by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
-    },
-    {
-        'id': 'logging.add_logger',
-        'group_id': 'logging',
-        'feature_key': 'add_logger',
-        'name': 'Add Logger',
-        'description': 'Add a new logger configuration.',
-        'params_schema': {
-            'id': 'str',
-            'name': 'str',
-            'level': 'str',
-            'description': {'type': 'str', 'required': False},
-            'propagate': {'type': 'bool', 'required': False, 'default': True},
-        },
-        'steps': [{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
-    },
-    {
-        'id': 'logging.remove_logger',
-        'group_id': 'logging',
-        'feature_key': 'remove_logger',
-        'name': 'Remove Logger',
-        'description': 'Remove a logger by ID.',
-        'params_schema': {
-            'id': 'str',
-        },
-        'steps': [{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
-    },
-    {
-        'id': 'logging.list',
-        'group_id': 'logging',
-        'feature_key': 'list',
-        'name': 'List Logging Configs',
-        'description': 'List all logging configurations (formatters, handlers, loggers).',
-        'steps': [{'service_id': 'logging_list_all_evt', 'name': 'List all logging configs'}],
-    },
-]
+# ** constant: feature_add_step_id
+FEATURE_ADD_STEP_ID = 'feature.add_step'
 
-# ** constant: admin_default_features
-# Id-keyed mapping mirroring YAML shape: the key is the feature id and the
-# value is the record minus id. The bootstrap builder in the orchestration
-# layer materializes each record into a typed Feature object.
-ADMIN_DEFAULT_FEATURES: Dict[str, Dict[str, Any]] = {
-    entry['id']: {key: value for key, value in entry.items() if key != 'id'}
-    for entry in _DEFAULT_TIFERET_CLI_FEATURE_LIST
+# ** constant: feature_update_step_id
+FEATURE_UPDATE_STEP_ID = 'feature.update_step'
+
+# ** constant: feature_remove_step_id
+FEATURE_REMOVE_STEP_ID = 'feature.remove_step'
+
+# ** constant: feature_reorder_step_id
+FEATURE_REORDER_STEP_ID = 'feature.reorder_step'
+
+# ** constant: error_add_id
+ERROR_ADD_ID = 'error.add'
+
+# ** constant: error_get_id
+ERROR_GET_ID = 'error.get'
+
+# ** constant: error_list_id
+ERROR_LIST_ID = 'error.list'
+
+# ** constant: error_rename_id
+ERROR_RENAME_ID = 'error.rename'
+
+# ** constant: error_set_message_id
+ERROR_SET_MESSAGE_ID = 'error.set_message'
+
+# ** constant: error_remove_message_id
+ERROR_REMOVE_MESSAGE_ID = 'error.remove_message'
+
+# ** constant: error_remove_id
+ERROR_REMOVE_ID = 'error.remove'
+
+# ** constant: service_add_id
+SERVICE_ADD_ID = 'service.add'
+
+# ** constant: service_list_id
+SERVICE_LIST_ID = 'service.list'
+
+# ** constant: service_set_default_id
+SERVICE_SET_DEFAULT_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_id
+SERVICE_SET_DEPENDENCY_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_id
+SERVICE_REMOVE_DEPENDENCY_ID = 'service.remove_dependency'
+
+# ** constant: service_remove_id
+SERVICE_REMOVE_ID = 'service.remove'
+
+# ** constant: service_set_constants_id
+SERVICE_SET_CONSTANTS_ID = 'service.set_constants'
+
+# ** constant: app_add_id
+APP_ADD_ID = 'app.add'
+
+# ** constant: app_get_id
+APP_GET_ID = 'app.get'
+
+# ** constant: app_list_id
+APP_LIST_ID = 'app.list'
+
+# ** constant: app_update_id
+APP_UPDATE_ID = 'app.update'
+
+# ** constant: app_set_constants_id
+APP_SET_CONSTANTS_ID = 'app.set_constants'
+
+# ** constant: app_set_service_id
+APP_SET_SERVICE_ID = 'app.set_service'
+
+# ** constant: app_remove_service_id
+APP_REMOVE_SERVICE_ID = 'app.remove_service'
+
+# ** constant: app_remove_id
+APP_REMOVE_ID = 'app.remove'
+
+# ** constant: cli_add_command_id
+CLI_ADD_COMMAND_ID = 'cli.add_command'
+
+# ** constant: cli_list_commands_id
+CLI_LIST_COMMANDS_ID = 'cli.list_commands'
+
+# ** constant: cli_add_argument_id
+CLI_ADD_ARGUMENT_ID = 'cli.add_argument'
+
+# ** constant: logging_add_formatter_id
+LOGGING_ADD_FORMATTER_ID = 'logging.add_formatter'
+
+# ** constant: logging_remove_formatter_id
+LOGGING_REMOVE_FORMATTER_ID = 'logging.remove_formatter'
+
+# ** constant: logging_add_handler_id
+LOGGING_ADD_HANDLER_ID = 'logging.add_handler'
+
+# ** constant: logging_remove_handler_id
+LOGGING_REMOVE_HANDLER_ID = 'logging.remove_handler'
+
+# ** constant: logging_add_logger_id
+LOGGING_ADD_LOGGER_ID = 'logging.add_logger'
+
+# ** constant: logging_remove_logger_id
+LOGGING_REMOVE_LOGGER_ID = 'logging.remove_logger'
+
+# ** constant: logging_list_id
+LOGGING_LIST_ID = 'logging.list'
+
+# *** constants (features)
+
+# ** constant: feature_add
+FEATURE_ADD = create_default_feature(
+    FEATURE_ADD_ID,
+    'Add Feature',
+    'feature',
+    'add',
+    [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
+    description='Add a new feature configuration.',
+    params_schema={
+        'name': 'str',
+        'group_id': 'str',
+        'feature_key': {'type': 'str', 'required': False},
+        'id': {'type': 'str', 'required': False},
+        'description': {'type': 'str', 'required': False},
+        'steps': {'type': 'list', 'required': False},
+        'log_params': {'type': 'dict', 'required': False},
+    },
+)
+
+# ** constant: feature_get
+FEATURE_GET = create_default_feature(
+    FEATURE_GET_ID,
+    'Get Feature',
+    'feature',
+    'get',
+    [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
+    description='Retrieve a feature by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: feature_list
+FEATURE_LIST = create_default_feature(
+    FEATURE_LIST_ID,
+    'List Features',
+    'feature',
+    'list',
+    [{'service_id': 'list_features_evt', 'name': 'List features'}],
+    description='List all features, optionally filtered by group.',
+    params_schema={'group_id': {'type': 'str', 'required': False}},
+)
+
+# ** constant: feature_remove
+FEATURE_REMOVE = create_default_feature(
+    FEATURE_REMOVE_ID,
+    'Remove Feature',
+    'feature',
+    'remove',
+    [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
+    description='Remove a feature configuration by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: feature_update
+FEATURE_UPDATE = create_default_feature(
+    FEATURE_UPDATE_ID,
+    'Update Feature',
+    'feature',
+    'update',
+    [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
+    description='Update a feature attribute (name or description).',
+    params_schema={'id': 'str', 'attribute': 'str'},
+)
+
+# ** constant: feature_add_step
+FEATURE_ADD_STEP = create_default_feature(
+    FEATURE_ADD_STEP_ID,
+    'Add Feature Step',
+    'feature',
+    'add_step',
+    [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
+    description='Add a step to an existing feature workflow.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'service_id': 'str',
+        'parameters': {'type': 'dict', 'required': False},
+        'data_key': {'type': 'str', 'required': False},
+        'pass_on_error': {'type': 'bool', 'required': False, 'default': False},
+        'position': {'type': 'int', 'required': False},
+    },
+)
+
+# ** constant: feature_update_step
+FEATURE_UPDATE_STEP = create_default_feature(
+    FEATURE_UPDATE_STEP_ID,
+    'Update Feature Step',
+    'feature',
+    'update_step',
+    [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
+    description='Update an attribute on a feature step.',
+    params_schema={'id': 'str', 'position': 'int', 'attribute': 'str'},
+)
+
+# ** constant: feature_remove_step
+FEATURE_REMOVE_STEP = create_default_feature(
+    FEATURE_REMOVE_STEP_ID,
+    'Remove Feature Step',
+    'feature',
+    'remove_step',
+    [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
+    description='Remove a step from a feature by position.',
+    params_schema={'id': 'str', 'position': 'int'},
+)
+
+# ** constant: feature_reorder_step
+FEATURE_REORDER_STEP = create_default_feature(
+    FEATURE_REORDER_STEP_ID,
+    'Reorder Feature Step',
+    'feature',
+    'reorder_step',
+    [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
+    description='Move a feature step from one position to another.',
+    params_schema={'id': 'str', 'start_position': 'int', 'end_position': 'int'},
+)
+
+# ** constant: error_add
+ERROR_ADD = create_default_feature(
+    ERROR_ADD_ID,
+    'Add Error',
+    'error',
+    'add',
+    [{'service_id': 'add_error_evt', 'name': 'Add error'}],
+    description='Add a new error definition.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'message': 'str',
+        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+        'additional_messages': {'type': 'list', 'required': False, 'default': []},
+    },
+)
+
+# ** constant: error_get
+ERROR_GET = create_default_feature(
+    ERROR_GET_ID,
+    'Get Error',
+    'error',
+    'get',
+    [{'service_id': 'get_error_evt', 'name': 'Get error'}],
+    description='Retrieve an error by ID.',
+    params_schema={
+        'id': 'str',
+        'include_defaults': {'type': 'bool', 'required': False, 'default': False},
+    },
+)
+
+# ** constant: error_list
+ERROR_LIST = create_default_feature(
+    ERROR_LIST_ID,
+    'List Errors',
+    'error',
+    'list',
+    [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
+    description='List all error definitions.',
+    params_schema={
+        'include_defaults': {'type': 'bool', 'required': False, 'default': False},
+    },
+)
+
+# ** constant: error_rename
+ERROR_RENAME = create_default_feature(
+    ERROR_RENAME_ID,
+    'Rename Error',
+    'error',
+    'rename',
+    [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
+    description='Rename an existing error.',
+    params_schema={'id': 'str', 'new_name': 'str'},
+)
+
+# ** constant: error_set_message
+ERROR_SET_MESSAGE = create_default_feature(
+    ERROR_SET_MESSAGE_ID,
+    'Set Error Message',
+    'error',
+    'set_message',
+    [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
+    description='Set or update an error message for a language.',
+    params_schema={
+        'id': 'str',
+        'message': 'str',
+        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+    },
+)
+
+# ** constant: error_remove_message
+ERROR_REMOVE_MESSAGE = create_default_feature(
+    ERROR_REMOVE_MESSAGE_ID,
+    'Remove Error Message',
+    'error',
+    'remove_message',
+    [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
+    description='Remove an error message by language.',
+    params_schema={
+        'id': 'str',
+        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
+    },
+)
+
+# ** constant: error_remove
+ERROR_REMOVE = create_default_feature(
+    ERROR_REMOVE_ID,
+    'Remove Error',
+    'error',
+    'remove',
+    [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
+    description='Remove an error definition by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: service_add
+SERVICE_ADD = create_default_feature(
+    SERVICE_ADD_ID,
+    'Add Service Configuration',
+    'service',
+    'add',
+    [{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
+    description='Add a new service configuration.',
+    params_schema={
+        'id': 'str',
+        'module_path': {'type': 'str', 'required': False},
+        'class_name': {'type': 'str', 'required': False},
+        'parameters': {'type': 'dict', 'required': False, 'default': {}},
+        'flagged_dependencies': {'type': 'list', 'required': False, 'default': []},
+    },
+)
+
+# ** constant: service_list
+SERVICE_LIST = create_default_feature(
+    SERVICE_LIST_ID,
+    'List All Settings',
+    'service',
+    'list',
+    [{'service_id': 'di_list_all_configs_evt', 'name': 'List all settings'}],
+    description='List all service configurations and constants.',
+)
+
+# ** constant: service_set_default
+SERVICE_SET_DEFAULT = create_default_feature(
+    SERVICE_SET_DEFAULT_ID,
+    'Set Default Service Configuration',
+    'service',
+    'set_default',
+    [{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
+    description='Set or update the default type for a service configuration.',
+    params_schema={
+        'id': 'str',
+        'module_path': {'type': 'str', 'required': False},
+        'class_name': {'type': 'str', 'required': False},
+        'parameters': {'type': 'dict', 'required': False},
+    },
+)
+
+# ** constant: service_set_dependency
+SERVICE_SET_DEPENDENCY = create_default_feature(
+    SERVICE_SET_DEPENDENCY_ID,
+    'Set Service Dependency',
+    'service',
+    'set_dependency',
+    [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
+    description='Set or update a flagged dependency on a service configuration.',
+    params_schema={
+        'id': 'str',
+        'flag': 'str',
+        'module_path': 'str',
+        'class_name': 'str',
+        'parameters': {'type': 'dict', 'required': False, 'default': {}},
+    },
+)
+
+# ** constant: service_remove_dependency
+SERVICE_REMOVE_DEPENDENCY = create_default_feature(
+    SERVICE_REMOVE_DEPENDENCY_ID,
+    'Remove Service Dependency',
+    'service',
+    'remove_dependency',
+    [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
+    description='Remove a flagged dependency from a service configuration.',
+    params_schema={'id': 'str', 'flag': 'str'},
+)
+
+# ** constant: service_remove
+SERVICE_REMOVE = create_default_feature(
+    SERVICE_REMOVE_ID,
+    'Remove Service Configuration',
+    'service',
+    'remove',
+    [{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
+    description='Remove a service configuration by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: service_set_constants
+SERVICE_SET_CONSTANTS = create_default_feature(
+    SERVICE_SET_CONSTANTS_ID,
+    'Set Service Constants',
+    'service',
+    'set_constants',
+    [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
+    description='Set or clear service-level constants.',
+    params_schema={'constants': {'type': 'dict', 'required': False, 'default': {}}},
+)
+
+# ** constant: app_add
+APP_ADD = create_default_feature(
+    APP_ADD_ID,
+    'Add App Session',
+    'app',
+    'add',
+    [{'service_id': 'add_app_session_evt', 'name': 'Add app session'}],
+    description='Add a new application session configuration.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'module_path': 'str',
+        'class_name': 'str',
+        'description': {'type': 'str', 'required': False},
+        'logger_id': {'type': 'str', 'required': False, 'default': 'default'},
+        'flags': {'type': 'list', 'required': False, 'default': ['default']},
+        'services': {'type': 'list', 'required': False, 'default': []},
+        'constants': {'type': 'dict', 'required': False, 'default': {}},
+    },
+)
+
+# ** constant: app_get
+APP_GET = create_default_feature(
+    APP_GET_ID,
+    'Get App Session',
+    'app',
+    'get',
+    [{'service_id': 'get_app_session_evt', 'name': 'Get app session'}],
+    description='Retrieve an app session by ID.',
+    params_schema={'interface_id': 'str'},
+)
+
+# ** constant: app_list
+APP_LIST = create_default_feature(
+    APP_LIST_ID,
+    'List App Sessions',
+    'app',
+    'list',
+    [{'service_id': 'list_app_sessions_evt', 'name': 'List app sessions'}],
+    description='List all configured app sessions.',
+)
+
+# ** constant: app_update
+APP_UPDATE = create_default_feature(
+    APP_UPDATE_ID,
+    'Update App Session',
+    'app',
+    'update',
+    [{'service_id': 'update_app_session_evt', 'name': 'Update app session'}],
+    description='Update a scalar attribute on an app session.',
+    params_schema={'id': 'str', 'attribute': 'str'},
+)
+
+# ** constant: app_set_constants
+APP_SET_CONSTANTS = create_default_feature(
+    APP_SET_CONSTANTS_ID,
+    'Set App Constants',
+    'app',
+    'set_constants',
+    [{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
+    description='Set or clear constants on an app session.',
+    params_schema={
+        'id': 'str',
+        'constants': {'type': 'dict', 'required': False},
+    },
+)
+
+# ** constant: app_set_service
+APP_SET_SERVICE = create_default_feature(
+    APP_SET_SERVICE_ID,
+    'Set App Service Dependency',
+    'app',
+    'set_service',
+    [{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
+    description='Set or update a service dependency on an app session.',
+    params_schema={
+        'id': 'str',
+        'service_id': 'str',
+        'module_path': 'str',
+        'class_name': 'str',
+        'parameters': {'type': 'dict', 'required': False},
+    },
+)
+
+# ** constant: app_remove_service
+APP_REMOVE_SERVICE = create_default_feature(
+    APP_REMOVE_SERVICE_ID,
+    'Remove App Service Dependency',
+    'app',
+    'remove_service',
+    [{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
+    description='Remove a service dependency from an app session.',
+    params_schema={'id': 'str', 'service_id': 'str'},
+)
+
+# ** constant: app_remove
+APP_REMOVE = create_default_feature(
+    APP_REMOVE_ID,
+    'Remove App Session',
+    'app',
+    'remove',
+    [{'service_id': 'remove_app_session_evt', 'name': 'Remove app session'}],
+    description='Remove an app session by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: cli_add_command
+CLI_ADD_COMMAND = create_default_feature(
+    CLI_ADD_COMMAND_ID,
+    'Add CLI Command',
+    'cli',
+    'add_command',
+    [{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
+    description='Add a new CLI command definition.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'key': 'str',
+        'group_key': 'str',
+        'description': {'type': 'str', 'required': False},
+        'arguments': {'type': 'list', 'required': False, 'default': []},
+    },
+)
+
+# ** constant: cli_list_commands
+CLI_LIST_COMMANDS = create_default_feature(
+    CLI_LIST_COMMANDS_ID,
+    'List CLI Commands',
+    'cli',
+    'list_commands',
+    [{'service_id': 'list_commands_evt', 'name': 'List CLI commands'}],
+    description='List all CLI command definitions.',
+)
+
+# ** constant: cli_add_argument
+CLI_ADD_ARGUMENT = create_default_feature(
+    CLI_ADD_ARGUMENT_ID,
+    'Add CLI Argument',
+    'cli',
+    'add_argument',
+    [{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
+    description='Add an argument to an existing CLI command.',
+    params_schema={
+        'command_id': 'str',
+        'description': {'type': 'str', 'required': False},
+    },
+)
+
+# ** constant: logging_add_formatter
+LOGGING_ADD_FORMATTER = create_default_feature(
+    LOGGING_ADD_FORMATTER_ID,
+    'Add Formatter',
+    'logging',
+    'add_formatter',
+    [{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
+    description='Add a new logging formatter configuration.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'format': 'str',
+        'description': {'type': 'str', 'required': False},
+        'datefmt': {'type': 'str', 'required': False},
+    },
+)
+
+# ** constant: logging_remove_formatter
+LOGGING_REMOVE_FORMATTER = create_default_feature(
+    LOGGING_REMOVE_FORMATTER_ID,
+    'Remove Formatter',
+    'logging',
+    'remove_formatter',
+    [{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
+    description='Remove a logging formatter by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: logging_add_handler
+LOGGING_ADD_HANDLER = create_default_feature(
+    LOGGING_ADD_HANDLER_ID,
+    'Add Handler',
+    'logging',
+    'add_handler',
+    [{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
+    description='Add a new logging handler configuration.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'module_path': 'str',
+        'class_name': 'str',
+        'level': 'str',
+        'formatter': 'str',
+        'description': {'type': 'str', 'required': False},
+        'stream': {'type': 'str', 'required': False},
+        'filename': {'type': 'str', 'required': False},
+    },
+)
+
+# ** constant: logging_remove_handler
+LOGGING_REMOVE_HANDLER = create_default_feature(
+    LOGGING_REMOVE_HANDLER_ID,
+    'Remove Handler',
+    'logging',
+    'remove_handler',
+    [{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
+    description='Remove a logging handler by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: logging_add_logger
+LOGGING_ADD_LOGGER = create_default_feature(
+    LOGGING_ADD_LOGGER_ID,
+    'Add Logger',
+    'logging',
+    'add_logger',
+    [{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
+    description='Add a new logger configuration.',
+    params_schema={
+        'id': 'str',
+        'name': 'str',
+        'level': 'str',
+        'description': {'type': 'str', 'required': False},
+        'propagate': {'type': 'bool', 'required': False, 'default': True},
+    },
+)
+
+# ** constant: logging_remove_logger
+LOGGING_REMOVE_LOGGER = create_default_feature(
+    LOGGING_REMOVE_LOGGER_ID,
+    'Remove Logger',
+    'logging',
+    'remove_logger',
+    [{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
+    description='Remove a logger by ID.',
+    params_schema={'id': 'str'},
+)
+
+# ** constant: logging_list
+LOGGING_LIST = create_default_feature(
+    LOGGING_LIST_ID,
+    'List Logging Configs',
+    'logging',
+    'list',
+    [{'service_id': 'logging_list_all_evt', 'name': 'List all logging configs'}],
+    description='List all logging configurations (formatters, handlers, loggers).',
+)
+
+# *** constants (groups)
+
+# ** constant: default_tiferet_cli_features
+DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
+    FEATURE_ADD_ID: FEATURE_ADD,
+    FEATURE_GET_ID: FEATURE_GET,
+    FEATURE_LIST_ID: FEATURE_LIST,
+    FEATURE_REMOVE_ID: FEATURE_REMOVE,
+    FEATURE_UPDATE_ID: FEATURE_UPDATE,
+    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
+    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
+    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
+    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
+    ERROR_ADD_ID: ERROR_ADD,
+    ERROR_GET_ID: ERROR_GET,
+    ERROR_LIST_ID: ERROR_LIST,
+    ERROR_RENAME_ID: ERROR_RENAME,
+    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
+    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
+    ERROR_REMOVE_ID: ERROR_REMOVE,
+    SERVICE_ADD_ID: SERVICE_ADD,
+    SERVICE_LIST_ID: SERVICE_LIST,
+    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
+    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
+    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
+    SERVICE_REMOVE_ID: SERVICE_REMOVE,
+    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
+    APP_ADD_ID: APP_ADD,
+    APP_GET_ID: APP_GET,
+    APP_LIST_ID: APP_LIST,
+    APP_UPDATE_ID: APP_UPDATE,
+    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS,
+    APP_SET_SERVICE_ID: APP_SET_SERVICE,
+    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE,
+    APP_REMOVE_ID: APP_REMOVE,
+    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND,
+    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS,
+    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT,
+    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER,
+    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER,
+    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER,
+    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER,
+    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER,
+    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER,
+    LOGGING_LIST_ID: LOGGING_LIST,
 }
 
+# ** constant: admin_default_features
+ADMIN_DEFAULT_FEATURES: Dict[str, Any] = DEFAULT_TIFERET_CLI_FEATURES

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -14,7 +14,7 @@ at startup — they are not loaded from the consumer's config file.
 from typing import Any, Dict
 
 # ** app
-from .core import create_default_feature
+from .core import create_default_feature, create_params_schema
 
 # *** constants (ids)
 
@@ -151,15 +151,15 @@ FEATURE_ADD = create_default_feature(
     'add',
     [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
     description='Add a new feature configuration.',
-    params_schema={
-        'name': 'str',
-        'group_id': 'str',
-        'feature_key': {'type': 'str', 'required': False},
-        'id': {'type': 'str', 'required': False},
-        'description': {'type': 'str', 'required': False},
-        'steps': {'type': 'list', 'required': False},
-        'log_params': {'type': 'dict', 'required': False},
-    },
+    params_schema=create_params_schema(
+        name='str',
+        group_id='str',
+        feature_key={'type': 'str', 'required': False},
+        id={'type': 'str', 'required': False},
+        description={'type': 'str', 'required': False},
+        steps={'type': 'list', 'required': False},
+        log_params={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: feature_get
@@ -170,7 +170,7 @@ FEATURE_GET = create_default_feature(
     'get',
     [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
     description='Retrieve a feature by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: feature_list
@@ -181,7 +181,7 @@ FEATURE_LIST = create_default_feature(
     'list',
     [{'service_id': 'list_features_evt', 'name': 'List features'}],
     description='List all features, optionally filtered by group.',
-    params_schema={'group_id': {'type': 'str', 'required': False}},
+    params_schema=create_params_schema(group_id={'type': 'str', 'required': False}),
 )
 
 # ** constant: feature_remove
@@ -192,7 +192,7 @@ FEATURE_REMOVE = create_default_feature(
     'remove',
     [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
     description='Remove a feature configuration by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: feature_update
@@ -203,7 +203,7 @@ FEATURE_UPDATE = create_default_feature(
     'update',
     [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
     description='Update a feature attribute (name or description).',
-    params_schema={'id': 'str', 'attribute': 'str'},
+    params_schema=create_params_schema(id='str', attribute='str'),
 )
 
 # ** constant: feature_add_step
@@ -214,15 +214,15 @@ FEATURE_ADD_STEP = create_default_feature(
     'add_step',
     [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
     description='Add a step to an existing feature workflow.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'service_id': 'str',
-        'parameters': {'type': 'dict', 'required': False},
-        'data_key': {'type': 'str', 'required': False},
-        'pass_on_error': {'type': 'bool', 'required': False, 'default': False},
-        'position': {'type': 'int', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        service_id='str',
+        parameters={'type': 'dict', 'required': False},
+        data_key={'type': 'str', 'required': False},
+        pass_on_error={'type': 'bool', 'required': False, 'default': False},
+        position={'type': 'int', 'required': False},
+    ),
 )
 
 # ** constant: feature_update_step
@@ -233,7 +233,7 @@ FEATURE_UPDATE_STEP = create_default_feature(
     'update_step',
     [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
     description='Update an attribute on a feature step.',
-    params_schema={'id': 'str', 'position': 'int', 'attribute': 'str'},
+    params_schema=create_params_schema(id='str', position='int', attribute='str'),
 )
 
 # ** constant: feature_remove_step
@@ -244,7 +244,7 @@ FEATURE_REMOVE_STEP = create_default_feature(
     'remove_step',
     [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
     description='Remove a step from a feature by position.',
-    params_schema={'id': 'str', 'position': 'int'},
+    params_schema=create_params_schema(id='str', position='int'),
 )
 
 # ** constant: feature_reorder_step
@@ -255,7 +255,7 @@ FEATURE_REORDER_STEP = create_default_feature(
     'reorder_step',
     [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
     description='Move a feature step from one position to another.',
-    params_schema={'id': 'str', 'start_position': 'int', 'end_position': 'int'},
+    params_schema=create_params_schema(id='str', start_position='int', end_position='int'),
 )
 
 # ** constant: error_add
@@ -266,13 +266,13 @@ ERROR_ADD = create_default_feature(
     'add',
     [{'service_id': 'add_error_evt', 'name': 'Add error'}],
     description='Add a new error definition.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'message': 'str',
-        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-        'additional_messages': {'type': 'list', 'required': False, 'default': []},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+        additional_messages={'type': 'list', 'required': False, 'default': []},
+    ),
 )
 
 # ** constant: error_get
@@ -283,10 +283,10 @@ ERROR_GET = create_default_feature(
     'get',
     [{'service_id': 'get_error_evt', 'name': 'Get error'}],
     description='Retrieve an error by ID.',
-    params_schema={
-        'id': 'str',
-        'include_defaults': {'type': 'bool', 'required': False, 'default': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        include_defaults={'type': 'bool', 'required': False, 'default': False},
+    ),
 )
 
 # ** constant: error_list
@@ -297,9 +297,9 @@ ERROR_LIST = create_default_feature(
     'list',
     [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
     description='List all error definitions.',
-    params_schema={
-        'include_defaults': {'type': 'bool', 'required': False, 'default': False},
-    },
+    params_schema=create_params_schema(
+        include_defaults={'type': 'bool', 'required': False, 'default': False},
+    ),
 )
 
 # ** constant: error_rename
@@ -310,7 +310,7 @@ ERROR_RENAME = create_default_feature(
     'rename',
     [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
     description='Rename an existing error.',
-    params_schema={'id': 'str', 'new_name': 'str'},
+    params_schema=create_params_schema(id='str', new_name='str'),
 )
 
 # ** constant: error_set_message
@@ -321,11 +321,11 @@ ERROR_SET_MESSAGE = create_default_feature(
     'set_message',
     [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
     description='Set or update an error message for a language.',
-    params_schema={
-        'id': 'str',
-        'message': 'str',
-        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
 )
 
 # ** constant: error_remove_message
@@ -336,10 +336,10 @@ ERROR_REMOVE_MESSAGE = create_default_feature(
     'remove_message',
     [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
     description='Remove an error message by language.',
-    params_schema={
-        'id': 'str',
-        'lang': {'type': 'str', 'required': False, 'default': 'en_US'},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
 )
 
 # ** constant: error_remove
@@ -350,7 +350,7 @@ ERROR_REMOVE = create_default_feature(
     'remove',
     [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
     description='Remove an error definition by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: service_add
@@ -361,13 +361,13 @@ SERVICE_ADD = create_default_feature(
     'add',
     [{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
     description='Add a new service configuration.',
-    params_schema={
-        'id': 'str',
-        'module_path': {'type': 'str', 'required': False},
-        'class_name': {'type': 'str', 'required': False},
-        'parameters': {'type': 'dict', 'required': False, 'default': {}},
-        'flagged_dependencies': {'type': 'list', 'required': False, 'default': []},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+        flagged_dependencies={'type': 'list', 'required': False, 'default': []},
+    ),
 )
 
 # ** constant: service_list
@@ -388,12 +388,12 @@ SERVICE_SET_DEFAULT = create_default_feature(
     'set_default',
     [{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
     description='Set or update the default type for a service configuration.',
-    params_schema={
-        'id': 'str',
-        'module_path': {'type': 'str', 'required': False},
-        'class_name': {'type': 'str', 'required': False},
-        'parameters': {'type': 'dict', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: service_set_dependency
@@ -404,13 +404,13 @@ SERVICE_SET_DEPENDENCY = create_default_feature(
     'set_dependency',
     [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
     description='Set or update a flagged dependency on a service configuration.',
-    params_schema={
-        'id': 'str',
-        'flag': 'str',
-        'module_path': 'str',
-        'class_name': 'str',
-        'parameters': {'type': 'dict', 'required': False, 'default': {}},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        flag='str',
+        module_path='str',
+        class_name='str',
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: service_remove_dependency
@@ -421,7 +421,7 @@ SERVICE_REMOVE_DEPENDENCY = create_default_feature(
     'remove_dependency',
     [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
     description='Remove a flagged dependency from a service configuration.',
-    params_schema={'id': 'str', 'flag': 'str'},
+    params_schema=create_params_schema(id='str', flag='str'),
 )
 
 # ** constant: service_remove
@@ -432,7 +432,7 @@ SERVICE_REMOVE = create_default_feature(
     'remove',
     [{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
     description='Remove a service configuration by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: service_set_constants
@@ -443,7 +443,7 @@ SERVICE_SET_CONSTANTS = create_default_feature(
     'set_constants',
     [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
     description='Set or clear service-level constants.',
-    params_schema={'constants': {'type': 'dict', 'required': False, 'default': {}}},
+    params_schema=create_params_schema(constants={'type': 'dict', 'required': False, 'default': {}}),
 )
 
 # ** constant: app_add
@@ -454,17 +454,17 @@ APP_ADD = create_default_feature(
     'add',
     [{'service_id': 'add_app_session_evt', 'name': 'Add app session'}],
     description='Add a new application session configuration.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'module_path': 'str',
-        'class_name': 'str',
-        'description': {'type': 'str', 'required': False},
-        'logger_id': {'type': 'str', 'required': False, 'default': 'default'},
-        'flags': {'type': 'list', 'required': False, 'default': ['default']},
-        'services': {'type': 'list', 'required': False, 'default': []},
-        'constants': {'type': 'dict', 'required': False, 'default': {}},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        module_path='str',
+        class_name='str',
+        description={'type': 'str', 'required': False},
+        logger_id={'type': 'str', 'required': False, 'default': 'default'},
+        flags={'type': 'list', 'required': False, 'default': ['default']},
+        services={'type': 'list', 'required': False, 'default': []},
+        constants={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: app_get
@@ -475,7 +475,7 @@ APP_GET = create_default_feature(
     'get',
     [{'service_id': 'get_app_session_evt', 'name': 'Get app session'}],
     description='Retrieve an app session by ID.',
-    params_schema={'interface_id': 'str'},
+    params_schema=create_params_schema(interface_id='str'),
 )
 
 # ** constant: app_list
@@ -496,7 +496,7 @@ APP_UPDATE = create_default_feature(
     'update',
     [{'service_id': 'update_app_session_evt', 'name': 'Update app session'}],
     description='Update a scalar attribute on an app session.',
-    params_schema={'id': 'str', 'attribute': 'str'},
+    params_schema=create_params_schema(id='str', attribute='str'),
 )
 
 # ** constant: app_set_constants
@@ -507,10 +507,10 @@ APP_SET_CONSTANTS = create_default_feature(
     'set_constants',
     [{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
     description='Set or clear constants on an app session.',
-    params_schema={
-        'id': 'str',
-        'constants': {'type': 'dict', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        constants={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: app_set_service
@@ -521,13 +521,13 @@ APP_SET_SERVICE = create_default_feature(
     'set_service',
     [{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
     description='Set or update a service dependency on an app session.',
-    params_schema={
-        'id': 'str',
-        'service_id': 'str',
-        'module_path': 'str',
-        'class_name': 'str',
-        'parameters': {'type': 'dict', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        service_id='str',
+        module_path='str',
+        class_name='str',
+        parameters={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: app_remove_service
@@ -538,7 +538,7 @@ APP_REMOVE_SERVICE = create_default_feature(
     'remove_service',
     [{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
     description='Remove a service dependency from an app session.',
-    params_schema={'id': 'str', 'service_id': 'str'},
+    params_schema=create_params_schema(id='str', service_id='str'),
 )
 
 # ** constant: app_remove
@@ -549,7 +549,7 @@ APP_REMOVE = create_default_feature(
     'remove',
     [{'service_id': 'remove_app_session_evt', 'name': 'Remove app session'}],
     description='Remove an app session by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: cli_add_command
@@ -560,14 +560,14 @@ CLI_ADD_COMMAND = create_default_feature(
     'add_command',
     [{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
     description='Add a new CLI command definition.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'key': 'str',
-        'group_key': 'str',
-        'description': {'type': 'str', 'required': False},
-        'arguments': {'type': 'list', 'required': False, 'default': []},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        key='str',
+        group_key='str',
+        description={'type': 'str', 'required': False},
+        arguments={'type': 'list', 'required': False, 'default': []},
+    ),
 )
 
 # ** constant: cli_list_commands
@@ -588,10 +588,10 @@ CLI_ADD_ARGUMENT = create_default_feature(
     'add_argument',
     [{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
     description='Add an argument to an existing CLI command.',
-    params_schema={
-        'command_id': 'str',
-        'description': {'type': 'str', 'required': False},
-    },
+    params_schema=create_params_schema(
+        command_id='str',
+        description={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: logging_add_formatter
@@ -602,13 +602,13 @@ LOGGING_ADD_FORMATTER = create_default_feature(
     'add_formatter',
     [{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
     description='Add a new logging formatter configuration.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'format': 'str',
-        'description': {'type': 'str', 'required': False},
-        'datefmt': {'type': 'str', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        format='str',
+        description={'type': 'str', 'required': False},
+        datefmt={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: logging_remove_formatter
@@ -619,7 +619,7 @@ LOGGING_REMOVE_FORMATTER = create_default_feature(
     'remove_formatter',
     [{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
     description='Remove a logging formatter by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: logging_add_handler
@@ -630,17 +630,17 @@ LOGGING_ADD_HANDLER = create_default_feature(
     'add_handler',
     [{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
     description='Add a new logging handler configuration.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'module_path': 'str',
-        'class_name': 'str',
-        'level': 'str',
-        'formatter': 'str',
-        'description': {'type': 'str', 'required': False},
-        'stream': {'type': 'str', 'required': False},
-        'filename': {'type': 'str', 'required': False},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        module_path='str',
+        class_name='str',
+        level='str',
+        formatter='str',
+        description={'type': 'str', 'required': False},
+        stream={'type': 'str', 'required': False},
+        filename={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: logging_remove_handler
@@ -651,7 +651,7 @@ LOGGING_REMOVE_HANDLER = create_default_feature(
     'remove_handler',
     [{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
     description='Remove a logging handler by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: logging_add_logger
@@ -662,13 +662,13 @@ LOGGING_ADD_LOGGER = create_default_feature(
     'add_logger',
     [{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
     description='Add a new logger configuration.',
-    params_schema={
-        'id': 'str',
-        'name': 'str',
-        'level': 'str',
-        'description': {'type': 'str', 'required': False},
-        'propagate': {'type': 'bool', 'required': False, 'default': True},
-    },
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        level='str',
+        description={'type': 'str', 'required': False},
+        propagate={'type': 'bool', 'required': False, 'default': True},
+    ),
 )
 
 # ** constant: logging_remove_logger
@@ -679,7 +679,7 @@ LOGGING_REMOVE_LOGGER = create_default_feature(
     'remove_logger',
     [{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
     description='Remove a logger by ID.',
-    params_schema={'id': 'str'},
+    params_schema=create_params_schema(id='str'),
 )
 
 # ** constant: logging_list

--- a/tiferet/assets/logging.py
+++ b/tiferet/assets/logging.py
@@ -1,84 +1,135 @@
-# *** constants
+"""Tiferet Logging Assets
 
-# ** constant: default_formatters
-DEFAULT_FORMATTERS = [
-    {
-        'id': 'default',
-        'name': 'Default Formatter',
-        'description': 'The default logging formatter.',
-        'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        'datefmt': '%Y-%m-%d %H:%M:%S'
-    }
-]
+Provides the default logging configuration definitions for the built-in
+Tiferet application. Each formatter, handler, and logger is declared as an
+individually named constant built via the corresponding factory function from
+``assets/core.py``.
 
-# ** constant: default_handlers
-DEFAULT_HANDLERS = [
-    {
-        'id': 'default_root',
-        'name': 'Default Root Handler',
-        'description': 'The default root logging handler.',
-        'module_path': 'logging',
-        'class_name': 'StreamHandler',
-        'level': 'WARNING',
-        'formatter': 'default',
-        'stream': 'ext://sys.stderr'
-    },
-    {
-        'id': 'default',
-        'name': 'Default Handler',
-        'description': 'The default logging handler.',
-        'module_path': 'logging',
-        'class_name': 'StreamHandler',
-        'level': 'INFO',
-        'formatter': 'default',
-        'stream': 'ext://sys.stdout'
-    },
-    {
-        'id': 'debug',
-        'name': 'Debug Handler',
-        'description': 'A handler for debugging purposes.',
-        'module_path': 'logging',
-        'class_name': 'StreamHandler',
-        'level': 'DEBUG',
-        'formatter': 'default',
-        'stream': 'ext://sys.stdout'
-    }
-]
+The bootstrap layer validates and seeds these definitions into the cache via
+``add_default_logging_settings`` — they are not loaded from the consumer's
+config file.
+"""
 
-# ** constant: default_loggers
-DEFAULT_LOGGERS = [
-    {
-        'id': 'root',
-        'name': 'Default Root Logger',
-        'description': 'The default logging configuration.',
-        'level': 'WARNING',
-        'handlers': ['default_root'],
-        'propagate': False,
-        'is_root': True
-    },
-    {
-        'id': 'default',
-        'name': 'Default Logger',
-        'description': 'The default logging configuration.',
-        'level': 'INFO',
-        'handlers': ['default'],
-        'propagate': True,
-        'is_root': False
-    },
-    {
-        'id': 'debug',
-        'name': 'Debug Logger',
-        'description': 'A logger for debugging purposes.',
-        'level': 'DEBUG',
-        'handlers': ['debug'],
-        'propagate': True,
-        'is_root': False
-    }
-]
+# *** imports
+
+# ** core
+from typing import Any, Dict
+
+# ** app
+from .core import create_default_formatter, create_default_handler, create_default_logger
+
+# *** constants (ids)
+
+# ** constant: default_formatter_id
+DEFAULT_FORMATTER_ID = 'default'
+
+# ** constant: default_root_handler_id
+DEFAULT_ROOT_HANDLER_ID = 'default_root'
+
+# ** constant: default_handler_id
+DEFAULT_HANDLER_ID = 'default'
+
+# ** constant: debug_handler_id
+DEBUG_HANDLER_ID = 'debug'
+
+# ** constant: root_logger_id
+ROOT_LOGGER_ID = 'root'
+
+# ** constant: default_logger_id
+DEFAULT_LOGGER_ID = 'default'
+
+# ** constant: debug_logger_id
+DEBUG_LOGGER_ID = 'debug'
+
+# *** constants (formatters)
+
+# ** constant: default_formatter
+DEFAULT_FORMATTER = create_default_formatter(
+    DEFAULT_FORMATTER_ID,
+    'Default Formatter',
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    description='The default logging formatter.',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+
+# *** constants (handlers)
+
+# ** constant: default_root_handler
+DEFAULT_ROOT_HANDLER = create_default_handler(
+    DEFAULT_ROOT_HANDLER_ID,
+    'Default Root Handler',
+    'logging',
+    'StreamHandler',
+    'WARNING',
+    DEFAULT_FORMATTER_ID,
+    description='The default root logging handler.',
+    stream='ext://sys.stderr',
+)
+
+# ** constant: default_handler
+DEFAULT_HANDLER = create_default_handler(
+    DEFAULT_HANDLER_ID,
+    'Default Handler',
+    'logging',
+    'StreamHandler',
+    'INFO',
+    DEFAULT_FORMATTER_ID,
+    description='The default logging handler.',
+    stream='ext://sys.stdout',
+)
+
+# ** constant: debug_handler
+DEBUG_HANDLER = create_default_handler(
+    DEBUG_HANDLER_ID,
+    'Debug Handler',
+    'logging',
+    'StreamHandler',
+    'DEBUG',
+    DEFAULT_FORMATTER_ID,
+    description='A handler for debugging purposes.',
+    stream='ext://sys.stdout',
+)
+
+# *** constants (loggers)
+
+# ** constant: root_logger
+ROOT_LOGGER = create_default_logger(
+    ROOT_LOGGER_ID,
+    'Default Root Logger',
+    'WARNING',
+    [DEFAULT_ROOT_HANDLER_ID],
+    propagate=False,
+    is_root=True,
+    description='The default logging configuration.',
+)
+
+# ** constant: default_logger
+DEFAULT_LOGGER = create_default_logger(
+    DEFAULT_LOGGER_ID,
+    'Default Logger',
+    'INFO',
+    [DEFAULT_HANDLER_ID],
+    propagate=True,
+    is_root=False,
+    description='The default logging configuration.',
+)
+
+# ** constant: debug_logger
+DEBUG_LOGGER = create_default_logger(
+    DEBUG_LOGGER_ID,
+    'Debug Logger',
+    'DEBUG',
+    [DEBUG_HANDLER_ID],
+    propagate=True,
+    is_root=False,
+    description='A logger for debugging purposes.',
+)
+
+# *** constants (groups)
 
 # ** constant: core_default_logging_settings
-CORE_DEFAULT_LOGGING_SETTINGS = {
-    'formatters': DEFAULT_FORMATTERS,
-    'handlers':   DEFAULT_HANDLERS,
-    'loggers':    DEFAULT_LOGGERS,
+CORE_DEFAULT_LOGGING_SETTINGS: Dict[str, Any] = {
+    'formatters': [DEFAULT_FORMATTER],
+    'handlers':   [DEFAULT_ROOT_HANDLER, DEFAULT_HANDLER, DEBUG_HANDLER],
+    'loggers':    [ROOT_LOGGER, DEFAULT_LOGGER, DEBUG_LOGGER],
 }

--- a/tiferet/blueprints/admin.py
+++ b/tiferet/blueprints/admin.py
@@ -186,7 +186,7 @@ def build_admin_app_session_context(
 
 # ** blueprint: build_admin_app
 def build_admin_app(
-    interface_id: str = 'tiferet_app',
+    interface_id: str = a.app.TIFERET_ADMIN_ID,
     **parameters: Any,
 ) -> AppSessionContext:
     '''
@@ -199,7 +199,7 @@ def build_admin_app(
     falls back to :data:`~tiferet.assets.app.DEFAULT_ADMIN_APP_SESSION` so the
     built-in admin interface is always available without a config entry.
 
-    :param interface_id: The session ID to load; defaults to ``'tiferet_app'``.
+    :param interface_id: The session ID to load; defaults to ``'admin'``.
     :type interface_id: str
     :param parameters: Additional parameters forwarded to the app service
         constructor (e.g. ``app_config='config.yml'``).

--- a/tiferet/blueprints/admin_cli.py
+++ b/tiferet/blueprints/admin_cli.py
@@ -232,7 +232,7 @@ def build_admin_cli(
 
     Parallel to the consumer-facing :func:`cli.build_app` but targeted at the
     built-in admin interface: uses the admin cache (full admin catalog plus CLI
-    commands), resolves the ``tiferet_cli`` session with a built-in fallback,
+    commands), resolves the ``admin_cli`` session with a built-in fallback,
     re-seeds the session constants so all config-file repos point to the
     consumer's ``app_config`` file, builds the admin CLI session context via
     :func:`build_admin_cli_session_context`, and delegates parsing, dispatch,
@@ -254,7 +254,7 @@ def build_admin_cli(
     cache = build_cache()
 
     # Resolve the session; built-in sessions are cache-seeded so no fallback needed.
-    app_session = core.get_app_session('tiferet_cli', cache, app_config=app_config)
+    app_session = core.get_app_session(a.app.TIFERET_ADMIN_CLI_ID, cache, app_config=app_config)
 
     # Re-seed the session constants so all config-file repos point to the
     # consumer's app_config file rather than the seeded 'config.yml' placeholders.


### PR DESCRIPTION
## Summary

Applies the `error.py` three-section pattern (`(ids)` → individually named objects via factory → `(groups)`) to `feature.py`, `di.py`, and the app session section of `app.py`. Adds four new factory functions to `core.py` and 10 tests.

## Changes

### `core.py`
- Add `create_service_dependency` — base factory producing `{module_path, class_name, parameters}`
- Refactor `create_app_service_dependency` to use `**create_service_dependency(...)` internally
- Add `create_service_registration` — produces `{id, **create_service_dependency(...)}` for `di.py`
- Add `create_default_feature` — produces feature workflow dict for `feature.py`
- Add `create_default_app_session` — produces app session dict for `app.py`

### `di.py`
- Replace `List[Tuple]` format with three-section pattern
- 37 ID constants + 37 named service registration objects via `create_service_registration()`
- `DEFAULT_TIFERET_CLI_SERVICES` as `Dict[str, Dict]` group (was `List[Tuple]`)

### `feature.py`
- Replace private list + comprehension with three-section pattern
- 41 ID constants + 41 named feature objects via `create_default_feature()`
- `DEFAULT_TIFERET_CLI_FEATURES` dict group + `ADMIN_DEFAULT_FEATURES` alias

### `app.py`
- Add `TIFERET_ADMIN_ID = 'admin'` and `TIFERET_ADMIN_CLI_ID = 'admin_cli'` to ids section
- Replace raw session dicts with `create_default_app_session()` calls
- Update `CORE_DEFAULT_APP_SESSIONS` to key by the new ID constants
- Update `ADMIN_DEFAULT_SERVICES` to merge over new `di.py` dict format
- Remove `_CLI_SERVICES_LIST` import

### `blueprints/admin.py` / `blueprints/admin_cli.py`
- Update `build_admin_app` default `interface_id` to `a.app.TIFERET_ADMIN_ID` (`'admin'`)
- Update `build_admin_cli` to use `a.app.TIFERET_ADMIN_CLI_ID` (`'admin_cli'`)

### `tests/assets/test_core.py` _(new)_
- 10 tests covering all five factory functions

## Test Results

999 passed, 11 skipped (full suite) + 10 new tests for factory functions.

---

**Plan:** https://app.warp.dev/drive/notebook/baaB3bV1UafXr4uSJsDazY
**Conversation:** https://app.warp.dev/conversation/f57d9618-3c5e-46e6-85f7-ee2f751326f3

Co-Authored-By: Oz <oz-agent@warp.dev>