### PR TITLE
Super-TRD #935: Assets — Core Foundation and Bootstrap Catalog Standardization

### DIFF
--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -1,0 +1,87 @@
+"""Tests for Core Assets"""
+
+# *** imports
+
+# ** app
+from tiferet.assets.core import (
+    create_service_module_path,
+    create_service_dependency,
+    TIFERET,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    FEATURE_DOMAIN_PATH,
+)
+
+# *** tests
+
+# ** test: create_service_module_path_returns_dotted_path
+def test_create_service_module_path_returns_dotted_path():
+    '''
+    Verify create_service_module_path joins three segments with dots for the events sub-package.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the module path using the events sub-package and feature domain.
+    result = create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH)
+
+    # Verify the result equals the expected dotted path.
+    assert result == 'tiferet.events.feature'
+
+
+# ** test: create_service_module_path_repos_path
+def test_create_service_module_path_repos_path():
+    '''
+    Verify create_service_module_path joins three segments with dots for the repos sub-package.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build the module path using the repos sub-package and feature domain.
+    result = create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH)
+
+    # Verify the result equals the expected dotted path.
+    assert result == 'tiferet.repos.feature'
+
+
+# ** test: create_service_dependency_returns_expected_shape
+def test_create_service_dependency_returns_expected_shape():
+    '''
+    Verify create_service_dependency returns a dict with the expected keys and values,
+    and that parameters defaults to an empty dict when omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a service dependency without explicit parameters.
+    result = create_service_dependency('tiferet.repos.feature', 'FeatureConfigRepository')
+
+    # Verify the result has all expected keys and correct values.
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
+    assert result['module_path'] == 'tiferet.repos.feature'
+    assert result['class_name'] == 'FeatureConfigRepository'
+    assert result['parameters'] == {}
+
+
+# ** test: create_service_dependency_with_parameters
+def test_create_service_dependency_with_parameters():
+    '''
+    Verify create_service_dependency preserves an explicitly provided parameters dict as-is.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a service dependency with an explicit parameters dict.
+    params = {'feature_config': 'config.yml'}
+    result = create_service_dependency(
+        'tiferet.repos.feature',
+        'FeatureConfigRepository',
+        parameters=params,
+    )
+
+    # Verify the parameters dict is preserved unchanged.
+    assert result['parameters'] == {'feature_config': 'config.yml'}

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -8,6 +8,9 @@ from tiferet.assets.core import (
     create_service_dependency,
     create_app_service_dependency,
     create_default_app_session,
+    create_default_formatter,
+    create_default_handler,
+    create_default_logger,
     TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
@@ -172,3 +175,151 @@ def test_create_default_app_session_includes_description_when_provided():
 
     # Verify the description is present and correct.
     assert result['description'] == 'Default built-in admin application session'
+
+
+# ** test: create_default_formatter_returns_required_fields
+def test_create_default_formatter_returns_required_fields():
+    '''
+    Verify create_default_formatter returns a dict with id, name, and format;
+    description and datefmt are absent when not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a formatter with required fields only.
+    result = create_default_formatter('default', 'Default Formatter', '%(message)s')
+
+    # Verify required fields are present and optional fields are absent.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Formatter'
+    assert result['format'] == '%(message)s'
+    assert 'description' not in result
+    assert 'datefmt' not in result
+
+
+# ** test: create_default_formatter_includes_optional_fields_when_provided
+def test_create_default_formatter_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_formatter includes description and datefmt when supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a formatter with all optional fields.
+    result = create_default_formatter(
+        'default',
+        'Default Formatter',
+        '%(message)s',
+        description='A test formatter.',
+        datefmt='%Y-%m-%d',
+    )
+
+    # Verify optional fields are present and correct.
+    assert result['description'] == 'A test formatter.'
+    assert result['datefmt'] == '%Y-%m-%d'
+
+
+# ** test: create_default_handler_returns_required_fields
+def test_create_default_handler_returns_required_fields():
+    '''
+    Verify create_default_handler returns a dict with the six required fields;
+    description, stream, and filename are absent when not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a handler with required fields only.
+    result = create_default_handler(
+        'default', 'Default Handler', 'logging', 'StreamHandler', 'INFO', 'default'
+    )
+
+    # Verify required fields are present and optional fields are absent.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Handler'
+    assert result['module_path'] == 'logging'
+    assert result['class_name'] == 'StreamHandler'
+    assert result['level'] == 'INFO'
+    assert result['formatter'] == 'default'
+    assert 'description' not in result
+    assert 'stream' not in result
+    assert 'filename' not in result
+
+
+# ** test: create_default_handler_includes_optional_fields_when_provided
+def test_create_default_handler_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_handler includes description, stream, and filename when supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a handler with all optional fields.
+    result = create_default_handler(
+        'default',
+        'Default Handler',
+        'logging',
+        'StreamHandler',
+        'INFO',
+        'default',
+        description='A test handler.',
+        stream='ext://sys.stdout',
+        filename='app.log',
+    )
+
+    # Verify optional fields are present and correct.
+    assert result['description'] == 'A test handler.'
+    assert result['stream'] == 'ext://sys.stdout'
+    assert result['filename'] == 'app.log'
+
+
+# ** test: create_default_logger_returns_required_fields
+def test_create_default_logger_returns_required_fields():
+    '''
+    Verify create_default_logger returns a dict with all required fields; propagate and
+    is_root default to False; description is absent when not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a logger with required fields only.
+    result = create_default_logger('default', 'Default Logger', 'INFO', ['default'])
+
+    # Verify required fields are present with correct defaults.
+    assert result['id'] == 'default'
+    assert result['name'] == 'Default Logger'
+    assert result['level'] == 'INFO'
+    assert result['handlers'] == ['default']
+    assert result['propagate'] is False
+    assert result['is_root'] is False
+    assert 'description' not in result
+
+
+# ** test: create_default_logger_includes_optional_fields_when_provided
+def test_create_default_logger_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_logger preserves explicit propagate, is_root, and description values.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a logger with all optional fields supplied.
+    result = create_default_logger(
+        'root',
+        'Root Logger',
+        'WARNING',
+        ['default_root'],
+        propagate=False,
+        is_root=True,
+        description='The root logger.',
+    )
+
+    # Verify explicit values are preserved.
+    assert result['propagate'] is False
+    assert result['is_root'] is True
+    assert result['description'] == 'The root logger.'

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -6,6 +6,8 @@
 from tiferet.assets.core import (
     create_service_module_path,
     create_service_dependency,
+    create_app_service_dependency,
+    create_default_app_session,
     TIFERET,
     TIFERET_EVENTS_PATH,
     TIFERET_REPOS_PATH,
@@ -85,3 +87,88 @@ def test_create_service_dependency_with_parameters():
 
     # Verify the parameters dict is preserved unchanged.
     assert result['parameters'] == {'feature_config': 'config.yml'}
+
+
+# ** test: create_app_service_dependency_returns_expected_shape
+def test_create_app_service_dependency_returns_expected_shape():
+    '''
+    Verify create_app_service_dependency returns a dict with the expected keys and values,
+    and that parameters defaults to an empty dict when omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a service dependency without explicit parameters.
+    result = create_app_service_dependency(
+        'test_service',
+        'tiferet.repos.test',
+        'TestRepository',
+    )
+
+    # Verify the result has all expected keys and correct values.
+    assert set(result.keys()) == {'service_id', 'module_path', 'class_name', 'parameters'}
+    assert result['service_id'] == 'test_service'
+    assert result['module_path'] == 'tiferet.repos.test'
+    assert result['class_name'] == 'TestRepository'
+    assert result['parameters'] == {}
+
+
+# ** test: create_app_service_dependency_omitting_parameters_yields_empty_dict
+def test_create_app_service_dependency_omitting_parameters_yields_empty_dict():
+    '''
+    Verify omitting parameters in create_app_service_dependency yields an empty dict, not None.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a dependency without explicit parameters.
+    result = create_app_service_dependency(
+        'test_service',
+        'tiferet.repos.test',
+        'TestRepository',
+    )
+
+    # Verify parameters is an empty dict, not None.
+    assert result['parameters'] == {}
+    assert result['parameters'] is not None
+
+
+# ** test: create_default_app_session_returns_required_fields
+def test_create_default_app_session_returns_required_fields():
+    '''
+    Verify create_default_app_session returns a dict with id and name; description is
+    absent when not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a session with required fields only.
+    result = create_default_app_session('admin', 'Admin App')
+
+    # Verify id and name are present and description is absent.
+    assert result['id'] == 'admin'
+    assert result['name'] == 'Admin App'
+    assert 'description' not in result
+
+
+# ** test: create_default_app_session_includes_description_when_provided
+def test_create_default_app_session_includes_description_when_provided():
+    '''
+    Verify create_default_app_session includes description in the returned dict when supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a session with an explicit description.
+    result = create_default_app_session(
+        'admin',
+        'Admin App',
+        'Default built-in admin application session',
+    )
+
+    # Verify the description is present and correct.
+    assert result['description'] == 'Default built-in admin application session'

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -122,14 +122,14 @@ DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
 DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
     TIFERET_ADMIN_ID,
     'Admin App',
-    'Default built-in admin application session',
+    description='Default built-in admin application session',
 )
 
 # ** constant: default_admin_cli_session
 DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
     TIFERET_ADMIN_CLI_ID,
     'Admin CLI',
-    'Built-in CLI for managing Tiferet application configurations',
+    description='Built-in CLI for managing Tiferet application configurations',
 )
 
 # *** constants (services)

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -1,8 +1,8 @@
 """Tiferet App Assets
 
-App service ID constants, default app service data, and the CORE_DEFAULT_SERVICES /
-CORE_DEFAULT_CONSTANTS bootstrap catalogs consumed by the blueprint layer during
-cache seeding for application bootstrapping.
+App service ID constants, module path constants, default app service and session
+definitions, service model constants (built via create_service_module_path), and
+the bootstrap catalog dicts consumed by the blueprint layer during cache seeding.
 """
 
 # *** imports
@@ -11,7 +11,22 @@ cache seeding for application bootstrapping.
 from typing import Any, Dict
 
 # ** app
-from .core import create_app_service_dependency
+from .core import (
+    create_app_service_dependency,
+    create_default_app_session,
+    create_service_module_path,
+    TIFERET,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    TIFERET_UTILS_PATH,
+    FEATURE_DOMAIN_PATH,
+    ERROR_DOMAIN_PATH,
+    DI_DOMAIN_PATH,
+    APP_DOMAIN_PATH,
+    LOGGING_DOMAIN_PATH,
+    CLI_DOMAIN_PATH,
+    MIDDLEWARE_DOMAIN_PATH,
+)
 
 # *** constants (ids)
 
@@ -63,96 +78,161 @@ LOGGING_CONFIG_ID = 'logging_config'
 # ** constant: feature_config_id
 FEATURE_CONFIG_ID = 'feature_config'
 
-# *** constants (models)
+# ** constant: logging_middleware_id
+LOGGING_MIDDLEWARE_ID = 'logging_middleware'
+
+# ** constant: timing_middleware_id
+TIMING_MIDDLEWARE_ID = 'timing_middleware'
+
+# ** constant: cache_middleware_id
+CACHE_MIDDLEWARE_ID = 'cache_middleware'
+
+# ** constant: tiferet_admin_id
+TIFERET_ADMIN_ID = 'admin'
+
+# ** constant: tiferet_admin_cli_id
+TIFERET_ADMIN_CLI_ID = 'admin_cli'
+
+# *** constants (paths)
 
 # ** constant: default_config_file
 DEFAULT_CONFIG_FILE = 'config.yml'
 
+# ** constant: default_app_config_file
+DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
+
+# *** constants (app_service)
+
 # ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH = 'tiferet.repos.app'
+DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(
+    TIFERET,
+    TIFERET_REPOS_PATH,
+    APP_DOMAIN_PATH,
+)
 
 # ** constant: default_app_service_class_name
 DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
 
 # ** constant: default_app_service_parameters
-DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_CONFIG_FILE}
+DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+
+# *** constants (sessions)
+
+# ** constant: default_admin_app_session
+DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
+    TIFERET_ADMIN_ID,
+    'Admin App',
+    'Default built-in admin application session',
+)
+
+# ** constant: default_admin_cli_session
+DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
+    TIFERET_ADMIN_CLI_ID,
+    'Admin CLI',
+    'Built-in CLI for managing Tiferet application configurations',
+)
+
+# *** constants (services)
 
 # ** constant: di_service
 DI_SERVICE = create_app_service_dependency(
     DI_SERVICE_ID,
-    'tiferet.repos.di',
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
     'DIConfigRepository',
 )
 
 # ** constant: error_service
 ERROR_SERVICE = create_app_service_dependency(
     ERROR_SERVICE_ID,
-    'tiferet.repos.error',
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
     'ErrorConfigRepository',
 )
 
 # ** constant: logging_service
 LOGGING_SERVICE = create_app_service_dependency(
     LOGGING_SERVICE_ID,
-    'tiferet.repos.logging',
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
     'LoggingConfigRepository',
 )
 
 # ** constant: feature_service
 FEATURE_SERVICE = create_app_service_dependency(
     FEATURE_SERVICE_ID,
-    'tiferet.repos.feature',
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
     'FeatureConfigRepository',
 )
 
 # ** constant: get_error_evt
 GET_ERROR_EVT = create_app_service_dependency(
     GET_ERROR_EVT_ID,
-    'tiferet.events.error',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'GetError',
 )
 
 # ** constant: get_feature_evt
 GET_FEATURE_EVT = create_app_service_dependency(
     GET_FEATURE_EVT_ID,
-    'tiferet.events.feature',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'GetFeature',
 )
 
 # ** constant: logging_list_all_evt
 LOGGING_LIST_ALL_EVT = create_app_service_dependency(
     LOGGING_LIST_ALL_EVT_ID,
-    'tiferet.events.logging',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'ListAllLoggingConfigs',
 )
 
 # ** constant: cli_service
 CLI_SERVICE = create_app_service_dependency(
     CLI_SERVICE_ID,
-    'tiferet.repos.cli',
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
     'CliConfigRepository',
 )
 
 # ** constant: list_commands_evt
 LIST_COMMANDS_EVT = create_app_service_dependency(
     LIST_COMMANDS_EVT_ID,
-    'tiferet.events.cli',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'ListCliCommands',
 )
 
 # ** constant: get_parent_args_evt
 GET_PARENT_ARGS_EVT = create_app_service_dependency(
     GET_PARENT_ARGS_EVT_ID,
-    'tiferet.events.cli',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'GetParentArguments',
 )
 
 # ** constant: di_list_all_configs_evt
 DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
     DI_LIST_ALL_CONFIGS_EVT_ID,
-    'tiferet.events.di',
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'ListAllSettings',
 )
+
+# ** constant: logging_middleware
+LOGGING_MIDDLEWARE = create_app_service_dependency(
+    LOGGING_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'LoggingMiddleware',
+)
+
+# ** constant: timing_middleware
+TIMING_MIDDLEWARE = create_app_service_dependency(
+    TIMING_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'TimingMiddleware',
+)
+
+# ** constant: cache_middleware
+CACHE_MIDDLEWARE = create_app_service_dependency(
+    CACHE_MIDDLEWARE_ID,
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    'CacheMiddleware',
+)
+
+# *** constants (groups)
 
 # ** constant: core_default_services
 CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
@@ -167,6 +247,9 @@ CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
     LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT,
     GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT,
     DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT,
+    LOGGING_MIDDLEWARE_ID: LOGGING_MIDDLEWARE,
+    TIMING_MIDDLEWARE_ID: TIMING_MIDDLEWARE,
+    CACHE_MIDDLEWARE_ID: CACHE_MIDDLEWARE,
 }
 
 # ** constant: core_default_constants
@@ -176,4 +259,18 @@ CORE_DEFAULT_CONSTANTS: Dict[str, str] = {
     ERROR_CONFIG_ID: DEFAULT_CONFIG_FILE,
     LOGGING_CONFIG_ID: DEFAULT_CONFIG_FILE,
     FEATURE_CONFIG_ID: DEFAULT_CONFIG_FILE,
+}
+
+# ** constant: admin_default_services
+ADMIN_DEFAULT_SERVICES = {**CORE_DEFAULT_SERVICES}
+
+# ** constant: admin_default_constants
+# Core constants plus the app_config key that the admin layer exposes directly.
+ADMIN_DEFAULT_CONSTANTS = {**CORE_DEFAULT_CONSTANTS, 'app_config': DEFAULT_CONFIG_FILE}
+
+# ** constant: core_default_app_sessions
+# Built-in session definitions seeded into the cache by build_cache.
+CORE_DEFAULT_APP_SESSIONS = {
+    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION,
+    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION,
 }

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -171,3 +171,140 @@ def create_default_app_session(id: str,
 
     # Return the assembled session definition.
     return session
+
+# ** function: create_default_formatter
+def create_default_formatter(id: str,
+        name: str,
+        format: str,
+        description: str = None,
+        datefmt: str = None) -> Dict[str, Any]:
+    '''
+    Build a default logging formatter definition dictionary.
+
+    :param id: The unique formatter identifier.
+    :type id: str
+    :param name: The human-readable formatter name.
+    :type name: str
+    :param format: The log format string.
+    :type format: str
+    :param description: Optional formatter description.
+    :type description: str
+    :param datefmt: Optional date format string.
+    :type datefmt: str
+    :return: The formatter definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base formatter definition.
+    formatter = {'id': id, 'name': name, 'format': format}
+
+    # Add optional fields when provided.
+    if description is not None:
+        formatter['description'] = description
+    if datefmt is not None:
+        formatter['datefmt'] = datefmt
+
+    # Return the assembled formatter definition.
+    return formatter
+
+# ** function: create_default_handler
+def create_default_handler(id: str,
+        name: str,
+        module_path: str,
+        class_name: str,
+        level: str,
+        formatter: str,
+        description: str = None,
+        stream: str = None,
+        filename: str = None) -> Dict[str, Any]:
+    '''
+    Build a default logging handler definition dictionary.
+
+    :param id: The unique handler identifier.
+    :type id: str
+    :param name: The human-readable handler name.
+    :type name: str
+    :param module_path: The module path of the handler class.
+    :type module_path: str
+    :param class_name: The class name of the handler.
+    :type class_name: str
+    :param level: The logging level string (e.g. \'INFO\', \'DEBUG\').
+    :type level: str
+    :param formatter: The ID of the formatter to use.
+    :type formatter: str
+    :param description: Optional handler description.
+    :type description: str
+    :param stream: Optional stream target (e.g. \'ext://sys.stdout\').
+    :type stream: str
+    :param filename: Optional log file path for file-based handlers.
+    :type filename: str
+    :return: The handler definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base handler definition.
+    handler = {
+        'id': id,
+        'name': name,
+        'module_path': module_path,
+        'class_name': class_name,
+        'level': level,
+        'formatter': formatter,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        handler['description'] = description
+    if stream is not None:
+        handler['stream'] = stream
+    if filename is not None:
+        handler['filename'] = filename
+
+    # Return the assembled handler definition.
+    return handler
+
+# ** function: create_default_logger
+def create_default_logger(id: str,
+        name: str,
+        level: str,
+        handlers: List[str],
+        propagate: bool = False,
+        is_root: bool = False,
+        description: str = None) -> Dict[str, Any]:
+    '''
+    Build a default logging logger definition dictionary.
+
+    :param id: The unique logger identifier.
+    :type id: str
+    :param name: The human-readable logger name.
+    :type name: str
+    :param level: The logging level string (e.g. \'INFO\', \'DEBUG\').
+    :type level: str
+    :param handlers: List of handler IDs attached to this logger.
+    :type handlers: List[str]
+    :param propagate: Whether log records propagate to parent loggers.
+    :type propagate: bool
+    :param is_root: Whether this logger is the root logger.
+    :type is_root: bool
+    :param description: Optional logger description.
+    :type description: str
+    :return: The logger definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base logger definition.
+    logger = {
+        'id': id,
+        'name': name,
+        'level': level,
+        'handlers': handlers,
+        'propagate': propagate,
+        'is_root': is_root,
+    }
+
+    # Add the optional description when provided.
+    if description is not None:
+        logger['description'] = description
+
+    # Return the assembled logger definition.
+    return logger

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -10,43 +10,88 @@ from typing import Any, Dict, List, Tuple
 # ** constant: en_us
 EN_US = 'en_US'
 
-# *** constants (bootstrap)
+# ** constant: tiferet
+TIFERET = 'tiferet'
 
-# ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH: str = 'tiferet.repos.app'
+# *** constants (paths_packages)
 
-# ** constant: default_app_service_class_name
-DEFAULT_APP_SERVICE_CLASS_NAME: str = 'AppYamlRepository'
+# ** constant: tiferet_events_path
+TIFERET_EVENTS_PATH = 'events'
 
-# ** constant: default_constants
-DEFAULT_CONSTANTS: Dict[str, str] = {
-    'cli_yaml_file': 'config.yml',
-    'di_yaml_file': 'config.yml',
-    'error_yaml_file': 'config.yml',
-    'logging_yaml_file': 'config.yml',
-    'feature_yaml_file': 'config.yml',
-}
+# ** constant: tiferet_repos_path
+TIFERET_REPOS_PATH = 'repos'
 
-# ** constant: default_services
-DEFAULT_SERVICES: List[Tuple[str, str, str, Dict[str, Any] | None]] = [
-    ('di_service', 'tiferet.repos.di', 'DIYamlRepository', None),
-    ('error_service', 'tiferet.repos.error', 'ErrorYamlRepository', None),
-    ('logging_service', 'tiferet.repos.logging', 'LoggingYamlRepository', None),
-    ('feature_service', 'tiferet.repos.feature', 'FeatureYamlRepository', None),
-    ('get_error_evt', 'tiferet.events.error', 'GetError', None),
-    ('get_feature_evt', 'tiferet.events.feature', 'GetFeature', None),
-    ('logging_list_all_evt', 'tiferet.events.logging', 'ListAllLoggingConfigs', None),
-    ('cli_service', 'tiferet.repos.cli', 'CliYamlRepository', None),
-    ('list_commands_evt', 'tiferet.events.cli', 'ListCliCommands', None),
-    ('get_parent_args_evt', 'tiferet.events.cli', 'GetParentArguments', None),
-    ('di_list_all_configs_evt', 'tiferet.events.di', 'ListAllSettings', None),
-    ('services', 'tiferet.contexts.di', 'DIContext', None),
-    ('features', 'tiferet.contexts.feature', 'FeatureContext', None),
-    ('errors', 'tiferet.contexts.error', 'ErrorContext', None),
-    ('logging', 'tiferet.contexts.logging', 'LoggingContext', None),
-]
+# ** constant: tiferet_utils_path
+TIFERET_UTILS_PATH = 'utils'
+
+# *** constants (paths_domains)
+
+# ** constant: feature_domain_path
+FEATURE_DOMAIN_PATH = 'feature'
+
+# ** constant: error_domain_path
+ERROR_DOMAIN_PATH = 'error'
+
+# ** constant: di_domain_path
+DI_DOMAIN_PATH = 'di'
+
+# ** constant: app_domain_path
+APP_DOMAIN_PATH = 'app'
+
+# ** constant: logging_domain_path
+LOGGING_DOMAIN_PATH = 'logging'
+
+# ** constant: cli_domain_path
+CLI_DOMAIN_PATH = 'cli'
+
+# ** constant: middleware_domain_path
+MIDDLEWARE_DOMAIN_PATH = 'middleware'
 
 # *** functions
+
+# ** function: create_service_module_path
+def create_service_module_path(app_base_path: str,
+        base_path: str,
+        domain_path: str) -> str:
+    '''
+    Build a fully-qualified module path from three dot-joined segments.
+
+    :param app_base_path: The application base package path segment.
+    :type app_base_path: str
+    :param base_path: The sub-package path segment (e.g. events, repos, utils).
+    :type base_path: str
+    :param domain_path: The domain module path segment.
+    :type domain_path: str
+    :return: The fully-qualified module path.
+    :rtype: str
+    '''
+
+    # Assemble and return the fully-qualified module path.
+    return f'{app_base_path}.{base_path}.{domain_path}'
+
+# ** function: create_service_dependency
+def create_service_dependency(module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None) -> Dict[str, Any]:
+    '''
+    Build a base service dependency definition dictionary.
+
+    :param module_path: The module path of the service implementation.
+    :type module_path: str
+    :param class_name: The class name of the service implementation.
+    :type class_name: str
+    :param parameters: Optional DI parameters for the dependency.
+    :type parameters: Dict[str, Any]
+    :return: The base service dependency definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the base service dependency definition dictionary.
+    return {
+        'module_path': module_path,
+        'class_name': class_name,
+        'parameters': parameters or {},
+    }
 
 # ** function: create_default_error
 def create_default_error(id: str,

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -142,7 +142,32 @@ def create_app_service_dependency(
     # Assemble and return the default app service dependency definition dictionary.
     return {
         'service_id': service_id,
-        'module_path': module_path,
-        'class_name': class_name,
-        'parameters': parameters or {},
+        **create_service_dependency(module_path, class_name, parameters),
     }
+
+# ** function: create_default_app_session
+def create_default_app_session(id: str,
+        name: str,
+        description: str = None) -> Dict[str, Any]:
+    '''
+    Build a default app session definition dictionary.
+
+    :param id: The unique session identifier.
+    :type id: str
+    :param name: The human-readable session name.
+    :type name: str
+    :param description: Optional session description.
+    :type description: str
+    :return: The app session definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base session definition.
+    session = {'id': id, 'name': name}
+
+    # Add the optional description when provided.
+    if description is not None:
+        session['description'] = description
+
+    # Return the assembled session definition.
+    return session

--- a/tiferet/assets/logging.py
+++ b/tiferet/assets/logging.py
@@ -1,77 +1,130 @@
-# *** constants
+"""Tiferet Logging Assets
 
-# ** constant: default_formatters
-DEFAULT_FORMATTERS = [
-    dict(
-        id='default',
-        name='Default Formatter',
-        description='The default logging formatter.',
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
-]
+Default logging formatter, handler, and logger definitions using the three-section
+catalog pattern. The bootstrap layer seeds these definitions into the application
+cache via add_default_logging_settings during cache initialization.
+"""
 
-# ** constant: default_handlers
-DEFAULT_HANDLERS = [
-    dict(
-        id='default_root',
-        name='Default Root Handler',
-        description='The default root logging handler.',
-        module_path='logging',
-        class_name='StreamHandler',
-        level='WARNING',
-        formatter='default',
-        stream='ext://sys.stderr'
-    ),
-    dict(
-        id='default',
-        name='Default Handler',
-        description='The default logging handler.',
-        module_path='logging',
-        class_name='StreamHandler',
-        level='INFO',
-        formatter='default',
-        stream='ext://sys.stdout'
-    ),
-    dict(
-        id='debug',
-        name='Debug Handler',
-        description='A handler for debugging purposes.',
-        module_path='logging',
-        class_name='StreamHandler',
-        level='DEBUG',
-        formatter='default',
-        stream='ext://sys.stdout'
-    )
-]
+# *** imports
 
-# ** constant: default_loggers
-DEFAULT_LOGGERS = [
-    dict(
-        id='root',
-        name='Default Root Logger',
-        description='The default logging configuration.',
-        level='WARNING',
-        handlers=['default_root'],
-        propagate=False,
-        is_root=True
-    ),
-    dict(
-        id='default',
-        name='Default Logger',
-        description='The default logging configuration.',
-        level='INFO',
-        handlers=['default'],
-        propagate=True,
-        is_root=False
-    ),
-    dict(
-        id='debug',
-        name='Debug Logger',
-        description='A logger for debugging purposes.',
-        level='DEBUG',
-        handlers=['debug'],
-        propagate=True,
-        is_root=False
-    )
-]
+# ** core
+from typing import Any, Dict
+
+# ** app
+from .core import create_default_formatter, create_default_handler, create_default_logger
+
+# *** constants (ids)
+
+# ** constant: default_formatter_id
+DEFAULT_FORMATTER_ID = 'default'
+
+# ** constant: default_root_handler_id
+DEFAULT_ROOT_HANDLER_ID = 'default_root'
+
+# ** constant: default_handler_id
+DEFAULT_HANDLER_ID = 'default'
+
+# ** constant: debug_handler_id
+DEBUG_HANDLER_ID = 'debug'
+
+# ** constant: root_logger_id
+ROOT_LOGGER_ID = 'root'
+
+# ** constant: default_logger_id
+DEFAULT_LOGGER_ID = 'default'
+
+# ** constant: debug_logger_id
+DEBUG_LOGGER_ID = 'debug'
+
+# *** constants (formatters)
+
+# ** constant: default_formatter
+DEFAULT_FORMATTER = create_default_formatter(
+    DEFAULT_FORMATTER_ID,
+    'Default Formatter',
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    description='The default logging formatter.',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+
+# *** constants (handlers)
+
+# ** constant: default_root_handler
+DEFAULT_ROOT_HANDLER = create_default_handler(
+    DEFAULT_ROOT_HANDLER_ID,
+    'Default Root Handler',
+    'logging',
+    'StreamHandler',
+    'WARNING',
+    DEFAULT_FORMATTER_ID,
+    description='The default root logging handler.',
+    stream='ext://sys.stderr',
+)
+
+# ** constant: default_handler
+DEFAULT_HANDLER = create_default_handler(
+    DEFAULT_HANDLER_ID,
+    'Default Handler',
+    'logging',
+    'StreamHandler',
+    'INFO',
+    DEFAULT_FORMATTER_ID,
+    description='The default logging handler.',
+    stream='ext://sys.stdout',
+)
+
+# ** constant: debug_handler
+DEBUG_HANDLER = create_default_handler(
+    DEBUG_HANDLER_ID,
+    'Debug Handler',
+    'logging',
+    'StreamHandler',
+    'DEBUG',
+    DEFAULT_FORMATTER_ID,
+    description='A handler for debugging purposes.',
+    stream='ext://sys.stdout',
+)
+
+# *** constants (loggers)
+
+# ** constant: root_logger
+ROOT_LOGGER = create_default_logger(
+    ROOT_LOGGER_ID,
+    'Default Root Logger',
+    'WARNING',
+    [DEFAULT_ROOT_HANDLER_ID],
+    propagate=False,
+    is_root=True,
+    description='The default logging configuration.',
+)
+
+# ** constant: default_logger
+DEFAULT_LOGGER = create_default_logger(
+    DEFAULT_LOGGER_ID,
+    'Default Logger',
+    'INFO',
+    [DEFAULT_HANDLER_ID],
+    propagate=True,
+    is_root=False,
+    description='The default logging configuration.',
+)
+
+# ** constant: debug_logger
+DEBUG_LOGGER = create_default_logger(
+    DEBUG_LOGGER_ID,
+    'Debug Logger',
+    'DEBUG',
+    [DEBUG_HANDLER_ID],
+    propagate=True,
+    is_root=False,
+    description='A logger for debugging purposes.',
+)
+
+# *** constants (groups)
+
+# ** constant: core_default_logging_settings
+CORE_DEFAULT_LOGGING_SETTINGS: Dict[str, Any] = {
+    'formatters': [DEFAULT_FORMATTER],
+    'handlers': [DEFAULT_ROOT_HANDLER, DEFAULT_HANDLER, DEBUG_HANDLER],
+    'loggers': [ROOT_LOGGER, DEFAULT_LOGGER, DEBUG_LOGGER],
+}


### PR DESCRIPTION
## Summary
Implements Super-TRD #935: Assets — Core Foundation and Bootstrap Catalog Standardization.

This PR delivers the three child stories that remove stale bootstrap constants from `assets/core.py`, introduce shared path-constant and factory infrastructure, restructure `assets/app.py`, and rewrite `assets/logging.py` using the three-section catalog pattern.

## Changes

### Child 1 — #936: Assets/Core — Path Constants, Service Dependency Factory, and Module Path Factory ✅
- Removed the stale `# *** constants (bootstrap)` section and its four artifacts from `assets/core.py`
- Added `TIFERET = 'tiferet'` to `# *** constants`
- Added `# *** constants (paths_packages)` with `TIFERET_EVENTS_PATH`, `TIFERET_REPOS_PATH`, `TIFERET_UTILS_PATH`
- Added `# *** constants (paths_domains)` with seven domain path constants
- Added `create_service_module_path` and `create_service_dependency` factory functions to `# *** functions`
- Created `tests/assets/test_core.py` with 4 tests; all pass

### Child 2 — #937: Assets/App — Bootstrap Catalog Reorganization and Admin Session Standardization ✅
- Refactored `create_app_service_dependency` in `core.py` to delegate to `create_service_dependency` internally
- Added `create_default_app_session(id, name, description=None)` to `core.py`
- Reorganized `assets/app.py` from two sections into six: `(ids)`, `(paths)`, `(app_service)`, `(sessions)`, `(services)`, `(groups)`
- Updated all eleven service constants in `(services)` to use `create_service_module_path`; added `LOGGING_MIDDLEWARE`, `TIMING_MIDDLEWARE`, `CACHE_MIDDLEWARE`
- Added `ADMIN_DEFAULT_SERVICES`, `ADMIN_DEFAULT_CONSTANTS`, `CORE_DEFAULT_APP_SESSIONS` to `(groups)`
- Added 4 tests to `tests/assets/test_core.py`; all 13 asset tests pass

### Child 3 — #938: Assets/Logging — Three-Section Catalog ✅
- Added `create_default_formatter`, `create_default_handler`, `create_default_logger` to `core.py`
- Rewrote `assets/logging.py` to five-section three-section pattern: `(ids)`, `(formatters)`, `(handlers)`, `(loggers)`, `(groups)`
- Replaced `DEFAULT_FORMATTERS`, `DEFAULT_HANDLERS`, `DEFAULT_LOGGERS` list constants with 7 individually named ID constants, 7 named object constants, and `CORE_DEFAULT_LOGGING_SETTINGS: Dict[str, Any]`
- Added 6 tests to `tests/assets/test_core.py`; all 19 asset tests pass

## Acceptance Criteria

### Child 1 — #936
- [x] `TIFERET = 'tiferet'` present in `# *** constants` of `core.py`
- [x] `# *** constants (paths_packages)` present with `TIFERET_EVENTS_PATH`, `TIFERET_REPOS_PATH`, `TIFERET_UTILS_PATH`
- [x] `# *** constants (paths_domains)` present with seven domain path constants
- [x] `create_service_module_path` present in `# *** functions` with correct behavior and RST docstring
- [x] `create_service_dependency` present; `parameters` defaults to `{}` not `None`
- [x] `# *** constants (bootstrap)` section and all four artifacts absent from `core.py`
- [x] `tests/assets/test_core.py` exists; all four tests pass

### Child 2 — #937
- [x] `create_app_service_dependency` delegates to `create_service_dependency` internally; behavior unchanged
- [x] `create_default_app_session` present in `core.py`; returns `{id, name}` with optional `description`
- [x] `app.py` has exactly six constant sections: `(ids)`, `(paths)`, `(app_service)`, `(sessions)`, `(services)`, `(groups)`
- [x] `(ids)` contains all sixteen ID constants including middleware and admin IDs
- [x] `(paths)` contains `DEFAULT_CONFIG_FILE` and `DEFAULT_APP_CONFIG_FILE`
- [x] `(app_service)` contains `DEFAULT_APP_SERVICE_MODULE_PATH` using `create_service_module_path`
- [x] `(sessions)` contains `DEFAULT_ADMIN_APP_SESSION` and `DEFAULT_ADMIN_CLI_SESSION`
- [x] All eleven existing service constants use `create_service_module_path` — no hardcoded dotted strings
- [x] `(services)` contains `LOGGING_MIDDLEWARE`, `TIMING_MIDDLEWARE`, `CACHE_MIDDLEWARE`
- [x] `(groups)` contains `CORE_DEFAULT_SERVICES` (14 entries), `CORE_DEFAULT_CONSTANTS`, `ADMIN_DEFAULT_SERVICES`, `ADMIN_DEFAULT_CONSTANTS`, `CORE_DEFAULT_APP_SESSIONS`
- [x] Old `# *** constants (models)` section header is gone
- [x] Four new tests pass; full asset test suite passes

### Child 3 — #938
- [x] `create_default_formatter`, `create_default_handler`, `create_default_logger` present in `core.py` with RST docstrings
- [x] `logging.py` has a module docstring
- [x] `logging.py` has `# *** imports` importing the three factory functions
- [x] `logging.py` has `# *** constants (ids)` with 7 named ID constants
- [x] `logging.py` has `# *** constants (formatters)` with `DEFAULT_FORMATTER`
- [x] `logging.py` has `# *** constants (handlers)` with `DEFAULT_ROOT_HANDLER`, `DEFAULT_HANDLER`, `DEBUG_HANDLER`
- [x] `logging.py` has `# *** constants (loggers)` with `ROOT_LOGGER`, `DEFAULT_LOGGER`, `DEBUG_LOGGER`
- [x] `logging.py` has `# *** constants (groups)` with `CORE_DEFAULT_LOGGING_SETTINGS: Dict[str, Any]`
- [x] `DEFAULT_FORMATTERS`, `DEFAULT_HANDLERS`, `DEFAULT_LOGGERS` list constants removed
- [x] Six new tests pass; all 19 asset tests pass

Closes #935