### PR TITLE
Super-TRD #939: Assets — Domain Catalog Standardization

### DIFF
--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -4,6 +4,8 @@
 
 # ** app
 from tiferet.assets.core import (
+    create_default_feature,
+    create_params_schema,
     create_service_module_path,
     create_service_dependency,
     create_app_service_dependency,
@@ -297,6 +299,89 @@ def test_create_default_logger_returns_required_fields():
     assert result['propagate'] is False
     assert result['is_root'] is False
     assert 'description' not in result
+
+
+# ** test: create_default_feature_returns_required_fields
+def test_create_default_feature_returns_required_fields():
+    '''
+    Verify create_default_feature returns required fields and omits optional
+    fields when description and params_schema are not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Call the factory with only required arguments.
+    result = create_default_feature(
+        id='test.feature',
+        name='Test Feature',
+        group_id='test',
+        feature_key='feature',
+        steps=[{'service_id': 'test_evt'}],
+    )
+
+    # Assert all required fields are present with correct values.
+    assert result['id'] == 'test.feature'
+    assert result['name'] == 'Test Feature'
+    assert result['group_id'] == 'test'
+    assert result['feature_key'] == 'feature'
+    assert result['steps'] == [{'service_id': 'test_evt'}]
+
+    # Assert optional fields are absent when not provided.
+    assert 'description' not in result
+    assert 'params_schema' not in result
+
+
+# ** test: create_default_feature_includes_optional_fields_when_provided
+def test_create_default_feature_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_feature includes description and params_schema
+    when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a schema for use in the call.
+    schema = create_params_schema(name='str', count='int')
+
+    # Call the factory with all optional arguments supplied.
+    result = create_default_feature(
+        id='test.optional',
+        name='Test Optional',
+        group_id='test',
+        feature_key='optional',
+        steps=[{'service_id': 'optional_evt'}],
+        description='An optional test feature.',
+        params_schema=schema,
+    )
+
+    # Assert optional fields are present with correct values.
+    assert result['description'] == 'An optional test feature.'
+    assert result['params_schema'] == {'name': 'str', 'count': 'int'}
+
+
+# ** test: create_params_schema_returns_expected_dict
+def test_create_params_schema_returns_expected_dict():
+    '''
+    Verify create_params_schema assembles keyword arguments into a dict,
+    supporting both shorthand type strings and expanded spec dicts.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Call with a mix of shorthand type strings and expanded spec dicts.
+    result = create_params_schema(
+        name='str',
+        count={'type': 'int', 'required': True},
+    )
+
+    # Assert the result is the expected assembled dict.
+    assert result == {
+        'name': 'str',
+        'count': {'type': 'int', 'required': True},
+    }
 
 
 # ** test: create_default_logger_includes_optional_fields_when_provided

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -8,6 +8,7 @@ from tiferet.assets.core import (
     create_params_schema,
     create_service_module_path,
     create_service_dependency,
+    create_service_registration,
     create_app_service_dependency,
     create_default_app_session,
     create_default_formatter,
@@ -382,6 +383,57 @@ def test_create_params_schema_returns_expected_dict():
         'name': 'str',
         'count': {'type': 'int', 'required': True},
     }
+
+
+# ** test: create_service_registration_returns_expected_shape
+def test_create_service_registration_returns_expected_shape():
+    '''
+    Verify create_service_registration returns a dict with keys
+    ``{'id', 'module_path', 'class_name', 'parameters'}``; ``id`` matches
+    the first argument; values match inputs; and ``parameters`` defaults
+    to an empty dict when omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a service registration without explicit parameters.
+    result = create_service_registration(
+        'feature_config_repo',
+        'tiferet.repos.feature',
+        'FeatureConfigRepository',
+    )
+
+    # Verify all expected keys are present.
+    assert set(result.keys()) == {'id', 'module_path', 'class_name', 'parameters'}
+
+    # Verify each value matches the input.
+    assert result['id'] == 'feature_config_repo'
+    assert result['module_path'] == 'tiferet.repos.feature'
+    assert result['class_name'] == 'FeatureConfigRepository'
+    assert result['parameters'] == {}
+
+
+# ** test: create_service_registration_omitting_parameters_yields_empty_dict
+def test_create_service_registration_omitting_parameters_yields_empty_dict():
+    '''
+    Verify omitting ``parameters`` in create_service_registration yields
+    an empty dict, not ``None``.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Create a registration without explicit parameters.
+    result = create_service_registration(
+        'test_service',
+        'tiferet.repos.test',
+        'TestRepository',
+    )
+
+    # Verify parameters is an empty dict, not None.
+    assert result['parameters'] == {}
+    assert result['parameters'] is not None
 
 
 # ** test: create_default_logger_includes_optional_fields_when_provided

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -4,6 +4,8 @@
 
 # ** app
 from tiferet.assets.core import (
+    create_default_cli_argument,
+    create_default_cli_command,
     create_default_feature,
     create_params_schema,
     create_service_module_path,
@@ -434,6 +436,115 @@ def test_create_service_registration_omitting_parameters_yields_empty_dict():
     # Verify parameters is an empty dict, not None.
     assert result['parameters'] == {}
     assert result['parameters'] is not None
+
+
+# ** test: create_default_cli_argument_returns_required_field
+def test_create_default_cli_argument_returns_required_field():
+    '''
+    Verify create_default_cli_argument returns only the ``name_or_flags`` key
+    when all optional arguments are omitted.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Call the factory with only the required argument.
+    result = create_default_cli_argument(name_or_flags=['id'])
+
+    # Assert only name_or_flags is present.
+    assert set(result.keys()) == {'name_or_flags'}
+    assert result['name_or_flags'] == ['id']
+
+
+# ** test: create_default_cli_argument_includes_optional_fields_when_provided
+def test_create_default_cli_argument_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_cli_argument includes all optional fields when supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Call the factory with all optional arguments supplied.
+    result = create_default_cli_argument(
+        name_or_flags=['--level'],
+        description='The logging level.',
+        type='str',
+        default='INFO',
+        required=True,
+        nargs='?',
+        choices=['DEBUG', 'INFO', 'WARNING'],
+        action='store',
+    )
+
+    # Assert all optional fields are present with correct values.
+    assert result['name_or_flags'] == ['--level']
+    assert result['description'] == 'The logging level.'
+    assert result['type'] == 'str'
+    assert result['default'] == 'INFO'
+    assert result['required'] is True
+    assert result['nargs'] == '?'
+    assert result['choices'] == ['DEBUG', 'INFO', 'WARNING']
+    assert result['action'] == 'store'
+
+
+# ** test: create_default_cli_command_returns_required_fields
+def test_create_default_cli_command_returns_required_fields():
+    '''
+    Verify create_default_cli_command returns a dict with ``id``, ``key``,
+    ``group_key``, and ``name``; ``description`` and ``arguments`` are absent
+    when not provided.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Call the factory with only the required arguments.
+    result = create_default_cli_command(
+        id='app.list',
+        key='list',
+        group_key='app',
+        name='List App Interfaces',
+    )
+
+    # Assert required fields are present and optional fields are absent.
+    assert result['id'] == 'app.list'
+    assert result['key'] == 'list'
+    assert result['group_key'] == 'app'
+    assert result['name'] == 'List App Interfaces'
+    assert 'description' not in result
+    assert 'arguments' not in result
+
+
+# ** test: create_default_cli_command_includes_optional_fields_when_provided
+def test_create_default_cli_command_includes_optional_fields_when_provided():
+    '''
+    Verify create_default_cli_command includes ``description`` and ``arguments``
+    when they are supplied.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Build a sample argument for use in the call.
+    arg = create_default_cli_argument(
+        name_or_flags=['id'],
+        description='The identifier.',
+    )
+
+    # Call the factory with all optional arguments supplied.
+    result = create_default_cli_command(
+        id='app.get',
+        key='get',
+        group_key='app',
+        name='Get App Interface',
+        description='Retrieve an app interface by ID.',
+        arguments=[arg],
+    )
+
+    # Assert optional fields are present with correct values.
+    assert result['description'] == 'Retrieve an app interface by ID.'
+    assert result['arguments'] == [arg]
 
 
 # ** test: create_default_logger_includes_optional_fields_when_provided

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -1,764 +1,1062 @@
-"""Tiferet CLI Command Catalog"""
+"""Tiferet CLI Command Catalog
+
+Three-section catalog of built-in administrative CLI command definitions:
+IDs, individually named command constants, and the ADMIN_DEFAULT_COMMANDS group dict.
+"""
 
 # *** imports
 
 # ** core
 from typing import Any, Dict, List
 
-# *** constants
+# ** app
+from .core import create_default_cli_argument, create_default_cli_command
 
-# ** constant: default_tiferet_cli_commands
-DEFAULT_TIFERET_CLI_COMMANDS: Dict[str, Dict[str, Any]] = {
+# *** constants (ids)
 
-    # -- app group --
+# ** constant: app_list_cli_cmd_id
+APP_LIST_CLI_CMD_ID = 'app.list'
 
-    'app.list': {
-        'id': 'app.list',
-        'name': 'List App Interfaces',
-        'description': 'List all configured application interfaces.',
-        'key': 'list',
-        'group_key': 'app',
-        'arguments': [],
-    },
-    'app.get': {
-        'id': 'app.get',
-        'name': 'Get App Interface',
-        'description': 'Retrieve an app interface by ID.',
-        'key': 'get',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['interface_id'],
-                'description': 'The interface identifier.',
-            },
-        ],
-    },
-    'app.add': {
-        'id': 'app.add',
-        'name': 'Add App Interface',
-        'description': 'Add a new application interface configuration.',
-        'key': 'add',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique interface identifier.',
-            },
-            {
-                'name_or_flags': ['name'],
-                'description': 'The human-readable interface name.',
-            },
-            {
-                'name_or_flags': ['module_path'],
-                'description': 'The Python module path of the context class.',
-            },
-            {
-                'name_or_flags': ['class_name'],
-                'description': 'The context class name.',
-            },
-            {
-                'name_or_flags': ['--description'],
-                'description': 'Optional interface description.',
-            },
-            {
-                'name_or_flags': ['--logger-id'],
-                'description': 'Optional logger identifier. Defaults to "default".',
-            },
-            {
-                'name_or_flags': ['--flags'],
-                'description': 'Optional JSON-encoded list of flags.',
-            },
-            {
-                'name_or_flags': ['--constants'],
-                'description': 'Optional JSON-encoded constants dictionary.',
-            },
-        ],
-    },
-    'app.update': {
-        'id': 'app.update',
-        'name': 'Update App Interface',
-        'description': 'Update a scalar attribute on an existing application interface.',
-        'key': 'update',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The interface identifier.',
-            },
-            {
-                'name_or_flags': ['attribute'],
-                'description': 'The attribute to update.',
-            },
-            {
-                'name_or_flags': ['value'],
-                'description': 'The new value for the attribute.',
-            },
-        ],
-    },
-    'app.set_service': {
-        'id': 'app.set_service',
-        'name': 'Set App Service Dependency',
-        'description': 'Set or update a service dependency on an application interface.',
-        'key': 'set-service',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The interface identifier.',
-            },
-            {
-                'name_or_flags': ['service_id'],
-                'description': 'The service dependency identifier.',
-            },
-            {
-                'name_or_flags': ['module_path'],
-                'description': 'The module path of the service implementation.',
-            },
-            {
-                'name_or_flags': ['class_name'],
-                'description': 'The class name of the service implementation.',
-            },
-            {
-                'name_or_flags': ['--parameters'],
-                'description': 'Optional JSON-encoded parameters dictionary.',
-            },
-        ],
-    },
-    'app.remove_service': {
-        'id': 'app.remove_service',
-        'name': 'Remove App Service Dependency',
-        'description': 'Remove a service dependency from an application interface.',
-        'key': 'remove-service',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The interface identifier.',
-            },
-            {
-                'name_or_flags': ['service_id'],
-                'description': 'The service dependency identifier to remove.',
-            },
-        ],
-    },
-    'app.set_constants': {
-        'id': 'app.set_constants',
-        'name': 'Set App Constants',
-        'description': 'Set or clear constants on an application interface.',
-        'key': 'set-constants',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The interface identifier.',
-            },
-            {
-                'name_or_flags': ['--constants'],
-                'description': 'Optional JSON-encoded constants dictionary. Omit to clear all constants.',
-            },
-        ],
-    },
-    'app.remove': {
-        'id': 'app.remove',
-        'name': 'Remove App Interface',
-        'description': 'Remove an application interface configuration.',
-        'key': 'remove',
-        'group_key': 'app',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The interface identifier to remove.',
-            },
-        ],
-    },
+# ** constant: app_get_cli_cmd_id
+APP_GET_CLI_CMD_ID = 'app.get'
 
-    # -- cli group --
+# ** constant: app_add_cli_cmd_id
+APP_ADD_CLI_CMD_ID = 'app.add'
 
-    'cli.list_commands': {
-        'id': 'cli.list_commands',
-        'name': 'List CLI Commands',
-        'description': 'List all configured CLI commands.',
-        'key': 'list-commands',
-        'group_key': 'cli',
-        'arguments': [],
-    },
-    'cli.add_command': {
-        'id': 'cli.add_command',
-        'name': 'Add CLI Command',
-        'description': 'Add a new CLI command definition.',
-        'key': 'add-command',
-        'group_key': 'cli',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique command identifier.',
-            },
-            {
-                'name_or_flags': ['name'],
-                'description': 'The human-readable command name.',
-            },
-            {
-                'name_or_flags': ['key'],
-                'description': 'The command key used in the CLI.',
-            },
-            {
-                'name_or_flags': ['group_key'],
-                'description': 'The group key this command belongs to.',
-            },
-            {
-                'name_or_flags': ['--description'],
-                'description': 'Optional command description.',
-            },
-        ],
-    },
-    'cli.add_argument': {
-        'id': 'cli.add_argument',
-        'name': 'Add CLI Argument',
-        'description': 'Add an argument to an existing CLI command.',
-        'key': 'add-argument',
-        'group_key': 'cli',
-        'arguments': [
-            {
-                'name_or_flags': ['command_id'],
-                'description': 'The CLI command identifier.',
-            },
-            {
-                'name_or_flags': ['--name-or-flags'],
-                'description': 'JSON-encoded list of argument names or flags.',
-                'required': True,
-            },
-            {
-                'name_or_flags': ['--description'],
-                'description': 'Optional argument description.',
-            },
-        ],
-    },
+# ** constant: app_update_cli_cmd_id
+APP_UPDATE_CLI_CMD_ID = 'app.update'
 
-    # -- error group --
+# ** constant: app_set_service_cli_cmd_id
+APP_SET_SERVICE_CLI_CMD_ID = 'app.set_service'
 
-    'error.list': {
-        'id': 'error.list',
-        'name': 'List Errors',
-        'description': 'List all error definitions.',
-        'key': 'list',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['--include-defaults'],
-                'description': 'Include built-in default error definitions.',
-                'action': 'store_true',
-            },
-        ],
-    },
-    'error.get': {
-        'id': 'error.get',
-        'name': 'Get Error',
-        'description': 'Retrieve an error by ID.',
-        'key': 'get',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The error identifier.',
-            },
-        ],
-    },
-    'error.add': {
-        'id': 'error.add',
-        'name': 'Add Error',
-        'description': 'Add a new error definition.',
-        'key': 'add',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique error identifier.',
-            },
-            {
-                'name_or_flags': ['name'],
-                'description': 'The human-readable error name.',
-            },
-            {
-                'name_or_flags': ['message'],
-                'description': 'The primary error message text.',
-            },
-            {
-                'name_or_flags': ['--lang'],
-                'description': 'Language code for the message. Defaults to "en_US".',
-            },
-        ],
-    },
-    'error.rename': {
-        'id': 'error.rename',
-        'name': 'Rename Error',
-        'description': 'Rename an existing error definition.',
-        'key': 'rename',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique error identifier.',
-            },
-            {
-                'name_or_flags': ['new_name'],
-                'description': 'The new error name.',
-            },
-        ],
-    },
-    'error.set_message': {
-        'id': 'error.set_message',
-        'name': 'Set Error Message',
-        'description': 'Set the message text on an existing error definition.',
-        'key': 'set-message',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique error identifier.',
-            },
-            {
-                'name_or_flags': ['message'],
-                'description': 'The new message text.',
-            },
-            {
-                'name_or_flags': ['--lang'],
-                'description': 'Language code for the message. Defaults to "en_US".',
-            },
-        ],
-    },
-    'error.remove_message': {
-        'id': 'error.remove_message',
-        'name': 'Remove Error Message',
-        'description': 'Remove a language message from an existing error definition.',
-        'key': 'remove-message',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique error identifier.',
-            },
-            {
-                'name_or_flags': ['--lang'],
-                'description': 'Language code of the message to remove. Defaults to "en_US".',
-            },
-        ],
-    },
-    'error.remove': {
-        'id': 'error.remove',
-        'name': 'Remove Error',
-        'description': 'Remove an error definition.',
-        'key': 'remove',
-        'group_key': 'error',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique error identifier to remove.',
-            },
-        ],
-    },
+# ** constant: app_remove_service_cli_cmd_id
+APP_REMOVE_SERVICE_CLI_CMD_ID = 'app.remove_service'
 
-    # -- feature group --
+# ** constant: app_set_constants_cli_cmd_id
+APP_SET_CONSTANTS_CLI_CMD_ID = 'app.set_constants'
 
-    'feature.list': {
-        'id': 'feature.list',
-        'name': 'List Features',
-        'description': 'List all feature workflow definitions.',
-        'key': 'list',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['--group-id'],
-                'description': 'Optional group identifier to filter results.',
-            },
-        ],
-    },
-    'feature.add': {
-        'id': 'feature.add',
-        'name': 'Add Feature',
-        'description': 'Add a new feature workflow definition.',
-        'key': 'add',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['name'],
-                'description': 'The feature name.',
-            },
-            {
-                'name_or_flags': ['group_id'],
-                'description': 'The group identifier.',
-            },
-            {
-                'name_or_flags': ['--feature-key'],
-                'description': 'Optional explicit feature key. Defaults to snake_case of name.',
-            },
-            {
-                'name_or_flags': ['--description'],
-                'description': 'Optional feature description.',
-            },
-        ],
-    },
-    'feature.update': {
-        'id': 'feature.update',
-        'name': 'Update Feature',
-        'description': 'Update a metadata attribute on an existing feature.',
-        'key': 'update',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier.',
-            },
-            {
-                'name_or_flags': ['attribute'],
-                'description': 'The attribute to update (name or description).',
-            },
-            {
-                'name_or_flags': ['value'],
-                'description': 'The new value.',
-            },
-        ],
-    },
-    'feature.add_step': {
-        'id': 'feature.add_step',
-        'name': 'Add Feature Step',
-        'description': 'Add a step to an existing feature workflow.',
-        'key': 'add-step',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier.',
-            },
-            {
-                'name_or_flags': ['name'],
-                'description': 'The step name.',
-            },
-            {
-                'name_or_flags': ['service_id'],
-                'description': 'The DI service registration identifier for this step.',
-            },
-            {
-                'name_or_flags': ['--parameters'],
-                'description': 'Optional JSON-encoded step parameters.',
-            },
-            {
-                'name_or_flags': ['--data-key'],
-                'description': 'Optional result data key.',
-            },
-            {
-                'name_or_flags': ['--pass-on-error'],
-                'description': 'Continue execution if this step raises an error.',
-                'action': 'store_true',
-            },
-            {
-                'name_or_flags': ['--position'],
-                'description': 'Optional insertion index. Defaults to append.',
-                'type': 'int',
-            },
-        ],
-    },
-    'feature.update_step': {
-        'id': 'feature.update_step',
-        'name': 'Update Feature Step',
-        'description': 'Update an attribute on an existing feature step.',
-        'key': 'update-step',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier.',
-            },
-            {
-                'name_or_flags': ['position'],
-                'description': 'The zero-based step index.',
-                'type': 'int',
-            },
-            {
-                'name_or_flags': ['attribute'],
-                'description': 'The step attribute to update.',
-            },
-            {
-                'name_or_flags': ['--value'],
-                'description': 'The new value for the attribute.',
-            },
-        ],
-    },
-    'feature.remove_step': {
-        'id': 'feature.remove_step',
-        'name': 'Remove Feature Step',
-        'description': 'Remove a step from an existing feature workflow.',
-        'key': 'remove-step',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier.',
-            },
-            {
-                'name_or_flags': ['position'],
-                'description': 'The zero-based index of the step to remove.',
-                'type': 'int',
-            },
-        ],
-    },
-    'feature.reorder_step': {
-        'id': 'feature.reorder_step',
-        'name': 'Reorder Feature Step',
-        'description': 'Reorder a step within an existing feature workflow.',
-        'key': 'reorder-step',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier.',
-            },
-            {
-                'name_or_flags': ['start_position'],
-                'description': 'The current zero-based step index.',
-                'type': 'int',
-            },
-            {
-                'name_or_flags': ['end_position'],
-                'description': 'The target zero-based step index.',
-                'type': 'int',
-            },
-        ],
-    },
-    'feature.remove': {
-        'id': 'feature.remove',
-        'name': 'Remove Feature',
-        'description': 'Remove an existing feature workflow definition.',
-        'key': 'remove',
-        'group_key': 'feature',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The feature identifier to remove.',
-            },
-        ],
-    },
+# ** constant: app_remove_cli_cmd_id
+APP_REMOVE_CLI_CMD_ID = 'app.remove'
 
-    # -- service group --
+# ** constant: cli_list_commands_cli_cmd_id
+CLI_LIST_COMMANDS_CLI_CMD_ID = 'cli.list_commands'
 
-    'service.list': {
-        'id': 'service.list',
-        'name': 'List Services',
-        'description': 'List all DI service registrations and constants.',
-        'key': 'list',
-        'group_key': 'service',
-        'arguments': [],
-    },
-    'service.add': {
-        'id': 'service.add',
-        'name': 'Add Service',
-        'description': 'Add a new DI service registration.',
-        'key': 'add',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The unique service registration identifier.',
-            },
-            {
-                'name_or_flags': ['--module-path'],
-                'description': 'The module path of the service implementation.',
-            },
-            {
-                'name_or_flags': ['--class-name'],
-                'description': 'The class name of the service implementation.',
-            },
-            {
-                'name_or_flags': ['--parameters'],
-                'description': 'Optional JSON-encoded parameters dictionary.',
-            },
-        ],
-    },
-    'service.set_default': {
-        'id': 'service.set_default',
-        'name': 'Set Default Service Registration',
-        'description': 'Set or update the default type for an existing service registration.',
-        'key': 'set-default',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The service registration identifier.',
-            },
-            {
-                'name_or_flags': ['--module-path'],
-                'description': 'The new default module path.',
-            },
-            {
-                'name_or_flags': ['--class-name'],
-                'description': 'The new default class name.',
-            },
-            {
-                'name_or_flags': ['--parameters'],
-                'description': 'Optional JSON-encoded parameters dictionary.',
-            },
-        ],
-    },
-    'service.set_dependency': {
-        'id': 'service.set_dependency',
-        'name': 'Set Service Dependency',
-        'description': 'Set or update a flagged dependency on a service registration.',
-        'key': 'set-dependency',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The service registration identifier.',
-            },
-            {
-                'name_or_flags': ['flag'],
-                'description': 'The flag identifying this dependency.',
-            },
-            {
-                'name_or_flags': ['module_path'],
-                'description': 'The module path for the flagged dependency.',
-            },
-            {
-                'name_or_flags': ['class_name'],
-                'description': 'The class name for the flagged dependency.',
-            },
-            {
-                'name_or_flags': ['--parameters'],
-                'description': 'Optional JSON-encoded parameters dictionary.',
-            },
-        ],
-    },
-    'service.remove_dependency': {
-        'id': 'service.remove_dependency',
-        'name': 'Remove Service Dependency',
-        'description': 'Remove a flagged dependency from a service registration.',
-        'key': 'remove-dependency',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The service registration identifier.',
-            },
-            {
-                'name_or_flags': ['flag'],
-                'description': 'The flag identifying the dependency to remove.',
-            },
-        ],
-    },
-    'service.set_constants': {
-        'id': 'service.set_constants',
-        'name': 'Set Service Constants',
-        'description': 'Set or clear DI service constants.',
-        'key': 'set-constants',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['--constants'],
-                'description': 'Optional JSON-encoded constants dictionary. Omit to clear all.',
-            },
-        ],
-    },
-    'service.remove': {
-        'id': 'service.remove',
-        'name': 'Remove Service',
-        'description': 'Remove a DI service registration.',
-        'key': 'remove',
-        'group_key': 'service',
-        'arguments': [
-            {
-                'name_or_flags': ['id'],
-                'description': 'The service registration identifier to remove.',
-            },
-        ],
-    },
+# ** constant: cli_add_command_cli_cmd_id
+CLI_ADD_COMMAND_CLI_CMD_ID = 'cli.add_command'
 
-    # -- logging group --
+# ** constant: cli_add_argument_cli_cmd_id
+CLI_ADD_ARGUMENT_CLI_CMD_ID = 'cli.add_argument'
 
-    'logging.add_formatter': {
-        'id': 'logging.add_formatter',
-        'name': 'Add Formatter',
-        'description': 'Add a new logging formatter configuration.',
-        'key': 'add-formatter',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique formatter identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Formatter name.'},
-            {'name_or_flags': ['format'], 'description': 'Format string for log messages.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--datefmt'], 'description': 'Optional date format string.'},
-        ],
-    },
-    'logging.remove_formatter': {
-        'id': 'logging.remove_formatter',
-        'name': 'Remove Formatter',
-        'description': 'Remove a logging formatter by ID.',
-        'key': 'remove-formatter',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The formatter identifier to remove.'},
-        ],
-    },
-    'logging.add_handler': {
-        'id': 'logging.add_handler',
-        'name': 'Add Handler',
-        'description': 'Add a new logging handler configuration.',
-        'key': 'add-handler',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique handler identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Handler name.'},
-            {'name_or_flags': ['module_path'], 'description': 'Module path of the handler class.'},
-            {'name_or_flags': ['class_name'], 'description': 'Handler class name.'},
-            {'name_or_flags': ['level'], 'description': 'Logging level.', 'choices': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']},
-            {'name_or_flags': ['formatter'], 'description': 'Formatter ID to use.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--stream'], 'description': 'Optional stream specification.'},
-            {'name_or_flags': ['--filename'], 'description': 'Optional filename for FileHandler.'},
-        ],
-    },
-    'logging.remove_handler': {
-        'id': 'logging.remove_handler',
-        'name': 'Remove Handler',
-        'description': 'Remove a logging handler by ID.',
-        'key': 'remove-handler',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The handler identifier to remove.'},
-        ],
-    },
-    'logging.add_logger': {
-        'id': 'logging.add_logger',
-        'name': 'Add Logger',
-        'description': 'Add a new logger configuration.',
-        'key': 'add-logger',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'Unique logger identifier.'},
-            {'name_or_flags': ['name'], 'description': 'Logger name.'},
-            {'name_or_flags': ['level'], 'description': 'Logging level.', 'choices': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']},
-            {'name_or_flags': ['handlers'], 'description': 'Comma-separated list of handler IDs.'},
-            {'name_or_flags': ['--description'], 'description': 'Optional description.'},
-            {'name_or_flags': ['--no-propagate'], 'description': 'Disable message propagation.', 'action': 'store_true'},
-        ],
-    },
-    'logging.remove_logger': {
-        'id': 'logging.remove_logger',
-        'name': 'Remove Logger',
-        'description': 'Remove a logger by ID.',
-        'key': 'remove-logger',
-        'group_key': 'logging',
-        'arguments': [
-            {'name_or_flags': ['id'], 'description': 'The logger identifier to remove.'},
-        ],
-    },
-    'logging.list': {
-        'id': 'logging.list',
-        'name': 'List Logging Configs',
-        'description': 'List all logging configurations (formatters, handlers, loggers).',
-        'key': 'list',
-        'group_key': 'logging',
-        'arguments': [],
-    },
-}
+# ** constant: error_list_cli_cmd_id
+ERROR_LIST_CLI_CMD_ID = 'error.list'
+
+# ** constant: error_get_cli_cmd_id
+ERROR_GET_CLI_CMD_ID = 'error.get'
+
+# ** constant: error_add_cli_cmd_id
+ERROR_ADD_CLI_CMD_ID = 'error.add'
+
+# ** constant: error_rename_cli_cmd_id
+ERROR_RENAME_CLI_CMD_ID = 'error.rename'
+
+# ** constant: error_set_message_cli_cmd_id
+ERROR_SET_MESSAGE_CLI_CMD_ID = 'error.set_message'
+
+# ** constant: error_remove_message_cli_cmd_id
+ERROR_REMOVE_MESSAGE_CLI_CMD_ID = 'error.remove_message'
+
+# ** constant: error_remove_cli_cmd_id
+ERROR_REMOVE_CLI_CMD_ID = 'error.remove'
+
+# ** constant: feature_list_cli_cmd_id
+FEATURE_LIST_CLI_CMD_ID = 'feature.list'
+
+# ** constant: feature_add_cli_cmd_id
+FEATURE_ADD_CLI_CMD_ID = 'feature.add'
+
+# ** constant: feature_update_cli_cmd_id
+FEATURE_UPDATE_CLI_CMD_ID = 'feature.update'
+
+# ** constant: feature_add_step_cli_cmd_id
+FEATURE_ADD_STEP_CLI_CMD_ID = 'feature.add_step'
+
+# ** constant: feature_update_step_cli_cmd_id
+FEATURE_UPDATE_STEP_CLI_CMD_ID = 'feature.update_step'
+
+# ** constant: feature_remove_step_cli_cmd_id
+FEATURE_REMOVE_STEP_CLI_CMD_ID = 'feature.remove_step'
+
+# ** constant: feature_reorder_step_cli_cmd_id
+FEATURE_REORDER_STEP_CLI_CMD_ID = 'feature.reorder_step'
+
+# ** constant: feature_remove_cli_cmd_id
+FEATURE_REMOVE_CLI_CMD_ID = 'feature.remove'
+
+# ** constant: service_list_cli_cmd_id
+SERVICE_LIST_CLI_CMD_ID = 'service.list'
+
+# ** constant: service_add_cli_cmd_id
+SERVICE_ADD_CLI_CMD_ID = 'service.add'
+
+# ** constant: service_set_default_cli_cmd_id
+SERVICE_SET_DEFAULT_CLI_CMD_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_cli_cmd_id
+SERVICE_SET_DEPENDENCY_CLI_CMD_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_cli_cmd_id
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID = 'service.remove_dependency'
+
+# ** constant: service_set_constants_cli_cmd_id
+SERVICE_SET_CONSTANTS_CLI_CMD_ID = 'service.set_constants'
+
+# ** constant: service_remove_cli_cmd_id
+SERVICE_REMOVE_CLI_CMD_ID = 'service.remove'
+
+# ** constant: logging_add_formatter_cli_cmd_id
+LOGGING_ADD_FORMATTER_CLI_CMD_ID = 'logging.add_formatter'
+
+# ** constant: logging_remove_formatter_cli_cmd_id
+LOGGING_REMOVE_FORMATTER_CLI_CMD_ID = 'logging.remove_formatter'
+
+# ** constant: logging_add_handler_cli_cmd_id
+LOGGING_ADD_HANDLER_CLI_CMD_ID = 'logging.add_handler'
+
+# ** constant: logging_remove_handler_cli_cmd_id
+LOGGING_REMOVE_HANDLER_CLI_CMD_ID = 'logging.remove_handler'
+
+# ** constant: logging_add_logger_cli_cmd_id
+LOGGING_ADD_LOGGER_CLI_CMD_ID = 'logging.add_logger'
+
+# ** constant: logging_remove_logger_cli_cmd_id
+LOGGING_REMOVE_LOGGER_CLI_CMD_ID = 'logging.remove_logger'
+
+# ** constant: logging_list_cli_cmd_id
+LOGGING_LIST_CLI_CMD_ID = 'logging.list'
+
+# *** constants (commands)
+
+# ** constant: app_list_cli_cmd
+APP_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_LIST_CLI_CMD_ID,
+    key='list',
+    group_key='app',
+    name='List App Interfaces',
+    description='List all configured application interfaces.',
+)
+
+# ** constant: app_get_cli_cmd
+APP_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_GET_CLI_CMD_ID,
+    key='get',
+    group_key='app',
+    name='Get App Interface',
+    description='Retrieve an app interface by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['interface_id'],
+            description='The interface identifier.',
+        ),
+    ],
+)
+
+# ** constant: app_add_cli_cmd
+APP_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_ADD_CLI_CMD_ID,
+    key='add',
+    group_key='app',
+    name='Add App Interface',
+    description='Add a new application interface configuration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique interface identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='The human-readable interface name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['module_path'],
+            description='The Python module path of the context class.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['class_name'],
+            description='The context class name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional interface description.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--logger-id'],
+            description='Optional logger identifier. Defaults to "default".',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--flags'],
+            description='Optional JSON-encoded list of flags.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--constants'],
+            description='Optional JSON-encoded constants dictionary.',
+        ),
+    ],
+)
+
+# ** constant: app_update_cli_cmd
+APP_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_UPDATE_CLI_CMD_ID,
+    key='update',
+    group_key='app',
+    name='Update App Interface',
+    description='Update a scalar attribute on an existing application interface.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The interface identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['attribute'],
+            description='The attribute to update.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['value'],
+            description='The new value for the attribute.',
+        ),
+    ],
+)
+
+# ** constant: app_set_service_cli_cmd
+APP_SET_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_SET_SERVICE_CLI_CMD_ID,
+    key='set-service',
+    group_key='app',
+    name='Set App Service Dependency',
+    description='Set or update a service dependency on an application interface.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The interface identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['service_id'],
+            description='The service dependency identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['module_path'],
+            description='The module path of the service implementation.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['class_name'],
+            description='The class name of the service implementation.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--parameters'],
+            description='Optional JSON-encoded parameters dictionary.',
+        ),
+    ],
+)
+
+# ** constant: app_remove_service_cli_cmd
+APP_REMOVE_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_REMOVE_SERVICE_CLI_CMD_ID,
+    key='remove-service',
+    group_key='app',
+    name='Remove App Service Dependency',
+    description='Remove a service dependency from an application interface.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The interface identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['service_id'],
+            description='The service dependency identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: app_set_constants_cli_cmd
+APP_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_SET_CONSTANTS_CLI_CMD_ID,
+    key='set-constants',
+    group_key='app',
+    name='Set App Constants',
+    description='Set or clear constants on an application interface.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The interface identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--constants'],
+            description='Optional JSON-encoded constants dictionary. Omit to clear all constants.',
+        ),
+    ],
+)
+
+# ** constant: app_remove_cli_cmd
+APP_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=APP_REMOVE_CLI_CMD_ID,
+    key='remove',
+    group_key='app',
+    name='Remove App Interface',
+    description='Remove an application interface configuration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The interface identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: cli_list_commands_cli_cmd
+CLI_LIST_COMMANDS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=CLI_LIST_COMMANDS_CLI_CMD_ID,
+    key='list-commands',
+    group_key='cli',
+    name='List CLI Commands',
+    description='List all configured CLI commands.',
+)
+
+# ** constant: cli_add_command_cli_cmd
+CLI_ADD_COMMAND_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=CLI_ADD_COMMAND_CLI_CMD_ID,
+    key='add-command',
+    group_key='cli',
+    name='Add CLI Command',
+    description='Add a new CLI command definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique command identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='The human-readable command name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['key'],
+            description='The command key used in the CLI.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['group_key'],
+            description='The group key this command belongs to.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional command description.',
+        ),
+    ],
+)
+
+# ** constant: cli_add_argument_cli_cmd
+CLI_ADD_ARGUMENT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=CLI_ADD_ARGUMENT_CLI_CMD_ID,
+    key='add-argument',
+    group_key='cli',
+    name='Add CLI Argument',
+    description='Add an argument to an existing CLI command.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['command_id'],
+            description='The CLI command identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--name-or-flags'],
+            description='JSON-encoded list of argument names or flags.',
+            required=True,
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional argument description.',
+        ),
+    ],
+)
+
+# ** constant: error_list_cli_cmd
+ERROR_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_LIST_CLI_CMD_ID,
+    key='list',
+    group_key='error',
+    name='List Errors',
+    description='List all error definitions.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['--include-defaults'],
+            description='Include built-in default error definitions.',
+            action='store_true',
+        ),
+    ],
+)
+
+# ** constant: error_get_cli_cmd
+ERROR_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_GET_CLI_CMD_ID,
+    key='get',
+    group_key='error',
+    name='Get Error',
+    description='Retrieve an error by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The error identifier.',
+        ),
+    ],
+)
+
+# ** constant: error_add_cli_cmd
+ERROR_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_ADD_CLI_CMD_ID,
+    key='add',
+    group_key='error',
+    name='Add Error',
+    description='Add a new error definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique error identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='The human-readable error name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['message'],
+            description='The primary error message text.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--lang'],
+            description='Language code for the message. Defaults to "en_US".',
+        ),
+    ],
+)
+
+# ** constant: error_rename_cli_cmd
+ERROR_RENAME_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_RENAME_CLI_CMD_ID,
+    key='rename',
+    group_key='error',
+    name='Rename Error',
+    description='Rename an existing error definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique error identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['new_name'],
+            description='The new error name.',
+        ),
+    ],
+)
+
+# ** constant: error_set_message_cli_cmd
+ERROR_SET_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_SET_MESSAGE_CLI_CMD_ID,
+    key='set-message',
+    group_key='error',
+    name='Set Error Message',
+    description='Set the message text on an existing error definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique error identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['message'],
+            description='The new message text.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--lang'],
+            description='Language code for the message. Defaults to "en_US".',
+        ),
+    ],
+)
+
+# ** constant: error_remove_message_cli_cmd
+ERROR_REMOVE_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
+    key='remove-message',
+    group_key='error',
+    name='Remove Error Message',
+    description='Remove a language message from an existing error definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique error identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--lang'],
+            description='Language code of the message to remove. Defaults to "en_US".',
+        ),
+    ],
+)
+
+# ** constant: error_remove_cli_cmd
+ERROR_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=ERROR_REMOVE_CLI_CMD_ID,
+    key='remove',
+    group_key='error',
+    name='Remove Error',
+    description='Remove an error definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique error identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: feature_list_cli_cmd
+FEATURE_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_LIST_CLI_CMD_ID,
+    key='list',
+    group_key='feature',
+    name='List Features',
+    description='List all feature workflow definitions.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['--group-id'],
+            description='Optional group identifier to filter results.',
+        ),
+    ],
+)
+
+# ** constant: feature_add_cli_cmd
+FEATURE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_ADD_CLI_CMD_ID,
+    key='add',
+    group_key='feature',
+    name='Add Feature',
+    description='Add a new feature workflow definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='The feature name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['group_id'],
+            description='The group identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--feature-key'],
+            description='Optional explicit feature key. Defaults to snake_case of name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional feature description.',
+        ),
+    ],
+)
+
+# ** constant: feature_update_cli_cmd
+FEATURE_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_UPDATE_CLI_CMD_ID,
+    key='update',
+    group_key='feature',
+    name='Update Feature',
+    description='Update a metadata attribute on an existing feature.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['attribute'],
+            description='The attribute to update (name or description).',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['value'],
+            description='The new value.',
+        ),
+    ],
+)
+
+# ** constant: feature_add_step_cli_cmd
+FEATURE_ADD_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_ADD_STEP_CLI_CMD_ID,
+    key='add-step',
+    group_key='feature',
+    name='Add Feature Step',
+    description='Add a step to an existing feature workflow.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='The step name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['service_id'],
+            description='The DI service registration identifier for this step.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--parameters'],
+            description='Optional JSON-encoded step parameters.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--data-key'],
+            description='Optional result data key.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--pass-on-error'],
+            description='Continue execution if this step raises an error.',
+            action='store_true',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--position'],
+            description='Optional insertion index. Defaults to append.',
+            type='int',
+        ),
+    ],
+)
+
+# ** constant: feature_update_step_cli_cmd
+FEATURE_UPDATE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_UPDATE_STEP_CLI_CMD_ID,
+    key='update-step',
+    group_key='feature',
+    name='Update Feature Step',
+    description='Update an attribute on an existing feature step.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['position'],
+            description='The zero-based step index.',
+            type='int',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['attribute'],
+            description='The step attribute to update.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--value'],
+            description='The new value for the attribute.',
+        ),
+    ],
+)
+
+# ** constant: feature_remove_step_cli_cmd
+FEATURE_REMOVE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_REMOVE_STEP_CLI_CMD_ID,
+    key='remove-step',
+    group_key='feature',
+    name='Remove Feature Step',
+    description='Remove a step from an existing feature workflow.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['position'],
+            description='The zero-based index of the step to remove.',
+            type='int',
+        ),
+    ],
+)
+
+# ** constant: feature_reorder_step_cli_cmd
+FEATURE_REORDER_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_REORDER_STEP_CLI_CMD_ID,
+    key='reorder-step',
+    group_key='feature',
+    name='Reorder Feature Step',
+    description='Reorder a step within an existing feature workflow.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['start_position'],
+            description='The current zero-based step index.',
+            type='int',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['end_position'],
+            description='The target zero-based step index.',
+            type='int',
+        ),
+    ],
+)
+
+# ** constant: feature_remove_cli_cmd
+FEATURE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=FEATURE_REMOVE_CLI_CMD_ID,
+    key='remove',
+    group_key='feature',
+    name='Remove Feature',
+    description='Remove an existing feature workflow definition.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: service_list_cli_cmd
+SERVICE_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_LIST_CLI_CMD_ID,
+    key='list',
+    group_key='service',
+    name='List Services',
+    description='List all DI service registrations and constants.',
+)
+
+# ** constant: service_add_cli_cmd
+SERVICE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_ADD_CLI_CMD_ID,
+    key='add',
+    group_key='service',
+    name='Add Service',
+    description='Add a new DI service registration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The unique service registration identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--module-path'],
+            description='The module path of the service implementation.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--class-name'],
+            description='The class name of the service implementation.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--parameters'],
+            description='Optional JSON-encoded parameters dictionary.',
+        ),
+    ],
+)
+
+# ** constant: service_set_default_cli_cmd
+SERVICE_SET_DEFAULT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_SET_DEFAULT_CLI_CMD_ID,
+    key='set-default',
+    group_key='service',
+    name='Set Default Service Registration',
+    description='Set or update the default type for an existing service registration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The service registration identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--module-path'],
+            description='The new default module path.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--class-name'],
+            description='The new default class name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--parameters'],
+            description='Optional JSON-encoded parameters dictionary.',
+        ),
+    ],
+)
+
+# ** constant: service_set_dependency_cli_cmd
+SERVICE_SET_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
+    key='set-dependency',
+    group_key='service',
+    name='Set Service Dependency',
+    description='Set or update a flagged dependency on a service registration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The service registration identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['flag'],
+            description='The flag identifying this dependency.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['module_path'],
+            description='The module path for the flagged dependency.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['class_name'],
+            description='The class name for the flagged dependency.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--parameters'],
+            description='Optional JSON-encoded parameters dictionary.',
+        ),
+    ],
+)
+
+# ** constant: service_remove_dependency_cli_cmd
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
+    key='remove-dependency',
+    group_key='service',
+    name='Remove Service Dependency',
+    description='Remove a flagged dependency from a service registration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The service registration identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['flag'],
+            description='The flag identifying the dependency to remove.',
+        ),
+    ],
+)
+
+# ** constant: service_set_constants_cli_cmd
+SERVICE_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_SET_CONSTANTS_CLI_CMD_ID,
+    key='set-constants',
+    group_key='service',
+    name='Set Service Constants',
+    description='Set or clear DI service constants.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['--constants'],
+            description='Optional JSON-encoded constants dictionary. Omit to clear all.',
+        ),
+    ],
+)
+
+# ** constant: service_remove_cli_cmd
+SERVICE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=SERVICE_REMOVE_CLI_CMD_ID,
+    key='remove',
+    group_key='service',
+    name='Remove Service',
+    description='Remove a DI service registration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The service registration identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: logging_add_formatter_cli_cmd
+LOGGING_ADD_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_ADD_FORMATTER_CLI_CMD_ID,
+    key='add-formatter',
+    group_key='logging',
+    name='Add Formatter',
+    description='Add a new logging formatter configuration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='Unique formatter identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='Formatter name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['format'],
+            description='Format string for log messages.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional description.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--datefmt'],
+            description='Optional date format string.',
+        ),
+    ],
+)
+
+# ** constant: logging_remove_formatter_cli_cmd
+LOGGING_REMOVE_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_REMOVE_FORMATTER_CLI_CMD_ID,
+    key='remove-formatter',
+    group_key='logging',
+    name='Remove Formatter',
+    description='Remove a logging formatter by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The formatter identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: logging_add_handler_cli_cmd
+LOGGING_ADD_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_ADD_HANDLER_CLI_CMD_ID,
+    key='add-handler',
+    group_key='logging',
+    name='Add Handler',
+    description='Add a new logging handler configuration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='Unique handler identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='Handler name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['module_path'],
+            description='Module path of the handler class.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['class_name'],
+            description='Handler class name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['level'],
+            description='Logging level.',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        ),
+        create_default_cli_argument(
+            name_or_flags=['formatter'],
+            description='Formatter ID to use.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional description.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--stream'],
+            description='Optional stream specification.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--filename'],
+            description='Optional filename for FileHandler.',
+        ),
+    ],
+)
+
+# ** constant: logging_remove_handler_cli_cmd
+LOGGING_REMOVE_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_REMOVE_HANDLER_CLI_CMD_ID,
+    key='remove-handler',
+    group_key='logging',
+    name='Remove Handler',
+    description='Remove a logging handler by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The handler identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: logging_add_logger_cli_cmd
+LOGGING_ADD_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_ADD_LOGGER_CLI_CMD_ID,
+    key='add-logger',
+    group_key='logging',
+    name='Add Logger',
+    description='Add a new logger configuration.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='Unique logger identifier.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['name'],
+            description='Logger name.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['level'],
+            description='Logging level.',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        ),
+        create_default_cli_argument(
+            name_or_flags=['handlers'],
+            description='Comma-separated list of handler IDs.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--description'],
+            description='Optional description.',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--no-propagate'],
+            description='Disable message propagation.',
+            action='store_true',
+        ),
+    ],
+)
+
+# ** constant: logging_remove_logger_cli_cmd
+LOGGING_REMOVE_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_REMOVE_LOGGER_CLI_CMD_ID,
+    key='remove-logger',
+    group_key='logging',
+    name='Remove Logger',
+    description='Remove a logger by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The logger identifier to remove.',
+        ),
+    ],
+)
+
+# ** constant: logging_list_cli_cmd
+LOGGING_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
+    id=LOGGING_LIST_CLI_CMD_ID,
+    key='list',
+    group_key='logging',
+    name='List Logging Configs',
+    description='List all logging configurations (formatters, handlers, loggers).',
+)
+
+# *** constants (groups)
 
 # ** constant: admin_default_commands
-ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = DEFAULT_TIFERET_CLI_COMMANDS
+ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
+    APP_LIST_CLI_CMD_ID: APP_LIST_CLI_CMD,
+    APP_GET_CLI_CMD_ID: APP_GET_CLI_CMD,
+    APP_ADD_CLI_CMD_ID: APP_ADD_CLI_CMD,
+    APP_UPDATE_CLI_CMD_ID: APP_UPDATE_CLI_CMD,
+    APP_SET_SERVICE_CLI_CMD_ID: APP_SET_SERVICE_CLI_CMD,
+    APP_REMOVE_SERVICE_CLI_CMD_ID: APP_REMOVE_SERVICE_CLI_CMD,
+    APP_SET_CONSTANTS_CLI_CMD_ID: APP_SET_CONSTANTS_CLI_CMD,
+    APP_REMOVE_CLI_CMD_ID: APP_REMOVE_CLI_CMD,
+    CLI_LIST_COMMANDS_CLI_CMD_ID: CLI_LIST_COMMANDS_CLI_CMD,
+    CLI_ADD_COMMAND_CLI_CMD_ID: CLI_ADD_COMMAND_CLI_CMD,
+    CLI_ADD_ARGUMENT_CLI_CMD_ID: CLI_ADD_ARGUMENT_CLI_CMD,
+    ERROR_LIST_CLI_CMD_ID: ERROR_LIST_CLI_CMD,
+    ERROR_GET_CLI_CMD_ID: ERROR_GET_CLI_CMD,
+    ERROR_ADD_CLI_CMD_ID: ERROR_ADD_CLI_CMD,
+    ERROR_RENAME_CLI_CMD_ID: ERROR_RENAME_CLI_CMD,
+    ERROR_SET_MESSAGE_CLI_CMD_ID: ERROR_SET_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID: ERROR_REMOVE_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_CLI_CMD_ID: ERROR_REMOVE_CLI_CMD,
+    FEATURE_LIST_CLI_CMD_ID: FEATURE_LIST_CLI_CMD,
+    FEATURE_ADD_CLI_CMD_ID: FEATURE_ADD_CLI_CMD,
+    FEATURE_UPDATE_CLI_CMD_ID: FEATURE_UPDATE_CLI_CMD,
+    FEATURE_ADD_STEP_CLI_CMD_ID: FEATURE_ADD_STEP_CLI_CMD,
+    FEATURE_UPDATE_STEP_CLI_CMD_ID: FEATURE_UPDATE_STEP_CLI_CMD,
+    FEATURE_REMOVE_STEP_CLI_CMD_ID: FEATURE_REMOVE_STEP_CLI_CMD,
+    FEATURE_REORDER_STEP_CLI_CMD_ID: FEATURE_REORDER_STEP_CLI_CMD,
+    FEATURE_REMOVE_CLI_CMD_ID: FEATURE_REMOVE_CLI_CMD,
+    SERVICE_LIST_CLI_CMD_ID: SERVICE_LIST_CLI_CMD,
+    SERVICE_ADD_CLI_CMD_ID: SERVICE_ADD_CLI_CMD,
+    SERVICE_SET_DEFAULT_CLI_CMD_ID: SERVICE_SET_DEFAULT_CLI_CMD,
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
+    SERVICE_REMOVE_CLI_CMD_ID: SERVICE_REMOVE_CLI_CMD,
+    LOGGING_ADD_FORMATTER_CLI_CMD_ID: LOGGING_ADD_FORMATTER_CLI_CMD,
+    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD,
+    LOGGING_ADD_HANDLER_CLI_CMD_ID: LOGGING_ADD_HANDLER_CLI_CMD,
+    LOGGING_REMOVE_HANDLER_CLI_CMD_ID: LOGGING_REMOVE_HANDLER_CLI_CMD,
+    LOGGING_ADD_LOGGER_CLI_CMD_ID: LOGGING_ADD_LOGGER_CLI_CMD,
+    LOGGING_REMOVE_LOGGER_CLI_CMD_ID: LOGGING_REMOVE_LOGGER_CLI_CMD,
+    LOGGING_LIST_CLI_CMD_ID: LOGGING_LIST_CLI_CMD,
+}

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -180,6 +180,98 @@ def create_service_registration(id: str,
     # Assemble and return the service registration definition dictionary.
     return {'id': id, **create_service_dependency(module_path, class_name, parameters)}
 
+# ** function: create_default_cli_argument
+def create_default_cli_argument(name_or_flags: List[str],
+        description: str = None,
+        type: str = None,
+        default: Any = None,
+        required: bool = None,
+        nargs: str = None,
+        choices: List[str] = None,
+        action: str = None) -> Dict[str, Any]:
+    '''
+    Build a default CLI argument definition dictionary.
+
+    :param name_or_flags: List of argument names or option strings.
+    :type name_or_flags: List[str]
+    :param description: Optional argument description.
+    :type description: str
+    :param type: Optional argument type string (e.g. 'int', 'str').
+    :type type: str
+    :param default: Optional default value for the argument.
+    :type default: Any
+    :param required: Optional flag indicating whether the argument is required.
+    :type required: bool
+    :param nargs: Optional number-of-arguments specifier.
+    :type nargs: str
+    :param choices: Optional list of allowed values.
+    :type choices: List[str]
+    :param action: Optional argparse action string (e.g. 'store_true').
+    :type action: str
+    :return: The argument definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base argument definition.
+    argument = {'name_or_flags': name_or_flags}
+
+    # Add optional fields when provided.
+    if description is not None:
+        argument['description'] = description
+    if type is not None:
+        argument['type'] = type
+    if default is not None:
+        argument['default'] = default
+    if required is not None:
+        argument['required'] = required
+    if nargs is not None:
+        argument['nargs'] = nargs
+    if choices is not None:
+        argument['choices'] = choices
+    if action is not None:
+        argument['action'] = action
+
+    # Return the assembled argument definition.
+    return argument
+
+# ** function: create_default_cli_command
+def create_default_cli_command(id: str,
+        key: str,
+        group_key: str,
+        name: str,
+        description: str = None,
+        arguments: List[Dict[str, Any]] = None) -> Dict[str, Any]:
+    '''
+    Build a default CLI command definition dictionary.
+
+    :param id: The unique command identifier.
+    :type id: str
+    :param key: The command key used in the CLI.
+    :type key: str
+    :param group_key: The group key this command belongs to.
+    :type group_key: str
+    :param name: The human-readable command name.
+    :type name: str
+    :param description: Optional command description.
+    :type description: str
+    :param arguments: Optional list of argument definition dicts.
+    :type arguments: List[Dict[str, Any]]
+    :return: The command definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base command definition.
+    command = {'id': id, 'key': key, 'group_key': group_key, 'name': name}
+
+    # Add optional fields when provided.
+    if description is not None:
+        command['description'] = description
+    if arguments:
+        command['arguments'] = arguments
+
+    # Return the assembled command definition.
+    return command
+
 # ** function: create_default_error
 def create_default_error(id: str,
         name: str,

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -157,6 +157,29 @@ def create_service_dependency(module_path: str,
         'parameters': parameters or {},
     }
 
+# ** function: create_service_registration
+def create_service_registration(id: str,
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None) -> Dict[str, Any]:
+    '''
+    Build a service registration definition dictionary.
+
+    :param id: The unique service registration identifier.
+    :type id: str
+    :param module_path: The module path of the service implementation.
+    :type module_path: str
+    :param class_name: The class name of the service implementation.
+    :type class_name: str
+    :param parameters: Optional DI parameters for the registration.
+    :type parameters: Dict[str, Any]
+    :return: The service registration definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the service registration definition dictionary.
+    return {'id': id, **create_service_dependency(module_path, class_name, parameters)}
+
 # ** function: create_default_error
 def create_default_error(id: str,
         name: str,

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -49,6 +49,70 @@ MIDDLEWARE_DOMAIN_PATH = 'middleware'
 
 # *** functions
 
+# ** function: create_default_feature
+def create_default_feature(id: str,
+        name: str,
+        group_id: str,
+        feature_key: str,
+        steps: List[Dict[str, Any]],
+        description: str = None,
+        params_schema: Dict[str, Any] = None) -> Dict[str, Any]:
+    '''
+    Build a default feature definition dictionary.
+
+    :param id: The unique feature identifier.
+    :type id: str
+    :param name: The human-readable feature name.
+    :type name: str
+    :param group_id: The feature group identifier.
+    :type group_id: str
+    :param feature_key: The feature key within the group.
+    :type feature_key: str
+    :param steps: Ordered list of feature step dicts.
+    :type steps: List[Dict[str, Any]]
+    :param description: Optional feature description.
+    :type description: str
+    :param params_schema: Optional parameter schema dict.
+    :type params_schema: Dict[str, Any]
+    :return: The feature definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base feature definition.
+    feature = {
+        'id': id,
+        'name': name,
+        'group_id': group_id,
+        'feature_key': feature_key,
+        'steps': steps,
+    }
+
+    # Add optional fields when provided.
+    if description is not None:
+        feature['description'] = description
+    if params_schema is not None:
+        feature['params_schema'] = params_schema
+
+    # Return the assembled feature definition.
+    return feature
+
+# ** function: create_params_schema
+def create_params_schema(**params: Any) -> Dict[str, Any]:
+    '''
+    Build a parameter schema dictionary from keyword arguments.
+
+    Each keyword argument names one expected request parameter; the value
+    is either a plain type string or a parameter-spec dict.
+
+    :param params: Named parameter specifications.
+    :type params: Any
+    :return: The assembled parameter schema dict.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Return the assembled parameter schema dict.
+    return dict(params)
+
 # ** function: create_service_module_path
 def create_service_module_path(app_base_path: str,
         base_path: str,

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -5,7 +5,7 @@ Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 37 individually named service ID string constants.
 - ``constants (services)`` — 37 individually named service registration
   dicts, each built via ``create_service_registration``.
-- ``constants (groups)`` — the ``DEFAULT_TIFERET_CLI_SERVICES`` catalog dict
+- ``constants (groups)`` — the ``DEFAULT_ADMIN_SERVICES`` catalog dict
   keyed by ID constants.
 """
 
@@ -405,8 +405,8 @@ REMOVE_LOGGER_EVT = create_service_registration(
 
 # *** constants (groups)
 
-# ** constant: default_tiferet_cli_services
-DEFAULT_TIFERET_CLI_SERVICES: Dict[str, Dict] = {
+# ** constant: default_admin_services
+DEFAULT_ADMIN_SERVICES: Dict[str, Dict] = {
     APP_SERVICE_ID: APP_SERVICE,
     ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
     LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -1,73 +1,447 @@
-"""Tiferet Assets Service
+"""Tiferet DI Assets
 
-Provides the default service configurations for the built-in Tiferet CLI
-management application. These register domain events as injectable services
-for CLI feature workflows.
-
-Services already defined in ``app.CORE_DEFAULT_SERVICES`` (e.g.
-``get_error_evt``, ``get_feature_evt``, ``list_all_settings_evt``) are
-**not** duplicated here. The blueprint merges both lists at startup.
+Three-section catalog for the built-in Tiferet CLI service registrations.
+Each section follows the pattern established by ``assets/error.py``:
+- ``constants (ids)`` — 37 individually named service ID string constants.
+- ``constants (services)`` — 37 individually named service registration
+  dicts, each built via ``create_service_registration``.
+- ``constants (groups)`` — the ``DEFAULT_TIFERET_CLI_SERVICES`` catalog dict
+  keyed by ID constants.
 """
 
 # *** imports
 
 # ** core
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
-# *** constants
+# ** app
+from .core import (
+    create_service_registration,
+    create_service_module_path,
+    TIFERET,
+    TIFERET_EVENTS_PATH,
+    TIFERET_REPOS_PATH,
+    FEATURE_DOMAIN_PATH,
+    ERROR_DOMAIN_PATH,
+    DI_DOMAIN_PATH,
+    APP_DOMAIN_PATH,
+    LOGGING_DOMAIN_PATH,
+    CLI_DOMAIN_PATH,
+)
+
+# *** constants (ids)
+
+# ** constant: app_service_id
+APP_SERVICE_ID = 'app_service'
+
+# ** constant: add_feature_evt_id
+ADD_FEATURE_EVT_ID = 'add_feature_evt'
+
+# ** constant: list_features_evt_id
+LIST_FEATURES_EVT_ID = 'list_features_evt'
+
+# ** constant: remove_feature_evt_id
+REMOVE_FEATURE_EVT_ID = 'remove_feature_evt'
+
+# ** constant: update_feature_evt_id
+UPDATE_FEATURE_EVT_ID = 'update_feature_evt'
+
+# ** constant: add_feature_step_evt_id
+ADD_FEATURE_STEP_EVT_ID = 'add_feature_step_evt'
+
+# ** constant: update_feature_step_evt_id
+UPDATE_FEATURE_STEP_EVT_ID = 'update_feature_step_evt'
+
+# ** constant: remove_feature_step_evt_id
+REMOVE_FEATURE_STEP_EVT_ID = 'remove_feature_step_evt'
+
+# ** constant: reorder_feature_step_evt_id
+REORDER_FEATURE_STEP_EVT_ID = 'reorder_feature_step_evt'
+
+# ** constant: add_error_evt_id
+ADD_ERROR_EVT_ID = 'add_error_evt'
+
+# ** constant: list_errors_evt_id
+LIST_ERRORS_EVT_ID = 'list_errors_evt'
+
+# ** constant: rename_error_evt_id
+RENAME_ERROR_EVT_ID = 'rename_error_evt'
+
+# ** constant: set_error_message_evt_id
+SET_ERROR_MESSAGE_EVT_ID = 'set_error_message_evt'
+
+# ** constant: remove_error_message_evt_id
+REMOVE_ERROR_MESSAGE_EVT_ID = 'remove_error_message_evt'
+
+# ** constant: remove_error_evt_id
+REMOVE_ERROR_EVT_ID = 'remove_error_evt'
+
+# ** constant: add_service_registration_evt_id
+ADD_SERVICE_REGISTRATION_EVT_ID = 'add_service_registration_evt'
+
+# ** constant: set_default_service_registration_evt_id
+SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID = 'set_default_service_registration_evt'
+
+# ** constant: set_di_service_dependency_evt_id
+SET_DI_SERVICE_DEPENDENCY_EVT_ID = 'set_di_service_dependency_evt'
+
+# ** constant: remove_di_service_dependency_evt_id
+REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID = 'remove_di_service_dependency_evt'
+
+# ** constant: remove_service_registration_evt_id
+REMOVE_SERVICE_REGISTRATION_EVT_ID = 'remove_service_registration_evt'
+
+# ** constant: set_service_constants_evt_id
+SET_SERVICE_CONSTANTS_EVT_ID = 'set_service_constants_evt'
+
+# ** constant: add_app_session_evt_id
+ADD_APP_SESSION_EVT_ID = 'add_app_session_evt'
+
+# ** constant: get_app_session_evt_id
+GET_APP_SESSION_EVT_ID = 'get_app_session_evt'
+
+# ** constant: update_app_session_evt_id
+UPDATE_APP_SESSION_EVT_ID = 'update_app_session_evt'
+
+# ** constant: set_app_constants_evt_id
+SET_APP_CONSTANTS_EVT_ID = 'set_app_constants_evt'
+
+# ** constant: list_app_sessions_evt_id
+LIST_APP_SESSIONS_EVT_ID = 'list_app_sessions_evt'
+
+# ** constant: set_app_service_dependency_evt_id
+SET_APP_SERVICE_DEPENDENCY_EVT_ID = 'set_app_service_dependency_evt'
+
+# ** constant: remove_app_service_dependency_evt_id
+REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID = 'remove_app_service_dependency_evt'
+
+# ** constant: remove_app_session_evt_id
+REMOVE_APP_SESSION_EVT_ID = 'remove_app_session_evt'
+
+# ** constant: add_cli_command_evt_id
+ADD_CLI_COMMAND_EVT_ID = 'add_cli_command_evt'
+
+# ** constant: add_cli_argument_evt_id
+ADD_CLI_ARGUMENT_EVT_ID = 'add_cli_argument_evt'
+
+# ** constant: add_formatter_evt_id
+ADD_FORMATTER_EVT_ID = 'add_formatter_evt'
+
+# ** constant: remove_formatter_evt_id
+REMOVE_FORMATTER_EVT_ID = 'remove_formatter_evt'
+
+# ** constant: add_handler_evt_id
+ADD_HANDLER_EVT_ID = 'add_handler_evt'
+
+# ** constant: remove_handler_evt_id
+REMOVE_HANDLER_EVT_ID = 'remove_handler_evt'
+
+# ** constant: add_logger_evt_id
+ADD_LOGGER_EVT_ID = 'add_logger_evt'
+
+# ** constant: remove_logger_evt_id
+REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
+
+# *** constants (services)
+
+# ** constant: app_service
+APP_SERVICE = create_service_registration(
+    APP_SERVICE_ID,
+    create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
+    'AppConfigRepository',
+)
+
+# ** constant: add_feature_evt
+ADD_FEATURE_EVT = create_service_registration(
+    ADD_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'AddFeature',
+)
+
+# ** constant: list_features_evt
+LIST_FEATURES_EVT = create_service_registration(
+    LIST_FEATURES_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'ListFeatures',
+)
+
+# ** constant: remove_feature_evt
+REMOVE_FEATURE_EVT = create_service_registration(
+    REMOVE_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'RemoveFeature',
+)
+
+# ** constant: update_feature_evt
+UPDATE_FEATURE_EVT = create_service_registration(
+    UPDATE_FEATURE_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'UpdateFeature',
+)
+
+# ** constant: add_feature_step_evt
+ADD_FEATURE_STEP_EVT = create_service_registration(
+    ADD_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'AddFeatureStep',
+)
+
+# ** constant: update_feature_step_evt
+UPDATE_FEATURE_STEP_EVT = create_service_registration(
+    UPDATE_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'UpdateFeatureStep',
+)
+
+# ** constant: remove_feature_step_evt
+REMOVE_FEATURE_STEP_EVT = create_service_registration(
+    REMOVE_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'RemoveFeatureStep',
+)
+
+# ** constant: reorder_feature_step_evt
+REORDER_FEATURE_STEP_EVT = create_service_registration(
+    REORDER_FEATURE_STEP_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
+    'ReorderFeatureStep',
+)
+
+# ** constant: add_error_evt
+ADD_ERROR_EVT = create_service_registration(
+    ADD_ERROR_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'AddError',
+)
+
+# ** constant: list_errors_evt
+LIST_ERRORS_EVT = create_service_registration(
+    LIST_ERRORS_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'ListErrors',
+)
+
+# ** constant: rename_error_evt
+RENAME_ERROR_EVT = create_service_registration(
+    RENAME_ERROR_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RenameError',
+)
+
+# ** constant: set_error_message_evt
+SET_ERROR_MESSAGE_EVT = create_service_registration(
+    SET_ERROR_MESSAGE_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'SetErrorMessage',
+)
+
+# ** constant: remove_error_message_evt
+REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
+    REMOVE_ERROR_MESSAGE_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RemoveErrorMessage',
+)
+
+# ** constant: remove_error_evt
+REMOVE_ERROR_EVT = create_service_registration(
+    REMOVE_ERROR_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
+    'RemoveError',
+)
+
+# ** constant: add_service_registration_evt
+ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
+    ADD_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'AddServiceRegistration',
+)
+
+# ** constant: set_default_service_registration_evt
+SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetDefaultServiceRegistration',
+)
+
+# ** constant: set_di_service_dependency_evt
+SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetServiceDependency',
+)
+
+# ** constant: remove_di_service_dependency_evt
+REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_service_registration_evt
+REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
+    REMOVE_SERVICE_REGISTRATION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'RemoveServiceRegistration',
+)
+
+# ** constant: set_service_constants_evt
+SET_SERVICE_CONSTANTS_EVT = create_service_registration(
+    SET_SERVICE_CONSTANTS_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
+    'SetServiceConstants',
+)
+
+# ** constant: add_app_session_evt
+ADD_APP_SESSION_EVT = create_service_registration(
+    ADD_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'AddAppSession',
+)
+
+# ** constant: get_app_session_evt
+GET_APP_SESSION_EVT = create_service_registration(
+    GET_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'GetAppSession',
+)
+
+# ** constant: update_app_session_evt
+UPDATE_APP_SESSION_EVT = create_service_registration(
+    UPDATE_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'UpdateAppSession',
+)
+
+# ** constant: set_app_constants_evt
+SET_APP_CONSTANTS_EVT = create_service_registration(
+    SET_APP_CONSTANTS_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'SetAppConstants',
+)
+
+# ** constant: list_app_sessions_evt
+LIST_APP_SESSIONS_EVT = create_service_registration(
+    LIST_APP_SESSIONS_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'ListAppSessions',
+)
+
+# ** constant: set_app_service_dependency_evt
+SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'SetServiceDependency',
+)
+
+# ** constant: remove_app_service_dependency_evt
+REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'RemoveServiceDependency',
+)
+
+# ** constant: remove_app_session_evt
+REMOVE_APP_SESSION_EVT = create_service_registration(
+    REMOVE_APP_SESSION_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
+    'RemoveAppSession',
+)
+
+# ** constant: add_cli_command_evt
+ADD_CLI_COMMAND_EVT = create_service_registration(
+    ADD_CLI_COMMAND_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'AddCliCommand',
+)
+
+# ** constant: add_cli_argument_evt
+ADD_CLI_ARGUMENT_EVT = create_service_registration(
+    ADD_CLI_ARGUMENT_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
+    'AddCliArgument',
+)
+
+# ** constant: add_formatter_evt
+ADD_FORMATTER_EVT = create_service_registration(
+    ADD_FORMATTER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddFormatter',
+)
+
+# ** constant: remove_formatter_evt
+REMOVE_FORMATTER_EVT = create_service_registration(
+    REMOVE_FORMATTER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveFormatter',
+)
+
+# ** constant: add_handler_evt
+ADD_HANDLER_EVT = create_service_registration(
+    ADD_HANDLER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddHandler',
+)
+
+# ** constant: remove_handler_evt
+REMOVE_HANDLER_EVT = create_service_registration(
+    REMOVE_HANDLER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveHandler',
+)
+
+# ** constant: add_logger_evt
+ADD_LOGGER_EVT = create_service_registration(
+    ADD_LOGGER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'AddLogger',
+)
+
+# ** constant: remove_logger_evt
+REMOVE_LOGGER_EVT = create_service_registration(
+    REMOVE_LOGGER_EVT_ID,
+    create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
+    'RemoveLogger',
+)
+
+# *** constants (groups)
 
 # ** constant: default_tiferet_cli_services
-# Each tuple: (service_id, module_path, class_name, parameters | None)
-DEFAULT_TIFERET_CLI_SERVICES: List[Tuple[str, str, str, Dict[str, Any] | None]] = [
-
-    # * services: app_service (repository — needed by app domain events)
-    ('app_service', 'tiferet.repos.app', 'AppConfigRepository', None),
-
-    # * services: feature domain events
-    ('add_feature_evt', 'tiferet.events.feature', 'AddFeature', None),
-    ('list_features_evt', 'tiferet.events.feature', 'ListFeatures', None),
-    ('remove_feature_evt', 'tiferet.events.feature', 'RemoveFeature', None),
-    ('update_feature_evt', 'tiferet.events.feature', 'UpdateFeature', None),
-    ('add_feature_step_evt', 'tiferet.events.feature', 'AddFeatureStep', None),
-    ('update_feature_step_evt', 'tiferet.events.feature', 'UpdateFeatureStep', None),
-    ('remove_feature_step_evt', 'tiferet.events.feature', 'RemoveFeatureStep', None),
-    ('reorder_feature_step_evt', 'tiferet.events.feature', 'ReorderFeatureStep', None),
-
-    # * services: error domain events
-    ('add_error_evt', 'tiferet.events.error', 'AddError', None),
-    ('list_errors_evt', 'tiferet.events.error', 'ListErrors', None),
-    ('rename_error_evt', 'tiferet.events.error', 'RenameError', None),
-    ('set_error_message_evt', 'tiferet.events.error', 'SetErrorMessage', None),
-    ('remove_error_message_evt', 'tiferet.events.error', 'RemoveErrorMessage', None),
-    ('remove_error_evt', 'tiferet.events.error', 'RemoveError', None),
-
-    # * services: di (service configuration) domain events
-    ('add_service_registration_evt', 'tiferet.events.di', 'AddServiceRegistration', None),
-    ('set_default_service_registration_evt', 'tiferet.events.di', 'SetDefaultServiceRegistration', None),
-    ('set_di_service_dependency_evt', 'tiferet.events.di', 'SetServiceDependency', None),
-    ('remove_di_service_dependency_evt', 'tiferet.events.di', 'RemoveServiceDependency', None),
-    ('remove_service_registration_evt', 'tiferet.events.di', 'RemoveServiceRegistration', None),
-    ('set_service_constants_evt', 'tiferet.events.di', 'SetServiceConstants', None),
-
-    # * services: app session domain events
-    ('add_app_session_evt', 'tiferet.events.app', 'AddAppSession', None),
-    ('get_app_session_evt', 'tiferet.events.app', 'GetAppSession', None),
-    ('update_app_session_evt', 'tiferet.events.app', 'UpdateAppSession', None),
-    ('set_app_constants_evt', 'tiferet.events.app', 'SetAppConstants', None),
-    ('list_app_sessions_evt', 'tiferet.events.app', 'ListAppSessions', None),
-    ('set_app_service_dependency_evt', 'tiferet.events.app', 'SetServiceDependency', None),
-    ('remove_app_service_dependency_evt', 'tiferet.events.app', 'RemoveServiceDependency', None),
-    ('remove_app_session_evt', 'tiferet.events.app', 'RemoveAppSession', None),
-
-    # * services: cli domain events
-    ('add_cli_command_evt', 'tiferet.events.cli', 'AddCliCommand', None),
-    ('add_cli_argument_evt', 'tiferet.events.cli', 'AddCliArgument', None),
-
-    # * services: logging domain events
-    ('add_formatter_evt', 'tiferet.events.logging', 'AddFormatter', None),
-    ('remove_formatter_evt', 'tiferet.events.logging', 'RemoveFormatter', None),
-    ('add_handler_evt', 'tiferet.events.logging', 'AddHandler', None),
-    ('remove_handler_evt', 'tiferet.events.logging', 'RemoveHandler', None),
-    ('add_logger_evt', 'tiferet.events.logging', 'AddLogger', None),
-    ('remove_logger_evt', 'tiferet.events.logging', 'RemoveLogger', None),
-]
+DEFAULT_TIFERET_CLI_SERVICES: Dict[str, Dict] = {
+    APP_SERVICE_ID: APP_SERVICE,
+    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
+    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
+    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
+    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
+    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
+    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
+    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
+    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
+    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
+    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
+    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
+    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
+    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
+    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
+    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
+    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
+    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
+    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
+    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
+    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
+    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
+    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
+    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
+    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
+    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
+    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
+    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
+    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
+    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
+    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
+}

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -5,8 +5,8 @@ Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 41 individually named feature ID string constants.
 - ``constants (features)`` — 41 individually named feature definition dicts,
   each built via ``create_default_feature``.
-- ``constants (groups)`` — the ``DEFAULT_TIFERET_CLI_FEATURES`` catalog dict
-  keyed by ID constants, plus the ``ADMIN_DEFAULT_FEATURES`` alias.
+- ``constants (groups)`` — the ``DEFAULT_ADMIN_FEATURES`` catalog dict
+  keyed by ID constants.
 """
 
 # *** imports
@@ -556,8 +556,8 @@ LOGGING_LIST = create_default_feature(
 
 # *** constants (groups)
 
-# ** constant: default_tiferet_cli_features
-DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
+# ** constant: default_admin_features
+DEFAULT_ADMIN_FEATURES: Dict[str, Any] = {
     APP_ADD_ID: APP_ADD,
     APP_GET_ID: APP_GET,
     APP_LIST_ID: APP_LIST,
@@ -600,6 +600,3 @@ DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
     LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER,
     LOGGING_LIST_ID: LOGGING_LIST,
 }
-
-# ** constant: admin_default_features
-ADMIN_DEFAULT_FEATURES: Dict[str, Any] = DEFAULT_TIFERET_CLI_FEATURES

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -1,443 +1,605 @@
-"""Tiferet CLI Feature Catalog"""
+"""Tiferet CLI Feature Catalog
+
+Three-section catalog for the built-in Tiferet CLI feature workflows.
+Each section follows the pattern established by ``assets/error.py``:
+- ``constants (ids)`` — 41 individually named feature ID string constants.
+- ``constants (features)`` — 41 individually named feature definition dicts,
+  each built via ``create_default_feature``.
+- ``constants (groups)`` — the ``DEFAULT_TIFERET_CLI_FEATURES`` catalog dict
+  keyed by ID constants, plus the ``ADMIN_DEFAULT_FEATURES`` alias.
+"""
 
 # *** imports
 
 # ** core
 from typing import Any, Dict, List
 
-# *** constants
+# ** app
+from .core import create_default_feature
+
+# *** constants (ids)
+
+# ** constant: app_add_id
+APP_ADD_ID = 'app.add'
+
+# ** constant: app_get_id
+APP_GET_ID = 'app.get'
+
+# ** constant: app_list_id
+APP_LIST_ID = 'app.list'
+
+# ** constant: app_update_id
+APP_UPDATE_ID = 'app.update'
+
+# ** constant: app_set_constants_id
+APP_SET_CONSTANTS_ID = 'app.set_constants'
+
+# ** constant: app_set_service_id
+APP_SET_SERVICE_ID = 'app.set_service'
+
+# ** constant: app_remove_service_id
+APP_REMOVE_SERVICE_ID = 'app.remove_service'
+
+# ** constant: app_remove_id
+APP_REMOVE_ID = 'app.remove'
+
+# ** constant: cli_list_commands_id
+CLI_LIST_COMMANDS_ID = 'cli.list_commands'
+
+# ** constant: cli_add_command_id
+CLI_ADD_COMMAND_ID = 'cli.add_command'
+
+# ** constant: cli_add_argument_id
+CLI_ADD_ARGUMENT_ID = 'cli.add_argument'
+
+# ** constant: error_list_id
+ERROR_LIST_ID = 'error.list'
+
+# ** constant: error_add_id
+ERROR_ADD_ID = 'error.add'
+
+# ** constant: error_get_id
+ERROR_GET_ID = 'error.get'
+
+# ** constant: error_rename_id
+ERROR_RENAME_ID = 'error.rename'
+
+# ** constant: error_set_message_id
+ERROR_SET_MESSAGE_ID = 'error.set_message'
+
+# ** constant: error_remove_message_id
+ERROR_REMOVE_MESSAGE_ID = 'error.remove_message'
+
+# ** constant: error_remove_id
+ERROR_REMOVE_ID = 'error.remove'
+
+# ** constant: feature_list_id
+FEATURE_LIST_ID = 'feature.list'
+
+# ** constant: feature_add_id
+FEATURE_ADD_ID = 'feature.add'
+
+# ** constant: feature_get_id
+FEATURE_GET_ID = 'feature.get'
+
+# ** constant: feature_update_id
+FEATURE_UPDATE_ID = 'feature.update'
+
+# ** constant: feature_add_step_id
+FEATURE_ADD_STEP_ID = 'feature.add_step'
+
+# ** constant: feature_update_step_id
+FEATURE_UPDATE_STEP_ID = 'feature.update_step'
+
+# ** constant: feature_remove_step_id
+FEATURE_REMOVE_STEP_ID = 'feature.remove_step'
+
+# ** constant: feature_reorder_step_id
+FEATURE_REORDER_STEP_ID = 'feature.reorder_step'
+
+# ** constant: feature_remove_id
+FEATURE_REMOVE_ID = 'feature.remove'
+
+# ** constant: service_list_id
+SERVICE_LIST_ID = 'service.list'
+
+# ** constant: service_add_id
+SERVICE_ADD_ID = 'service.add'
+
+# ** constant: service_set_default_id
+SERVICE_SET_DEFAULT_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_id
+SERVICE_SET_DEPENDENCY_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_id
+SERVICE_REMOVE_DEPENDENCY_ID = 'service.remove_dependency'
+
+# ** constant: service_set_constants_id
+SERVICE_SET_CONSTANTS_ID = 'service.set_constants'
+
+# ** constant: service_remove_id
+SERVICE_REMOVE_ID = 'service.remove'
+
+# ** constant: logging_add_formatter_id
+LOGGING_ADD_FORMATTER_ID = 'logging.add_formatter'
+
+# ** constant: logging_remove_formatter_id
+LOGGING_REMOVE_FORMATTER_ID = 'logging.remove_formatter'
+
+# ** constant: logging_add_handler_id
+LOGGING_ADD_HANDLER_ID = 'logging.add_handler'
+
+# ** constant: logging_remove_handler_id
+LOGGING_REMOVE_HANDLER_ID = 'logging.remove_handler'
+
+# ** constant: logging_add_logger_id
+LOGGING_ADD_LOGGER_ID = 'logging.add_logger'
+
+# ** constant: logging_remove_logger_id
+LOGGING_REMOVE_LOGGER_ID = 'logging.remove_logger'
+
+# ** constant: logging_list_id
+LOGGING_LIST_ID = 'logging.list'
+
+# *** constants (features)
+
+# ** constant: app_add
+APP_ADD = create_default_feature(
+    id=APP_ADD_ID,
+    name='Add App Session',
+    group_id='app',
+    feature_key='add',
+    steps=[{'service_id': 'add_app_session_evt'}],
+    description='Add a new application session configuration.',
+)
+
+# ** constant: app_get
+APP_GET = create_default_feature(
+    id=APP_GET_ID,
+    name='Get App Session',
+    group_id='app',
+    feature_key='get',
+    steps=[{'service_id': 'get_app_session_evt'}],
+    description='Retrieve an app session by ID.',
+)
+
+# ** constant: app_list
+APP_LIST = create_default_feature(
+    id=APP_LIST_ID,
+    name='List App Sessions',
+    group_id='app',
+    feature_key='list',
+    steps=[{'service_id': 'list_app_sessions_evt'}],
+    description='List all configured app sessions.',
+)
+
+# ** constant: app_update
+APP_UPDATE = create_default_feature(
+    id=APP_UPDATE_ID,
+    name='Update App Session',
+    group_id='app',
+    feature_key='update',
+    steps=[{'service_id': 'update_app_session_evt'}],
+    description='Update a scalar attribute on an app session.',
+)
+
+# ** constant: app_set_constants
+APP_SET_CONSTANTS = create_default_feature(
+    id=APP_SET_CONSTANTS_ID,
+    name='Set App Constants',
+    group_id='app',
+    feature_key='set_constants',
+    steps=[{'service_id': 'set_app_constants_evt'}],
+    description='Set or clear constants on an app session.',
+)
+
+# ** constant: app_set_service
+APP_SET_SERVICE = create_default_feature(
+    id=APP_SET_SERVICE_ID,
+    name='Set App Service Dependency',
+    group_id='app',
+    feature_key='set_service',
+    steps=[{'service_id': 'set_app_service_dependency_evt'}],
+    description='Set or update a service dependency on an app session.',
+)
+
+# ** constant: app_remove_service
+APP_REMOVE_SERVICE = create_default_feature(
+    id=APP_REMOVE_SERVICE_ID,
+    name='Remove App Service Dependency',
+    group_id='app',
+    feature_key='remove_service',
+    steps=[{'service_id': 'remove_app_service_dependency_evt'}],
+    description='Remove a service dependency from an app session.',
+)
+
+# ** constant: app_remove
+APP_REMOVE = create_default_feature(
+    id=APP_REMOVE_ID,
+    name='Remove App Session',
+    group_id='app',
+    feature_key='remove',
+    steps=[{'service_id': 'remove_app_session_evt'}],
+    description='Remove an app session by ID.',
+)
+
+# ** constant: cli_list_commands
+CLI_LIST_COMMANDS = create_default_feature(
+    id=CLI_LIST_COMMANDS_ID,
+    name='List CLI Commands',
+    group_id='cli',
+    feature_key='list_commands',
+    steps=[{'service_id': 'list_commands_evt'}],
+    description='List all configured CLI commands.',
+)
+
+# ** constant: cli_add_command
+CLI_ADD_COMMAND = create_default_feature(
+    id=CLI_ADD_COMMAND_ID,
+    name='Add CLI Command',
+    group_id='cli',
+    feature_key='add_command',
+    steps=[{'service_id': 'add_cli_command_evt'}],
+    description='Add a new CLI command definition.',
+)
+
+# ** constant: cli_add_argument
+CLI_ADD_ARGUMENT = create_default_feature(
+    id=CLI_ADD_ARGUMENT_ID,
+    name='Add CLI Argument',
+    group_id='cli',
+    feature_key='add_argument',
+    steps=[{'service_id': 'add_cli_argument_evt'}],
+    description='Add an argument to an existing CLI command.',
+)
+
+# ** constant: error_list
+ERROR_LIST = create_default_feature(
+    id=ERROR_LIST_ID,
+    name='List Errors',
+    group_id='error',
+    feature_key='list',
+    steps=[{'service_id': 'list_errors_evt'}],
+    description='List all error definitions.',
+)
+
+# ** constant: error_add
+ERROR_ADD = create_default_feature(
+    id=ERROR_ADD_ID,
+    name='Add Error',
+    group_id='error',
+    feature_key='add',
+    steps=[{'service_id': 'add_error_evt'}],
+    description='Add a new error definition.',
+)
+
+# ** constant: error_get
+ERROR_GET = create_default_feature(
+    id=ERROR_GET_ID,
+    name='Get Error',
+    group_id='error',
+    feature_key='get',
+    steps=[{'service_id': 'get_error_evt'}],
+    description='Retrieve an error by ID.',
+)
+
+# ** constant: error_rename
+ERROR_RENAME = create_default_feature(
+    id=ERROR_RENAME_ID,
+    name='Rename Error',
+    group_id='error',
+    feature_key='rename',
+    steps=[{'service_id': 'rename_error_evt'}],
+    description='Rename an existing error definition.',
+)
+
+# ** constant: error_set_message
+ERROR_SET_MESSAGE = create_default_feature(
+    id=ERROR_SET_MESSAGE_ID,
+    name='Set Error Message',
+    group_id='error',
+    feature_key='set_message',
+    steps=[{'service_id': 'set_error_message_evt'}],
+    description='Set the message text on an existing error definition.',
+)
+
+# ** constant: error_remove_message
+ERROR_REMOVE_MESSAGE = create_default_feature(
+    id=ERROR_REMOVE_MESSAGE_ID,
+    name='Remove Error Message',
+    group_id='error',
+    feature_key='remove_message',
+    steps=[{'service_id': 'remove_error_message_evt'}],
+    description='Remove a language message from an existing error definition.',
+)
+
+# ** constant: error_remove
+ERROR_REMOVE = create_default_feature(
+    id=ERROR_REMOVE_ID,
+    name='Remove Error',
+    group_id='error',
+    feature_key='remove',
+    steps=[{'service_id': 'remove_error_evt'}],
+    description='Remove an error definition.',
+)
+
+# ** constant: feature_list
+FEATURE_LIST = create_default_feature(
+    id=FEATURE_LIST_ID,
+    name='List Features',
+    group_id='feature',
+    feature_key='list',
+    steps=[{'service_id': 'list_features_evt'}],
+    description='List all feature workflow definitions.',
+)
+
+# ** constant: feature_add
+FEATURE_ADD = create_default_feature(
+    id=FEATURE_ADD_ID,
+    name='Add Feature',
+    group_id='feature',
+    feature_key='add',
+    steps=[{'service_id': 'add_feature_evt'}],
+    description='Add a new feature workflow definition.',
+)
+
+# ** constant: feature_get
+FEATURE_GET = create_default_feature(
+    id=FEATURE_GET_ID,
+    name='Get Feature',
+    group_id='feature',
+    feature_key='get',
+    steps=[{'service_id': 'get_feature_evt'}],
+    description='Retrieve a feature by ID.',
+)
+
+# ** constant: feature_update
+FEATURE_UPDATE = create_default_feature(
+    id=FEATURE_UPDATE_ID,
+    name='Update Feature',
+    group_id='feature',
+    feature_key='update',
+    steps=[{'service_id': 'update_feature_evt'}],
+    description='Update a metadata attribute on an existing feature.',
+)
+
+# ** constant: feature_add_step
+FEATURE_ADD_STEP = create_default_feature(
+    id=FEATURE_ADD_STEP_ID,
+    name='Add Feature Step',
+    group_id='feature',
+    feature_key='add_step',
+    steps=[{'service_id': 'add_feature_step_evt'}],
+    description='Add a step to an existing feature workflow.',
+)
+
+# ** constant: feature_update_step
+FEATURE_UPDATE_STEP = create_default_feature(
+    id=FEATURE_UPDATE_STEP_ID,
+    name='Update Feature Step',
+    group_id='feature',
+    feature_key='update_step',
+    steps=[{'service_id': 'update_feature_step_evt'}],
+    description='Update an attribute on an existing feature step.',
+)
+
+# ** constant: feature_remove_step
+FEATURE_REMOVE_STEP = create_default_feature(
+    id=FEATURE_REMOVE_STEP_ID,
+    name='Remove Feature Step',
+    group_id='feature',
+    feature_key='remove_step',
+    steps=[{'service_id': 'remove_feature_step_evt'}],
+    description='Remove a step from an existing feature workflow.',
+)
+
+# ** constant: feature_reorder_step
+FEATURE_REORDER_STEP = create_default_feature(
+    id=FEATURE_REORDER_STEP_ID,
+    name='Reorder Feature Step',
+    group_id='feature',
+    feature_key='reorder_step',
+    steps=[{'service_id': 'reorder_feature_step_evt'}],
+    description='Reorder a step within an existing feature workflow.',
+)
+
+# ** constant: feature_remove
+FEATURE_REMOVE = create_default_feature(
+    id=FEATURE_REMOVE_ID,
+    name='Remove Feature',
+    group_id='feature',
+    feature_key='remove',
+    steps=[{'service_id': 'remove_feature_evt'}],
+    description='Remove an existing feature workflow definition.',
+)
+
+# ** constant: service_list
+SERVICE_LIST = create_default_feature(
+    id=SERVICE_LIST_ID,
+    name='List Services',
+    group_id='service',
+    feature_key='list',
+    steps=[{'service_id': 'di_list_all_configs_evt'}],
+    description='List all DI service registrations and constants.',
+)
+
+# ** constant: service_add
+SERVICE_ADD = create_default_feature(
+    id=SERVICE_ADD_ID,
+    name='Add Service',
+    group_id='service',
+    feature_key='add',
+    steps=[{'service_id': 'add_service_registration_evt'}],
+    description='Add a new DI service registration.',
+)
+
+# ** constant: service_set_default
+SERVICE_SET_DEFAULT = create_default_feature(
+    id=SERVICE_SET_DEFAULT_ID,
+    name='Set Default Service Registration',
+    group_id='service',
+    feature_key='set_default',
+    steps=[{'service_id': 'set_default_service_registration_evt'}],
+    description='Set or update the default type for an existing service registration.',
+)
+
+# ** constant: service_set_dependency
+SERVICE_SET_DEPENDENCY = create_default_feature(
+    id=SERVICE_SET_DEPENDENCY_ID,
+    name='Set Service Dependency',
+    group_id='service',
+    feature_key='set_dependency',
+    steps=[{'service_id': 'set_di_service_dependency_evt'}],
+    description='Set or update a flagged dependency on a service registration.',
+)
+
+# ** constant: service_remove_dependency
+SERVICE_REMOVE_DEPENDENCY = create_default_feature(
+    id=SERVICE_REMOVE_DEPENDENCY_ID,
+    name='Remove Service Dependency',
+    group_id='service',
+    feature_key='remove_dependency',
+    steps=[{'service_id': 'remove_di_service_dependency_evt'}],
+    description='Remove a flagged dependency from a service registration.',
+)
+
+# ** constant: service_set_constants
+SERVICE_SET_CONSTANTS = create_default_feature(
+    id=SERVICE_SET_CONSTANTS_ID,
+    name='Set Service Constants',
+    group_id='service',
+    feature_key='set_constants',
+    steps=[{'service_id': 'set_service_constants_evt'}],
+    description='Set or clear DI service constants.',
+)
+
+# ** constant: service_remove
+SERVICE_REMOVE = create_default_feature(
+    id=SERVICE_REMOVE_ID,
+    name='Remove Service',
+    group_id='service',
+    feature_key='remove',
+    steps=[{'service_id': 'remove_service_registration_evt'}],
+    description='Remove a DI service registration.',
+)
+
+# ** constant: logging_add_formatter
+LOGGING_ADD_FORMATTER = create_default_feature(
+    id=LOGGING_ADD_FORMATTER_ID,
+    name='Add Formatter',
+    group_id='logging',
+    feature_key='add_formatter',
+    steps=[{'service_id': 'add_formatter_evt'}],
+    description='Add a new logging formatter configuration.',
+)
+
+# ** constant: logging_remove_formatter
+LOGGING_REMOVE_FORMATTER = create_default_feature(
+    id=LOGGING_REMOVE_FORMATTER_ID,
+    name='Remove Formatter',
+    group_id='logging',
+    feature_key='remove_formatter',
+    steps=[{'service_id': 'remove_formatter_evt'}],
+    description='Remove a logging formatter by ID.',
+)
+
+# ** constant: logging_add_handler
+LOGGING_ADD_HANDLER = create_default_feature(
+    id=LOGGING_ADD_HANDLER_ID,
+    name='Add Handler',
+    group_id='logging',
+    feature_key='add_handler',
+    steps=[{'service_id': 'add_handler_evt'}],
+    description='Add a new logging handler configuration.',
+)
+
+# ** constant: logging_remove_handler
+LOGGING_REMOVE_HANDLER = create_default_feature(
+    id=LOGGING_REMOVE_HANDLER_ID,
+    name='Remove Handler',
+    group_id='logging',
+    feature_key='remove_handler',
+    steps=[{'service_id': 'remove_handler_evt'}],
+    description='Remove a logging handler by ID.',
+)
+
+# ** constant: logging_add_logger
+LOGGING_ADD_LOGGER = create_default_feature(
+    id=LOGGING_ADD_LOGGER_ID,
+    name='Add Logger',
+    group_id='logging',
+    feature_key='add_logger',
+    steps=[{'service_id': 'add_logger_evt'}],
+    description='Add a new logger configuration.',
+)
+
+# ** constant: logging_remove_logger
+LOGGING_REMOVE_LOGGER = create_default_feature(
+    id=LOGGING_REMOVE_LOGGER_ID,
+    name='Remove Logger',
+    group_id='logging',
+    feature_key='remove_logger',
+    steps=[{'service_id': 'remove_logger_evt'}],
+    description='Remove a logger by ID.',
+)
+
+# ** constant: logging_list
+LOGGING_LIST = create_default_feature(
+    id=LOGGING_LIST_ID,
+    name='List Logging Configs',
+    group_id='logging',
+    feature_key='list',
+    steps=[{'service_id': 'logging_list_all_evt'}],
+    description='List all logging configurations (formatters, handlers, loggers).',
+)
+
+# *** constants (groups)
 
 # ** constant: default_tiferet_cli_features
-DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Dict[str, Any]] = {
-
-    # -- app group --
-
-    'app.add': {
-        'id': 'app.add',
-        'name': 'Add App Session',
-        'group_id': 'app',
-        'feature_key': 'add',
-        'description': 'Add a new application session configuration.',
-        'steps': [
-            {'service_id': 'add_app_session_evt'},
-        ],
-    },
-    'app.get': {
-        'id': 'app.get',
-        'name': 'Get App Session',
-        'group_id': 'app',
-        'feature_key': 'get',
-        'description': 'Retrieve an app session by ID.',
-        'steps': [
-            {'service_id': 'get_app_session_evt'},
-        ],
-    },
-    'app.list': {
-        'id': 'app.list',
-        'name': 'List App Sessions',
-        'group_id': 'app',
-        'feature_key': 'list',
-        'description': 'List all configured app sessions.',
-        'steps': [
-            {'service_id': 'list_app_sessions_evt'},
-        ],
-    },
-    'app.update': {
-        'id': 'app.update',
-        'name': 'Update App Session',
-        'group_id': 'app',
-        'feature_key': 'update',
-        'description': 'Update a scalar attribute on an app session.',
-        'steps': [
-            {'service_id': 'update_app_session_evt'},
-        ],
-    },
-    'app.set_constants': {
-        'id': 'app.set_constants',
-        'name': 'Set App Constants',
-        'group_id': 'app',
-        'feature_key': 'set_constants',
-        'description': 'Set or clear constants on an app session.',
-        'steps': [
-            {'service_id': 'set_app_constants_evt'},
-        ],
-    },
-    'app.set_service': {
-        'id': 'app.set_service',
-        'name': 'Set App Service Dependency',
-        'group_id': 'app',
-        'feature_key': 'set_service',
-        'description': 'Set or update a service dependency on an app session.',
-        'steps': [
-            {'service_id': 'set_app_service_dependency_evt'},
-        ],
-    },
-    'app.remove_service': {
-        'id': 'app.remove_service',
-        'name': 'Remove App Service Dependency',
-        'group_id': 'app',
-        'feature_key': 'remove_service',
-        'description': 'Remove a service dependency from an app session.',
-        'steps': [
-            {'service_id': 'remove_app_service_dependency_evt'},
-        ],
-    },
-    'app.remove': {
-        'id': 'app.remove',
-        'name': 'Remove App Session',
-        'group_id': 'app',
-        'feature_key': 'remove',
-        'description': 'Remove an app session by ID.',
-        'steps': [
-            {'service_id': 'remove_app_session_evt'},
-        ],
-    },
-
-    # -- cli group --
-
-    'cli.list_commands': {
-        'id': 'cli.list_commands',
-        'name': 'List CLI Commands',
-        'group_id': 'cli',
-        'feature_key': 'list_commands',
-        'description': 'List all configured CLI commands.',
-        'steps': [
-            {'service_id': 'list_commands_evt'},
-        ],
-    },
-    'cli.add_command': {
-        'id': 'cli.add_command',
-        'name': 'Add CLI Command',
-        'group_id': 'cli',
-        'feature_key': 'add_command',
-        'description': 'Add a new CLI command definition.',
-        'steps': [
-            {'service_id': 'add_cli_command_evt'},
-        ],
-    },
-    'cli.add_argument': {
-        'id': 'cli.add_argument',
-        'name': 'Add CLI Argument',
-        'group_id': 'cli',
-        'feature_key': 'add_argument',
-        'description': 'Add an argument to an existing CLI command.',
-        'steps': [
-            {'service_id': 'add_cli_argument_evt'},
-        ],
-    },
-
-    # -- error group --
-
-    'error.list': {
-        'id': 'error.list',
-        'name': 'List Errors',
-        'group_id': 'error',
-        'feature_key': 'list',
-        'description': 'List all error definitions.',
-        'steps': [
-            {'service_id': 'list_errors_evt'},
-        ],
-    },
-    'error.add': {
-        'id': 'error.add',
-        'name': 'Add Error',
-        'group_id': 'error',
-        'feature_key': 'add',
-        'description': 'Add a new error definition.',
-        'steps': [
-            {'service_id': 'add_error_evt'},
-        ],
-    },
-    'error.get': {
-        'id': 'error.get',
-        'name': 'Get Error',
-        'group_id': 'error',
-        'feature_key': 'get',
-        'description': 'Retrieve an error by ID.',
-        'steps': [
-            {'service_id': 'get_error_evt'},
-        ],
-    },
-    'error.rename': {
-        'id': 'error.rename',
-        'name': 'Rename Error',
-        'group_id': 'error',
-        'feature_key': 'rename',
-        'description': 'Rename an existing error definition.',
-        'steps': [
-            {'service_id': 'rename_error_evt'},
-        ],
-    },
-    'error.set_message': {
-        'id': 'error.set_message',
-        'name': 'Set Error Message',
-        'group_id': 'error',
-        'feature_key': 'set_message',
-        'description': 'Set the message text on an existing error definition.',
-        'steps': [
-            {'service_id': 'set_error_message_evt'},
-        ],
-    },
-    'error.remove_message': {
-        'id': 'error.remove_message',
-        'name': 'Remove Error Message',
-        'group_id': 'error',
-        'feature_key': 'remove_message',
-        'description': 'Remove a language message from an existing error definition.',
-        'steps': [
-            {'service_id': 'remove_error_message_evt'},
-        ],
-    },
-    'error.remove': {
-        'id': 'error.remove',
-        'name': 'Remove Error',
-        'group_id': 'error',
-        'feature_key': 'remove',
-        'description': 'Remove an error definition.',
-        'steps': [
-            {'service_id': 'remove_error_evt'},
-        ],
-    },
-
-    # -- feature group --
-
-    'feature.list': {
-        'id': 'feature.list',
-        'name': 'List Features',
-        'group_id': 'feature',
-        'feature_key': 'list',
-        'description': 'List all feature workflow definitions.',
-        'steps': [
-            {'service_id': 'list_features_evt'},
-        ],
-    },
-    'feature.add': {
-        'id': 'feature.add',
-        'name': 'Add Feature',
-        'group_id': 'feature',
-        'feature_key': 'add',
-        'description': 'Add a new feature workflow definition.',
-        'steps': [
-            {'service_id': 'add_feature_evt'},
-        ],
-    },
-    'feature.get': {
-        'id': 'feature.get',
-        'name': 'Get Feature',
-        'group_id': 'feature',
-        'feature_key': 'get',
-        'description': 'Retrieve a feature by ID.',
-        'steps': [
-            {'service_id': 'get_feature_evt'},
-        ],
-    },
-    'feature.update': {
-        'id': 'feature.update',
-        'name': 'Update Feature',
-        'group_id': 'feature',
-        'feature_key': 'update',
-        'description': 'Update a metadata attribute on an existing feature.',
-        'steps': [
-            {'service_id': 'update_feature_evt'},
-        ],
-    },
-    'feature.add_step': {
-        'id': 'feature.add_step',
-        'name': 'Add Feature Step',
-        'group_id': 'feature',
-        'feature_key': 'add_step',
-        'description': 'Add a step to an existing feature workflow.',
-        'steps': [
-            {'service_id': 'add_feature_step_evt'},
-        ],
-    },
-    'feature.update_step': {
-        'id': 'feature.update_step',
-        'name': 'Update Feature Step',
-        'group_id': 'feature',
-        'feature_key': 'update_step',
-        'description': 'Update an attribute on an existing feature step.',
-        'steps': [
-            {'service_id': 'update_feature_step_evt'},
-        ],
-    },
-    'feature.remove_step': {
-        'id': 'feature.remove_step',
-        'name': 'Remove Feature Step',
-        'group_id': 'feature',
-        'feature_key': 'remove_step',
-        'description': 'Remove a step from an existing feature workflow.',
-        'steps': [
-            {'service_id': 'remove_feature_step_evt'},
-        ],
-    },
-    'feature.reorder_step': {
-        'id': 'feature.reorder_step',
-        'name': 'Reorder Feature Step',
-        'group_id': 'feature',
-        'feature_key': 'reorder_step',
-        'description': 'Reorder a step within an existing feature workflow.',
-        'steps': [
-            {'service_id': 'reorder_feature_step_evt'},
-        ],
-    },
-    'feature.remove': {
-        'id': 'feature.remove',
-        'name': 'Remove Feature',
-        'group_id': 'feature',
-        'feature_key': 'remove',
-        'description': 'Remove an existing feature workflow definition.',
-        'steps': [
-            {'service_id': 'remove_feature_evt'},
-        ],
-    },
-
-    # -- service group --
-
-    'service.list': {
-        'id': 'service.list',
-        'name': 'List Services',
-        'group_id': 'service',
-        'feature_key': 'list',
-        'description': 'List all DI service registrations and constants.',
-        'steps': [
-            {'service_id': 'di_list_all_configs_evt'},
-        ],
-    },
-    'service.add': {
-        'id': 'service.add',
-        'name': 'Add Service',
-        'group_id': 'service',
-        'feature_key': 'add',
-        'description': 'Add a new DI service registration.',
-        'steps': [
-            {'service_id': 'add_service_registration_evt'},
-        ],
-    },
-    'service.set_default': {
-        'id': 'service.set_default',
-        'name': 'Set Default Service Registration',
-        'group_id': 'service',
-        'feature_key': 'set_default',
-        'description': 'Set or update the default type for an existing service registration.',
-        'steps': [
-            {'service_id': 'set_default_service_registration_evt'},
-        ],
-    },
-    'service.set_dependency': {
-        'id': 'service.set_dependency',
-        'name': 'Set Service Dependency',
-        'group_id': 'service',
-        'feature_key': 'set_dependency',
-        'description': 'Set or update a flagged dependency on a service registration.',
-        'steps': [
-            {'service_id': 'set_di_service_dependency_evt'},
-        ],
-    },
-    'service.remove_dependency': {
-        'id': 'service.remove_dependency',
-        'name': 'Remove Service Dependency',
-        'group_id': 'service',
-        'feature_key': 'remove_dependency',
-        'description': 'Remove a flagged dependency from a service registration.',
-        'steps': [
-            {'service_id': 'remove_di_service_dependency_evt'},
-        ],
-    },
-    'service.set_constants': {
-        'id': 'service.set_constants',
-        'name': 'Set Service Constants',
-        'group_id': 'service',
-        'feature_key': 'set_constants',
-        'description': 'Set or clear DI service constants.',
-        'steps': [
-            {'service_id': 'set_service_constants_evt'},
-        ],
-    },
-    'service.remove': {
-        'id': 'service.remove',
-        'name': 'Remove Service',
-        'group_id': 'service',
-        'feature_key': 'remove',
-        'description': 'Remove a DI service registration.',
-        'steps': [
-            {'service_id': 'remove_service_registration_evt'},
-        ],
-    },
-
-    # -- logging group --
-
-    'logging.add_formatter': {
-        'id': 'logging.add_formatter',
-        'name': 'Add Formatter',
-        'group_id': 'logging',
-        'feature_key': 'add_formatter',
-        'description': 'Add a new logging formatter configuration.',
-        'steps': [
-            {'service_id': 'add_formatter_evt'},
-        ],
-    },
-    'logging.remove_formatter': {
-        'id': 'logging.remove_formatter',
-        'name': 'Remove Formatter',
-        'group_id': 'logging',
-        'feature_key': 'remove_formatter',
-        'description': 'Remove a logging formatter by ID.',
-        'steps': [
-            {'service_id': 'remove_formatter_evt'},
-        ],
-    },
-    'logging.add_handler': {
-        'id': 'logging.add_handler',
-        'name': 'Add Handler',
-        'group_id': 'logging',
-        'feature_key': 'add_handler',
-        'description': 'Add a new logging handler configuration.',
-        'steps': [
-            {'service_id': 'add_handler_evt'},
-        ],
-    },
-    'logging.remove_handler': {
-        'id': 'logging.remove_handler',
-        'name': 'Remove Handler',
-        'group_id': 'logging',
-        'feature_key': 'remove_handler',
-        'description': 'Remove a logging handler by ID.',
-        'steps': [
-            {'service_id': 'remove_handler_evt'},
-        ],
-    },
-    'logging.add_logger': {
-        'id': 'logging.add_logger',
-        'name': 'Add Logger',
-        'group_id': 'logging',
-        'feature_key': 'add_logger',
-        'description': 'Add a new logger configuration.',
-        'steps': [
-            {'service_id': 'add_logger_evt'},
-        ],
-    },
-    'logging.remove_logger': {
-        'id': 'logging.remove_logger',
-        'name': 'Remove Logger',
-        'group_id': 'logging',
-        'feature_key': 'remove_logger',
-        'description': 'Remove a logger by ID.',
-        'steps': [
-            {'service_id': 'remove_logger_evt'},
-        ],
-    },
-    'logging.list': {
-        'id': 'logging.list',
-        'name': 'List Logging Configs',
-        'group_id': 'logging',
-        'feature_key': 'list',
-        'description': 'List all logging configurations (formatters, handlers, loggers).',
-        'steps': [
-            {'service_id': 'logging_list_all_evt'},
-        ],
-    },
+DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
+    APP_ADD_ID: APP_ADD,
+    APP_GET_ID: APP_GET,
+    APP_LIST_ID: APP_LIST,
+    APP_UPDATE_ID: APP_UPDATE,
+    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS,
+    APP_SET_SERVICE_ID: APP_SET_SERVICE,
+    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE,
+    APP_REMOVE_ID: APP_REMOVE,
+    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS,
+    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND,
+    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT,
+    ERROR_LIST_ID: ERROR_LIST,
+    ERROR_ADD_ID: ERROR_ADD,
+    ERROR_GET_ID: ERROR_GET,
+    ERROR_RENAME_ID: ERROR_RENAME,
+    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
+    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
+    ERROR_REMOVE_ID: ERROR_REMOVE,
+    FEATURE_LIST_ID: FEATURE_LIST,
+    FEATURE_ADD_ID: FEATURE_ADD,
+    FEATURE_GET_ID: FEATURE_GET,
+    FEATURE_UPDATE_ID: FEATURE_UPDATE,
+    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
+    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
+    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
+    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
+    FEATURE_REMOVE_ID: FEATURE_REMOVE,
+    SERVICE_LIST_ID: SERVICE_LIST,
+    SERVICE_ADD_ID: SERVICE_ADD,
+    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
+    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
+    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
+    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
+    SERVICE_REMOVE_ID: SERVICE_REMOVE,
+    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER,
+    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER,
+    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER,
+    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER,
+    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER,
+    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER,
+    LOGGING_LIST_ID: LOGGING_LIST,
 }
 
 # ** constant: admin_default_features
-ADMIN_DEFAULT_FEATURES: Dict[str, Dict[str, Any]] = DEFAULT_TIFERET_CLI_FEATURES
+ADMIN_DEFAULT_FEATURES: Dict[str, Any] = DEFAULT_TIFERET_CLI_FEATURES


### PR DESCRIPTION
## Summary
Implements the three-section catalog standardization for the built-in Tiferet CLI domain asset modules (`feature.py`, `di.py`, `cli.py`), following the pattern established by `assets/error.py`. Each catalog entry becomes an individually named constant built via a dedicated factory function.

## Changes

### Child 1 — Assets/Feature (#940) ✅
- Added `create_default_feature` and `create_params_schema` to `assets/core.py`
- Rewrote `assets/feature.py` to the three-section catalog pattern: 41 named ID constants, 41 individually named feature objects, `DEFAULT_ADMIN_FEATURES` group dict keyed by ID constants
- Added 3 tests to `tests/assets/test_core.py`

### Child 2 — Assets/DI (#941) ✅
- Added `create_service_registration` to `assets/core.py`
- Rewrote `assets/di.py` to the three-section catalog pattern: 37 named ID constants, 37 individually named registration objects built via `create_service_registration` + `create_service_module_path`, `DEFAULT_ADMIN_SERVICES` group dict keyed by ID constants; removed `List[Tuple]` format and inline `# * services:` comments
- Added 2 tests to `tests/assets/test_core.py`

### Child 3 — Assets/CLI (#942) ✅
- Added `create_default_cli_argument` and `create_default_cli_command` to `assets/core.py`
- Rewrote `assets/cli.py` to the three-section catalog pattern: 40 named ID constants using the `_CLI_CMD_ID` suffix convention, 40 individually named command objects built via `create_default_cli_command()` with inline `create_default_cli_argument()` calls, `ADMIN_DEFAULT_COMMANDS` group dict keyed by ID constants; old `DEFAULT_TIFERET_CLI_COMMANDS` flat-dict literal and `ADMIN_DEFAULT_COMMANDS` bare assignment removed
- Added 4 tests to `tests/assets/test_core.py`

## Acceptance Criteria

### Child 1 — Feature Catalog
- [x] `create_default_feature` and `create_params_schema` present in `core.py` with RST docstrings
- [x] `feature.py` has `# *** constants (ids)` with 41 named ID constants
- [x] `feature.py` has `# *** constants (features)` with 41 individually named feature objects built via `create_default_feature()`
- [x] `feature.py` has `# *** constants (groups)` containing `DEFAULT_ADMIN_FEATURES` (keyed by ID constants) as the sole exported group name
- [x] Old `DEFAULT_TIFERET_CLI_FEATURES` flat-dict literal replaced by `DEFAULT_ADMIN_FEATURES`

### Child 2 — DI Catalog
- [x] `create_service_registration` present in `core.py` with RST docstring
- [x] `di.py` has `# *** constants (ids)` with 37 named ID constants
- [x] `di.py` has `# *** constants (services)` with 37 individually named registration objects built via `create_service_registration()` using `create_service_module_path()`
- [x] `di.py` has `# *** constants (groups)` containing `DEFAULT_ADMIN_SERVICES` (keyed by ID constants)
- [x] Old `DEFAULT_TIFERET_CLI_SERVICES` `List[Tuple]` constant and inline `# * services:` comments removed from `di.py`

### Child 3 — CLI Catalog
- [x] `create_default_cli_command` and `create_default_cli_argument` present in `core.py` with RST docstrings
- [x] `cli.py` has `# *** constants (ids)` with 40 named ID constants using the `_CLI_CMD_ID` suffix convention
- [x] `cli.py` has `# *** constants (commands)` with 40 individually named command objects built via `create_default_cli_command()` with inline `create_default_cli_argument()` calls
- [x] `cli.py` has `# *** constants (groups)` containing `ADMIN_DEFAULT_COMMANDS` (keyed by ID constants)
- [x] Old `DEFAULT_TIFERET_CLI_COMMANDS` flat-dict literal and `ADMIN_DEFAULT_COMMANDS` bare assignment removed

### Cross-Cutting
- [x] All group dicts keyed by their ID constants (not bare string literals)
- [x] `tests/assets/test_core.py` receives 9 new tests across all three children covering all 5 factory functions; full suite passes

Closes #939
