### PR TITLE
hotfix(m30): proto branch fixup and audit items

### DIFF
--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -65,21 +65,6 @@ GET_PARENT_ARGS_EVT_ID = 'get_parent_args_evt'
 # ** constant: di_list_all_configs_evt_id
 DI_LIST_ALL_CONFIGS_EVT_ID = 'di_list_all_configs_evt'
 
-# ** constant: logging_middleware_id
-LOGGING_MIDDLEWARE_ID = 'logging_middleware'
-
-# ** constant: timing_middleware_id
-TIMING_MIDDLEWARE_ID = 'timing_middleware'
-
-# ** constant: cache_middleware_id
-CACHE_MIDDLEWARE_ID = 'cache_middleware'
-
-# ** constant: tiferet_admin_id
-TIFERET_ADMIN_ID = 'admin'
-
-# ** constant: tiferet_admin_cli_id
-TIFERET_ADMIN_CLI_ID = 'admin_cli'
-
 # ** constant: cli_config_id
 CLI_CONFIG_ID = 'cli_config'
 
@@ -95,7 +80,45 @@ LOGGING_CONFIG_ID = 'logging_config'
 # ** constant: feature_config_id
 FEATURE_CONFIG_ID = 'feature_config'
 
-# *** constants (models)
+# ** constant: logging_middleware_id
+LOGGING_MIDDLEWARE_ID = 'logging_middleware'
+
+# ** constant: timing_middleware_id
+TIMING_MIDDLEWARE_ID = 'timing_middleware'
+
+# ** constant: cache_middleware_id
+CACHE_MIDDLEWARE_ID = 'cache_middleware'
+
+# ** constant: tiferet_admin_id
+TIFERET_ADMIN_ID = 'admin'
+
+# ** constant: tiferet_admin_cli_id
+TIFERET_ADMIN_CLI_ID = 'admin_cli'
+
+# *** constants (paths)
+
+# ** constant: default_config_file
+DEFAULT_CONFIG_FILE = 'config.yml'
+
+# ** constant: default_app_config_file
+DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
+
+# *** constants (app_service)
+
+# ** constant: default_app_service_module_path
+DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(
+    TIFERET,
+    TIFERET_REPOS_PATH,
+    APP_DOMAIN_PATH,
+)
+
+# ** constant: default_app_service_class_name
+DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
+
+# ** constant: default_app_service_parameters
+DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+
+# *** constants (sessions)
 
 # ** constant: default_admin_app_session
 DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
@@ -111,20 +134,7 @@ DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
     description='Built-in CLI for managing Tiferet application configurations',
 )
 
-# ** constant: default_config_file
-DEFAULT_CONFIG_FILE = 'config.yml'
-
-# ** constant: default_app_config_file
-DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
-
-# ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH)
-
-# ** constant: default_app_service_class_name
-DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
-
-# ** constant: default_app_service_parameters
-DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+# *** constants (services)
 
 # ** constant: di_service
 DI_SERVICE = create_app_service_dependency(


### PR DESCRIPTION
## Hotfix RFP — Milestone 30 Proto Fixup & Audit

**Target branch:** `v2.x-proto`
**Milestone:** Core DDD Parity III — Domain, Assets, and Mapper Parity (m30)
**Ref:** `.handoff/parity-3-proto-diff-analysis.handoff.md`

This is the consolidated hotfix branch for all Fix-up RFP (FU) and Auditing RFP (AU) items identified in the Parity III diff analysis. All items are now resolved.

---

### Commits

#### AU-1 — `assets/cli.py` CLI Command Constant Rename
Renamed all 40 `_COMMAND_ID` / `_COMMAND` suffix constants to `_CLI_CMD_ID` / `_CLI_CMD` to match main's convention and prevent namespace shadowing with feature ID constants.

#### FU-1 — `assets/app.py` Six-Section Catalog Structure
Split the monolithic `# *** constants (models)` block into four clearly labeled sub-sections matching main's six-section layout: `(paths)`, `(app_service)`, `(sessions)`, `(services)`.

#### FU-4 — `repos/app.py` Variable Naming Consistency
Renamed `interfaces_data` / `interface_data` / `interface_id` locals to `sessions_data` / `session_data` / `session_id` in `exists()`, `get()`, and `list()`.

#### FU-5 — `events/app.py` `GetAppSession` Parameter Rename
Renamed `GetAppSession.execute` parameter from `interface_id` to `id` throughout (decorator, signature, body, docstring).

#### AU-4 — `domain/app.py` `AppSession` Field Description Terminology
Updated `id`, `name`, `description`, and `flags` field descriptions from "application interface" to "application session".

#### FU-2 — `assets/app.py` Type Annotations on Group Dict Constants
Added `Dict[str, Dict[str, Any]]` to `CORE_DEFAULT_SERVICES` and `Dict[str, str]` to `CORE_DEFAULT_CONSTANTS`. Restored `from typing import Any, Dict`.

#### FU-6 — `events/app.py` Residual "Interface" Terminology in Docstrings
Normalized all "app interface" references to "app session" in docstrings and comments across `UpdateAppSession`, `SetAppConstants`, `SetServiceDependency`, `RemoveServiceDependency`, `ListAppSessions`.

#### AU-2 — `assets/cli.py` + `assets/feature.py` Domain Group Ordering
Reordered all three blocks (ids, commands/features, groups) in both files from proto's operational-priority order to match main's order: `app → cli → error → feature → service → logging`.

#### AU-3 — `assets/error.py` Responsibility Sub-Sections + Alphabetization
Split the flat `(ids)` and `(models)` sections into responsibility sub-sections: `ids` / `ids_admin` / `ids_sqlite` / `ids_toml` / `ids_csv` and `models` / `models_admin` / `models_sqlite` / `models_toml` / `models_csv`. Alphabetized entries within each sub-section and each group dict.

---

### Warp conversations
- [Session 1](https://app.warp.dev/conversation/7fc1c079-504a-46c1-a047-c35338bd0e73)
- [Session 2 & 3](https://app.warp.dev/conversation/019fabce-1adc-7590-a046-297ab5885781)

Co-Authored-By: Oz <oz-agent@warp.dev>