### PR TITLE
hotfix(m30): proto branch fixup and audit items

### DIFF
--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -29,26 +29,52 @@ Artifact labels:
 # ** class: <snake_case_name>       ← individual class
 ```
 
-**Sub-groups** — partition a large `# *** constants` section with a parenthetical qualifier. The framework convention (e.g. `assets/error.py`) uses three sub-groups:
+**Sub-groups** — partition a large `# *** constants` section with a parenthetical qualifier. The framework convention (e.g. `assets/error.py`) uses three correlated sub-group layers:
 ```python
-# *** constants (ids)               ← raw error-code identifier strings
+# *** constants (ids)               ← raw error-code identifier strings (core group)
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
-# *** constants (errors)            ← assembled default definition dicts
+# *** constants (models)            ← assembled default definition constants (core group)
 # ** constant: feature_not_found
-FEATURE_NOT_FOUND = { 'id': FEATURE_NOT_FOUND_ID, 'name': 'Feature Not Found', ... }
+FEATURE_NOT_FOUND = create_default_error(...)
 
-# *** constants (groups)            ← catalog dicts grouping the above
-# ** constant: default_errors
-DEFAULT_ERRORS = { FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND }
+# *** constants (groups)            ← catalog dicts aggregating the above
+# ** constant: core_default_errors
+CORE_DEFAULT_ERRORS = {
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+}
 ```
+
+**Multi-group catalogs** — when a module defines additional capability groups (e.g., `admin`, `sqlite`, `csv`), each group name is a shared key across all three layers: `(ids_<group>)`, `(models_<group>)`, and a named dict entry in `(groups)`. Adding an entry to a capability group always requires touching all three locations:
+```python
+# *** constants (ids_sqlite)
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+
+# *** constants (models_sqlite)
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect: {original_error}')],
+)
+
+# *** constants (groups)
+# ** constant: sqlite_default_errors
+SQLITE_DEFAULT_ERRORS = {
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+}
+```
+
+The plain `(ids)` / `(models)` sub-groups (no suffix) hold the core/baseline group. All additional groups use the `_<group>` suffix consistently.
 
 ## Key conventions
 
 - **Layer boundary — valid `# ** app` imports:** none. `assets` is the root layer; it has no framework imports. Only `# ** core` (stdlib) and `# ** infra` (minimal third-party, e.g. `json`) are valid. Never import from any other framework layer.
 - **Constants:** `SCREAMING_SNAKE_CASE`. Each constant has its own `# ** constant: <snake_case>` label. Do not group multiple constants under a single `# ** constants: <group>` mid-level label — use a top-level sub-group instead.
 - **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error`), not inline dicts. Define each entry as a named constant, then assemble the catalog dict as a separate constant.
+- **Multi-line constants:** All dict- and list-typed constants in `assets/` modules use the multi-line hanging-indent style with a trailing comma, even for simple one-element spreads. Never `{ **OTHER_DICT }` inline — always expand to multi-line.
 - **Functions:** Small, stateless, no framework dependencies. Use RST docstrings.
 - **Classes:** Plain standalone classes (exception types, data primitives). Use `# *** classes` / `# ** class: <name>`, `# * attribute: <name>`, `# * init`.
 - **Exports:** Only in `__init__.py` under `# *** exports`. Use short module aliases for frequently consumed modules (e.g. `from . import constants as const`).

--- a/docs/collab/agents/skills/tiferet-code-style/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-style/SKILL.md
@@ -63,6 +63,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
   - `# ++ todo: <message>` — deferred work; remove when done.
   - `# -- obsolete: <reason>` — deprecated artifact; remove with the artifact. Shorthand: `# * method: foo (obsolete)`.
 - **Pre-session scan:** Before editing, run `grep -rn "# ++\|# --" tiferet/` to find open annotations.
+- **Constants in `assets/` modules:** All dict- and list-typed constants must use the multi-line hanging-indent style with a trailing comma, even for simple spreads. Never `{ **OTHER_DICT }` inline.
 
 ## Example
 

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -88,6 +88,39 @@ The most common use is grouping unit tests by the class or method under test, so
 
 **Spacing**: One empty line between a sub-group comment and its first mid-level comment, the same as any top-level section.
 
+**Multi-group asset catalogs** — When an `assets/` module defines multiple capability groups (e.g., `admin`, `sqlite`, `csv`), apply a three-layer sub-group structure. Each capability group name is a shared key across all three layers:
+
+1. `# *** constants (ids_<group>)` — raw string ID constants for the group.
+2. `# *** constants (models_<group>)` — assembled model constants (e.g., via `create_default_error`) in the same order as the corresponding `(ids_<group>)` section.
+3. A named dict entry under `# *** constants (groups)` — aggregates the group's models.
+
+When adding an entry to a capability group, touch all three locations: `(ids_<group>)`, `(models_<group>)`, and the group dict in `(groups)`. See `tiferet/assets/error.py` for the canonical reference.
+
+```python
+# *** constants (ids_sqlite)
+
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+
+# *** constants (models_sqlite)
+
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect: {original_error}')],
+)
+
+# *** constants (groups)
+
+# ** constant: sqlite_default_errors
+SQLITE_DEFAULT_ERRORS = {
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+}
+```
+
+The plain `(ids)` and `(models)` sub-groups (no suffix) hold the core/baseline group. All additional capability groups use the `_<group>` suffix consistently.
+
 ### Mid-Level (`# **`)
 Specifies categories or individual components:
 - For imports: `# ** core`, `# ** infra`, `# ** app`.
@@ -158,6 +191,28 @@ def load_feature(self, feature_id: str) -> Feature:
   - Code snippets within a method.
   - Methods/attributes within a class.
   - Classes within a component group.
+
+### Constants in `assets/` modules
+
+All list- and dictionary-typed constants in `assets/` modules must use the multi-line hanging-indent style with a trailing comma, even when the content fits on one line:
+
+```python
+# Correct — multi-line with trailing comma
+ADMIN_DEFAULT_ERRORS = {
+    **CORE_DEFAULT_ERRORS,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
+}
+
+# Correct even for a simple spread
+ADMIN_DEFAULT_SERVICES = {
+    **CORE_DEFAULT_SERVICES,
+}
+
+# Incorrect — never single-line in assets/
+ADMIN_DEFAULT_SERVICES = {**CORE_DEFAULT_SERVICES}
+```
+
+This eliminates line-length judgment calls and prevents drift as catalogs grow.
 
 ## Annotation Artifacts
 

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -65,21 +65,6 @@ GET_PARENT_ARGS_EVT_ID = 'get_parent_args_evt'
 # ** constant: di_list_all_configs_evt_id
 DI_LIST_ALL_CONFIGS_EVT_ID = 'di_list_all_configs_evt'
 
-# ** constant: logging_middleware_id
-LOGGING_MIDDLEWARE_ID = 'logging_middleware'
-
-# ** constant: timing_middleware_id
-TIMING_MIDDLEWARE_ID = 'timing_middleware'
-
-# ** constant: cache_middleware_id
-CACHE_MIDDLEWARE_ID = 'cache_middleware'
-
-# ** constant: tiferet_admin_id
-TIFERET_ADMIN_ID = 'admin'
-
-# ** constant: tiferet_admin_cli_id
-TIFERET_ADMIN_CLI_ID = 'admin_cli'
-
 # ** constant: cli_config_id
 CLI_CONFIG_ID = 'cli_config'
 
@@ -95,7 +80,45 @@ LOGGING_CONFIG_ID = 'logging_config'
 # ** constant: feature_config_id
 FEATURE_CONFIG_ID = 'feature_config'
 
-# *** constants (models)
+# ** constant: logging_middleware_id
+LOGGING_MIDDLEWARE_ID = 'logging_middleware'
+
+# ** constant: timing_middleware_id
+TIMING_MIDDLEWARE_ID = 'timing_middleware'
+
+# ** constant: cache_middleware_id
+CACHE_MIDDLEWARE_ID = 'cache_middleware'
+
+# ** constant: tiferet_admin_id
+TIFERET_ADMIN_ID = 'admin'
+
+# ** constant: tiferet_admin_cli_id
+TIFERET_ADMIN_CLI_ID = 'admin_cli'
+
+# *** constants (paths)
+
+# ** constant: default_config_file
+DEFAULT_CONFIG_FILE = 'config.yml'
+
+# ** constant: default_app_config_file
+DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
+
+# *** constants (app_service)
+
+# ** constant: default_app_service_module_path
+DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(
+    TIFERET,
+    TIFERET_REPOS_PATH,
+    APP_DOMAIN_PATH,
+)
+
+# ** constant: default_app_service_class_name
+DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
+
+# ** constant: default_app_service_parameters
+DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+
+# *** constants (sessions)
 
 # ** constant: default_admin_app_session
 DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
@@ -111,20 +134,7 @@ DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
     description='Built-in CLI for managing Tiferet application configurations',
 )
 
-# ** constant: default_config_file
-DEFAULT_CONFIG_FILE = 'config.yml'
-
-# ** constant: default_app_config_file
-DEFAULT_APP_CONFIG_FILE = DEFAULT_CONFIG_FILE
-
-# ** constant: default_app_service_module_path
-DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH)
-
-# ** constant: default_app_service_class_name
-DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
-
-# ** constant: default_app_service_parameters
-DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+# *** constants (services)
 
 # ** constant: di_service
 DI_SERVICE = create_app_service_dependency(

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -12,6 +12,9 @@ application bootstrapping and cache seeding.
 
 # *** imports
 
+# ** core
+from typing import Any, Dict
+
 # ** app
 from .core import (
     create_app_service_dependency,
@@ -237,7 +240,7 @@ CACHE_MIDDLEWARE = create_app_service_dependency(
 # *** constants (groups)
 
 # ** constant: core_default_services
-CORE_DEFAULT_SERVICES = {
+CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
     DI_SERVICE_ID: DI_SERVICE,
     ERROR_SERVICE_ID: ERROR_SERVICE,
     LOGGING_SERVICE_ID: LOGGING_SERVICE,
@@ -255,7 +258,7 @@ CORE_DEFAULT_SERVICES = {
 }
 
 # ** constant: core_default_constants
-CORE_DEFAULT_CONSTANTS = {
+CORE_DEFAULT_CONSTANTS: Dict[str, str] = {
     CLI_CONFIG_ID: DEFAULT_CONFIG_FILE,
     DI_CONFIG_ID: DEFAULT_CONFIG_FILE,
     ERROR_CONFIG_ID: DEFAULT_CONFIG_FILE,

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -18,134 +18,134 @@ from .core import create_default_cli_argument, create_default_cli_command
 
 # *** constants (ids)
 
-# ** constant: feature_add_command_id
-FEATURE_ADD_COMMAND_ID = 'feature.add'
+# ** constant: feature_add_cli_cmd_id
+FEATURE_ADD_CLI_CMD_ID = 'feature.add'
 
-# ** constant: feature_get_command_id
-FEATURE_GET_COMMAND_ID = 'feature.get'
+# ** constant: feature_get_cli_cmd_id
+FEATURE_GET_CLI_CMD_ID = 'feature.get'
 
-# ** constant: feature_list_command_id
-FEATURE_LIST_COMMAND_ID = 'feature.list'
+# ** constant: feature_list_cli_cmd_id
+FEATURE_LIST_CLI_CMD_ID = 'feature.list'
 
-# ** constant: feature_remove_command_id
-FEATURE_REMOVE_COMMAND_ID = 'feature.remove'
+# ** constant: feature_remove_cli_cmd_id
+FEATURE_REMOVE_CLI_CMD_ID = 'feature.remove'
 
-# ** constant: feature_update_command_id
-FEATURE_UPDATE_COMMAND_ID = 'feature.update'
+# ** constant: feature_update_cli_cmd_id
+FEATURE_UPDATE_CLI_CMD_ID = 'feature.update'
 
-# ** constant: feature_add_step_command_id
-FEATURE_ADD_STEP_COMMAND_ID = 'feature.add_step'
+# ** constant: feature_add_step_cli_cmd_id
+FEATURE_ADD_STEP_CLI_CMD_ID = 'feature.add_step'
 
-# ** constant: feature_update_step_command_id
-FEATURE_UPDATE_STEP_COMMAND_ID = 'feature.update_step'
+# ** constant: feature_update_step_cli_cmd_id
+FEATURE_UPDATE_STEP_CLI_CMD_ID = 'feature.update_step'
 
-# ** constant: feature_remove_step_command_id
-FEATURE_REMOVE_STEP_COMMAND_ID = 'feature.remove_step'
+# ** constant: feature_remove_step_cli_cmd_id
+FEATURE_REMOVE_STEP_CLI_CMD_ID = 'feature.remove_step'
 
-# ** constant: feature_reorder_step_command_id
-FEATURE_REORDER_STEP_COMMAND_ID = 'feature.reorder_step'
+# ** constant: feature_reorder_step_cli_cmd_id
+FEATURE_REORDER_STEP_CLI_CMD_ID = 'feature.reorder_step'
 
-# ** constant: error_add_command_id
-ERROR_ADD_COMMAND_ID = 'error.add'
+# ** constant: error_add_cli_cmd_id
+ERROR_ADD_CLI_CMD_ID = 'error.add'
 
-# ** constant: error_get_command_id
-ERROR_GET_COMMAND_ID = 'error.get'
+# ** constant: error_get_cli_cmd_id
+ERROR_GET_CLI_CMD_ID = 'error.get'
 
-# ** constant: error_list_command_id
-ERROR_LIST_COMMAND_ID = 'error.list'
+# ** constant: error_list_cli_cmd_id
+ERROR_LIST_CLI_CMD_ID = 'error.list'
 
-# ** constant: error_rename_command_id
-ERROR_RENAME_COMMAND_ID = 'error.rename'
+# ** constant: error_rename_cli_cmd_id
+ERROR_RENAME_CLI_CMD_ID = 'error.rename'
 
-# ** constant: error_set_message_command_id
-ERROR_SET_MESSAGE_COMMAND_ID = 'error.set_message'
+# ** constant: error_set_message_cli_cmd_id
+ERROR_SET_MESSAGE_CLI_CMD_ID = 'error.set_message'
 
-# ** constant: error_remove_message_command_id
-ERROR_REMOVE_MESSAGE_COMMAND_ID = 'error.remove_message'
+# ** constant: error_remove_message_cli_cmd_id
+ERROR_REMOVE_MESSAGE_CLI_CMD_ID = 'error.remove_message'
 
-# ** constant: error_remove_command_id
-ERROR_REMOVE_COMMAND_ID = 'error.remove'
+# ** constant: error_remove_cli_cmd_id
+ERROR_REMOVE_CLI_CMD_ID = 'error.remove'
 
-# ** constant: service_add_command_id
-SERVICE_ADD_COMMAND_ID = 'service.add'
+# ** constant: service_add_cli_cmd_id
+SERVICE_ADD_CLI_CMD_ID = 'service.add'
 
-# ** constant: service_list_command_id
-SERVICE_LIST_COMMAND_ID = 'service.list'
+# ** constant: service_list_cli_cmd_id
+SERVICE_LIST_CLI_CMD_ID = 'service.list'
 
-# ** constant: service_set_default_command_id
-SERVICE_SET_DEFAULT_COMMAND_ID = 'service.set_default'
+# ** constant: service_set_default_cli_cmd_id
+SERVICE_SET_DEFAULT_CLI_CMD_ID = 'service.set_default'
 
-# ** constant: service_set_dependency_command_id
-SERVICE_SET_DEPENDENCY_COMMAND_ID = 'service.set_dependency'
+# ** constant: service_set_dependency_cli_cmd_id
+SERVICE_SET_DEPENDENCY_CLI_CMD_ID = 'service.set_dependency'
 
-# ** constant: service_remove_dependency_command_id
-SERVICE_REMOVE_DEPENDENCY_COMMAND_ID = 'service.remove_dependency'
+# ** constant: service_remove_dependency_cli_cmd_id
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID = 'service.remove_dependency'
 
-# ** constant: service_remove_command_id
-SERVICE_REMOVE_COMMAND_ID = 'service.remove'
+# ** constant: service_remove_cli_cmd_id
+SERVICE_REMOVE_CLI_CMD_ID = 'service.remove'
 
-# ** constant: service_set_constants_command_id
-SERVICE_SET_CONSTANTS_COMMAND_ID = 'service.set_constants'
+# ** constant: service_set_constants_cli_cmd_id
+SERVICE_SET_CONSTANTS_CLI_CMD_ID = 'service.set_constants'
 
-# ** constant: app_add_command_id
-APP_ADD_COMMAND_ID = 'app.add'
+# ** constant: app_add_cli_cmd_id
+APP_ADD_CLI_CMD_ID = 'app.add'
 
-# ** constant: app_get_command_id
-APP_GET_COMMAND_ID = 'app.get'
+# ** constant: app_get_cli_cmd_id
+APP_GET_CLI_CMD_ID = 'app.get'
 
-# ** constant: app_list_command_id
-APP_LIST_COMMAND_ID = 'app.list'
+# ** constant: app_list_cli_cmd_id
+APP_LIST_CLI_CMD_ID = 'app.list'
 
-# ** constant: app_update_command_id
-APP_UPDATE_COMMAND_ID = 'app.update'
+# ** constant: app_update_cli_cmd_id
+APP_UPDATE_CLI_CMD_ID = 'app.update'
 
-# ** constant: app_set_constants_command_id
-APP_SET_CONSTANTS_COMMAND_ID = 'app.set_constants'
+# ** constant: app_set_constants_cli_cmd_id
+APP_SET_CONSTANTS_CLI_CMD_ID = 'app.set_constants'
 
-# ** constant: app_set_service_command_id
-APP_SET_SERVICE_COMMAND_ID = 'app.set_service'
+# ** constant: app_set_service_cli_cmd_id
+APP_SET_SERVICE_CLI_CMD_ID = 'app.set_service'
 
-# ** constant: app_remove_service_command_id
-APP_REMOVE_SERVICE_COMMAND_ID = 'app.remove_service'
+# ** constant: app_remove_service_cli_cmd_id
+APP_REMOVE_SERVICE_CLI_CMD_ID = 'app.remove_service'
 
-# ** constant: app_remove_command_id
-APP_REMOVE_COMMAND_ID = 'app.remove'
+# ** constant: app_remove_cli_cmd_id
+APP_REMOVE_CLI_CMD_ID = 'app.remove'
 
-# ** constant: cli_add_command_command_id
-CLI_ADD_COMMAND_COMMAND_ID = 'cli.add_command'
+# ** constant: cli_add_command_cli_cmd_id
+CLI_ADD_COMMAND_CLI_CMD_ID = 'cli.add_command'
 
-# ** constant: cli_list_commands_command_id
-CLI_LIST_COMMANDS_COMMAND_ID = 'cli.list_commands'
+# ** constant: cli_list_commands_cli_cmd_id
+CLI_LIST_COMMANDS_CLI_CMD_ID = 'cli.list_commands'
 
-# ** constant: cli_add_argument_command_id
-CLI_ADD_ARGUMENT_COMMAND_ID = 'cli.add_argument'
+# ** constant: cli_add_argument_cli_cmd_id
+CLI_ADD_ARGUMENT_CLI_CMD_ID = 'cli.add_argument'
 
-# ** constant: logging_add_formatter_command_id
-LOGGING_ADD_FORMATTER_COMMAND_ID = 'logging.add_formatter'
+# ** constant: logging_add_formatter_cli_cmd_id
+LOGGING_ADD_FORMATTER_CLI_CMD_ID = 'logging.add_formatter'
 
-# ** constant: logging_remove_formatter_command_id
-LOGGING_REMOVE_FORMATTER_COMMAND_ID = 'logging.remove_formatter'
+# ** constant: logging_remove_formatter_cli_cmd_id
+LOGGING_REMOVE_FORMATTER_CLI_CMD_ID = 'logging.remove_formatter'
 
-# ** constant: logging_add_handler_command_id
-LOGGING_ADD_HANDLER_COMMAND_ID = 'logging.add_handler'
+# ** constant: logging_add_handler_cli_cmd_id
+LOGGING_ADD_HANDLER_CLI_CMD_ID = 'logging.add_handler'
 
-# ** constant: logging_remove_handler_command_id
-LOGGING_REMOVE_HANDLER_COMMAND_ID = 'logging.remove_handler'
+# ** constant: logging_remove_handler_cli_cmd_id
+LOGGING_REMOVE_HANDLER_CLI_CMD_ID = 'logging.remove_handler'
 
-# ** constant: logging_add_logger_command_id
-LOGGING_ADD_LOGGER_COMMAND_ID = 'logging.add_logger'
+# ** constant: logging_add_logger_cli_cmd_id
+LOGGING_ADD_LOGGER_CLI_CMD_ID = 'logging.add_logger'
 
-# ** constant: logging_remove_logger_command_id
-LOGGING_REMOVE_LOGGER_COMMAND_ID = 'logging.remove_logger'
+# ** constant: logging_remove_logger_cli_cmd_id
+LOGGING_REMOVE_LOGGER_CLI_CMD_ID = 'logging.remove_logger'
 
-# ** constant: logging_list_command_id
-LOGGING_LIST_COMMAND_ID = 'logging.list'
+# ** constant: logging_list_cli_cmd_id
+LOGGING_LIST_CLI_CMD_ID = 'logging.list'
 
 # *** constants (commands)
 
-# ** constant: feature_add_command
-FEATURE_ADD_COMMAND = create_default_cli_command(
-    FEATURE_ADD_COMMAND_ID,
+# ** constant: feature_add_cli_cmd
+FEATURE_ADD_CLI_CMD = create_default_cli_command(
+    FEATURE_ADD_CLI_CMD_ID,
     'add',
     'feature',
     'Add Feature',
@@ -158,9 +158,9 @@ FEATURE_ADD_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_get_command
-FEATURE_GET_COMMAND = create_default_cli_command(
-    FEATURE_GET_COMMAND_ID,
+# ** constant: feature_get_cli_cmd
+FEATURE_GET_CLI_CMD = create_default_cli_command(
+    FEATURE_GET_CLI_CMD_ID,
     'get',
     'feature',
     'Get Feature',
@@ -170,9 +170,9 @@ FEATURE_GET_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_list_command
-FEATURE_LIST_COMMAND = create_default_cli_command(
-    FEATURE_LIST_COMMAND_ID,
+# ** constant: feature_list_cli_cmd
+FEATURE_LIST_CLI_CMD = create_default_cli_command(
+    FEATURE_LIST_CLI_CMD_ID,
     'list',
     'feature',
     'List Features',
@@ -182,9 +182,9 @@ FEATURE_LIST_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_command
-FEATURE_REMOVE_COMMAND = create_default_cli_command(
-    FEATURE_REMOVE_COMMAND_ID,
+# ** constant: feature_remove_cli_cmd
+FEATURE_REMOVE_CLI_CMD = create_default_cli_command(
+    FEATURE_REMOVE_CLI_CMD_ID,
     'remove',
     'feature',
     'Remove Feature',
@@ -194,9 +194,9 @@ FEATURE_REMOVE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_command
-FEATURE_UPDATE_COMMAND = create_default_cli_command(
-    FEATURE_UPDATE_COMMAND_ID,
+# ** constant: feature_update_cli_cmd
+FEATURE_UPDATE_CLI_CMD = create_default_cli_command(
+    FEATURE_UPDATE_CLI_CMD_ID,
     'update',
     'feature',
     'Update Feature',
@@ -208,9 +208,9 @@ FEATURE_UPDATE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_add_step_command
-FEATURE_ADD_STEP_COMMAND = create_default_cli_command(
-    FEATURE_ADD_STEP_COMMAND_ID,
+# ** constant: feature_add_step_cli_cmd
+FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_ADD_STEP_CLI_CMD_ID,
     'add-step',
     'feature',
     'Add Feature Step',
@@ -225,9 +225,9 @@ FEATURE_ADD_STEP_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_step_command
-FEATURE_UPDATE_STEP_COMMAND = create_default_cli_command(
-    FEATURE_UPDATE_STEP_COMMAND_ID,
+# ** constant: feature_update_step_cli_cmd
+FEATURE_UPDATE_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_UPDATE_STEP_CLI_CMD_ID,
     'update-step',
     'feature',
     'Update Feature Step',
@@ -244,9 +244,9 @@ FEATURE_UPDATE_STEP_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_step_command
-FEATURE_REMOVE_STEP_COMMAND = create_default_cli_command(
-    FEATURE_REMOVE_STEP_COMMAND_ID,
+# ** constant: feature_remove_step_cli_cmd
+FEATURE_REMOVE_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_REMOVE_STEP_CLI_CMD_ID,
     'remove-step',
     'feature',
     'Remove Feature Step',
@@ -257,9 +257,9 @@ FEATURE_REMOVE_STEP_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_reorder_step_command
-FEATURE_REORDER_STEP_COMMAND = create_default_cli_command(
-    FEATURE_REORDER_STEP_COMMAND_ID,
+# ** constant: feature_reorder_step_cli_cmd
+FEATURE_REORDER_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_REORDER_STEP_CLI_CMD_ID,
     'reorder-step',
     'feature',
     'Reorder Feature Step',
@@ -271,9 +271,9 @@ FEATURE_REORDER_STEP_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_add_command
-ERROR_ADD_COMMAND = create_default_cli_command(
-    ERROR_ADD_COMMAND_ID,
+# ** constant: error_add_cli_cmd
+ERROR_ADD_CLI_CMD = create_default_cli_command(
+    ERROR_ADD_CLI_CMD_ID,
     'add',
     'error',
     'Add Error',
@@ -286,9 +286,9 @@ ERROR_ADD_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_get_command
-ERROR_GET_COMMAND = create_default_cli_command(
-    ERROR_GET_COMMAND_ID,
+# ** constant: error_get_cli_cmd
+ERROR_GET_CLI_CMD = create_default_cli_command(
+    ERROR_GET_CLI_CMD_ID,
     'get',
     'error',
     'Get Error',
@@ -298,9 +298,9 @@ ERROR_GET_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_list_command
-ERROR_LIST_COMMAND = create_default_cli_command(
-    ERROR_LIST_COMMAND_ID,
+# ** constant: error_list_cli_cmd
+ERROR_LIST_CLI_CMD = create_default_cli_command(
+    ERROR_LIST_CLI_CMD_ID,
     'list',
     'error',
     'List Errors',
@@ -310,9 +310,9 @@ ERROR_LIST_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_rename_command
-ERROR_RENAME_COMMAND = create_default_cli_command(
-    ERROR_RENAME_COMMAND_ID,
+# ** constant: error_rename_cli_cmd
+ERROR_RENAME_CLI_CMD = create_default_cli_command(
+    ERROR_RENAME_CLI_CMD_ID,
     'rename',
     'error',
     'Rename Error',
@@ -323,9 +323,9 @@ ERROR_RENAME_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_set_message_command
-ERROR_SET_MESSAGE_COMMAND = create_default_cli_command(
-    ERROR_SET_MESSAGE_COMMAND_ID,
+# ** constant: error_set_message_cli_cmd
+ERROR_SET_MESSAGE_CLI_CMD = create_default_cli_command(
+    ERROR_SET_MESSAGE_CLI_CMD_ID,
     'set-message',
     'error',
     'Set Error Message',
@@ -337,9 +337,9 @@ ERROR_SET_MESSAGE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_message_command
-ERROR_REMOVE_MESSAGE_COMMAND = create_default_cli_command(
-    ERROR_REMOVE_MESSAGE_COMMAND_ID,
+# ** constant: error_remove_message_cli_cmd
+ERROR_REMOVE_MESSAGE_CLI_CMD = create_default_cli_command(
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
     'remove-message',
     'error',
     'Remove Error Message',
@@ -350,9 +350,9 @@ ERROR_REMOVE_MESSAGE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_command
-ERROR_REMOVE_COMMAND = create_default_cli_command(
-    ERROR_REMOVE_COMMAND_ID,
+# ** constant: error_remove_cli_cmd
+ERROR_REMOVE_CLI_CMD = create_default_cli_command(
+    ERROR_REMOVE_CLI_CMD_ID,
     'remove',
     'error',
     'Remove Error',
@@ -362,9 +362,9 @@ ERROR_REMOVE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_add_command
-SERVICE_ADD_COMMAND = create_default_cli_command(
-    SERVICE_ADD_COMMAND_ID,
+# ** constant: service_add_cli_cmd
+SERVICE_ADD_CLI_CMD = create_default_cli_command(
+    SERVICE_ADD_CLI_CMD_ID,
     'add',
     'service',
     'Add Service Configuration',
@@ -378,18 +378,18 @@ SERVICE_ADD_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_list_command
-SERVICE_LIST_COMMAND = create_default_cli_command(
-    SERVICE_LIST_COMMAND_ID,
+# ** constant: service_list_cli_cmd
+SERVICE_LIST_CLI_CMD = create_default_cli_command(
+    SERVICE_LIST_CLI_CMD_ID,
     'list',
     'service',
     'List All Settings',
     description='List all service configurations and constants.',
 )
 
-# ** constant: service_set_default_command
-SERVICE_SET_DEFAULT_COMMAND = create_default_cli_command(
-    SERVICE_SET_DEFAULT_COMMAND_ID,
+# ** constant: service_set_default_cli_cmd
+SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_DEFAULT_CLI_CMD_ID,
     'set-default',
     'service',
     'Set Default Service Configuration',
@@ -402,9 +402,9 @@ SERVICE_SET_DEFAULT_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_dependency_command
-SERVICE_SET_DEPENDENCY_COMMAND = create_default_cli_command(
-    SERVICE_SET_DEPENDENCY_COMMAND_ID,
+# ** constant: service_set_dependency_cli_cmd
+SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
     'set-dependency',
     'service',
     'Set Service Dependency',
@@ -418,9 +418,9 @@ SERVICE_SET_DEPENDENCY_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_dependency_command
-SERVICE_REMOVE_DEPENDENCY_COMMAND = create_default_cli_command(
-    SERVICE_REMOVE_DEPENDENCY_COMMAND_ID,
+# ** constant: service_remove_dependency_cli_cmd
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD = create_default_cli_command(
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
     'remove-dependency',
     'service',
     'Remove Service Dependency',
@@ -431,9 +431,9 @@ SERVICE_REMOVE_DEPENDENCY_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_command
-SERVICE_REMOVE_COMMAND = create_default_cli_command(
-    SERVICE_REMOVE_COMMAND_ID,
+# ** constant: service_remove_cli_cmd
+SERVICE_REMOVE_CLI_CMD = create_default_cli_command(
+    SERVICE_REMOVE_CLI_CMD_ID,
     'remove',
     'service',
     'Remove Service Configuration',
@@ -443,9 +443,9 @@ SERVICE_REMOVE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_constants_command
-SERVICE_SET_CONSTANTS_COMMAND = create_default_cli_command(
-    SERVICE_SET_CONSTANTS_COMMAND_ID,
+# ** constant: service_set_constants_cli_cmd
+SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID,
     'set-constants',
     'service',
     'Set Service Constants',
@@ -455,9 +455,9 @@ SERVICE_SET_CONSTANTS_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_add_command
-APP_ADD_COMMAND = create_default_cli_command(
-    APP_ADD_COMMAND_ID,
+# ** constant: app_add_cli_cmd
+APP_ADD_CLI_CMD = create_default_cli_command(
+    APP_ADD_CLI_CMD_ID,
     'add',
     'app',
     'Add App Interface',
@@ -474,9 +474,9 @@ APP_ADD_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_get_command
-APP_GET_COMMAND = create_default_cli_command(
-    APP_GET_COMMAND_ID,
+# ** constant: app_get_cli_cmd
+APP_GET_CLI_CMD = create_default_cli_command(
+    APP_GET_CLI_CMD_ID,
     'get',
     'app',
     'Get App Interface',
@@ -486,18 +486,18 @@ APP_GET_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_list_command
-APP_LIST_COMMAND = create_default_cli_command(
-    APP_LIST_COMMAND_ID,
+# ** constant: app_list_cli_cmd
+APP_LIST_CLI_CMD = create_default_cli_command(
+    APP_LIST_CLI_CMD_ID,
     'list',
     'app',
     'List App Interfaces',
     description='List all configured app interfaces.',
 )
 
-# ** constant: app_update_command
-APP_UPDATE_COMMAND = create_default_cli_command(
-    APP_UPDATE_COMMAND_ID,
+# ** constant: app_update_cli_cmd
+APP_UPDATE_CLI_CMD = create_default_cli_command(
+    APP_UPDATE_CLI_CMD_ID,
     'update',
     'app',
     'Update App Interface',
@@ -509,9 +509,9 @@ APP_UPDATE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_constants_command
-APP_SET_CONSTANTS_COMMAND = create_default_cli_command(
-    APP_SET_CONSTANTS_COMMAND_ID,
+# ** constant: app_set_constants_cli_cmd
+APP_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
+    APP_SET_CONSTANTS_CLI_CMD_ID,
     'set-constants',
     'app',
     'Set App Constants',
@@ -522,9 +522,9 @@ APP_SET_CONSTANTS_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_service_command
-APP_SET_SERVICE_COMMAND = create_default_cli_command(
-    APP_SET_SERVICE_COMMAND_ID,
+# ** constant: app_set_service_cli_cmd
+APP_SET_SERVICE_CLI_CMD = create_default_cli_command(
+    APP_SET_SERVICE_CLI_CMD_ID,
     'set-service',
     'app',
     'Set App Service Dependency',
@@ -538,9 +538,9 @@ APP_SET_SERVICE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_service_command
-APP_REMOVE_SERVICE_COMMAND = create_default_cli_command(
-    APP_REMOVE_SERVICE_COMMAND_ID,
+# ** constant: app_remove_service_cli_cmd
+APP_REMOVE_SERVICE_CLI_CMD = create_default_cli_command(
+    APP_REMOVE_SERVICE_CLI_CMD_ID,
     'remove-service',
     'app',
     'Remove App Service Dependency',
@@ -551,9 +551,9 @@ APP_REMOVE_SERVICE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_command
-APP_REMOVE_COMMAND = create_default_cli_command(
-    APP_REMOVE_COMMAND_ID,
+# ** constant: app_remove_cli_cmd
+APP_REMOVE_CLI_CMD = create_default_cli_command(
+    APP_REMOVE_CLI_CMD_ID,
     'remove',
     'app',
     'Remove App Interface',
@@ -563,9 +563,9 @@ APP_REMOVE_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_add_command_command
-CLI_ADD_COMMAND_COMMAND = create_default_cli_command(
-    CLI_ADD_COMMAND_COMMAND_ID,
+# ** constant: cli_add_command_cli_cmd
+CLI_ADD_COMMAND_CLI_CMD = create_default_cli_command(
+    CLI_ADD_COMMAND_CLI_CMD_ID,
     'add-command',
     'cli',
     'Add CLI Command',
@@ -579,18 +579,18 @@ CLI_ADD_COMMAND_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_list_commands_command
-CLI_LIST_COMMANDS_COMMAND = create_default_cli_command(
-    CLI_LIST_COMMANDS_COMMAND_ID,
+# ** constant: cli_list_commands_cli_cmd
+CLI_LIST_COMMANDS_CLI_CMD = create_default_cli_command(
+    CLI_LIST_COMMANDS_CLI_CMD_ID,
     'list-commands',
     'cli',
     'List CLI Commands',
     description='List all CLI command definitions.',
 )
 
-# ** constant: cli_add_argument_command
-CLI_ADD_ARGUMENT_COMMAND = create_default_cli_command(
-    CLI_ADD_ARGUMENT_COMMAND_ID,
+# ** constant: cli_add_argument_cli_cmd
+CLI_ADD_ARGUMENT_CLI_CMD = create_default_cli_command(
+    CLI_ADD_ARGUMENT_CLI_CMD_ID,
     'add-argument',
     'cli',
     'Add CLI Argument',
@@ -605,9 +605,9 @@ CLI_ADD_ARGUMENT_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_formatter_command
-LOGGING_ADD_FORMATTER_COMMAND = create_default_cli_command(
-    LOGGING_ADD_FORMATTER_COMMAND_ID,
+# ** constant: logging_add_formatter_cli_cmd
+LOGGING_ADD_FORMATTER_CLI_CMD = create_default_cli_command(
+    LOGGING_ADD_FORMATTER_CLI_CMD_ID,
     'add-formatter',
     'logging',
     'Add Formatter',
@@ -621,9 +621,9 @@ LOGGING_ADD_FORMATTER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_formatter_command
-LOGGING_REMOVE_FORMATTER_COMMAND = create_default_cli_command(
-    LOGGING_REMOVE_FORMATTER_COMMAND_ID,
+# ** constant: logging_remove_formatter_cli_cmd
+LOGGING_REMOVE_FORMATTER_CLI_CMD = create_default_cli_command(
+    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID,
     'remove-formatter',
     'logging',
     'Remove Formatter',
@@ -633,9 +633,9 @@ LOGGING_REMOVE_FORMATTER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_handler_command
-LOGGING_ADD_HANDLER_COMMAND = create_default_cli_command(
-    LOGGING_ADD_HANDLER_COMMAND_ID,
+# ** constant: logging_add_handler_cli_cmd
+LOGGING_ADD_HANDLER_CLI_CMD = create_default_cli_command(
+    LOGGING_ADD_HANDLER_CLI_CMD_ID,
     'add-handler',
     'logging',
     'Add Handler',
@@ -657,9 +657,9 @@ LOGGING_ADD_HANDLER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_handler_command
-LOGGING_REMOVE_HANDLER_COMMAND = create_default_cli_command(
-    LOGGING_REMOVE_HANDLER_COMMAND_ID,
+# ** constant: logging_remove_handler_cli_cmd
+LOGGING_REMOVE_HANDLER_CLI_CMD = create_default_cli_command(
+    LOGGING_REMOVE_HANDLER_CLI_CMD_ID,
     'remove-handler',
     'logging',
     'Remove Handler',
@@ -669,9 +669,9 @@ LOGGING_REMOVE_HANDLER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_logger_command
-LOGGING_ADD_LOGGER_COMMAND = create_default_cli_command(
-    LOGGING_ADD_LOGGER_COMMAND_ID,
+# ** constant: logging_add_logger_cli_cmd
+LOGGING_ADD_LOGGER_CLI_CMD = create_default_cli_command(
+    LOGGING_ADD_LOGGER_CLI_CMD_ID,
     'add-logger',
     'logging',
     'Add Logger',
@@ -690,9 +690,9 @@ LOGGING_ADD_LOGGER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_logger_command
-LOGGING_REMOVE_LOGGER_COMMAND = create_default_cli_command(
-    LOGGING_REMOVE_LOGGER_COMMAND_ID,
+# ** constant: logging_remove_logger_cli_cmd
+LOGGING_REMOVE_LOGGER_CLI_CMD = create_default_cli_command(
+    LOGGING_REMOVE_LOGGER_CLI_CMD_ID,
     'remove-logger',
     'logging',
     'Remove Logger',
@@ -702,9 +702,9 @@ LOGGING_REMOVE_LOGGER_COMMAND = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_list_command
-LOGGING_LIST_COMMAND = create_default_cli_command(
-    LOGGING_LIST_COMMAND_ID,
+# ** constant: logging_list_cli_cmd
+LOGGING_LIST_CLI_CMD = create_default_cli_command(
+    LOGGING_LIST_CLI_CMD_ID,
     'list',
     'logging',
     'List Logging Configs',
@@ -715,46 +715,46 @@ LOGGING_LIST_COMMAND = create_default_cli_command(
 
 # ** constant: admin_default_commands
 ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
-    FEATURE_ADD_COMMAND_ID:           FEATURE_ADD_COMMAND,
-    FEATURE_GET_COMMAND_ID:           FEATURE_GET_COMMAND,
-    FEATURE_LIST_COMMAND_ID:          FEATURE_LIST_COMMAND,
-    FEATURE_REMOVE_COMMAND_ID:        FEATURE_REMOVE_COMMAND,
-    FEATURE_UPDATE_COMMAND_ID:        FEATURE_UPDATE_COMMAND,
-    FEATURE_ADD_STEP_COMMAND_ID:      FEATURE_ADD_STEP_COMMAND,
-    FEATURE_UPDATE_STEP_COMMAND_ID:   FEATURE_UPDATE_STEP_COMMAND,
-    FEATURE_REMOVE_STEP_COMMAND_ID:   FEATURE_REMOVE_STEP_COMMAND,
-    FEATURE_REORDER_STEP_COMMAND_ID:  FEATURE_REORDER_STEP_COMMAND,
-    ERROR_ADD_COMMAND_ID:             ERROR_ADD_COMMAND,
-    ERROR_GET_COMMAND_ID:             ERROR_GET_COMMAND,
-    ERROR_LIST_COMMAND_ID:            ERROR_LIST_COMMAND,
-    ERROR_RENAME_COMMAND_ID:          ERROR_RENAME_COMMAND,
-    ERROR_SET_MESSAGE_COMMAND_ID:     ERROR_SET_MESSAGE_COMMAND,
-    ERROR_REMOVE_MESSAGE_COMMAND_ID:  ERROR_REMOVE_MESSAGE_COMMAND,
-    ERROR_REMOVE_COMMAND_ID:          ERROR_REMOVE_COMMAND,
-    SERVICE_ADD_COMMAND_ID:           SERVICE_ADD_COMMAND,
-    SERVICE_LIST_COMMAND_ID:          SERVICE_LIST_COMMAND,
-    SERVICE_SET_DEFAULT_COMMAND_ID:   SERVICE_SET_DEFAULT_COMMAND,
-    SERVICE_SET_DEPENDENCY_COMMAND_ID: SERVICE_SET_DEPENDENCY_COMMAND,
-    SERVICE_REMOVE_DEPENDENCY_COMMAND_ID: SERVICE_REMOVE_DEPENDENCY_COMMAND,
-    SERVICE_REMOVE_COMMAND_ID:        SERVICE_REMOVE_COMMAND,
-    SERVICE_SET_CONSTANTS_COMMAND_ID: SERVICE_SET_CONSTANTS_COMMAND,
-    APP_ADD_COMMAND_ID:               APP_ADD_COMMAND,
-    APP_GET_COMMAND_ID:               APP_GET_COMMAND,
-    APP_LIST_COMMAND_ID:              APP_LIST_COMMAND,
-    APP_UPDATE_COMMAND_ID:            APP_UPDATE_COMMAND,
-    APP_SET_CONSTANTS_COMMAND_ID:     APP_SET_CONSTANTS_COMMAND,
-    APP_SET_SERVICE_COMMAND_ID:       APP_SET_SERVICE_COMMAND,
-    APP_REMOVE_SERVICE_COMMAND_ID:    APP_REMOVE_SERVICE_COMMAND,
-    APP_REMOVE_COMMAND_ID:            APP_REMOVE_COMMAND,
-    CLI_ADD_COMMAND_COMMAND_ID:       CLI_ADD_COMMAND_COMMAND,
-    CLI_LIST_COMMANDS_COMMAND_ID:     CLI_LIST_COMMANDS_COMMAND,
-    CLI_ADD_ARGUMENT_COMMAND_ID:      CLI_ADD_ARGUMENT_COMMAND,
-    LOGGING_ADD_FORMATTER_COMMAND_ID:    LOGGING_ADD_FORMATTER_COMMAND,
-    LOGGING_REMOVE_FORMATTER_COMMAND_ID: LOGGING_REMOVE_FORMATTER_COMMAND,
-    LOGGING_ADD_HANDLER_COMMAND_ID:      LOGGING_ADD_HANDLER_COMMAND,
-    LOGGING_REMOVE_HANDLER_COMMAND_ID:   LOGGING_REMOVE_HANDLER_COMMAND,
-    LOGGING_ADD_LOGGER_COMMAND_ID:       LOGGING_ADD_LOGGER_COMMAND,
-    LOGGING_REMOVE_LOGGER_COMMAND_ID:    LOGGING_REMOVE_LOGGER_COMMAND,
-    LOGGING_LIST_COMMAND_ID:             LOGGING_LIST_COMMAND,
+    FEATURE_ADD_CLI_CMD_ID:           FEATURE_ADD_CLI_CMD,
+    FEATURE_GET_CLI_CMD_ID:           FEATURE_GET_CLI_CMD,
+    FEATURE_LIST_CLI_CMD_ID:          FEATURE_LIST_CLI_CMD,
+    FEATURE_REMOVE_CLI_CMD_ID:        FEATURE_REMOVE_CLI_CMD,
+    FEATURE_UPDATE_CLI_CMD_ID:        FEATURE_UPDATE_CLI_CMD,
+    FEATURE_ADD_STEP_CLI_CMD_ID:      FEATURE_ADD_STEP_CLI_CMD,
+    FEATURE_UPDATE_STEP_CLI_CMD_ID:   FEATURE_UPDATE_STEP_CLI_CMD,
+    FEATURE_REMOVE_STEP_CLI_CMD_ID:   FEATURE_REMOVE_STEP_CLI_CMD,
+    FEATURE_REORDER_STEP_CLI_CMD_ID:  FEATURE_REORDER_STEP_CLI_CMD,
+    ERROR_ADD_CLI_CMD_ID:             ERROR_ADD_CLI_CMD,
+    ERROR_GET_CLI_CMD_ID:             ERROR_GET_CLI_CMD,
+    ERROR_LIST_CLI_CMD_ID:            ERROR_LIST_CLI_CMD,
+    ERROR_RENAME_CLI_CMD_ID:          ERROR_RENAME_CLI_CMD,
+    ERROR_SET_MESSAGE_CLI_CMD_ID:     ERROR_SET_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID:  ERROR_REMOVE_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_CLI_CMD_ID:          ERROR_REMOVE_CLI_CMD,
+    SERVICE_ADD_CLI_CMD_ID:           SERVICE_ADD_CLI_CMD,
+    SERVICE_LIST_CLI_CMD_ID:          SERVICE_LIST_CLI_CMD,
+    SERVICE_SET_DEFAULT_CLI_CMD_ID:   SERVICE_SET_DEFAULT_CLI_CMD,
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
+    SERVICE_REMOVE_CLI_CMD_ID:        SERVICE_REMOVE_CLI_CMD,
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
+    APP_ADD_CLI_CMD_ID:               APP_ADD_CLI_CMD,
+    APP_GET_CLI_CMD_ID:               APP_GET_CLI_CMD,
+    APP_LIST_CLI_CMD_ID:              APP_LIST_CLI_CMD,
+    APP_UPDATE_CLI_CMD_ID:            APP_UPDATE_CLI_CMD,
+    APP_SET_CONSTANTS_CLI_CMD_ID:     APP_SET_CONSTANTS_CLI_CMD,
+    APP_SET_SERVICE_CLI_CMD_ID:       APP_SET_SERVICE_CLI_CMD,
+    APP_REMOVE_SERVICE_CLI_CMD_ID:    APP_REMOVE_SERVICE_CLI_CMD,
+    APP_REMOVE_CLI_CMD_ID:            APP_REMOVE_CLI_CMD,
+    CLI_ADD_COMMAND_CLI_CMD_ID:       CLI_ADD_COMMAND_CLI_CMD,
+    CLI_LIST_COMMANDS_CLI_CMD_ID:     CLI_LIST_COMMANDS_CLI_CMD,
+    CLI_ADD_ARGUMENT_CLI_CMD_ID:      CLI_ADD_ARGUMENT_CLI_CMD,
+    LOGGING_ADD_FORMATTER_CLI_CMD_ID:    LOGGING_ADD_FORMATTER_CLI_CMD,
+    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD,
+    LOGGING_ADD_HANDLER_CLI_CMD_ID:      LOGGING_ADD_HANDLER_CLI_CMD,
+    LOGGING_REMOVE_HANDLER_CLI_CMD_ID:   LOGGING_REMOVE_HANDLER_CLI_CMD,
+    LOGGING_ADD_LOGGER_CLI_CMD_ID:       LOGGING_ADD_LOGGER_CLI_CMD,
+    LOGGING_REMOVE_LOGGER_CLI_CMD_ID:    LOGGING_REMOVE_LOGGER_CLI_CMD,
+    LOGGING_LIST_CLI_CMD_ID:             LOGGING_LIST_CLI_CMD,
 }
 

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -18,75 +18,6 @@ from .core import create_default_cli_argument, create_default_cli_command
 
 # *** constants (ids)
 
-# ** constant: feature_add_cli_cmd_id
-FEATURE_ADD_CLI_CMD_ID = 'feature.add'
-
-# ** constant: feature_get_cli_cmd_id
-FEATURE_GET_CLI_CMD_ID = 'feature.get'
-
-# ** constant: feature_list_cli_cmd_id
-FEATURE_LIST_CLI_CMD_ID = 'feature.list'
-
-# ** constant: feature_remove_cli_cmd_id
-FEATURE_REMOVE_CLI_CMD_ID = 'feature.remove'
-
-# ** constant: feature_update_cli_cmd_id
-FEATURE_UPDATE_CLI_CMD_ID = 'feature.update'
-
-# ** constant: feature_add_step_cli_cmd_id
-FEATURE_ADD_STEP_CLI_CMD_ID = 'feature.add_step'
-
-# ** constant: feature_update_step_cli_cmd_id
-FEATURE_UPDATE_STEP_CLI_CMD_ID = 'feature.update_step'
-
-# ** constant: feature_remove_step_cli_cmd_id
-FEATURE_REMOVE_STEP_CLI_CMD_ID = 'feature.remove_step'
-
-# ** constant: feature_reorder_step_cli_cmd_id
-FEATURE_REORDER_STEP_CLI_CMD_ID = 'feature.reorder_step'
-
-# ** constant: error_add_cli_cmd_id
-ERROR_ADD_CLI_CMD_ID = 'error.add'
-
-# ** constant: error_get_cli_cmd_id
-ERROR_GET_CLI_CMD_ID = 'error.get'
-
-# ** constant: error_list_cli_cmd_id
-ERROR_LIST_CLI_CMD_ID = 'error.list'
-
-# ** constant: error_rename_cli_cmd_id
-ERROR_RENAME_CLI_CMD_ID = 'error.rename'
-
-# ** constant: error_set_message_cli_cmd_id
-ERROR_SET_MESSAGE_CLI_CMD_ID = 'error.set_message'
-
-# ** constant: error_remove_message_cli_cmd_id
-ERROR_REMOVE_MESSAGE_CLI_CMD_ID = 'error.remove_message'
-
-# ** constant: error_remove_cli_cmd_id
-ERROR_REMOVE_CLI_CMD_ID = 'error.remove'
-
-# ** constant: service_add_cli_cmd_id
-SERVICE_ADD_CLI_CMD_ID = 'service.add'
-
-# ** constant: service_list_cli_cmd_id
-SERVICE_LIST_CLI_CMD_ID = 'service.list'
-
-# ** constant: service_set_default_cli_cmd_id
-SERVICE_SET_DEFAULT_CLI_CMD_ID = 'service.set_default'
-
-# ** constant: service_set_dependency_cli_cmd_id
-SERVICE_SET_DEPENDENCY_CLI_CMD_ID = 'service.set_dependency'
-
-# ** constant: service_remove_dependency_cli_cmd_id
-SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID = 'service.remove_dependency'
-
-# ** constant: service_remove_cli_cmd_id
-SERVICE_REMOVE_CLI_CMD_ID = 'service.remove'
-
-# ** constant: service_set_constants_cli_cmd_id
-SERVICE_SET_CONSTANTS_CLI_CMD_ID = 'service.set_constants'
-
 # ** constant: app_add_cli_cmd_id
 APP_ADD_CLI_CMD_ID = 'app.add'
 
@@ -120,6 +51,75 @@ CLI_LIST_COMMANDS_CLI_CMD_ID = 'cli.list_commands'
 # ** constant: cli_add_argument_cli_cmd_id
 CLI_ADD_ARGUMENT_CLI_CMD_ID = 'cli.add_argument'
 
+# ** constant: error_add_cli_cmd_id
+ERROR_ADD_CLI_CMD_ID = 'error.add'
+
+# ** constant: error_get_cli_cmd_id
+ERROR_GET_CLI_CMD_ID = 'error.get'
+
+# ** constant: error_list_cli_cmd_id
+ERROR_LIST_CLI_CMD_ID = 'error.list'
+
+# ** constant: error_rename_cli_cmd_id
+ERROR_RENAME_CLI_CMD_ID = 'error.rename'
+
+# ** constant: error_set_message_cli_cmd_id
+ERROR_SET_MESSAGE_CLI_CMD_ID = 'error.set_message'
+
+# ** constant: error_remove_message_cli_cmd_id
+ERROR_REMOVE_MESSAGE_CLI_CMD_ID = 'error.remove_message'
+
+# ** constant: error_remove_cli_cmd_id
+ERROR_REMOVE_CLI_CMD_ID = 'error.remove'
+
+# ** constant: feature_add_cli_cmd_id
+FEATURE_ADD_CLI_CMD_ID = 'feature.add'
+
+# ** constant: feature_get_cli_cmd_id
+FEATURE_GET_CLI_CMD_ID = 'feature.get'
+
+# ** constant: feature_list_cli_cmd_id
+FEATURE_LIST_CLI_CMD_ID = 'feature.list'
+
+# ** constant: feature_remove_cli_cmd_id
+FEATURE_REMOVE_CLI_CMD_ID = 'feature.remove'
+
+# ** constant: feature_update_cli_cmd_id
+FEATURE_UPDATE_CLI_CMD_ID = 'feature.update'
+
+# ** constant: feature_add_step_cli_cmd_id
+FEATURE_ADD_STEP_CLI_CMD_ID = 'feature.add_step'
+
+# ** constant: feature_update_step_cli_cmd_id
+FEATURE_UPDATE_STEP_CLI_CMD_ID = 'feature.update_step'
+
+# ** constant: feature_remove_step_cli_cmd_id
+FEATURE_REMOVE_STEP_CLI_CMD_ID = 'feature.remove_step'
+
+# ** constant: feature_reorder_step_cli_cmd_id
+FEATURE_REORDER_STEP_CLI_CMD_ID = 'feature.reorder_step'
+
+# ** constant: service_add_cli_cmd_id
+SERVICE_ADD_CLI_CMD_ID = 'service.add'
+
+# ** constant: service_list_cli_cmd_id
+SERVICE_LIST_CLI_CMD_ID = 'service.list'
+
+# ** constant: service_set_default_cli_cmd_id
+SERVICE_SET_DEFAULT_CLI_CMD_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_cli_cmd_id
+SERVICE_SET_DEPENDENCY_CLI_CMD_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_cli_cmd_id
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID = 'service.remove_dependency'
+
+# ** constant: service_remove_cli_cmd_id
+SERVICE_REMOVE_CLI_CMD_ID = 'service.remove'
+
+# ** constant: service_set_constants_cli_cmd_id
+SERVICE_SET_CONSTANTS_CLI_CMD_ID = 'service.set_constants'
+
 # ** constant: logging_add_formatter_cli_cmd_id
 LOGGING_ADD_FORMATTER_CLI_CMD_ID = 'logging.add_formatter'
 
@@ -142,318 +142,6 @@ LOGGING_REMOVE_LOGGER_CLI_CMD_ID = 'logging.remove_logger'
 LOGGING_LIST_CLI_CMD_ID = 'logging.list'
 
 # *** constants (commands)
-
-# ** constant: feature_add_cli_cmd
-FEATURE_ADD_CLI_CMD = create_default_cli_command(
-    FEATURE_ADD_CLI_CMD_ID,
-    'add',
-    'feature',
-    'Add Feature',
-    description='Add a new feature configuration.',
-    arguments=[
-        create_default_cli_argument(['name'], 'The feature name.'),
-        create_default_cli_argument(['group_id'], 'The group identifier.'),
-        create_default_cli_argument(['--feature-key'], 'Optional explicit feature key.'),
-        create_default_cli_argument(['--description'], 'Optional feature description.'),
-    ],
-)
-
-# ** constant: feature_get_cli_cmd
-FEATURE_GET_CLI_CMD = create_default_cli_command(
-    FEATURE_GET_CLI_CMD_ID,
-    'get',
-    'feature',
-    'Get Feature',
-    description='Retrieve a feature by ID.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier (e.g. calc.add).'),
-    ],
-)
-
-# ** constant: feature_list_cli_cmd
-FEATURE_LIST_CLI_CMD = create_default_cli_command(
-    FEATURE_LIST_CLI_CMD_ID,
-    'list',
-    'feature',
-    'List Features',
-    description='List all features, optionally filtered by group.',
-    arguments=[
-        create_default_cli_argument(['--group-id'], 'Optional group ID to filter results.'),
-    ],
-)
-
-# ** constant: feature_remove_cli_cmd
-FEATURE_REMOVE_CLI_CMD = create_default_cli_command(
-    FEATURE_REMOVE_CLI_CMD_ID,
-    'remove',
-    'feature',
-    'Remove Feature',
-    description='Remove a feature configuration by ID.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier to remove.'),
-    ],
-)
-
-# ** constant: feature_update_cli_cmd
-FEATURE_UPDATE_CLI_CMD = create_default_cli_command(
-    FEATURE_UPDATE_CLI_CMD_ID,
-    'update',
-    'feature',
-    'Update Feature',
-    description='Update a feature attribute (name or description).',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier.'),
-        create_default_cli_argument(['attribute'], 'The attribute to update.', choices=['name', 'description']),
-        create_default_cli_argument(['value'], 'The new value for the attribute.'),
-    ],
-)
-
-# ** constant: feature_add_step_cli_cmd
-FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_ADD_STEP_CLI_CMD_ID,
-    'add-step',
-    'feature',
-    'Add Feature Step',
-    description='Add a step to an existing feature workflow.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier.'),
-        create_default_cli_argument(['name'], 'The step name.'),
-        create_default_cli_argument(['service_id'], 'The service configuration ID for the step.'),
-        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.'),
-        create_default_cli_argument(['--data-key'], 'Optional result data key.'),
-        create_default_cli_argument(['--position'], 'Insertion position (default: append).', type='int'),
-    ],
-)
-
-# ** constant: feature_update_step_cli_cmd
-FEATURE_UPDATE_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_UPDATE_STEP_CLI_CMD_ID,
-    'update-step',
-    'feature',
-    'Update Feature Step',
-    description='Update an attribute on a feature step.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier.'),
-        create_default_cli_argument(['position'], 'Zero-based index of the step.', type='int'),
-        create_default_cli_argument(
-            ['attribute'],
-            'The attribute to update.',
-            choices=['name', 'service_id', 'data_key', 'pass_on_error', 'parameters'],
-        ),
-        create_default_cli_argument(['value'], 'The new value for the attribute.'),
-    ],
-)
-
-# ** constant: feature_remove_step_cli_cmd
-FEATURE_REMOVE_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_REMOVE_STEP_CLI_CMD_ID,
-    'remove-step',
-    'feature',
-    'Remove Feature Step',
-    description='Remove a step from a feature by position.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier.'),
-        create_default_cli_argument(['position'], 'The index of the step to remove.', type='int'),
-    ],
-)
-
-# ** constant: feature_reorder_step_cli_cmd
-FEATURE_REORDER_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_REORDER_STEP_CLI_CMD_ID,
-    'reorder-step',
-    'feature',
-    'Reorder Feature Step',
-    description='Move a feature step from one position to another.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The feature identifier.'),
-        create_default_cli_argument(['start_position'], 'Current index of the step.', type='int'),
-        create_default_cli_argument(['end_position'], 'Desired new index.', type='int'),
-    ],
-)
-
-# ** constant: error_add_cli_cmd
-ERROR_ADD_CLI_CMD = create_default_cli_command(
-    ERROR_ADD_CLI_CMD_ID,
-    'add',
-    'error',
-    'Add Error',
-    description='Add a new error definition.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The unique error identifier.'),
-        create_default_cli_argument(['name'], 'The error name.'),
-        create_default_cli_argument(['message'], 'The primary error message text.'),
-        create_default_cli_argument(['--lang'], 'Language code for the message (default: en_US).', default='en_US'),
-    ],
-)
-
-# ** constant: error_get_cli_cmd
-ERROR_GET_CLI_CMD = create_default_cli_command(
-    ERROR_GET_CLI_CMD_ID,
-    'get',
-    'error',
-    'Get Error',
-    description='Retrieve an error by ID.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The error identifier.'),
-    ],
-)
-
-# ** constant: error_list_cli_cmd
-ERROR_LIST_CLI_CMD = create_default_cli_command(
-    ERROR_LIST_CLI_CMD_ID,
-    'list',
-    'error',
-    'List Errors',
-    description='List all error definitions.',
-    arguments=[
-        create_default_cli_argument(['--include-defaults'], 'Include built-in default errors.', action='store_true'),
-    ],
-)
-
-# ** constant: error_rename_cli_cmd
-ERROR_RENAME_CLI_CMD = create_default_cli_command(
-    ERROR_RENAME_CLI_CMD_ID,
-    'rename',
-    'error',
-    'Rename Error',
-    description='Rename an existing error.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The error identifier.'),
-        create_default_cli_argument(['new_name'], 'The new name for the error.'),
-    ],
-)
-
-# ** constant: error_set_message_cli_cmd
-ERROR_SET_MESSAGE_CLI_CMD = create_default_cli_command(
-    ERROR_SET_MESSAGE_CLI_CMD_ID,
-    'set-message',
-    'error',
-    'Set Error Message',
-    description='Set or update an error message for a language.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The error identifier.'),
-        create_default_cli_argument(['message'], 'The message text.'),
-        create_default_cli_argument(['--lang'], 'Language code (default: en_US).', default='en_US'),
-    ],
-)
-
-# ** constant: error_remove_message_cli_cmd
-ERROR_REMOVE_MESSAGE_CLI_CMD = create_default_cli_command(
-    ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
-    'remove-message',
-    'error',
-    'Remove Error Message',
-    description='Remove an error message by language.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The error identifier.'),
-        create_default_cli_argument(['--lang'], 'Language code to remove (default: en_US).', default='en_US'),
-    ],
-)
-
-# ** constant: error_remove_cli_cmd
-ERROR_REMOVE_CLI_CMD = create_default_cli_command(
-    ERROR_REMOVE_CLI_CMD_ID,
-    'remove',
-    'error',
-    'Remove Error',
-    description='Remove an error definition by ID.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The error identifier to remove.'),
-    ],
-)
-
-# ** constant: service_add_cli_cmd
-SERVICE_ADD_CLI_CMD = create_default_cli_command(
-    SERVICE_ADD_CLI_CMD_ID,
-    'add',
-    'service',
-    'Add Service Configuration',
-    description='Add a new service configuration.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The unique service configuration identifier.'),
-        create_default_cli_argument(['--module-path'], 'Default module path.'),
-        create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.'),
-        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.'),
-    ],
-)
-
-# ** constant: service_list_cli_cmd
-SERVICE_LIST_CLI_CMD = create_default_cli_command(
-    SERVICE_LIST_CLI_CMD_ID,
-    'list',
-    'service',
-    'List All Settings',
-    description='List all service configurations and constants.',
-)
-
-# ** constant: service_set_default_cli_cmd
-SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_DEFAULT_CLI_CMD_ID,
-    'set-default',
-    'service',
-    'Set Default Service Configuration',
-    description='Set or update the default type for a service configuration.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The service configuration identifier.'),
-        create_default_cli_argument(['--module-path'], 'Default module path.'),
-        create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
-    ],
-)
-
-# ** constant: service_set_dependency_cli_cmd
-SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
-    'set-dependency',
-    'service',
-    'Set Service Dependency',
-    description='Set or update a flagged dependency on a service configuration.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The service configuration identifier.'),
-        create_default_cli_argument(['flag'], 'The flag identifying the dependency.'),
-        create_default_cli_argument(['module_path'], 'Module path for the dependency.'),
-        create_default_cli_argument(['class_name'], 'Class name for the dependency.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
-    ],
-)
-
-# ** constant: service_remove_dependency_cli_cmd
-SERVICE_REMOVE_DEPENDENCY_CLI_CMD = create_default_cli_command(
-    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
-    'remove-dependency',
-    'service',
-    'Remove Service Dependency',
-    description='Remove a flagged dependency from a service configuration.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The service configuration identifier.'),
-        create_default_cli_argument(['flag'], 'The flag identifying the dependency to remove.'),
-    ],
-)
-
-# ** constant: service_remove_cli_cmd
-SERVICE_REMOVE_CLI_CMD = create_default_cli_command(
-    SERVICE_REMOVE_CLI_CMD_ID,
-    'remove',
-    'service',
-    'Remove Service Configuration',
-    description='Remove a service configuration by ID.',
-    arguments=[
-        create_default_cli_argument(['id'], 'The service configuration identifier to remove.'),
-    ],
-)
-
-# ** constant: service_set_constants_cli_cmd
-SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_CONSTANTS_CLI_CMD_ID,
-    'set-constants',
-    'service',
-    'Set Service Constants',
-    description='Set or clear service-level constants.',
-    arguments=[
-        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
-    ],
-)
 
 # ** constant: app_add_cli_cmd
 APP_ADD_CLI_CMD = create_default_cli_command(
@@ -605,6 +293,318 @@ CLI_ADD_ARGUMENT_CLI_CMD = create_default_cli_command(
     ],
 )
 
+# ** constant: error_add_cli_cmd
+ERROR_ADD_CLI_CMD = create_default_cli_command(
+    ERROR_ADD_CLI_CMD_ID,
+    'add',
+    'error',
+    'Add Error',
+    description='Add a new error definition.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The unique error identifier.'),
+        create_default_cli_argument(['name'], 'The error name.'),
+        create_default_cli_argument(['message'], 'The primary error message text.'),
+        create_default_cli_argument(['--lang'], 'Language code for the message (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_get_cli_cmd
+ERROR_GET_CLI_CMD = create_default_cli_command(
+    ERROR_GET_CLI_CMD_ID,
+    'get',
+    'error',
+    'Get Error',
+    description='Retrieve an error by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+    ],
+)
+
+# ** constant: error_list_cli_cmd
+ERROR_LIST_CLI_CMD = create_default_cli_command(
+    ERROR_LIST_CLI_CMD_ID,
+    'list',
+    'error',
+    'List Errors',
+    description='List all error definitions.',
+    arguments=[
+        create_default_cli_argument(['--include-defaults'], 'Include built-in default errors.', action='store_true'),
+    ],
+)
+
+# ** constant: error_rename_cli_cmd
+ERROR_RENAME_CLI_CMD = create_default_cli_command(
+    ERROR_RENAME_CLI_CMD_ID,
+    'rename',
+    'error',
+    'Rename Error',
+    description='Rename an existing error.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['new_name'], 'The new name for the error.'),
+    ],
+)
+
+# ** constant: error_set_message_cli_cmd
+ERROR_SET_MESSAGE_CLI_CMD = create_default_cli_command(
+    ERROR_SET_MESSAGE_CLI_CMD_ID,
+    'set-message',
+    'error',
+    'Set Error Message',
+    description='Set or update an error message for a language.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['message'], 'The message text.'),
+        create_default_cli_argument(['--lang'], 'Language code (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_remove_message_cli_cmd
+ERROR_REMOVE_MESSAGE_CLI_CMD = create_default_cli_command(
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
+    'remove-message',
+    'error',
+    'Remove Error Message',
+    description='Remove an error message by language.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier.'),
+        create_default_cli_argument(['--lang'], 'Language code to remove (default: en_US).', default='en_US'),
+    ],
+)
+
+# ** constant: error_remove_cli_cmd
+ERROR_REMOVE_CLI_CMD = create_default_cli_command(
+    ERROR_REMOVE_CLI_CMD_ID,
+    'remove',
+    'error',
+    'Remove Error',
+    description='Remove an error definition by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The error identifier to remove.'),
+    ],
+)
+
+# ** constant: feature_add_cli_cmd
+FEATURE_ADD_CLI_CMD = create_default_cli_command(
+    FEATURE_ADD_CLI_CMD_ID,
+    'add',
+    'feature',
+    'Add Feature',
+    description='Add a new feature configuration.',
+    arguments=[
+        create_default_cli_argument(['name'], 'The feature name.'),
+        create_default_cli_argument(['group_id'], 'The group identifier.'),
+        create_default_cli_argument(['--feature-key'], 'Optional explicit feature key.'),
+        create_default_cli_argument(['--description'], 'Optional feature description.'),
+    ],
+)
+
+# ** constant: feature_get_cli_cmd
+FEATURE_GET_CLI_CMD = create_default_cli_command(
+    FEATURE_GET_CLI_CMD_ID,
+    'get',
+    'feature',
+    'Get Feature',
+    description='Retrieve a feature by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier (e.g. calc.add).'),
+    ],
+)
+
+# ** constant: feature_list_cli_cmd
+FEATURE_LIST_CLI_CMD = create_default_cli_command(
+    FEATURE_LIST_CLI_CMD_ID,
+    'list',
+    'feature',
+    'List Features',
+    description='List all features, optionally filtered by group.',
+    arguments=[
+        create_default_cli_argument(['--group-id'], 'Optional group ID to filter results.'),
+    ],
+)
+
+# ** constant: feature_remove_cli_cmd
+FEATURE_REMOVE_CLI_CMD = create_default_cli_command(
+    FEATURE_REMOVE_CLI_CMD_ID,
+    'remove',
+    'feature',
+    'Remove Feature',
+    description='Remove a feature configuration by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier to remove.'),
+    ],
+)
+
+# ** constant: feature_update_cli_cmd
+FEATURE_UPDATE_CLI_CMD = create_default_cli_command(
+    FEATURE_UPDATE_CLI_CMD_ID,
+    'update',
+    'feature',
+    'Update Feature',
+    description='Update a feature attribute (name or description).',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['attribute'], 'The attribute to update.', choices=['name', 'description']),
+        create_default_cli_argument(['value'], 'The new value for the attribute.'),
+    ],
+)
+
+# ** constant: feature_add_step_cli_cmd
+FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_ADD_STEP_CLI_CMD_ID,
+    'add-step',
+    'feature',
+    'Add Feature Step',
+    description='Add a step to an existing feature workflow.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['name'], 'The step name.'),
+        create_default_cli_argument(['service_id'], 'The service configuration ID for the step.'),
+        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.'),
+        create_default_cli_argument(['--data-key'], 'Optional result data key.'),
+        create_default_cli_argument(['--position'], 'Insertion position (default: append).', type='int'),
+    ],
+)
+
+# ** constant: feature_update_step_cli_cmd
+FEATURE_UPDATE_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_UPDATE_STEP_CLI_CMD_ID,
+    'update-step',
+    'feature',
+    'Update Feature Step',
+    description='Update an attribute on a feature step.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['position'], 'Zero-based index of the step.', type='int'),
+        create_default_cli_argument(
+            ['attribute'],
+            'The attribute to update.',
+            choices=['name', 'service_id', 'data_key', 'pass_on_error', 'parameters'],
+        ),
+        create_default_cli_argument(['value'], 'The new value for the attribute.'),
+    ],
+)
+
+# ** constant: feature_remove_step_cli_cmd
+FEATURE_REMOVE_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_REMOVE_STEP_CLI_CMD_ID,
+    'remove-step',
+    'feature',
+    'Remove Feature Step',
+    description='Remove a step from a feature by position.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['position'], 'The index of the step to remove.', type='int'),
+    ],
+)
+
+# ** constant: feature_reorder_step_cli_cmd
+FEATURE_REORDER_STEP_CLI_CMD = create_default_cli_command(
+    FEATURE_REORDER_STEP_CLI_CMD_ID,
+    'reorder-step',
+    'feature',
+    'Reorder Feature Step',
+    description='Move a feature step from one position to another.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The feature identifier.'),
+        create_default_cli_argument(['start_position'], 'Current index of the step.', type='int'),
+        create_default_cli_argument(['end_position'], 'Desired new index.', type='int'),
+    ],
+)
+
+# ** constant: service_add_cli_cmd
+SERVICE_ADD_CLI_CMD = create_default_cli_command(
+    SERVICE_ADD_CLI_CMD_ID,
+    'add',
+    'service',
+    'Add Service Configuration',
+    description='Add a new service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The unique service configuration identifier.'),
+        create_default_cli_argument(['--module-path'], 'Default module path.'),
+        create_default_cli_argument(['--class-name'], 'Default class name.'),
+        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.'),
+        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.'),
+    ],
+)
+
+# ** constant: service_list_cli_cmd
+SERVICE_LIST_CLI_CMD = create_default_cli_command(
+    SERVICE_LIST_CLI_CMD_ID,
+    'list',
+    'service',
+    'List All Settings',
+    description='List all service configurations and constants.',
+)
+
+# ** constant: service_set_default_cli_cmd
+SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_DEFAULT_CLI_CMD_ID,
+    'set-default',
+    'service',
+    'Set Default Service Configuration',
+    description='Set or update the default type for a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['--module-path'], 'Default module path.'),
+        create_default_cli_argument(['--class-name'], 'Default class name.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+    ],
+)
+
+# ** constant: service_set_dependency_cli_cmd
+SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
+    'set-dependency',
+    'service',
+    'Set Service Dependency',
+    description='Set or update a flagged dependency on a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['flag'], 'The flag identifying the dependency.'),
+        create_default_cli_argument(['module_path'], 'Module path for the dependency.'),
+        create_default_cli_argument(['class_name'], 'Class name for the dependency.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+    ],
+)
+
+# ** constant: service_remove_dependency_cli_cmd
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD = create_default_cli_command(
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
+    'remove-dependency',
+    'service',
+    'Remove Service Dependency',
+    description='Remove a flagged dependency from a service configuration.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier.'),
+        create_default_cli_argument(['flag'], 'The flag identifying the dependency to remove.'),
+    ],
+)
+
+# ** constant: service_remove_cli_cmd
+SERVICE_REMOVE_CLI_CMD = create_default_cli_command(
+    SERVICE_REMOVE_CLI_CMD_ID,
+    'remove',
+    'service',
+    'Remove Service Configuration',
+    description='Remove a service configuration by ID.',
+    arguments=[
+        create_default_cli_argument(['id'], 'The service configuration identifier to remove.'),
+    ],
+)
+
+# ** constant: service_set_constants_cli_cmd
+SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID,
+    'set-constants',
+    'service',
+    'Set Service Constants',
+    description='Set or clear service-level constants.',
+    arguments=[
+        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
+    ],
+)
+
 # ** constant: logging_add_formatter_cli_cmd
 LOGGING_ADD_FORMATTER_CLI_CMD = create_default_cli_command(
     LOGGING_ADD_FORMATTER_CLI_CMD_ID,
@@ -715,29 +715,6 @@ LOGGING_LIST_CLI_CMD = create_default_cli_command(
 
 # ** constant: admin_default_commands
 ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
-    FEATURE_ADD_CLI_CMD_ID:           FEATURE_ADD_CLI_CMD,
-    FEATURE_GET_CLI_CMD_ID:           FEATURE_GET_CLI_CMD,
-    FEATURE_LIST_CLI_CMD_ID:          FEATURE_LIST_CLI_CMD,
-    FEATURE_REMOVE_CLI_CMD_ID:        FEATURE_REMOVE_CLI_CMD,
-    FEATURE_UPDATE_CLI_CMD_ID:        FEATURE_UPDATE_CLI_CMD,
-    FEATURE_ADD_STEP_CLI_CMD_ID:      FEATURE_ADD_STEP_CLI_CMD,
-    FEATURE_UPDATE_STEP_CLI_CMD_ID:   FEATURE_UPDATE_STEP_CLI_CMD,
-    FEATURE_REMOVE_STEP_CLI_CMD_ID:   FEATURE_REMOVE_STEP_CLI_CMD,
-    FEATURE_REORDER_STEP_CLI_CMD_ID:  FEATURE_REORDER_STEP_CLI_CMD,
-    ERROR_ADD_CLI_CMD_ID:             ERROR_ADD_CLI_CMD,
-    ERROR_GET_CLI_CMD_ID:             ERROR_GET_CLI_CMD,
-    ERROR_LIST_CLI_CMD_ID:            ERROR_LIST_CLI_CMD,
-    ERROR_RENAME_CLI_CMD_ID:          ERROR_RENAME_CLI_CMD,
-    ERROR_SET_MESSAGE_CLI_CMD_ID:     ERROR_SET_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_MESSAGE_CLI_CMD_ID:  ERROR_REMOVE_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_CLI_CMD_ID:          ERROR_REMOVE_CLI_CMD,
-    SERVICE_ADD_CLI_CMD_ID:           SERVICE_ADD_CLI_CMD,
-    SERVICE_LIST_CLI_CMD_ID:          SERVICE_LIST_CLI_CMD,
-    SERVICE_SET_DEFAULT_CLI_CMD_ID:   SERVICE_SET_DEFAULT_CLI_CMD,
-    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
-    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
-    SERVICE_REMOVE_CLI_CMD_ID:        SERVICE_REMOVE_CLI_CMD,
-    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
     APP_ADD_CLI_CMD_ID:               APP_ADD_CLI_CMD,
     APP_GET_CLI_CMD_ID:               APP_GET_CLI_CMD,
     APP_LIST_CLI_CMD_ID:              APP_LIST_CLI_CMD,
@@ -749,6 +726,29 @@ ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
     CLI_ADD_COMMAND_CLI_CMD_ID:       CLI_ADD_COMMAND_CLI_CMD,
     CLI_LIST_COMMANDS_CLI_CMD_ID:     CLI_LIST_COMMANDS_CLI_CMD,
     CLI_ADD_ARGUMENT_CLI_CMD_ID:      CLI_ADD_ARGUMENT_CLI_CMD,
+    ERROR_ADD_CLI_CMD_ID:             ERROR_ADD_CLI_CMD,
+    ERROR_GET_CLI_CMD_ID:             ERROR_GET_CLI_CMD,
+    ERROR_LIST_CLI_CMD_ID:            ERROR_LIST_CLI_CMD,
+    ERROR_RENAME_CLI_CMD_ID:          ERROR_RENAME_CLI_CMD,
+    ERROR_SET_MESSAGE_CLI_CMD_ID:     ERROR_SET_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID:  ERROR_REMOVE_MESSAGE_CLI_CMD,
+    ERROR_REMOVE_CLI_CMD_ID:          ERROR_REMOVE_CLI_CMD,
+    FEATURE_ADD_CLI_CMD_ID:           FEATURE_ADD_CLI_CMD,
+    FEATURE_GET_CLI_CMD_ID:           FEATURE_GET_CLI_CMD,
+    FEATURE_LIST_CLI_CMD_ID:          FEATURE_LIST_CLI_CMD,
+    FEATURE_REMOVE_CLI_CMD_ID:        FEATURE_REMOVE_CLI_CMD,
+    FEATURE_UPDATE_CLI_CMD_ID:        FEATURE_UPDATE_CLI_CMD,
+    FEATURE_ADD_STEP_CLI_CMD_ID:      FEATURE_ADD_STEP_CLI_CMD,
+    FEATURE_UPDATE_STEP_CLI_CMD_ID:   FEATURE_UPDATE_STEP_CLI_CMD,
+    FEATURE_REMOVE_STEP_CLI_CMD_ID:   FEATURE_REMOVE_STEP_CLI_CMD,
+    FEATURE_REORDER_STEP_CLI_CMD_ID:  FEATURE_REORDER_STEP_CLI_CMD,
+    SERVICE_ADD_CLI_CMD_ID:           SERVICE_ADD_CLI_CMD,
+    SERVICE_LIST_CLI_CMD_ID:          SERVICE_LIST_CLI_CMD,
+    SERVICE_SET_DEFAULT_CLI_CMD_ID:   SERVICE_SET_DEFAULT_CLI_CMD,
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
+    SERVICE_REMOVE_CLI_CMD_ID:        SERVICE_REMOVE_CLI_CMD,
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
     LOGGING_ADD_FORMATTER_CLI_CMD_ID:    LOGGING_ADD_FORMATTER_CLI_CMD,
     LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD,
     LOGGING_ADD_HANDLER_CLI_CMD_ID:      LOGGING_ADD_HANDLER_CLI_CMD,

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -19,14 +19,136 @@ from .core import (
 
 # *** constants (ids)
 
+# ** constant: app_config_loading_failed_id
+APP_CONFIG_LOADING_FAILED_ID = 'APP_CONFIG_LOADING_FAILED'
+
+# ** constant: app_error_id
+APP_ERROR_ID = 'APP_ERROR'
+
+# ** constant: app_service_import_failed_id
+APP_SERVICE_IMPORT_FAILED_ID = 'APP_SERVICE_IMPORT_FAILED'
+
+# ** constant: app_session_not_found_id
+APP_SESSION_NOT_FOUND_ID = 'APP_SESSION_NOT_FOUND'
+
 # ** constant: command_parameter_required_id
 COMMAND_PARAMETER_REQUIRED_ID = 'COMMAND_PARAMETER_REQUIRED'
+
+# ** constant: config_file_not_found_id
+CONFIG_FILE_NOT_FOUND_ID = 'CONFIG_FILE_NOT_FOUND'
+
+# ** constant: container_config_loading_failed_id
+CONTAINER_CONFIG_LOADING_FAILED_ID = 'CONTAINER_CONFIG_LOADING_FAILED'
+
+# ** constant: context_not_found_id
+CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
+
+# ** constant: di_service_not_configured_id
+DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
+
+# ** constant: error_config_loading_failed_id
+ERROR_CONFIG_LOADING_FAILED_ID = 'ERROR_CONFIG_LOADING_FAILED'
 
 # ** constant: error_not_found_id
 ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
 
+# ** constant: feature_config_loading_failed_id
+FEATURE_CONFIG_LOADING_FAILED_ID = 'FEATURE_CONFIG_LOADING_FAILED'
+
+# ** constant: feature_not_found_id
+FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
+
+# ** constant: feature_step_loading_failed_id
+FEATURE_STEP_LOADING_FAILED_ID = 'FEATURE_STEP_LOADING_FAILED'
+
+# ** constant: file_already_open_id
+FILE_ALREADY_OPEN_ID = 'FILE_ALREADY_OPEN'
+
+# ** constant: file_not_found_id
+FILE_NOT_FOUND_ID = 'FILE_NOT_FOUND'
+
+# ** constant: import_dependency_failed_id
+IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
+
+# ** constant: invalid_app_session_type_id
+INVALID_APP_SESSION_TYPE_ID = 'INVALID_APP_SESSION_TYPE'
+
+# ** constant: invalid_encoding_id
+INVALID_ENCODING_ID = 'INVALID_ENCODING'
+
+# ** constant: invalid_file_id
+INVALID_FILE_ID = 'INVALID_FILE'
+
+# ** constant: invalid_file_mode_id
+INVALID_FILE_MODE_ID = 'INVALID_FILE_MODE'
+
+# ** constant: invalid_json_file_id
+INVALID_JSON_FILE_ID = 'INVALID_JSON_FILE'
+
+# ** constant: invalid_json_path_id
+INVALID_JSON_PATH_ID = 'INVALID_JSON_PATH'
+
+# ** constant: invalid_model_attribute_id
+INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
+
+# ** constant: invalid_yaml_file_id
+INVALID_YAML_FILE_ID = 'INVALID_YAML_FILE'
+
+# ** constant: json_file_load_error_id
+JSON_FILE_LOAD_ERROR_ID = 'JSON_FILE_LOAD_ERROR'
+
+# ** constant: json_file_not_found_id
+JSON_FILE_NOT_FOUND_ID = 'JSON_FILE_NOT_FOUND'
+
+# ** constant: logger_creation_failed_id
+LOGGER_CREATION_FAILED_ID = 'LOGGER_CREATION_FAILED'
+
+# ** constant: logging_config_failed_id
+LOGGING_CONFIG_FAILED_ID = 'LOGGING_CONFIG_FAILED'
+
+# ** constant: middleware_loading_failed_id
+MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
+
+# ** constant: parameter_not_found_id
+PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
+
+# ** constant: parameter_parsing_failed_id
+PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
+
+# ** constant: request_not_found_id
+REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
+
+# ** constant: request_validation_failed_id
+REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
+
+# ** constant: unsupported_config_file_type_id
+UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
+
+# ** constant: yaml_file_load_error_id
+YAML_FILE_LOAD_ERROR_ID = 'YAML_FILE_LOAD_ERROR'
+
+# ** constant: yaml_file_not_found_id
+YAML_FILE_NOT_FOUND_ID = 'YAML_FILE_NOT_FOUND'
+
+# *** constants (ids_admin)
+
+# ** constant: cli_command_already_exists_id
+CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
+
+# ** constant: cli_command_not_found_id
+CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
+
+# ** constant: cli_config_loading_failed_id
+CLI_CONFIG_LOADING_FAILED_ID = 'CLI_CONFIG_LOADING_FAILED'
+
 # ** constant: error_already_exists_id
 ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
+
+# ** constant: feature_already_exists_id
+FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
+
+# ** constant: feature_command_not_found_id
+FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
 
 # ** constant: feature_name_required_id
 FEATURE_NAME_REQUIRED_ID = 'FEATURE_NAME_REQUIRED'
@@ -37,179 +159,71 @@ INVALID_FEATURE_ATTRIBUTE_ID = 'INVALID_FEATURE_ATTRIBUTE'
 # ** constant: invalid_feature_command_attribute_id
 INVALID_FEATURE_COMMAND_ATTRIBUTE_ID = 'INVALID_FEATURE_COMMAND_ATTRIBUTE'
 
-# ** constant: no_error_messages_id
-NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
-
-# ** constant: parameter_parsing_failed_id
-PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
-
-# ** constant: import_dependency_failed_id
-IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
-
-# ** constant: app_service_import_failed_id
-APP_SERVICE_IMPORT_FAILED_ID = 'APP_SERVICE_IMPORT_FAILED'
-
-# ** constant: feature_step_loading_failed_id
-FEATURE_STEP_LOADING_FAILED_ID = 'FEATURE_STEP_LOADING_FAILED'
-
-# ** constant: middleware_loading_failed_id
-MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
-
-# ** constant: di_service_not_configured_id
-DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
-
-# ** constant: context_not_found_id
-CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
-
-# ** constant: request_not_found_id
-REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
-
-# ** constant: parameter_not_found_id
-PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
-
-# ** constant: request_validation_failed_id
-REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
-
-# ** constant: feature_not_found_id
-FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
-
-# ** constant: feature_already_exists_id
-FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
-
-# ** constant: feature_command_not_found_id
-FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
-
-# ** constant: logging_config_failed_id
-LOGGING_CONFIG_FAILED_ID = 'LOGGING_CONFIG_FAILED'
-
-# ** constant: logger_creation_failed_id
-LOGGER_CREATION_FAILED_ID = 'LOGGER_CREATION_FAILED'
-
-# ** constant: file_not_found_id
-FILE_NOT_FOUND_ID = 'FILE_NOT_FOUND'
-
-# ** constant: invalid_file_id
-INVALID_FILE_ID = 'INVALID_FILE'
-
-# ** constant: file_already_open_id
-FILE_ALREADY_OPEN_ID = 'FILE_ALREADY_OPEN'
-
-# ** constant: invalid_file_mode_id
-INVALID_FILE_MODE_ID = 'INVALID_FILE_MODE'
-
-# ** constant: invalid_encoding_id
-INVALID_ENCODING_ID = 'INVALID_ENCODING'
-
-# ** constant: invalid_json_file_id
-INVALID_JSON_FILE_ID = 'INVALID_JSON_FILE'
-
-# ** constant: json_file_load_error_id
-JSON_FILE_LOAD_ERROR_ID = 'JSON_FILE_LOAD_ERROR'
-
-# ** constant: json_file_save_error_id
-JSON_FILE_SAVE_ERROR_ID = 'JSON_FILE_SAVE_ERROR'
-
-# ** constant: invalid_yaml_file_id
-INVALID_YAML_FILE_ID = 'INVALID_YAML_FILE'
-
-# ** constant: yaml_file_not_found_id
-YAML_FILE_NOT_FOUND_ID = 'YAML_FILE_NOT_FOUND'
-
-# ** constant: yaml_file_load_error_id
-YAML_FILE_LOAD_ERROR_ID = 'YAML_FILE_LOAD_ERROR'
-
-# ** constant: yaml_file_save_error_id
-YAML_FILE_SAVE_ERROR_ID = 'YAML_FILE_SAVE_ERROR'
-
-# ** constant: unsupported_config_file_type_id
-UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
-
-# ** constant: app_session_not_found_id
-APP_SESSION_NOT_FOUND_ID = 'APP_SESSION_NOT_FOUND'
+# ** constant: invalid_flagged_dependency_id
+INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
 
 # ** constant: invalid_service_registration_id
 INVALID_SERVICE_REGISTRATION_ID = 'INVALID_SERVICE_REGISTRATION'
 
-# ** constant: service_registration_not_found_id
-SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
+# ** constant: json_file_save_error_id
+JSON_FILE_SAVE_ERROR_ID = 'JSON_FILE_SAVE_ERROR'
 
-# ** constant: invalid_flagged_dependency_id
-INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
+# ** constant: no_error_messages_id
+NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
 
 # ** constant: service_registration_already_exists_id
 SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
 
-# ** constant: invalid_model_attribute_id
-INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
+# ** constant: service_registration_not_found_id
+SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
-# ** constant: invalid_app_session_type_id
-INVALID_APP_SESSION_TYPE_ID = 'INVALID_APP_SESSION_TYPE'
+# ** constant: yaml_file_save_error_id
+YAML_FILE_SAVE_ERROR_ID = 'YAML_FILE_SAVE_ERROR'
 
-# ** constant: sqlite_conn_already_open_id
-SQLITE_CONN_ALREADY_OPEN_ID = 'SQLITE_CONN_ALREADY_OPEN'
-
-# ** constant: sqlite_invalid_mode_id
-SQLITE_INVALID_MODE_ID = 'SQLITE_INVALID_MODE'
-
-# ** constant: sqlite_file_not_found_or_readonly_id
-SQLITE_FILE_NOT_FOUND_OR_READONLY_ID = 'SQLITE_FILE_NOT_FOUND_OR_READONLY'
-
-# ** constant: sqlite_conn_failed_id
-SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+# *** constants (ids_sqlite)
 
 # ** constant: sqlite_backup_failed_id
 SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
 
+# ** constant: sqlite_conn_already_open_id
+SQLITE_CONN_ALREADY_OPEN_ID = 'SQLITE_CONN_ALREADY_OPEN'
+
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+
 # ** constant: sqlite_conn_not_initialized_id
 SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
 
-# ** constant: app_error_id
-APP_ERROR_ID = 'APP_ERROR'
+# ** constant: sqlite_file_not_found_or_readonly_id
+SQLITE_FILE_NOT_FOUND_OR_READONLY_ID = 'SQLITE_FILE_NOT_FOUND_OR_READONLY'
 
-# ** constant: config_file_not_found_id
-CONFIG_FILE_NOT_FOUND_ID = 'CONFIG_FILE_NOT_FOUND'
+# ** constant: sqlite_invalid_mode_id
+SQLITE_INVALID_MODE_ID = 'SQLITE_INVALID_MODE'
 
-# ** constant: app_config_loading_failed_id
-APP_CONFIG_LOADING_FAILED_ID = 'APP_CONFIG_LOADING_FAILED'
-
-# ** constant: container_config_loading_failed_id
-CONTAINER_CONFIG_LOADING_FAILED_ID = 'CONTAINER_CONFIG_LOADING_FAILED'
-
-# ** constant: feature_config_loading_failed_id
-FEATURE_CONFIG_LOADING_FAILED_ID = 'FEATURE_CONFIG_LOADING_FAILED'
-
-# ** constant: error_config_loading_failed_id
-ERROR_CONFIG_LOADING_FAILED_ID = 'ERROR_CONFIG_LOADING_FAILED'
-
-# ** constant: cli_config_loading_failed_id
-CLI_CONFIG_LOADING_FAILED_ID = 'CLI_CONFIG_LOADING_FAILED'
-
-# ** constant: cli_command_not_found_id
-CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
-
-# ** constant: cli_command_already_exists_id
-CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
-
-# ** constant: json_file_not_found_id
-JSON_FILE_NOT_FOUND_ID = 'JSON_FILE_NOT_FOUND'
-
-# ** constant: invalid_json_path_id
-INVALID_JSON_PATH_ID = 'INVALID_JSON_PATH'
-
-# ** constant: toml_file_not_found_id
-TOML_FILE_NOT_FOUND_ID = 'TOML_FILE_NOT_FOUND'
-
-# ** constant: toml_file_load_error_id
-TOML_FILE_LOAD_ERROR_ID = 'TOML_FILE_LOAD_ERROR'
+# *** constants (ids_toml)
 
 # ** constant: invalid_toml_file_id
 INVALID_TOML_FILE_ID = 'INVALID_TOML_FILE'
 
-# ** constant: csv_invalid_mode_id
-CSV_INVALID_MODE_ID = 'CSV_INVALID_MODE'
+# ** constant: toml_file_load_error_id
+TOML_FILE_LOAD_ERROR_ID = 'TOML_FILE_LOAD_ERROR'
+
+# ** constant: toml_file_not_found_id
+TOML_FILE_NOT_FOUND_ID = 'TOML_FILE_NOT_FOUND'
+
+# *** constants (ids_csv)
+
+# ** constant: csv_dict_no_header_id
+CSV_DICT_NO_HEADER_ID = 'CSV_DICT_NO_HEADER'
+
+# ** constant: csv_fieldnames_required_id
+CSV_FIELDNAMES_REQUIRED_ID = 'CSV_FIELDNAMES_REQUIRED'
 
 # ** constant: csv_handle_not_initialized_id
 CSV_HANDLE_NOT_INITIALIZED_ID = 'CSV_HANDLE_NOT_INITIALIZED'
+
+# ** constant: csv_invalid_mode_id
+CSV_INVALID_MODE_ID = 'CSV_INVALID_MODE'
 
 # ** constant: csv_invalid_read_mode_id
 CSV_INVALID_READ_MODE_ID = 'CSV_INVALID_READ_MODE'
@@ -217,19 +231,76 @@ CSV_INVALID_READ_MODE_ID = 'CSV_INVALID_READ_MODE'
 # ** constant: csv_invalid_write_mode_id
 CSV_INVALID_WRITE_MODE_ID = 'CSV_INVALID_WRITE_MODE'
 
-# ** constant: csv_fieldnames_required_id
-CSV_FIELDNAMES_REQUIRED_ID = 'CSV_FIELDNAMES_REQUIRED'
-
-# ** constant: csv_dict_no_header_id
-CSV_DICT_NO_HEADER_ID = 'CSV_DICT_NO_HEADER'
-
 # *** constants (models)
+
+# ** constant: app_config_loading_failed
+APP_CONFIG_LOADING_FAILED = create_default_error(
+    APP_CONFIG_LOADING_FAILED_ID,
+    'App Configuration Loading Failed',
+    [(EN_US, 'Unable to load app configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: app_error
+APP_ERROR = create_default_error(
+    APP_ERROR_ID,
+    'App Error',
+    [(EN_US, 'An error occurred in the app: {error_message}.')],
+)
+
+# ** constant: app_service_import_failed
+APP_SERVICE_IMPORT_FAILED = create_default_error(
+    APP_SERVICE_IMPORT_FAILED_ID,
+    'App Service Import Failed',
+    [(EN_US, 'Failed to import app service dependencies: {exception}.')],
+)
+
+# ** constant: app_session_not_found
+APP_SESSION_NOT_FOUND = create_default_error(
+    APP_SESSION_NOT_FOUND_ID,
+    'App Session Not Found',
+    [(EN_US, 'App session with ID {interface_id} not found.')],
+)
 
 # ** constant: command_parameter_required
 COMMAND_PARAMETER_REQUIRED = create_default_error(
     COMMAND_PARAMETER_REQUIRED_ID,
     'Command Parameter Required',
     [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
+)
+
+# ** constant: config_file_not_found
+CONFIG_FILE_NOT_FOUND = create_default_error(
+    CONFIG_FILE_NOT_FOUND_ID,
+    'Configuration File Not Found',
+    [(EN_US, 'Configuration file {file_path} not found.')],
+)
+
+# ** constant: container_config_loading_failed
+CONTAINER_CONFIG_LOADING_FAILED = create_default_error(
+    CONTAINER_CONFIG_LOADING_FAILED_ID,
+    'Container Configuration Loading Failed',
+    [(EN_US, 'Unable to load container configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: context_not_found
+CONTEXT_NOT_FOUND = create_default_error(
+    CONTEXT_NOT_FOUND_ID,
+    'Context Not Found',
+    [(EN_US, 'No context registered for domain type: {domain_type}.')],
+)
+
+# ** constant: di_service_not_configured
+DI_SERVICE_NOT_CONFIGURED = create_default_error(
+    DI_SERVICE_NOT_CONFIGURED_ID,
+    'DI Service Not Configured',
+    [(EN_US, 'No di_service dependency is configured for interface {interface_id}.')],
+)
+
+# ** constant: error_config_loading_failed
+ERROR_CONFIG_LOADING_FAILED = create_default_error(
+    ERROR_CONFIG_LOADING_FAILED_ID,
+    'Error Configuration Loading Failed',
+    [(EN_US, 'Unable to load error configuration file {file_path}: {exception}.')],
 )
 
 # ** constant: error_not_found
@@ -239,11 +310,230 @@ ERROR_NOT_FOUND = create_default_error(
     [(EN_US, 'Error not found: {id}.')],
 )
 
+# ** constant: feature_config_loading_failed
+FEATURE_CONFIG_LOADING_FAILED = create_default_error(
+    FEATURE_CONFIG_LOADING_FAILED_ID,
+    'Feature Configuration Loading Failed',
+    [(EN_US, 'Unable to load feature configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = create_default_error(
+    FEATURE_NOT_FOUND_ID,
+    'Feature Not Found',
+    [(EN_US, 'Feature not found: {feature_id}.')],
+)
+
+# ** constant: feature_step_loading_failed
+FEATURE_STEP_LOADING_FAILED = create_default_error(
+    FEATURE_STEP_LOADING_FAILED_ID,
+    'Feature Step Loading Failed',
+    [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
+)
+
+# ** constant: file_already_open
+FILE_ALREADY_OPEN = create_default_error(
+    FILE_ALREADY_OPEN_ID,
+    'File Already Open',
+    [(EN_US, 'File is already open: {path}.')],
+)
+
+# ** constant: file_not_found
+FILE_NOT_FOUND = create_default_error(
+    FILE_NOT_FOUND_ID,
+    'File Not Found',
+    [(EN_US, 'File not found: {path}.')],
+)
+
+# ** constant: import_dependency_failed
+IMPORT_DEPENDENCY_FAILED = create_default_error(
+    IMPORT_DEPENDENCY_FAILED_ID,
+    'Import Dependency Failed',
+    [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
+)
+
+# ** constant: invalid_app_session_type
+INVALID_APP_SESSION_TYPE = create_default_error(
+    INVALID_APP_SESSION_TYPE_ID,
+    'Invalid App Session Type',
+    [(EN_US, '{attribute} must be a non-empty string.')],
+)
+
+# ** constant: invalid_encoding
+INVALID_ENCODING = create_default_error(
+    INVALID_ENCODING_ID,
+    'Invalid Encoding',
+    [(EN_US, 'Invalid encoding: {encoding}. Supported encodings are: utf-8, ascii, latin-1.')],
+)
+
+# ** constant: invalid_file
+INVALID_FILE = create_default_error(
+    INVALID_FILE_ID,
+    'Invalid File',
+    [(EN_US, 'Path is not a file: {path}.')],
+)
+
+# ** constant: invalid_file_mode
+INVALID_FILE_MODE = create_default_error(
+    INVALID_FILE_MODE_ID,
+    'Invalid File Mode',
+    [(EN_US, 'Invalid file mode: {mode}. Valid modes include {modes}')],
+)
+
+# ** constant: invalid_json_file
+INVALID_JSON_FILE = create_default_error(
+    INVALID_JSON_FILE_ID,
+    'Invalid JSON File',
+    [(EN_US, 'File is not a valid JSON file: {path}.')],
+)
+
+# ** constant: invalid_json_path
+INVALID_JSON_PATH = create_default_error(
+    INVALID_JSON_PATH_ID,
+    'Invalid JSON Path',
+    [(EN_US, 'Invalid JSON path: {path}. Failed at segment: {part}.')],
+)
+
+# ** constant: invalid_model_attribute
+INVALID_MODEL_ATTRIBUTE = create_default_error(
+    INVALID_MODEL_ATTRIBUTE_ID,
+    'Invalid Model Attribute',
+    [(EN_US, 'Invalid attribute: {attribute}. Supported attributes are {supported}.')],
+)
+
+# ** constant: invalid_yaml_file
+INVALID_YAML_FILE = create_default_error(
+    INVALID_YAML_FILE_ID,
+    'Invalid YAML File',
+    [(EN_US, 'File is not a valid YAML file: {path}.')],
+)
+
+# ** constant: json_file_load_error
+JSON_FILE_LOAD_ERROR = create_default_error(
+    JSON_FILE_LOAD_ERROR_ID,
+    'JSON Load Failure',
+    [(EN_US, 'Failed to parse JSON: {error}. Path: {path}.')],
+)
+
+# ** constant: json_file_not_found
+JSON_FILE_NOT_FOUND = create_default_error(
+    JSON_FILE_NOT_FOUND_ID,
+    'JSON File Not Found',
+    [(EN_US, 'The specified JSON file could not be found at {path}.')],
+)
+
+# ** constant: logger_creation_failed
+LOGGER_CREATION_FAILED = create_default_error(
+    LOGGER_CREATION_FAILED_ID,
+    'Logger Creation Failed',
+    [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
+)
+
+# ** constant: logging_config_failed
+LOGGING_CONFIG_FAILED = create_default_error(
+    LOGGING_CONFIG_FAILED_ID,
+    'Logging Configuration Failed',
+    [(EN_US, 'Failed to configure logging: {exception}.')],
+)
+
+# ** constant: middleware_loading_failed
+MIDDLEWARE_LOADING_FAILED = create_default_error(
+    MIDDLEWARE_LOADING_FAILED_ID,
+    'Middleware Loading Failed',
+    [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
+)
+
+# ** constant: parameter_not_found
+PARAMETER_NOT_FOUND = create_default_error(
+    PARAMETER_NOT_FOUND_ID,
+    'Parameter Not Found',
+    [(EN_US, 'Parameter {parameter} not found in request data.')],
+)
+
+# ** constant: parameter_parsing_failed
+PARAMETER_PARSING_FAILED = create_default_error(
+    PARAMETER_PARSING_FAILED_ID,
+    'Parameter Parsing Failed',
+    [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
+)
+
+# ** constant: request_not_found
+REQUEST_NOT_FOUND = create_default_error(
+    REQUEST_NOT_FOUND_ID,
+    'Request Not Found',
+    [(EN_US, 'Request data is not available for parameter parsing.')],
+)
+
+# ** constant: request_validation_failed
+REQUEST_VALIDATION_FAILED = create_default_error(
+    REQUEST_VALIDATION_FAILED_ID,
+    'Request Validation Failed',
+    [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
+)
+
+# ** constant: unsupported_config_file_type
+UNSUPPORTED_CONFIG_FILE_TYPE = create_default_error(
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
+    'Unsupported Configuration File Type',
+    [(EN_US, 'Unsupported configuration file type: {file_extension}.')],
+)
+
+# ** constant: yaml_file_load_error
+YAML_FILE_LOAD_ERROR = create_default_error(
+    YAML_FILE_LOAD_ERROR_ID,
+    'YAML Load Failure',
+    [(EN_US, 'Failed to parse YAML file: {error}. Path: {path}.')],
+)
+
+# ** constant: yaml_file_not_found
+YAML_FILE_NOT_FOUND = create_default_error(
+    YAML_FILE_NOT_FOUND_ID,
+    'YAML File Not Found',
+    [(EN_US, 'The specified YAML file could not be found at {path}.')],
+)
+
+# *** constants (models_admin)
+
+# ** constant: cli_command_already_exists
+CLI_COMMAND_ALREADY_EXISTS = create_default_error(
+    CLI_COMMAND_ALREADY_EXISTS_ID,
+    'CLI Command Already Exists',
+    [(EN_US, 'CLI command with ID {id} already exists.')],
+)
+
+# ** constant: cli_command_not_found
+CLI_COMMAND_NOT_FOUND = create_default_error(
+    CLI_COMMAND_NOT_FOUND_ID,
+    'CLI Command Not Found',
+    [(EN_US, 'CLI command {command_id} not found.')],
+)
+
+# ** constant: cli_config_loading_failed
+CLI_CONFIG_LOADING_FAILED = create_default_error(
+    CLI_CONFIG_LOADING_FAILED_ID,
+    'CLI Configuration Loading Failed',
+    [(EN_US, 'Unable to load CLI configuration file {file_path}: {exception}.')],
+)
+
 # ** constant: error_already_exists
 ERROR_ALREADY_EXISTS = create_default_error(
     ERROR_ALREADY_EXISTS_ID,
     'Error Already Exists',
     [(EN_US, 'An error with ID {id} already exists.')],
+)
+
+# ** constant: feature_already_exists
+FEATURE_ALREADY_EXISTS = create_default_error(
+    FEATURE_ALREADY_EXISTS_ID,
+    'Feature Already Exists',
+    [(EN_US, 'Feature with ID {id} already exists.')],
+)
+
+# ** constant: feature_command_not_found
+FEATURE_COMMAND_NOT_FOUND = create_default_error(
+    FEATURE_COMMAND_NOT_FOUND_ID,
+    'Feature Command Not Found',
+    [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
 )
 
 # ** constant: feature_name_required
@@ -267,214 +557,11 @@ INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
     [(EN_US, 'Invalid feature command attribute: {attribute}. Supported attributes are name, attribute_id, data_key, pass_on_error, and parameters.')],
 )
 
-# ** constant: no_error_messages
-NO_ERROR_MESSAGES = create_default_error(
-    NO_ERROR_MESSAGES_ID,
-    'No Error Messages',
-    [(EN_US, 'No error messages are defined for error ID {id}.')],
-)
-
-# ** constant: parameter_parsing_failed
-PARAMETER_PARSING_FAILED = create_default_error(
-    PARAMETER_PARSING_FAILED_ID,
-    'Parameter Parsing Failed',
-    [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
-)
-
-# ** constant: import_dependency_failed
-IMPORT_DEPENDENCY_FAILED = create_default_error(
-    IMPORT_DEPENDENCY_FAILED_ID,
-    'Import Dependency Failed',
-    [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
-)
-
-# ** constant: app_service_import_failed
-APP_SERVICE_IMPORT_FAILED = create_default_error(
-    APP_SERVICE_IMPORT_FAILED_ID,
-    'App Service Import Failed',
-    [(EN_US, 'Failed to import app service dependencies: {exception}.')],
-)
-
-# ** constant: feature_step_loading_failed
-FEATURE_STEP_LOADING_FAILED = create_default_error(
-    FEATURE_STEP_LOADING_FAILED_ID,
-    'Feature Step Loading Failed',
-    [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
-)
-
-# ** constant: middleware_loading_failed
-MIDDLEWARE_LOADING_FAILED = create_default_error(
-    MIDDLEWARE_LOADING_FAILED_ID,
-    'Middleware Loading Failed',
-    [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
-)
-
-# ** constant: di_service_not_configured
-DI_SERVICE_NOT_CONFIGURED = create_default_error(
-    DI_SERVICE_NOT_CONFIGURED_ID,
-    'DI Service Not Configured',
-    [(EN_US, 'No di_service dependency is configured for interface {interface_id}.')],
-)
-
-# ** constant: context_not_found
-CONTEXT_NOT_FOUND = create_default_error(
-    CONTEXT_NOT_FOUND_ID,
-    'Context Not Found',
-    [(EN_US, 'No context registered for domain type: {domain_type}.')],
-)
-
-# ** constant: request_not_found
-REQUEST_NOT_FOUND = create_default_error(
-    REQUEST_NOT_FOUND_ID,
-    'Request Not Found',
-    [(EN_US, 'Request data is not available for parameter parsing.')],
-)
-
-# ** constant: parameter_not_found
-PARAMETER_NOT_FOUND = create_default_error(
-    PARAMETER_NOT_FOUND_ID,
-    'Parameter Not Found',
-    [(EN_US, 'Parameter {parameter} not found in request data.')],
-)
-
-# ** constant: request_validation_failed
-REQUEST_VALIDATION_FAILED = create_default_error(
-    REQUEST_VALIDATION_FAILED_ID,
-    'Request Validation Failed',
-    [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
-)
-
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
-    'Feature Not Found',
-    [(EN_US, 'Feature not found: {feature_id}.')],
-)
-
-# ** constant: feature_already_exists
-FEATURE_ALREADY_EXISTS = create_default_error(
-    FEATURE_ALREADY_EXISTS_ID,
-    'Feature Already Exists',
-    [(EN_US, 'Feature with ID {id} already exists.')],
-)
-
-# ** constant: feature_command_not_found
-FEATURE_COMMAND_NOT_FOUND = create_default_error(
-    FEATURE_COMMAND_NOT_FOUND_ID,
-    'Feature Command Not Found',
-    [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
-)
-
-# ** constant: logging_config_failed
-LOGGING_CONFIG_FAILED = create_default_error(
-    LOGGING_CONFIG_FAILED_ID,
-    'Logging Configuration Failed',
-    [(EN_US, 'Failed to configure logging: {exception}.')],
-)
-
-# ** constant: logger_creation_failed
-LOGGER_CREATION_FAILED = create_default_error(
-    LOGGER_CREATION_FAILED_ID,
-    'Logger Creation Failed',
-    [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
-)
-
-# ** constant: file_not_found
-FILE_NOT_FOUND = create_default_error(
-    FILE_NOT_FOUND_ID,
-    'File Not Found',
-    [(EN_US, 'File not found: {path}.')],
-)
-
-# ** constant: invalid_file
-INVALID_FILE = create_default_error(
-    INVALID_FILE_ID,
-    'Invalid File',
-    [(EN_US, 'Path is not a file: {path}.')],
-)
-
-# ** constant: file_already_open
-FILE_ALREADY_OPEN = create_default_error(
-    FILE_ALREADY_OPEN_ID,
-    'File Already Open',
-    [(EN_US, 'File is already open: {path}.')],
-)
-
-# ** constant: invalid_file_mode
-INVALID_FILE_MODE = create_default_error(
-    INVALID_FILE_MODE_ID,
-    'Invalid File Mode',
-    [(EN_US, 'Invalid file mode: {mode}. Valid modes include {modes}')],
-)
-
-# ** constant: invalid_encoding
-INVALID_ENCODING = create_default_error(
-    INVALID_ENCODING_ID,
-    'Invalid Encoding',
-    [(EN_US, 'Invalid encoding: {encoding}. Supported encodings are: utf-8, ascii, latin-1.')],
-)
-
-# ** constant: invalid_json_file
-INVALID_JSON_FILE = create_default_error(
-    INVALID_JSON_FILE_ID,
-    'Invalid JSON File',
-    [(EN_US, 'File is not a valid JSON file: {path}.')],
-)
-
-# ** constant: json_file_load_error
-JSON_FILE_LOAD_ERROR = create_default_error(
-    JSON_FILE_LOAD_ERROR_ID,
-    'JSON Load Failure',
-    [(EN_US, 'Failed to parse JSON: {error}. Path: {path}.')],
-)
-
-# ** constant: json_file_save_error
-JSON_FILE_SAVE_ERROR = create_default_error(
-    JSON_FILE_SAVE_ERROR_ID,
-    'JSON Save Failure',
-    [(EN_US, 'Failed to serialize/write JSON: {error}. Path: {path}.')],
-)
-
-# ** constant: invalid_yaml_file
-INVALID_YAML_FILE = create_default_error(
-    INVALID_YAML_FILE_ID,
-    'Invalid YAML File',
-    [(EN_US, 'File is not a valid YAML file: {path}.')],
-)
-
-# ** constant: yaml_file_not_found
-YAML_FILE_NOT_FOUND = create_default_error(
-    YAML_FILE_NOT_FOUND_ID,
-    'YAML File Not Found',
-    [(EN_US, 'The specified YAML file could not be found at {path}.')],
-)
-
-# ** constant: yaml_file_load_error
-YAML_FILE_LOAD_ERROR = create_default_error(
-    YAML_FILE_LOAD_ERROR_ID,
-    'YAML Load Failure',
-    [(EN_US, 'Failed to parse YAML file: {error}. Path: {path}.')],
-)
-
-# ** constant: yaml_file_save_error
-YAML_FILE_SAVE_ERROR = create_default_error(
-    YAML_FILE_SAVE_ERROR_ID,
-    'YAML Save Failure',
-    [(EN_US, 'Failed to write YAML file: {error}. Path: {path}.')],
-)
-
-# ** constant: unsupported_config_file_type
-UNSUPPORTED_CONFIG_FILE_TYPE = create_default_error(
-    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
-    'Unsupported Configuration File Type',
-    [(EN_US, 'Unsupported configuration file type: {file_extension}.')],
-)
-
-# ** constant: app_session_not_found
-APP_SESSION_NOT_FOUND = create_default_error(
-    APP_SESSION_NOT_FOUND_ID,
-    'App Session Not Found',
-    [(EN_US, 'App session with ID {interface_id} not found.')],
+# ** constant: invalid_flagged_dependency
+INVALID_FLAGGED_DEPENDENCY = create_default_error(
+    INVALID_FLAGGED_DEPENDENCY_ID,
+    'Invalid Flagged Dependency',
+    [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
 )
 
 # ** constant: invalid_service_registration
@@ -484,18 +571,18 @@ INVALID_SERVICE_REGISTRATION = create_default_error(
     [(EN_US, 'A service registration must define either a default type (module_path/class_name) or at least one flagged dependency.')],
 )
 
-# ** constant: service_registration_not_found
-SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
-    SERVICE_REGISTRATION_NOT_FOUND_ID,
-    'Service Registration Not Found',
-    [(EN_US, 'Service registration with ID {id} not found.')],
+# ** constant: json_file_save_error
+JSON_FILE_SAVE_ERROR = create_default_error(
+    JSON_FILE_SAVE_ERROR_ID,
+    'JSON Save Failure',
+    [(EN_US, 'Failed to serialize/write JSON: {error}. Path: {path}.')],
 )
 
-# ** constant: invalid_flagged_dependency
-INVALID_FLAGGED_DEPENDENCY = create_default_error(
-    INVALID_FLAGGED_DEPENDENCY_ID,
-    'Invalid Flagged Dependency',
-    [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
+# ** constant: no_error_messages
+NO_ERROR_MESSAGES = create_default_error(
+    NO_ERROR_MESSAGES_ID,
+    'No Error Messages',
+    [(EN_US, 'No error messages are defined for error ID {id}.')],
 )
 
 # ** constant: service_registration_already_exists
@@ -505,18 +592,27 @@ SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
     [(EN_US, 'A service registration with ID {id} already exists.')],
 )
 
-# ** constant: invalid_model_attribute
-INVALID_MODEL_ATTRIBUTE = create_default_error(
-    INVALID_MODEL_ATTRIBUTE_ID,
-    'Invalid Model Attribute',
-    [(EN_US, 'Invalid attribute: {attribute}. Supported attributes are {supported}.')],
+# ** constant: service_registration_not_found
+SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
+    SERVICE_REGISTRATION_NOT_FOUND_ID,
+    'Service Registration Not Found',
+    [(EN_US, 'Service registration with ID {id} not found.')],
 )
 
-# ** constant: invalid_app_session_type
-INVALID_APP_SESSION_TYPE = create_default_error(
-    INVALID_APP_SESSION_TYPE_ID,
-    'Invalid App Session Type',
-    [(EN_US, '{attribute} must be a non-empty string.')],
+# ** constant: yaml_file_save_error
+YAML_FILE_SAVE_ERROR = create_default_error(
+    YAML_FILE_SAVE_ERROR_ID,
+    'YAML Save Failure',
+    [(EN_US, 'Failed to write YAML file: {error}. Path: {path}.')],
+)
+
+# *** constants (models_sqlite)
+
+# ** constant: sqlite_backup_failed
+SQLITE_BACKUP_FAILED = create_default_error(
+    SQLITE_BACKUP_FAILED_ID,
+    'SQLite Backup Failed',
+    [(EN_US, 'Backup to {target_path} failed: {original_error}')],
 )
 
 # ** constant: sqlite_conn_already_open
@@ -526,32 +622,11 @@ SQLITE_CONN_ALREADY_OPEN = create_default_error(
     [(EN_US, 'Connection already open for path: {path}.')],
 )
 
-# ** constant: sqlite_invalid_mode
-SQLITE_INVALID_MODE = create_default_error(
-    SQLITE_INVALID_MODE_ID,
-    'Invalid SQLite Mode',
-    [(EN_US, 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).')],
-)
-
-# ** constant: sqlite_file_not_found_or_readonly
-SQLITE_FILE_NOT_FOUND_OR_READONLY = create_default_error(
-    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
-    'SQLite File Not Found or Read-Only',
-    [(EN_US, 'Unable to open SQLite database at {path}: {original_error}. Check path exists and is writable (use mode=rwc to create).')],
-)
-
 # ** constant: sqlite_conn_failed
 SQLITE_CONN_FAILED = create_default_error(
     SQLITE_CONN_FAILED_ID,
     'SQLite Connection Failed',
     [(EN_US, 'Failed to connect to SQLite database at {path}: {original_error}')],
-)
-
-# ** constant: sqlite_backup_failed
-SQLITE_BACKUP_FAILED = create_default_error(
-    SQLITE_BACKUP_FAILED_ID,
-    'SQLite Backup Failed',
-    [(EN_US, 'Backup to {target_path} failed: {original_error}')],
 )
 
 # ** constant: sqlite_conn_not_initialized
@@ -561,88 +636,27 @@ SQLITE_CONN_NOT_INITIALIZED = create_default_error(
     [(EN_US, 'SQLite connection not initialized. Must be used within a "with" block.')],
 )
 
-# ** constant: app_error
-APP_ERROR = create_default_error(
-    APP_ERROR_ID,
-    'App Error',
-    [(EN_US, 'An error occurred in the app: {error_message}.')],
+# ** constant: sqlite_file_not_found_or_readonly
+SQLITE_FILE_NOT_FOUND_OR_READONLY = create_default_error(
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
+    'SQLite File Not Found or Read-Only',
+    [(EN_US, 'Unable to open SQLite database at {path}: {original_error}. Check path exists and is writable (use mode=rwc to create).')],
 )
 
-# ** constant: config_file_not_found
-CONFIG_FILE_NOT_FOUND = create_default_error(
-    CONFIG_FILE_NOT_FOUND_ID,
-    'Configuration File Not Found',
-    [(EN_US, 'Configuration file {file_path} not found.')],
+# ** constant: sqlite_invalid_mode
+SQLITE_INVALID_MODE = create_default_error(
+    SQLITE_INVALID_MODE_ID,
+    'Invalid SQLite Mode',
+    [(EN_US, 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).')],
 )
 
-# ** constant: app_config_loading_failed
-APP_CONFIG_LOADING_FAILED = create_default_error(
-    APP_CONFIG_LOADING_FAILED_ID,
-    'App Configuration Loading Failed',
-    [(EN_US, 'Unable to load app configuration file {file_path}: {exception}.')],
-)
+# *** constants (models_toml)
 
-# ** constant: container_config_loading_failed
-CONTAINER_CONFIG_LOADING_FAILED = create_default_error(
-    CONTAINER_CONFIG_LOADING_FAILED_ID,
-    'Container Configuration Loading Failed',
-    [(EN_US, 'Unable to load container configuration file {file_path}: {exception}.')],
-)
-
-# ** constant: feature_config_loading_failed
-FEATURE_CONFIG_LOADING_FAILED = create_default_error(
-    FEATURE_CONFIG_LOADING_FAILED_ID,
-    'Feature Configuration Loading Failed',
-    [(EN_US, 'Unable to load feature configuration file {file_path}: {exception}.')],
-)
-
-# ** constant: error_config_loading_failed
-ERROR_CONFIG_LOADING_FAILED = create_default_error(
-    ERROR_CONFIG_LOADING_FAILED_ID,
-    'Error Configuration Loading Failed',
-    [(EN_US, 'Unable to load error configuration file {file_path}: {exception}.')],
-)
-
-# ** constant: cli_config_loading_failed
-CLI_CONFIG_LOADING_FAILED = create_default_error(
-    CLI_CONFIG_LOADING_FAILED_ID,
-    'CLI Configuration Loading Failed',
-    [(EN_US, 'Unable to load CLI configuration file {file_path}: {exception}.')],
-)
-
-# ** constant: cli_command_not_found
-CLI_COMMAND_NOT_FOUND = create_default_error(
-    CLI_COMMAND_NOT_FOUND_ID,
-    'CLI Command Not Found',
-    [(EN_US, 'CLI command {command_id} not found.')],
-)
-
-# ** constant: cli_command_already_exists
-CLI_COMMAND_ALREADY_EXISTS = create_default_error(
-    CLI_COMMAND_ALREADY_EXISTS_ID,
-    'CLI Command Already Exists',
-    [(EN_US, 'CLI command with ID {id} already exists.')],
-)
-
-# ** constant: json_file_not_found
-JSON_FILE_NOT_FOUND = create_default_error(
-    JSON_FILE_NOT_FOUND_ID,
-    'JSON File Not Found',
-    [(EN_US, 'The specified JSON file could not be found at {path}.')],
-)
-
-# ** constant: invalid_json_path
-INVALID_JSON_PATH = create_default_error(
-    INVALID_JSON_PATH_ID,
-    'Invalid JSON Path',
-    [(EN_US, 'Invalid JSON path: {path}. Failed at segment: {part}.')],
-)
-
-# ** constant: toml_file_not_found
-TOML_FILE_NOT_FOUND = create_default_error(
-    TOML_FILE_NOT_FOUND_ID,
-    'TOML File Not Found',
-    [(EN_US, 'The specified TOML file could not be found at {path}.')],
+# ** constant: invalid_toml_file
+INVALID_TOML_FILE = create_default_error(
+    INVALID_TOML_FILE_ID,
+    'Invalid TOML File',
+    [(EN_US, 'File is not a valid TOML file: {path}.')],
 )
 
 # ** constant: toml_file_load_error
@@ -652,18 +666,27 @@ TOML_FILE_LOAD_ERROR = create_default_error(
     [(EN_US, 'Failed to parse TOML file: {error}. Path: {path}.')],
 )
 
-# ** constant: invalid_toml_file
-INVALID_TOML_FILE = create_default_error(
-    INVALID_TOML_FILE_ID,
-    'Invalid TOML File',
-    [(EN_US, 'File is not a valid TOML file: {path}.')],
+# ** constant: toml_file_not_found
+TOML_FILE_NOT_FOUND = create_default_error(
+    TOML_FILE_NOT_FOUND_ID,
+    'TOML File Not Found',
+    [(EN_US, 'The specified TOML file could not be found at {path}.')],
 )
 
-# ** constant: csv_invalid_mode
-CSV_INVALID_MODE = create_default_error(
-    CSV_INVALID_MODE_ID,
-    'Invalid CSV Mode',
-    [(EN_US, 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.')],
+# *** constants (models_csv)
+
+# ** constant: csv_dict_no_header
+CSV_DICT_NO_HEADER = create_default_error(
+    CSV_DICT_NO_HEADER_ID,
+    'CSV Dict Reader Without Header',
+    [(EN_US, 'Dict reader expects header row; file appears to lack one or was not read correctly.')],
+)
+
+# ** constant: csv_fieldnames_required
+CSV_FIELDNAMES_REQUIRED = create_default_error(
+    CSV_FIELDNAMES_REQUIRED_ID,
+    'CSV Fieldnames Required',
+    [(EN_US, 'Fieldnames must be provided when writing dict-based CSV rows.')],
 )
 
 # ** constant: csv_handle_not_initialized
@@ -671,6 +694,13 @@ CSV_HANDLE_NOT_INITIALIZED = create_default_error(
     CSV_HANDLE_NOT_INITIALIZED_ID,
     'CSV Handle Not Initialized',
     [(EN_US, 'CSV file must be opened before reading/writing.')],
+)
+
+# ** constant: csv_invalid_mode
+CSV_INVALID_MODE = create_default_error(
+    CSV_INVALID_MODE_ID,
+    'Invalid CSV Mode',
+    [(EN_US, 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.')],
 )
 
 # ** constant: csv_invalid_read_mode
@@ -687,109 +717,95 @@ CSV_INVALID_WRITE_MODE = create_default_error(
     [(EN_US, 'File not opened in writable mode for CSV writing.')],
 )
 
-# ** constant: csv_fieldnames_required
-CSV_FIELDNAMES_REQUIRED = create_default_error(
-    CSV_FIELDNAMES_REQUIRED_ID,
-    'CSV Fieldnames Required',
-    [(EN_US, 'Fieldnames must be provided when writing dict-based CSV rows.')],
-)
-
-# ** constant: csv_dict_no_header
-CSV_DICT_NO_HEADER = create_default_error(
-    CSV_DICT_NO_HEADER_ID,
-    'CSV Dict Reader Without Header',
-    [(EN_US, 'Dict reader expects header row; file appears to lack one or was not read correctly.')],
-)
-
 # *** constants (groups)
 
 # ** constant: core_default_errors
 CORE_DEFAULT_ERRORS = {
-    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
-    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
-    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
+    APP_CONFIG_LOADING_FAILED_ID: APP_CONFIG_LOADING_FAILED,
+    APP_ERROR_ID: APP_ERROR,
     APP_SERVICE_IMPORT_FAILED_ID: APP_SERVICE_IMPORT_FAILED,
     APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND,
-    DI_SERVICE_NOT_CONFIGURED_ID: DI_SERVICE_NOT_CONFIGURED,
-    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
-    APP_ERROR_ID: APP_ERROR,
+    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
+    CONFIG_FILE_NOT_FOUND_ID: CONFIG_FILE_NOT_FOUND,
+    CONTAINER_CONFIG_LOADING_FAILED_ID: CONTAINER_CONFIG_LOADING_FAILED,
     CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND,
+    DI_SERVICE_NOT_CONFIGURED_ID: DI_SERVICE_NOT_CONFIGURED,
+    ERROR_CONFIG_LOADING_FAILED_ID: ERROR_CONFIG_LOADING_FAILED,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
+    FEATURE_CONFIG_LOADING_FAILED_ID: FEATURE_CONFIG_LOADING_FAILED,
     FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
     FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED,
-    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
-    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
-    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
-    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
-    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
-    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
-    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
-    CONFIG_FILE_NOT_FOUND_ID: CONFIG_FILE_NOT_FOUND,
-    APP_CONFIG_LOADING_FAILED_ID: APP_CONFIG_LOADING_FAILED,
-    CONTAINER_CONFIG_LOADING_FAILED_ID: CONTAINER_CONFIG_LOADING_FAILED,
-    FEATURE_CONFIG_LOADING_FAILED_ID: FEATURE_CONFIG_LOADING_FAILED,
-    ERROR_CONFIG_LOADING_FAILED_ID: ERROR_CONFIG_LOADING_FAILED,
-    UNSUPPORTED_CONFIG_FILE_TYPE_ID: UNSUPPORTED_CONFIG_FILE_TYPE,
-    FILE_NOT_FOUND_ID: FILE_NOT_FOUND,
-    INVALID_FILE_ID: INVALID_FILE,
     FILE_ALREADY_OPEN_ID: FILE_ALREADY_OPEN,
-    INVALID_FILE_MODE_ID: INVALID_FILE_MODE,
+    FILE_NOT_FOUND_ID: FILE_NOT_FOUND,
+    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
+    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
     INVALID_ENCODING_ID: INVALID_ENCODING,
-    INVALID_YAML_FILE_ID: INVALID_YAML_FILE,
-    YAML_FILE_NOT_FOUND_ID: YAML_FILE_NOT_FOUND,
-    YAML_FILE_LOAD_ERROR_ID: YAML_FILE_LOAD_ERROR,
+    INVALID_FILE_ID: INVALID_FILE,
+    INVALID_FILE_MODE_ID: INVALID_FILE_MODE,
     INVALID_JSON_FILE_ID: INVALID_JSON_FILE,
-    JSON_FILE_NOT_FOUND_ID: JSON_FILE_NOT_FOUND,
-    JSON_FILE_LOAD_ERROR_ID: JSON_FILE_LOAD_ERROR,
     INVALID_JSON_PATH_ID: INVALID_JSON_PATH,
     INVALID_MODEL_ATTRIBUTE_ID: INVALID_MODEL_ATTRIBUTE,
+    INVALID_YAML_FILE_ID: INVALID_YAML_FILE,
+    JSON_FILE_LOAD_ERROR_ID: JSON_FILE_LOAD_ERROR,
+    JSON_FILE_NOT_FOUND_ID: JSON_FILE_NOT_FOUND,
+    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
+    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
+    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
+    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
+    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
+    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
+    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID: UNSUPPORTED_CONFIG_FILE_TYPE,
+    YAML_FILE_LOAD_ERROR_ID: YAML_FILE_LOAD_ERROR,
+    YAML_FILE_NOT_FOUND_ID: YAML_FILE_NOT_FOUND,
 }
 
 # ** constant: admin_default_errors
 ADMIN_DEFAULT_ERRORS = {
     **CORE_DEFAULT_ERRORS,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
+    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
+    CLI_CONFIG_LOADING_FAILED_ID: CLI_CONFIG_LOADING_FAILED,
     ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
-    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
     FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
+    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
     FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
     INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
     INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
-    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
-    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
-    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
     INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
-    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
-    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
-    CLI_CONFIG_LOADING_FAILED_ID: CLI_CONFIG_LOADING_FAILED,
-    YAML_FILE_SAVE_ERROR_ID: YAML_FILE_SAVE_ERROR,
+    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
     JSON_FILE_SAVE_ERROR_ID: JSON_FILE_SAVE_ERROR,
+    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
+    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
+    YAML_FILE_SAVE_ERROR_ID: YAML_FILE_SAVE_ERROR,
 }
 
 # ** constant: sqlite_default_errors
 SQLITE_DEFAULT_ERRORS = {
-    SQLITE_CONN_ALREADY_OPEN_ID: SQLITE_CONN_ALREADY_OPEN,
-    SQLITE_INVALID_MODE_ID: SQLITE_INVALID_MODE,
-    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: SQLITE_FILE_NOT_FOUND_OR_READONLY,
-    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
     SQLITE_BACKUP_FAILED_ID: SQLITE_BACKUP_FAILED,
+    SQLITE_CONN_ALREADY_OPEN_ID: SQLITE_CONN_ALREADY_OPEN,
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
     SQLITE_CONN_NOT_INITIALIZED_ID: SQLITE_CONN_NOT_INITIALIZED,
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: SQLITE_FILE_NOT_FOUND_OR_READONLY,
+    SQLITE_INVALID_MODE_ID: SQLITE_INVALID_MODE,
 }
 
 # ** constant: toml_default_errors
 TOML_DEFAULT_ERRORS = {
-    TOML_FILE_NOT_FOUND_ID: TOML_FILE_NOT_FOUND,
-    TOML_FILE_LOAD_ERROR_ID: TOML_FILE_LOAD_ERROR,
     INVALID_TOML_FILE_ID: INVALID_TOML_FILE,
+    TOML_FILE_LOAD_ERROR_ID: TOML_FILE_LOAD_ERROR,
+    TOML_FILE_NOT_FOUND_ID: TOML_FILE_NOT_FOUND,
 }
 
 # ** constant: csv_default_errors
 CSV_DEFAULT_ERRORS = {
-    CSV_INVALID_MODE_ID: CSV_INVALID_MODE,
+    CSV_DICT_NO_HEADER_ID: CSV_DICT_NO_HEADER,
+    CSV_FIELDNAMES_REQUIRED_ID: CSV_FIELDNAMES_REQUIRED,
     CSV_HANDLE_NOT_INITIALIZED_ID: CSV_HANDLE_NOT_INITIALIZED,
+    CSV_INVALID_MODE_ID: CSV_INVALID_MODE,
     CSV_INVALID_READ_MODE_ID: CSV_INVALID_READ_MODE,
     CSV_INVALID_WRITE_MODE_ID: CSV_INVALID_WRITE_MODE,
-    CSV_FIELDNAMES_REQUIRED_ID: CSV_FIELDNAMES_REQUIRED,
-    CSV_DICT_NO_HEADER_ID: CSV_DICT_NO_HEADER,
 }
 
 # ** constant: default_errors

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -18,75 +18,6 @@ from .core import create_default_feature, create_params_schema
 
 # *** constants (ids)
 
-# ** constant: feature_add_id
-FEATURE_ADD_ID = 'feature.add'
-
-# ** constant: feature_get_id
-FEATURE_GET_ID = 'feature.get'
-
-# ** constant: feature_list_id
-FEATURE_LIST_ID = 'feature.list'
-
-# ** constant: feature_remove_id
-FEATURE_REMOVE_ID = 'feature.remove'
-
-# ** constant: feature_update_id
-FEATURE_UPDATE_ID = 'feature.update'
-
-# ** constant: feature_add_step_id
-FEATURE_ADD_STEP_ID = 'feature.add_step'
-
-# ** constant: feature_update_step_id
-FEATURE_UPDATE_STEP_ID = 'feature.update_step'
-
-# ** constant: feature_remove_step_id
-FEATURE_REMOVE_STEP_ID = 'feature.remove_step'
-
-# ** constant: feature_reorder_step_id
-FEATURE_REORDER_STEP_ID = 'feature.reorder_step'
-
-# ** constant: error_add_id
-ERROR_ADD_ID = 'error.add'
-
-# ** constant: error_get_id
-ERROR_GET_ID = 'error.get'
-
-# ** constant: error_list_id
-ERROR_LIST_ID = 'error.list'
-
-# ** constant: error_rename_id
-ERROR_RENAME_ID = 'error.rename'
-
-# ** constant: error_set_message_id
-ERROR_SET_MESSAGE_ID = 'error.set_message'
-
-# ** constant: error_remove_message_id
-ERROR_REMOVE_MESSAGE_ID = 'error.remove_message'
-
-# ** constant: error_remove_id
-ERROR_REMOVE_ID = 'error.remove'
-
-# ** constant: service_add_id
-SERVICE_ADD_ID = 'service.add'
-
-# ** constant: service_list_id
-SERVICE_LIST_ID = 'service.list'
-
-# ** constant: service_set_default_id
-SERVICE_SET_DEFAULT_ID = 'service.set_default'
-
-# ** constant: service_set_dependency_id
-SERVICE_SET_DEPENDENCY_ID = 'service.set_dependency'
-
-# ** constant: service_remove_dependency_id
-SERVICE_REMOVE_DEPENDENCY_ID = 'service.remove_dependency'
-
-# ** constant: service_remove_id
-SERVICE_REMOVE_ID = 'service.remove'
-
-# ** constant: service_set_constants_id
-SERVICE_SET_CONSTANTS_ID = 'service.set_constants'
-
 # ** constant: app_add_id
 APP_ADD_ID = 'app.add'
 
@@ -120,6 +51,75 @@ CLI_LIST_COMMANDS_ID = 'cli.list_commands'
 # ** constant: cli_add_argument_id
 CLI_ADD_ARGUMENT_ID = 'cli.add_argument'
 
+# ** constant: error_add_id
+ERROR_ADD_ID = 'error.add'
+
+# ** constant: error_get_id
+ERROR_GET_ID = 'error.get'
+
+# ** constant: error_list_id
+ERROR_LIST_ID = 'error.list'
+
+# ** constant: error_rename_id
+ERROR_RENAME_ID = 'error.rename'
+
+# ** constant: error_set_message_id
+ERROR_SET_MESSAGE_ID = 'error.set_message'
+
+# ** constant: error_remove_message_id
+ERROR_REMOVE_MESSAGE_ID = 'error.remove_message'
+
+# ** constant: error_remove_id
+ERROR_REMOVE_ID = 'error.remove'
+
+# ** constant: feature_add_id
+FEATURE_ADD_ID = 'feature.add'
+
+# ** constant: feature_get_id
+FEATURE_GET_ID = 'feature.get'
+
+# ** constant: feature_list_id
+FEATURE_LIST_ID = 'feature.list'
+
+# ** constant: feature_remove_id
+FEATURE_REMOVE_ID = 'feature.remove'
+
+# ** constant: feature_update_id
+FEATURE_UPDATE_ID = 'feature.update'
+
+# ** constant: feature_add_step_id
+FEATURE_ADD_STEP_ID = 'feature.add_step'
+
+# ** constant: feature_update_step_id
+FEATURE_UPDATE_STEP_ID = 'feature.update_step'
+
+# ** constant: feature_remove_step_id
+FEATURE_REMOVE_STEP_ID = 'feature.remove_step'
+
+# ** constant: feature_reorder_step_id
+FEATURE_REORDER_STEP_ID = 'feature.reorder_step'
+
+# ** constant: service_add_id
+SERVICE_ADD_ID = 'service.add'
+
+# ** constant: service_list_id
+SERVICE_LIST_ID = 'service.list'
+
+# ** constant: service_set_default_id
+SERVICE_SET_DEFAULT_ID = 'service.set_default'
+
+# ** constant: service_set_dependency_id
+SERVICE_SET_DEPENDENCY_ID = 'service.set_dependency'
+
+# ** constant: service_remove_dependency_id
+SERVICE_REMOVE_DEPENDENCY_ID = 'service.remove_dependency'
+
+# ** constant: service_remove_id
+SERVICE_REMOVE_ID = 'service.remove'
+
+# ** constant: service_set_constants_id
+SERVICE_SET_CONSTANTS_ID = 'service.set_constants'
+
 # ** constant: logging_add_formatter_id
 LOGGING_ADD_FORMATTER_ID = 'logging.add_formatter'
 
@@ -142,309 +142,6 @@ LOGGING_REMOVE_LOGGER_ID = 'logging.remove_logger'
 LOGGING_LIST_ID = 'logging.list'
 
 # *** constants (features)
-
-# ** constant: feature_add
-FEATURE_ADD = create_default_feature(
-    FEATURE_ADD_ID,
-    'Add Feature',
-    'feature',
-    'add',
-    [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
-    description='Add a new feature configuration.',
-    params_schema=create_params_schema(
-        name='str',
-        group_id='str',
-        feature_key={'type': 'str', 'required': False},
-        id={'type': 'str', 'required': False},
-        description={'type': 'str', 'required': False},
-        steps={'type': 'list', 'required': False},
-        log_params={'type': 'dict', 'required': False},
-    ),
-)
-
-# ** constant: feature_get
-FEATURE_GET = create_default_feature(
-    FEATURE_GET_ID,
-    'Get Feature',
-    'feature',
-    'get',
-    [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
-    description='Retrieve a feature by ID.',
-    params_schema=create_params_schema(id='str'),
-)
-
-# ** constant: feature_list
-FEATURE_LIST = create_default_feature(
-    FEATURE_LIST_ID,
-    'List Features',
-    'feature',
-    'list',
-    [{'service_id': 'list_features_evt', 'name': 'List features'}],
-    description='List all features, optionally filtered by group.',
-    params_schema=create_params_schema(group_id={'type': 'str', 'required': False}),
-)
-
-# ** constant: feature_remove
-FEATURE_REMOVE = create_default_feature(
-    FEATURE_REMOVE_ID,
-    'Remove Feature',
-    'feature',
-    'remove',
-    [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
-    description='Remove a feature configuration by ID.',
-    params_schema=create_params_schema(id='str'),
-)
-
-# ** constant: feature_update
-FEATURE_UPDATE = create_default_feature(
-    FEATURE_UPDATE_ID,
-    'Update Feature',
-    'feature',
-    'update',
-    [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
-    description='Update a feature attribute (name or description).',
-    params_schema=create_params_schema(id='str', attribute='str'),
-)
-
-# ** constant: feature_add_step
-FEATURE_ADD_STEP = create_default_feature(
-    FEATURE_ADD_STEP_ID,
-    'Add Feature Step',
-    'feature',
-    'add_step',
-    [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
-    description='Add a step to an existing feature workflow.',
-    params_schema=create_params_schema(
-        id='str',
-        name='str',
-        service_id='str',
-        parameters={'type': 'dict', 'required': False},
-        data_key={'type': 'str', 'required': False},
-        pass_on_error={'type': 'bool', 'required': False, 'default': False},
-        position={'type': 'int', 'required': False},
-    ),
-)
-
-# ** constant: feature_update_step
-FEATURE_UPDATE_STEP = create_default_feature(
-    FEATURE_UPDATE_STEP_ID,
-    'Update Feature Step',
-    'feature',
-    'update_step',
-    [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
-    description='Update an attribute on a feature step.',
-    params_schema=create_params_schema(id='str', position='int', attribute='str'),
-)
-
-# ** constant: feature_remove_step
-FEATURE_REMOVE_STEP = create_default_feature(
-    FEATURE_REMOVE_STEP_ID,
-    'Remove Feature Step',
-    'feature',
-    'remove_step',
-    [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
-    description='Remove a step from a feature by position.',
-    params_schema=create_params_schema(id='str', position='int'),
-)
-
-# ** constant: feature_reorder_step
-FEATURE_REORDER_STEP = create_default_feature(
-    FEATURE_REORDER_STEP_ID,
-    'Reorder Feature Step',
-    'feature',
-    'reorder_step',
-    [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
-    description='Move a feature step from one position to another.',
-    params_schema=create_params_schema(id='str', start_position='int', end_position='int'),
-)
-
-# ** constant: error_add
-ERROR_ADD = create_default_feature(
-    ERROR_ADD_ID,
-    'Add Error',
-    'error',
-    'add',
-    [{'service_id': 'add_error_evt', 'name': 'Add error'}],
-    description='Add a new error definition.',
-    params_schema=create_params_schema(
-        id='str',
-        name='str',
-        message='str',
-        lang={'type': 'str', 'required': False, 'default': 'en_US'},
-        additional_messages={'type': 'list', 'required': False, 'default': []},
-    ),
-)
-
-# ** constant: error_get
-ERROR_GET = create_default_feature(
-    ERROR_GET_ID,
-    'Get Error',
-    'error',
-    'get',
-    [{'service_id': 'get_error_evt', 'name': 'Get error'}],
-    description='Retrieve an error by ID.',
-    params_schema=create_params_schema(
-        id='str',
-        include_defaults={'type': 'bool', 'required': False, 'default': False},
-    ),
-)
-
-# ** constant: error_list
-ERROR_LIST = create_default_feature(
-    ERROR_LIST_ID,
-    'List Errors',
-    'error',
-    'list',
-    [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
-    description='List all error definitions.',
-    params_schema=create_params_schema(
-        include_defaults={'type': 'bool', 'required': False, 'default': False},
-    ),
-)
-
-# ** constant: error_rename
-ERROR_RENAME = create_default_feature(
-    ERROR_RENAME_ID,
-    'Rename Error',
-    'error',
-    'rename',
-    [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
-    description='Rename an existing error.',
-    params_schema=create_params_schema(id='str', new_name='str'),
-)
-
-# ** constant: error_set_message
-ERROR_SET_MESSAGE = create_default_feature(
-    ERROR_SET_MESSAGE_ID,
-    'Set Error Message',
-    'error',
-    'set_message',
-    [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
-    description='Set or update an error message for a language.',
-    params_schema=create_params_schema(
-        id='str',
-        message='str',
-        lang={'type': 'str', 'required': False, 'default': 'en_US'},
-    ),
-)
-
-# ** constant: error_remove_message
-ERROR_REMOVE_MESSAGE = create_default_feature(
-    ERROR_REMOVE_MESSAGE_ID,
-    'Remove Error Message',
-    'error',
-    'remove_message',
-    [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
-    description='Remove an error message by language.',
-    params_schema=create_params_schema(
-        id='str',
-        lang={'type': 'str', 'required': False, 'default': 'en_US'},
-    ),
-)
-
-# ** constant: error_remove
-ERROR_REMOVE = create_default_feature(
-    ERROR_REMOVE_ID,
-    'Remove Error',
-    'error',
-    'remove',
-    [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
-    description='Remove an error definition by ID.',
-    params_schema=create_params_schema(id='str'),
-)
-
-# ** constant: service_add
-SERVICE_ADD = create_default_feature(
-    SERVICE_ADD_ID,
-    'Add Service Configuration',
-    'service',
-    'add',
-    [{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
-    description='Add a new service configuration.',
-    params_schema=create_params_schema(
-        id='str',
-        module_path={'type': 'str', 'required': False},
-        class_name={'type': 'str', 'required': False},
-        parameters={'type': 'dict', 'required': False, 'default': {}},
-        flagged_dependencies={'type': 'list', 'required': False, 'default': []},
-    ),
-)
-
-# ** constant: service_list
-SERVICE_LIST = create_default_feature(
-    SERVICE_LIST_ID,
-    'List All Settings',
-    'service',
-    'list',
-    [{'service_id': 'di_list_all_configs_evt', 'name': 'List all settings'}],
-    description='List all service configurations and constants.',
-)
-
-# ** constant: service_set_default
-SERVICE_SET_DEFAULT = create_default_feature(
-    SERVICE_SET_DEFAULT_ID,
-    'Set Default Service Configuration',
-    'service',
-    'set_default',
-    [{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
-    description='Set or update the default type for a service configuration.',
-    params_schema=create_params_schema(
-        id='str',
-        module_path={'type': 'str', 'required': False},
-        class_name={'type': 'str', 'required': False},
-        parameters={'type': 'dict', 'required': False},
-    ),
-)
-
-# ** constant: service_set_dependency
-SERVICE_SET_DEPENDENCY = create_default_feature(
-    SERVICE_SET_DEPENDENCY_ID,
-    'Set Service Dependency',
-    'service',
-    'set_dependency',
-    [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
-    description='Set or update a flagged dependency on a service configuration.',
-    params_schema=create_params_schema(
-        id='str',
-        flag='str',
-        module_path='str',
-        class_name='str',
-        parameters={'type': 'dict', 'required': False, 'default': {}},
-    ),
-)
-
-# ** constant: service_remove_dependency
-SERVICE_REMOVE_DEPENDENCY = create_default_feature(
-    SERVICE_REMOVE_DEPENDENCY_ID,
-    'Remove Service Dependency',
-    'service',
-    'remove_dependency',
-    [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
-    description='Remove a flagged dependency from a service configuration.',
-    params_schema=create_params_schema(id='str', flag='str'),
-)
-
-# ** constant: service_remove
-SERVICE_REMOVE = create_default_feature(
-    SERVICE_REMOVE_ID,
-    'Remove Service Configuration',
-    'service',
-    'remove',
-    [{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
-    description='Remove a service configuration by ID.',
-    params_schema=create_params_schema(id='str'),
-)
-
-# ** constant: service_set_constants
-SERVICE_SET_CONSTANTS = create_default_feature(
-    SERVICE_SET_CONSTANTS_ID,
-    'Set Service Constants',
-    'service',
-    'set_constants',
-    [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
-    description='Set or clear service-level constants.',
-    params_schema=create_params_schema(constants={'type': 'dict', 'required': False, 'default': {}}),
-)
 
 # ** constant: app_add
 APP_ADD = create_default_feature(
@@ -594,6 +291,309 @@ CLI_ADD_ARGUMENT = create_default_feature(
     ),
 )
 
+# ** constant: error_add
+ERROR_ADD = create_default_feature(
+    ERROR_ADD_ID,
+    'Add Error',
+    'error',
+    'add',
+    [{'service_id': 'add_error_evt', 'name': 'Add error'}],
+    description='Add a new error definition.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+        additional_messages={'type': 'list', 'required': False, 'default': []},
+    ),
+)
+
+# ** constant: error_get
+ERROR_GET = create_default_feature(
+    ERROR_GET_ID,
+    'Get Error',
+    'error',
+    'get',
+    [{'service_id': 'get_error_evt', 'name': 'Get error'}],
+    description='Retrieve an error by ID.',
+    params_schema=create_params_schema(
+        id='str',
+        include_defaults={'type': 'bool', 'required': False, 'default': False},
+    ),
+)
+
+# ** constant: error_list
+ERROR_LIST = create_default_feature(
+    ERROR_LIST_ID,
+    'List Errors',
+    'error',
+    'list',
+    [{'service_id': 'list_errors_evt', 'name': 'List errors'}],
+    description='List all error definitions.',
+    params_schema=create_params_schema(
+        include_defaults={'type': 'bool', 'required': False, 'default': False},
+    ),
+)
+
+# ** constant: error_rename
+ERROR_RENAME = create_default_feature(
+    ERROR_RENAME_ID,
+    'Rename Error',
+    'error',
+    'rename',
+    [{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
+    description='Rename an existing error.',
+    params_schema=create_params_schema(id='str', new_name='str'),
+)
+
+# ** constant: error_set_message
+ERROR_SET_MESSAGE = create_default_feature(
+    ERROR_SET_MESSAGE_ID,
+    'Set Error Message',
+    'error',
+    'set_message',
+    [{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
+    description='Set or update an error message for a language.',
+    params_schema=create_params_schema(
+        id='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
+)
+
+# ** constant: error_remove_message
+ERROR_REMOVE_MESSAGE = create_default_feature(
+    ERROR_REMOVE_MESSAGE_ID,
+    'Remove Error Message',
+    'error',
+    'remove_message',
+    [{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
+    description='Remove an error message by language.',
+    params_schema=create_params_schema(
+        id='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
+)
+
+# ** constant: error_remove
+ERROR_REMOVE = create_default_feature(
+    ERROR_REMOVE_ID,
+    'Remove Error',
+    'error',
+    'remove',
+    [{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
+    description='Remove an error definition by ID.',
+    params_schema=create_params_schema(id='str'),
+)
+
+# ** constant: feature_add
+FEATURE_ADD = create_default_feature(
+    FEATURE_ADD_ID,
+    'Add Feature',
+    'feature',
+    'add',
+    [{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
+    description='Add a new feature configuration.',
+    params_schema=create_params_schema(
+        name='str',
+        group_id='str',
+        feature_key={'type': 'str', 'required': False},
+        id={'type': 'str', 'required': False},
+        description={'type': 'str', 'required': False},
+        steps={'type': 'list', 'required': False},
+        log_params={'type': 'dict', 'required': False},
+    ),
+)
+
+# ** constant: feature_get
+FEATURE_GET = create_default_feature(
+    FEATURE_GET_ID,
+    'Get Feature',
+    'feature',
+    'get',
+    [{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
+    description='Retrieve a feature by ID.',
+    params_schema=create_params_schema(id='str'),
+)
+
+# ** constant: feature_list
+FEATURE_LIST = create_default_feature(
+    FEATURE_LIST_ID,
+    'List Features',
+    'feature',
+    'list',
+    [{'service_id': 'list_features_evt', 'name': 'List features'}],
+    description='List all features, optionally filtered by group.',
+    params_schema=create_params_schema(group_id={'type': 'str', 'required': False}),
+)
+
+# ** constant: feature_remove
+FEATURE_REMOVE = create_default_feature(
+    FEATURE_REMOVE_ID,
+    'Remove Feature',
+    'feature',
+    'remove',
+    [{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
+    description='Remove a feature configuration by ID.',
+    params_schema=create_params_schema(id='str'),
+)
+
+# ** constant: feature_update
+FEATURE_UPDATE = create_default_feature(
+    FEATURE_UPDATE_ID,
+    'Update Feature',
+    'feature',
+    'update',
+    [{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
+    description='Update a feature attribute (name or description).',
+    params_schema=create_params_schema(id='str', attribute='str'),
+)
+
+# ** constant: feature_add_step
+FEATURE_ADD_STEP = create_default_feature(
+    FEATURE_ADD_STEP_ID,
+    'Add Feature Step',
+    'feature',
+    'add_step',
+    [{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
+    description='Add a step to an existing feature workflow.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        service_id='str',
+        parameters={'type': 'dict', 'required': False},
+        data_key={'type': 'str', 'required': False},
+        pass_on_error={'type': 'bool', 'required': False, 'default': False},
+        position={'type': 'int', 'required': False},
+    ),
+)
+
+# ** constant: feature_update_step
+FEATURE_UPDATE_STEP = create_default_feature(
+    FEATURE_UPDATE_STEP_ID,
+    'Update Feature Step',
+    'feature',
+    'update_step',
+    [{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
+    description='Update an attribute on a feature step.',
+    params_schema=create_params_schema(id='str', position='int', attribute='str'),
+)
+
+# ** constant: feature_remove_step
+FEATURE_REMOVE_STEP = create_default_feature(
+    FEATURE_REMOVE_STEP_ID,
+    'Remove Feature Step',
+    'feature',
+    'remove_step',
+    [{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
+    description='Remove a step from a feature by position.',
+    params_schema=create_params_schema(id='str', position='int'),
+)
+
+# ** constant: feature_reorder_step
+FEATURE_REORDER_STEP = create_default_feature(
+    FEATURE_REORDER_STEP_ID,
+    'Reorder Feature Step',
+    'feature',
+    'reorder_step',
+    [{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
+    description='Move a feature step from one position to another.',
+    params_schema=create_params_schema(id='str', start_position='int', end_position='int'),
+)
+
+# ** constant: service_add
+SERVICE_ADD = create_default_feature(
+    SERVICE_ADD_ID,
+    'Add Service Configuration',
+    'service',
+    'add',
+    [{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
+    description='Add a new service configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+        flagged_dependencies={'type': 'list', 'required': False, 'default': []},
+    ),
+)
+
+# ** constant: service_list
+SERVICE_LIST = create_default_feature(
+    SERVICE_LIST_ID,
+    'List All Settings',
+    'service',
+    'list',
+    [{'service_id': 'di_list_all_configs_evt', 'name': 'List all settings'}],
+    description='List all service configurations and constants.',
+)
+
+# ** constant: service_set_default
+SERVICE_SET_DEFAULT = create_default_feature(
+    SERVICE_SET_DEFAULT_ID,
+    'Set Default Service Configuration',
+    'service',
+    'set_default',
+    [{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
+    description='Set or update the default type for a service configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False},
+    ),
+)
+
+# ** constant: service_set_dependency
+SERVICE_SET_DEPENDENCY = create_default_feature(
+    SERVICE_SET_DEPENDENCY_ID,
+    'Set Service Dependency',
+    'service',
+    'set_dependency',
+    [{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
+    description='Set or update a flagged dependency on a service configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        flag='str',
+        module_path='str',
+        class_name='str',
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+    ),
+)
+
+# ** constant: service_remove_dependency
+SERVICE_REMOVE_DEPENDENCY = create_default_feature(
+    SERVICE_REMOVE_DEPENDENCY_ID,
+    'Remove Service Dependency',
+    'service',
+    'remove_dependency',
+    [{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
+    description='Remove a flagged dependency from a service configuration.',
+    params_schema=create_params_schema(id='str', flag='str'),
+)
+
+# ** constant: service_remove
+SERVICE_REMOVE = create_default_feature(
+    SERVICE_REMOVE_ID,
+    'Remove Service Configuration',
+    'service',
+    'remove',
+    [{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
+    description='Remove a service configuration by ID.',
+    params_schema=create_params_schema(id='str'),
+)
+
+# ** constant: service_set_constants
+SERVICE_SET_CONSTANTS = create_default_feature(
+    SERVICE_SET_CONSTANTS_ID,
+    'Set Service Constants',
+    'service',
+    'set_constants',
+    [{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
+    description='Set or clear service-level constants.',
+    params_schema=create_params_schema(constants={'type': 'dict', 'required': False, 'default': {}}),
+)
+
 # ** constant: logging_add_formatter
 LOGGING_ADD_FORMATTER = create_default_feature(
     LOGGING_ADD_FORMATTER_ID,
@@ -696,29 +696,6 @@ LOGGING_LIST = create_default_feature(
 
 # ** constant: default_tiferet_cli_features
 DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
-    FEATURE_ADD_ID: FEATURE_ADD,
-    FEATURE_GET_ID: FEATURE_GET,
-    FEATURE_LIST_ID: FEATURE_LIST,
-    FEATURE_REMOVE_ID: FEATURE_REMOVE,
-    FEATURE_UPDATE_ID: FEATURE_UPDATE,
-    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
-    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
-    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
-    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
-    ERROR_ADD_ID: ERROR_ADD,
-    ERROR_GET_ID: ERROR_GET,
-    ERROR_LIST_ID: ERROR_LIST,
-    ERROR_RENAME_ID: ERROR_RENAME,
-    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
-    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
-    ERROR_REMOVE_ID: ERROR_REMOVE,
-    SERVICE_ADD_ID: SERVICE_ADD,
-    SERVICE_LIST_ID: SERVICE_LIST,
-    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
-    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
-    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
-    SERVICE_REMOVE_ID: SERVICE_REMOVE,
-    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
     APP_ADD_ID: APP_ADD,
     APP_GET_ID: APP_GET,
     APP_LIST_ID: APP_LIST,
@@ -730,6 +707,29 @@ DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
     CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND,
     CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS,
     CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT,
+    ERROR_ADD_ID: ERROR_ADD,
+    ERROR_GET_ID: ERROR_GET,
+    ERROR_LIST_ID: ERROR_LIST,
+    ERROR_RENAME_ID: ERROR_RENAME,
+    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
+    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
+    ERROR_REMOVE_ID: ERROR_REMOVE,
+    FEATURE_ADD_ID: FEATURE_ADD,
+    FEATURE_GET_ID: FEATURE_GET,
+    FEATURE_LIST_ID: FEATURE_LIST,
+    FEATURE_REMOVE_ID: FEATURE_REMOVE,
+    FEATURE_UPDATE_ID: FEATURE_UPDATE,
+    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
+    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
+    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
+    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
+    SERVICE_ADD_ID: SERVICE_ADD,
+    SERVICE_LIST_ID: SERVICE_LIST,
+    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
+    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
+    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
+    SERVICE_REMOVE_ID: SERVICE_REMOVE,
+    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
     LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER,
     LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER,
     LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER,

--- a/tiferet/domain/app.py
+++ b/tiferet/domain/app.py
@@ -34,19 +34,19 @@ class AppSession(DomainObject):
     # * attribute: id
     id: str = Field(
         ...,
-        description='The unique identifier for the application interface.',
+        description='The unique identifier for the application session.',
     )
 
     # * attribute: name
     name: str = Field(
         ...,
-        description='The name of the application interface.',
+        description='The name of the application session.',
     )
 
     # * attribute: description
     description: str | None = Field(
         default=None,
-        description='The description of the application interface.',
+        description='The description of the application session.',
     )
 
     # * attribute: logger_id
@@ -58,7 +58,7 @@ class AppSession(DomainObject):
     # * attribute: flags
     flags: List[str] = Field(
         default_factory=lambda: ['default'],
-        description='The flags for the application interface.',
+        description='The flags for the application session.',
     )
 
     # * attribute: services

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -149,7 +149,7 @@ class UpdateAppSession(AppEvent):
         '''
         Update a scalar attribute on an existing app session.
 
-        :param id: The unique identifier for the app interface to update.
+        :param id: The unique identifier for the app session to update.
         :type id: str
         :param attribute: The attribute name to update.
         :type attribute: str
@@ -157,7 +157,7 @@ class UpdateAppSession(AppEvent):
         :type value: Any
         :param kwargs: Additional keyword arguments (unused).
         :type kwargs: dict
-        :return: The ID of the updated app interface.
+        :return: The ID of the updated app session.
         :rtype: str
         '''
 
@@ -184,7 +184,7 @@ class UpdateAppSession(AppEvent):
 # ** event: set_app_constants
 class SetAppConstants(AppEvent):
     '''
-    A domain event to set or clear constants on an app interface.
+    A domain event to set or clear constants on an app session.
     '''
 
     # * method: execute
@@ -196,15 +196,15 @@ class SetAppConstants(AppEvent):
             **kwargs,
         ) -> str:
         '''
-        Set constants on an app interface.
+        Set constants on an app session.
 
-        :param id: The unique identifier for the app interface.
+        :param id: The unique identifier for the app session.
         :type id: str
         :param constants: A mapping of constants to apply. ``None`` clears all constants.
         :type constants: dict[str, Any] | None
         :param kwargs: Additional keyword arguments (unused).
         :type kwargs: dict
-        :return: The ID of the app interface whose constants were updated.
+        :return: The ID of the app session whose constants were updated.
         :rtype: str
         '''
 
@@ -245,13 +245,13 @@ class ListAppSessions(AppEvent):
         :rtype: List[AppSession]
         '''
 
-        # Delegate to the app service to retrieve all interfaces.
+        # Delegate to the app service to retrieve all sessions.
         return self.app_service.list()
 
 # ** event: set_service_dependency
 class SetServiceDependency(AppEvent):
     '''
-    A domain event to set or update a service dependency on an app interface.
+    A domain event to set or update a service dependency on an app session.
     '''
 
     # * method: execute
@@ -266,9 +266,9 @@ class SetServiceDependency(AppEvent):
             **kwargs,
         ) -> str:
         '''
-        Set or update a service dependency on an app interface.
+        Set or update a service dependency on an app session.
 
-        :param id: The unique identifier for the app interface.
+        :param id: The unique identifier for the app session.
         :type id: str
         :param service_id: The service dependency identifier.
         :type service_id: str
@@ -280,7 +280,7 @@ class SetServiceDependency(AppEvent):
         :type parameters: dict[str, Any] | None
         :param kwargs: Additional keyword arguments (unused).
         :type kwargs: dict
-        :return: The ID of the app interface whose service dependency was set.
+        :return: The ID of the app session whose service dependency was set.
         :rtype: str
         '''
 
@@ -303,16 +303,16 @@ class SetServiceDependency(AppEvent):
             parameters=parameters,
         )
 
-        # Persist the updated interface.
+        # Persist the updated session.
         self.app_service.save(interface)
 
-        # Return the interface ID.
+        # Return the session ID.
         return id
 
 # ** event: remove_service_dependency
 class RemoveServiceDependency(AppEvent):
     '''
-    A domain event to remove a service dependency from an app interface (idempotent).
+    A domain event to remove a service dependency from an app session (idempotent).
     '''
 
     # * method: execute
@@ -321,13 +321,13 @@ class RemoveServiceDependency(AppEvent):
         '''
         Remove a service dependency by service_id.
 
-        :param id: The unique identifier for the app interface.
+        :param id: The unique identifier for the app session.
         :type id: str
         :param service_id: The service dependency identifier to remove.
         :type service_id: str
         :param kwargs: Additional keyword arguments (unused).
         :type kwargs: dict
-        :return: The ID of the app interface whose service dependency was removed.
+        :return: The ID of the app session whose service dependency was removed.
         :rtype: str
         '''
 
@@ -345,10 +345,10 @@ class RemoveServiceDependency(AppEvent):
         # Remove the service dependency idempotently from the session.
         interface.remove_service(service_id=service_id)
 
-        # Persist the updated interface.
+        # Persist the updated session.
         self.app_service.save(interface)
 
-        # Return the interface ID.
+        # Return the session ID.
         return id
 
 # ** event: remove_app_session

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -109,13 +109,13 @@ class GetAppSession(AppEvent):
     '''
 
     # * method: execute
-    @DomainEvent.parameters_required(['interface_id'])
-    def execute(self, interface_id: str, **kwargs) -> AppSession:
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> AppSession:
         '''
         Retrieve an application session by ID from the app service.
 
-        :param interface_id: The ID of the application session to load.
-        :type interface_id: str
+        :param id: The ID of the application session to load.
+        :type id: str
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: The loaded application session.
@@ -124,18 +124,18 @@ class GetAppSession(AppEvent):
         '''
 
         # Retrieve the session from the app service.
-        interface = self.app_service.get(interface_id)
+        session = self.app_service.get(id)
 
         # Raise an error if the session is not found.
-        if not interface:
+        if not session:
             self.raise_error(
                 a.error.APP_SESSION_NOT_FOUND_ID,
-                f'App session with ID {interface_id} not found.',
-                interface_id=interface_id,
+                f'App session with ID {id} not found.',
+                id=id,
             )
 
         # Return the loaded application session.
-        return interface
+        return session
 
 # ** event: update_app_session
 class UpdateAppSession(AppEvent):

--- a/tiferet/repos/app.py
+++ b/tiferet/repos/app.py
@@ -47,12 +47,12 @@ class AppConfigRepository(AppService, ConfigurationRepository):
         '''
 
         # Load the sessions mapping from the configuration file.
-        interfaces_data = self._load(
+        sessions_data = self._load(
             start_node=lambda data: data.get('sessions', {})
         )
 
-        # Return whether the interface id exists in the mapping.
-        return id in interfaces_data
+        # Return whether the session id exists in the mapping.
+        return id in sessions_data
 
     # * method: get
     def get(self, id: str) -> AppSessionAggregate | None:
@@ -66,17 +66,17 @@ class AppConfigRepository(AppService, ConfigurationRepository):
         '''
 
         # Load the specific session data from the configuration file.
-        interface_data = self._load(
+        session_data = self._load(
             start_node=lambda data: data.get('sessions', {}).get(id)
         )
 
         # If no data is found, return None.
-        if not interface_data:
+        if not session_data:
             return None
 
         # Map the data to an AppSessionAggregate and return it.
         return AppSessionConfigObject.model_validate(
-            {**interface_data, 'id': id}
+            {**session_data, 'id': id}
         ).map()
 
     # * method: list
@@ -89,16 +89,16 @@ class AppConfigRepository(AppService, ConfigurationRepository):
         '''
 
         # Load all sessions data from the configuration file.
-        interfaces_data = self._load(
+        sessions_data = self._load(
             start_node=lambda data: data.get('sessions', {})
         )
 
         # Map each session entry to an AppSessionAggregate.
         return [
             AppSessionConfigObject.model_validate(
-                {**interface_data, 'id': interface_id}
+                {**session_data, 'id': session_id}
             ).map()
-            for interface_id, interface_data in interfaces_data.items()
+            for session_id, session_data in sessions_data.items()
         ]
 
     # * method: save


### PR DESCRIPTION
## Summary

Consolidates all Fix-up (FU) and Auditing (AU) items from the Parity III diff analysis into a single hotfix PR against `v2.x-proto`. Also includes SD-1 and SD-2 documentation updates (standards identified during the diff analysis).

## Changes

### FU-1 — `assets/app.py`: Six-section catalog structure
Restructured `assets/app.py` into the six-section layout established by main: `(ids)`, `(paths)`, `(app_service)`, `(sessions)`, `(services)`, `(groups)`. Proto previously collapsed `(paths)`, `(app_service)`, and `(sessions)` into an undifferentiated `(models)` block.

### FU-2 — `assets/app.py`: Explicit type annotations on group dicts
Restored `Dict[str, Dict[str, Any]]` and `Dict[str, str]` annotations on `CORE_DEFAULT_SERVICES` and `CORE_DEFAULT_CONSTANTS`. Restored the `from typing import Any, Dict` import.

### FU-3 — `assets/__init__.py`: Duplicate import (reclassified as Cleanup TRD for main)
Proto is already clean. Cleanup TRD drafted for main at `.trd/assets-init-remove-duplicate-app-import__XS_1_P1.md`.

### FU-4 — `repos/app.py`: Variable naming consistency
Renamed all `interfaces_data` / `interface_data` / `interface_id` local variables to `sessions_data` / `session_data` / `session_id` for consistent session-era terminology.

### FU-5 — `events/app.py`: `GetAppSession` parameter name
Renamed `GetAppSession.execute` parameter from `interface_id` to `id`, matching all other `*AppSession` events.

### FU-6 — `events/app.py`: Residual "interface" terminology in docstrings
Normalized all "app interface" references to "app session" in docstrings and inline comments across `UpdateAppSession`, `SetAppConstants`, `SetServiceDependency`, `RemoveServiceDependency`, and `ListAppSessions`.

### AU-1 — `assets/cli.py`: CLI ID constant naming convention
Renamed all 41 ID and model constants from `_COMMAND_ID` / `_COMMAND` suffix to `_CLI_CMD_ID` / `_CLI_CMD`. The `_CLI_CMD_ID` suffix is more semantically correct and prevents namespace shadowing with feature ID constants from `assets/feature.py` that share the same string values.

### AU-2 — `assets/cli.py` + `assets/feature.py`: Domain group ordering
Reordered all domain groups in both catalogs to match main's established ordering: **app → cli → error → feature → service → logging** (across `(ids)`, `(commands)`/`(features)`, and `(groups)` sections).

### AU-3 — `assets/error.py`: Responsibility sub-sections
Split the flat `(ids)` and `(models)` blocks into responsibility-aligned sub-sections:
- `(ids)` / `(ids_admin)` / `(ids_sqlite)` / `(ids_toml)` / `(ids_csv)`
- `(models)` / `(models_admin)` / `(models_sqlite)` / `(models_toml)` / `(models_csv)`

Alphabetized entries within each sub-section and within each group dict.

### AU-4 — `domain/app.py`: `AppSession` field description terminology
Updated all field descriptions from "application interface" to "application session" language to match the renamed domain concept.

### SD-1 + SD-2 — `docs/core/code_style.md` + skills: Standards documentation
Documented two standards identified during the Parity III diff analysis:

**SD-1 (multi-line constants):** Added "Constants in `assets/` modules" subsection to `docs/core/code_style.md` establishing the multi-line hanging-indent + trailing comma requirement for all dict/list constants in `assets/` modules. Updated `tiferet-code-assets` and `tiferet-code-style` skills with the corresponding key convention bullet.

**SD-2 (multi-group catalog pattern):** Added "Multi-group asset catalogs" explanation to the Sub-Groups section of `docs/core/code_style.md` documenting the three-layer `(ids_<group>)` → `(models_<group>)` → `(groups)` correlation pattern. Updated `tiferet-code-assets` skill: corrected the sub-groups pseudo-code section name (`(errors)` → `(models)`), fixed single-line dict pseudo-code to multi-line, and added the multi-group pattern with a canonical sqlite example.

---

Co-Authored-By: Oz <oz-agent@warp.dev>

Warp conversation: https://app.warp.dev/conversation/020dd1cd-761a-43f8-8080-0eeeed616d7b