### PR TITLE
Docs – Universal constant declaration style, multi-group catalog pattern, and factory function format

### DIFF
--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -29,26 +29,54 @@ Artifact labels:
 # ** class: <snake_case_name>       ← individual class
 ```
 
-**Sub-groups** — partition a large `# *** constants` section with a parenthetical qualifier. The framework convention (e.g. `assets/error.py`) uses three sub-groups:
+**Sub-groups** — partition a large `# *** constants` section with a parenthetical qualifier. The framework convention (e.g. `assets/error.py`) uses three correlated sub-group layers:
 ```python
-# *** constants (ids)               ← raw error-code identifier strings
+# *** constants (ids)               ← raw error-code identifier strings (core group)
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
-# *** constants (errors)            ← assembled default definition dicts
+# *** constants (models)            ← assembled default definition constants (core group)
 # ** constant: feature_not_found
-FEATURE_NOT_FOUND = { 'id': FEATURE_NOT_FOUND_ID, 'name': 'Feature Not Found', ... }
+FEATURE_NOT_FOUND = create_default_error(...)
 
-# *** constants (groups)            ← catalog dicts grouping the above
-# ** constant: default_errors
-DEFAULT_ERRORS = { FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND }
+# *** constants (groups)            ← catalog dicts aggregating the above
+# ** constant: core_default_errors
+CORE_DEFAULT_ERRORS = {
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+}
 ```
+
+**Multi-group catalogs** — when a module defines additional capability groups (e.g., `admin`, `sqlite`, `csv`), each group name is a shared key across all three layers: `(ids_<group>)`, `(models_<group>)`, and a named dict entry in `(groups)`. Adding an entry to a capability group always requires touching all three locations:
+```python
+# *** constants (ids_sqlite)
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+
+# *** constants (models_sqlite)
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect: {original_error}')],
+)
+
+# *** constants (groups)
+# ** constant: sqlite_default_errors
+SQLITE_DEFAULT_ERRORS = {
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+}
+```
+
+The plain `(ids)` / `(models)` sub-groups (no suffix) hold the core/baseline group. All additional groups use the `_<group>` suffix consistently.
 
 ## Key conventions
 
 - **Layer boundary — valid `# ** app` imports:** none. `assets` is the root layer; it has no framework imports. Only `# ** core` (stdlib) and `# ** infra` (minimal third-party, e.g. `json`) are valid. Never import from any other framework layer.
 - **Constants:** `SCREAMING_SNAKE_CASE`. Each constant has its own `# ** constant: <snake_case>` label. Do not group multiple constants under a single `# ** constants: <group>` mid-level label — use a top-level sub-group instead.
 - **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error`), not inline dicts. Define each entry as a named constant, then assemble the catalog dict as a separate constant.
+- **Constant declaration style:** All list- and dictionary-typed constants use the multi-line hanging-indent style with a trailing comma everywhere. This is especially important in `assets/` modules: unlike `# *** events`, `# *** mappers`, and other construct groups, the assets layer has no unique construct-level section designation — it is a pure repository of constants, functions, and classes, making constant formatting the primary quality signal. Never `{ **OTHER_DICT }` inline — always expand to multi-line.
+- **Factory function constants:** Constants whose value is a factory function call (e.g. `create_default_error`, `create_app_service_dependency`) must list each argument on its own line with hanging indent and a trailing comma. Never collapse a factory call to a single line.
+- **Optional parameters in factory calls:** must always be passed as keyword arguments. Required positional parameters may be passed positionally. See `tiferet-code-style` for the general keyword-argument rule and example.
 - **Functions:** Small, stateless, no framework dependencies. Use RST docstrings.
 - **Classes:** Plain standalone classes (exception types, data primitives). Use `# *** classes` / `# ** class: <name>`, `# * attribute: <name>`, `# * init`.
 - **Exports:** Only in `__init__.py` under `# *** exports`. Use short module aliases for frequently consumed modules (e.g. `from . import constants as const`).
@@ -70,14 +98,14 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 # ** constant: feature_already_exists_id
 FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
 
-# *** constants (errors)
+# *** constants (models)
 
 # ** constant: feature_not_found
-FEATURE_NOT_FOUND = {
-    'id': FEATURE_NOT_FOUND_ID,
-    'name': 'Feature Not Found',
-    'message': [{'lang': 'en_US', 'text': 'Feature not found: {feature_id}.'}],
-}
+FEATURE_NOT_FOUND = create_default_error(
+    FEATURE_NOT_FOUND_ID,
+    'Feature Not Found',
+    [('en_US', 'Feature not found: {feature_id}.')],
+)
 
 # *** constants (groups)
 

--- a/docs/collab/agents/skills/tiferet-code-style/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-style/SKILL.md
@@ -63,6 +63,8 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
   - `# ++ todo: <message>` — deferred work; remove when done.
   - `# -- obsolete: <reason>` — deprecated artifact; remove with the artifact. Shorthand: `# * method: foo (obsolete)`.
 - **Pre-session scan:** Before editing, run `grep -rn "# ++\|# --" tiferet/` to find open annotations.
+- **Constant declaration style:** All list- and dictionary-typed constants use the multi-line hanging-indent style with a trailing comma, wherever they appear. Short constants are just as mandatory as long ones. Never `{ **OTHER_DICT }` inline.
+- **Optional parameters in function/factory calls:** must be passed as keyword arguments — not positionally. Required positional parameters may continue to be passed positionally. Correct: `create_default_app_session(TIFERET_ADMIN_ID, 'Admin App', description='...')`. Incorrect: `create_default_app_session(TIFERET_ADMIN_ID, 'Admin App', '...')` (the optional `description` passed positionally loses its self-documenting value).
 
 ## Example
 

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -88,6 +88,39 @@ The most common use is grouping unit tests by the class or method under test, so
 
 **Spacing**: One empty line between a sub-group comment and its first mid-level comment, the same as any top-level section.
 
+**Multi-group asset catalogs** — When an `assets/` module defines multiple capability groups (e.g., `admin`, `sqlite`, `csv`), apply a three-layer sub-group structure. Each capability group name is a shared key across all three layers:
+
+1. `# *** constants (ids_<group>)` — raw string ID constants for the group.
+2. `# *** constants (models_<group>)` — assembled model constants (e.g., via `create_default_error`) in the same order as the corresponding `(ids_<group>)` section.
+3. A named dict entry under `# *** constants (groups)` — aggregates the group's models.
+
+When adding an entry to a capability group, touch all three locations: `(ids_<group>)`, `(models_<group>)`, and the group dict in `(groups)`. See `tiferet/assets/error.py` for the canonical reference.
+
+```python
+# *** constants (ids_sqlite)
+
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
+
+# *** constants (models_sqlite)
+
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect: {original_error}')],
+)
+
+# *** constants (groups)
+
+# ** constant: sqlite_default_errors
+SQLITE_DEFAULT_ERRORS = {
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+}
+```
+
+The plain `(ids)` and `(models)` sub-groups (no suffix) hold the core/baseline group. All additional capability groups use the `_<group>` suffix consistently.
+
 ### Mid-Level (`# **`)
 Specifies categories or individual components:
 - For imports: `# ** core`, `# ** infra`, `# ** app`.
@@ -125,6 +158,26 @@ def execute(self,
             **kwargs):
 ```
 
+### Keyword Arguments for Optional Parameters
+
+When calling a function or factory that has optional parameters, those parameters **must** be passed as keyword arguments. Required positional parameters may continue to be passed positionally, as their role is unambiguous by position. Optional parameters passed positionally lose their self-documenting value and silently conflict with the optional-field-omission pattern.
+
+```python
+# Correct — optional 'description' passed as keyword argument
+DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
+    TIFERET_ADMIN_ID,
+    'Admin App',
+    description='Default built-in admin application session',
+)
+
+# Incorrect — optional 'description' passed positionally; do not use
+DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
+    TIFERET_ADMIN_ID,
+    'Admin App',
+    'Default built-in admin application session',
+)
+```
+
 ### Code Snippets
 - Each logical step is a separate snippet.
 - Precede with 1–2 comment lines describing intent.
@@ -158,6 +211,26 @@ def load_feature(self, feature_id: str) -> Feature:
   - Code snippets within a method.
   - Methods/attributes within a class.
   - Classes within a component group.
+
+### Constant declaration style
+
+All list- and dictionary-typed constants must use the multi-line hanging-indent style with a trailing comma, wherever they appear in the codebase. Short constants are just as mandatory as long ones — uniformity eliminates line-length judgment calls and prevents drift as catalogs grow.
+
+```python
+# Correct — multi-line with trailing comma
+ADMIN_DEFAULT_ERRORS = {
+    **CORE_DEFAULT_ERRORS,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
+}
+
+# Correct even for a simple spread
+ADMIN_DEFAULT_SERVICES = {
+    **CORE_DEFAULT_SERVICES,
+}
+
+# Incorrect — never single-line
+ADMIN_DEFAULT_SERVICES = {**CORE_DEFAULT_SERVICES}
+```
 
 ## Annotation Artifacts
 


### PR DESCRIPTION
## Summary

Three documentation updates formalizing constant formatting conventions across the code style guide and the two skills most directly concerned with them.

---

### `docs/core/code_style.md`

**New section — Constant declaration style** (under Code Formatting Conventions)

Establishes the universal rule: all list- and dictionary-typed constants use the multi-line hanging-indent style with a trailing comma, regardless of length or location. Uniformity is the principle — short constants are just as mandatory as long ones.

**New subsection — Multi-group asset catalogs** (under Sub-Groups)

Documents the three-layer structural pattern used when an `assets/` module defines multiple capability groups. Each capability group name is a shared key across three correlated sub-sections:
1. `# *** constants (ids_<group>)` — raw string ID constants
2. `# *** constants (models_<group>)` — assembled model constants in the same order
3. A named dict entry under `# *** constants (groups)` — aggregates the group

Adding an entry to a capability group always requires touching all three locations. Includes a canonical SQLite example.

---

### `tiferet-code-style` skill

Adds a **Constant declaration style** key convention bullet — universal in scope, consistent with the updated guide.

---

### `tiferet-code-assets` skill

- **Sub-groups section** updated: sub-group label corrected from `(errors)` to `(models)`; pseudo-code examples expanded to multi-line; multi-group catalog pattern added with a three-layer example.
- **New key convention — Constant declaration style**: restates the universal rule with the assets-specific context — the assets layer has no unique construct-level section designation (unlike `# *** events`, `# *** mappers`, etc.), making constant formatting the primary quality signal in that layer.
- **New key convention — Factory function constants**: constants assigned via a factory function call (`create_default_error`, `create_app_service_dependency`, etc.) list each argument on its own line with hanging indent and trailing comma. Never collapsed to a single line.
- **Example block** corrected: `# *** constants (errors)` renamed to `(models)`; inline dict assignment replaced with a `create_default_error(...)` multi-line call.

---

## Scope

Documentation only. No source changes.

Co-Authored-By: Oz <oz-agent@warp.dev>