### PR TITLE
Docs/Collab – Super-TRD Workflow: Skills, Docs, and Process Unification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,9 +307,9 @@ Applications are configured in a consolidated root `config.yml` file:
 ## Testing
 
 - **Framework:** `pytest` (with `pytest_env` for environment variables).
-- **Test location:** Co-located in `<package>/tests/` directories (e.g., `domain/tests/`, `events/tests/`, `mappers/tests/`).
+- **Test location:** `tests/<component>/` at the repository root (e.g., `tests/domain/`, `tests/events/`, `tests/mappers/`).
 - **Integration tests:** `tiferet/tests_int/`.
-- **Run tests:** `pytest tiferet/` from project root (with venv activated).
+- **Run tests:** `pytest tests/` (or plain `pytest` per `pyproject.toml`) from project root (with venv activated).
 - **Test structure:** Uses artifact comments (`# *** fixtures`, `# ** fixture: <name>`, `# *** tests`, `# ** test: <name>`).
 - **Mocking:** Use `unittest.mock`. Mock injected services. Verify calls and return values.
 - **Event testing:** Always invoke via `DomainEvent.handle(EventClass, dependencies={...}, **kwargs)`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,19 @@ Warp/AI agents contributing to Tiferet follow the same conventions described abo
 
 **Collaboration skills** handle process workflows:
 
+- **`tiferet-annotation-artifacts`** — scan, add, and resolve `# ++ todo:` / `# -- obsolete:` annotation artifacts; covers the pre-session scan, resolution procedure, and Collaboration Report integration ([code_style.md § Annotation Artifacts](docs/core/code_style.md)). **Use this at the start of every implementation session.**
 - **`tiferet-create-milestone`** — create or format a GitHub milestone (title and description conventions).
 - **`tiferet-author-trd`** — author a TRD in the standard structure ([tech_requirements.md](docs/collab/tech_requirements.md)).
 - **`tiferet-collab-report`** — generate a Collaboration Report once an issue is confirmed complete ([collab_report.md](docs/collab/collab_report.md)).
 - **`tiferet-milestone-session`** — run a milestone's per-issue branch → PR → merge → report loop ([main.md](docs/collab/main.md)).
 - **`tiferet-pr-code-review`** — review a PR by comparing its feature branch against a prototype source of truth and posting only actionable comments ([code_review.md](docs/collab/code_review.md)).
+
+**Super-TRD skills** handle multi-child implementation workflows (XL+ issues decomposed into sequenced children). See [docs/collab/super_trd_workflow.md](docs/collab/super_trd_workflow.md) for the complete workflow reference.
+
+- **`tiferet-super-trd`** — dispatch skill; read first to self-identify your role via the state machine.
+- **`tiferet-super-trd-implementor`** — Starter and Implementor roles: branch creation, implementation, human-in-the-loop PR gate, review comment addressing.
+- **`tiferet-super-trd-reviewer`** — Reviewer role: AC-first verification of the combined PR, before-posting checklist, AC update authority.
+- **`tiferet-super-trd-closer`** — Closer role: address Reviewer findings, post Collaboration Report, rename parent TRD, verify automation.
 
 **Code style skills** (`tiferet-code-*`) handle implementation conventions — read `tiferet-code-style` at the start of every implementation session, then the component skill(s) for what you’re modifying:
 

--- a/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-author-trd/SKILL.md
@@ -67,6 +67,26 @@ Follow this exact structure (pure Markdown — headers, tables, code blocks):
 ## Artifact-based requirements
 Specify work as artifacts to **Add / Update / Remove** — modules, classes, `# * method:` / `# ** <component>:` labels / `# *** <section>` headers per the structured code style — not prose or "copy from X". In §3 give each module an artifact-action summary; in §4 enumerate the named artifacts, using a `From (current)` → `To (target)` delta table for renames/migrations with an Add/Update/Remove legend (factor the shared pattern once, list per-module exceptions). In §5 assert target artifacts exist and retired ones are gone. Make cross-layer prerequisites, artifact-label corrections, and behavioral shifts explicit.
 
+
+## Operation-level artifact notation in §4
+
+Every requirement in §4 is an **operation** (Add / Update / Remove) on a named artifact. Tables must be **informationally complete** — an agent reading a row must be able to produce the artifact without any other source. Each `# *** constants (<subgroup>)` section in the code maps 1:1 to a `#### Add/Update/Remove: # *** constants (<subgroup>)` heading in §4.
+
+For full notation syntax, scalar and factory-built table expressions, supplementary notes conventions, and the informational completeness requirement, see [`docs/collab/tech_requirements.md`](https://github.com/greatstrength/tiferet/blob/main/docs/collab/tech_requirements.md).
+
+### Constant section subgroups
+
+When a module contains many constants of a given type, organize them into named `# *** constants (<subgroup>)` sections — not a flat `# *** constants` block. The subgroup label is semantic: it names what the group *represents*.
+
+Canonical subgroup labels: `(ids)`, `(paths_packages)`, `(paths_domains)`, `(features)`, `(services)`, `(commands)`, `(formatters)`, `(handlers)`, `(loggers)`, `(groups)`, etc.
+
+The section-mirroring rule extends to subgroup level: each `# *** constants (<subgroup>)` code section maps 1:1 to a `#### Add: # *** constants (<subgroup>)` heading in §4. A flat `# *** constants` block where subgroups apply is a defect — assert the correct section structure in §5.
+
+### "Update Constant" and "Remove Constant"
+
+- **Update**: use a delta table with columns for the current value and the target value (or target expression). Identify each constant by name in the first column. State unchanged fields only if they provide disambiguation context.
+- **Remove**: a plain list of artifact labels is sufficient. Assert removal in §5.
+
 ## Migration / parity stories (branch-agnostic)
 For parity/migration work sourced from a prototype branch, keep the dev-facing TRD **branch-agnostic and in the target ubiquitous language**. Do not tell the implementation agent to read, diff, or copy a prototype/source branch — extract the terminology and artifacts into the TRD. Record not-yet-met cross-layer dependencies in §7 Prerequisites with their status in `main`. The prototype source-of-truth comparison belongs to the separate `tiferet-pr-code-review` skill, not authoring or implementation.
 
@@ -97,6 +117,25 @@ The TRD also feeds the issue's project fields: Components Affected, Acceptance C
 **Child TRD addition:** `**Parent:** \`<parent-filename>\` (Child N of M)` in the header.
 
 **Child priority rule:** a child that is a prerequisite for sibling children → P0; all other children → parent's priority.
+
+**Semantic scoping principles (issues #935 and #939 are canonical references):**
+- Super-TRDs are scoped around a **semantic concern** — a named domain problem — not around a file, layer label, or count of changes.
+- Children are divided by **semantic ownership**: each child owns a bounded domain area that can be read and verified independently.
+- Child TRD titles name the **actual artifacts delivered** (e.g. "Path Constants, Service Dependency Factory, and Module Path Factory"), not generic descriptions.
+- Every §4 requirement names a specific artifact (section header, constant name, factory function, count).
+- Every §5 AC line is a binary assertion on a named artifact — true or false given the code, no interpretation required.
+- §6 NFR states artifact comment requirements per entry (`# ** constant: <snake_case_name>` per named constant, etc.).
+
+**Child TRD size cap (hard constraint):**
+A child TRD covers exactly **one primary module**, its test file (if applicable), and at most **1–2 non-testable dependency touches** (e.g. a factory in `core.py` the primary module uses, or an `__init__.py` export). Maximum size is **Medium (3 pts)**.
+
+| Scope | Size |
+|---|---|
+| Single file only | XS (1 pt) |
+| Primary module + tests | S (2 pts) |
+| Primary module + tests + 1–2 dependency touches | M (3 pts) |
+
+If a child would exceed M (3 pts), split it into additional children. The TRD author takes creative latitude in how work is divided — but the size cap is a hard constraint.
 
 **Super-TRD closing:** parent issue closes when all child sub-issues close. Rename parent TRD file to `.complete.md` and close the parent GitHub issue.
 

--- a/docs/collab/agents/skills/tiferet-super-trd-closer/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-super-trd-closer/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tiferet-super-trd-closer
+description: Close out a Super-TRD after the Reviewer posts findings: address review comments, push, await merge, post Collaboration Report, rename parent TRD to .complete.md, and verify GitHub automation closed the issue. Read after tiferet-super-trd identifies your role as CLOSER.
+---
+
+# Tiferet Super-TRD — Closer
+
+## When to use
+Read this after `tiferet-super-trd` identifies your role as **CLOSER**. Trigger: Super-TRD project status is In Progress **and** all child sub-issues are closed **and** the linked PR has open/unresolved review comments. This combination means the Reviewer has finished and the branch needs final fixes before merge.
+
+Canonical source of truth:
+- https://github.com/greatstrength/tiferet/blob/main/docs/collab/super_trd_workflow.md
+
+## Closing procedure
+
+### 1. Read all review comments
+```bash
+# pr-comments skill, or:
+gh api /repos/greatstrength/tiferet/pulls/<pr-number>/reviews
+gh api /repos/greatstrength/tiferet/pulls/<pr-number>/comments
+```
+
+Read every unresolved comment before making any code edits.
+
+### 2. Check out the feature branch and address findings
+```bash
+git checkout <branch-name> && git pull origin <branch-name>
+```
+
+Address every actionable finding in code. Follow `tiferet-code-style` conventions. Push when done:
+```bash
+git push origin <branch-name>
+```
+
+### 3. Post a PR comment (optional for trivial fixes)
+For non-trivial fixes, post a comment on the PR noting:
+- What was addressed (scope-of-work bullets, no out-of-scope context).
+- Your Warp conversation link (`https://app.warp.dev/conversation/...`).
+
+For trivial fixes (e.g. a single annotation or comment-only change), the commit message on the push is sufficient — omit the PR comment.
+
+### 4. Await user PR approval and merge
+Stop here and wait for the developer to approve and squash-merge the PR.
+
+### 5. Post-merge cleanup
+After the PR is merged:
+```bash
+git checkout main && git pull origin main
+git branch -d <branch-name>
+```
+
+### 6. Retrieve conversation links before drafting the Collaboration Report
+
+Before drafting **any** part of the Collaboration Report:
+
+1. Retrieve all PR comments: `pr-comments` skill or `gh api /repos/greatstrength/tiferet/pulls/<n>/reviews` + `/comments`.
+2. Extract every `https://app.warp.dev/conversation/...` link present — one per Implementor comment, one in the Reviewer's review body.
+3. Search each conversation for the AI↔Human exchange.
+4. Only then begin drafting any part of the Collaboration Report.
+
+A collaboration log written without consulting these conversations will be incomplete or inaccurate.
+
+Use the `tiferet-collab-report` skill to post the Collaboration Report as a comment on the Super-TRD parent issue.
+
+### 7. Rename the parent TRD file
+Rename the Super-TRD parent's `.trd/` file to carry the `.complete.md` extension, signaling the entire Super-TRD workflow is done:
+```bash
+git mv .trd/<parent-name>.md .trd/<parent-name>.complete.md
+git commit -m "Docs – rename Super-TRD parent TRD to .complete.md after merge"
+```
+
+### 8. GitHub issue and project status
+**Verify automation before acting manually.** For Super-TRD PRs that include `Closes #<n>` in the body, GitHub auto-closes the parent issue on squash-merge and typically sets project status to Done.
+
+- Check issue state: `gh issue view <n> --repo greatstrength/tiferet --json state`
+- If already closed: **skip** manual close.
+- If not closed: `gh issue close <n> --repo greatstrength/tiferet`
+- Check project status in the GitHub UI or via GraphQL; if not Done, set it manually and set the End date via `gh project item-edit`.
+
+### 9. Update the handoff
+Update `.handoff/ddd-parity-agent-workflow.handoff.md`: session log, §6 parent tracking (all sub-issues `close: done`), and Super-TRD entry in the parents table (status → closed).

--- a/docs/collab/agents/skills/tiferet-super-trd-implementor/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-super-trd-implementor/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: tiferet-super-trd-implementor
+description: Implement child sub-issues on a Super-TRD feature branch. Covers both the Starter role (first child, branch creation, human gate, PR opening) and the Implementor role (subsequent children, PR-already-open procedure, addressing review comments). Read after tiferet-super-trd identifies your role as STARTER or IMPLEMENTOR.
+---
+
+# Tiferet Super-TRD — Implementor & Starter
+
+## When to use
+Read this after `tiferet-super-trd` identifies your role as **STARTER** (no branch yet) or **IMPLEMENTOR** (branch exists, child is In Progress or In Review with unresolved comments).
+
+Canonical source of truth:
+- https://github.com/greatstrength/tiferet/blob/main/docs/collab/super_trd_workflow.md
+
+## Starter rituals (first child only)
+
+When you are the **Starter** (no feature branch exists yet):
+
+1. **Cut the feature branch** from `main` using `<parent-issue-number>-<slug>` (e.g. `930-assets-error-id-migration`):
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b <branch-name>
+   ```
+2. **Set the first child sub-issue to In Progress** on the project board. Do **not** manually set the Super-TRD parent — GitHub automation handles the parent lifecycle when the PR is created.
+3. **Proceed to implement the first child** on the feature branch (see Implementation procedure below).
+
+## Implementation procedure
+
+Before writing any code, read `tiferet-code-style` (mandatory every session) and the `tiferet-code-<component>` skill(s) for the layers this child touches. For multi-component children, also read `tiferet-code-architecture`.
+
+Implement the child by working through its TRD **section-by-section**: read the child TRD's §4, match each `#### Add/Update/Remove: # *** <section> (<subgroup>)` heading to the corresponding code section, and execute the artifact table row-by-row. The child TRD is the complete and sufficient specification — execute it directly without paraphrasing.
+
+Run tests (`pytest tests/`) after implementing. Verify the changes compile with no syntax errors.
+
+## PR Body as Full Template — Starter-Gate Requirement
+
+The PR body must be written by the **Starter** and must cover **all children up front**: a Changes sub-section and Acceptance Criteria sub-section for every child (in order), with unchecked AC boxes for pending children. The `Closes #<parent-issue-number>` line goes in the Related Issues section.
+
+As each child is implemented and pushed, the active Implementor checks off that child's AC rows, marks the Changes section ✅, and adds its bullet list of changes. The `Closes` line is never touched after PR creation. A PR body that covers only Child 1 forces subsequent Implementors to invent the format — this is a **Starter-gate requirement**, not a post-hoc best practice.
+
+## Human-in-the-loop PR gate (Starter only)
+
+After implementing and testing the first child:
+
+1. **Commit** the changes with a descriptive message (include `Co-Authored-By: Oz <oz-agent@warp.dev>`).
+2. **Stop.** Do **not** push or open a PR without explicit human approval.
+3. After the developer reviews the commit(s) and signals approval, **push the branch** and **open the PR** targeting `main`.
+
+## Post-PR protocol (Starter — first PR creation)
+
+After pushing and opening the PR:
+
+1. **Set the child sub-issue to In Review** on the project board.
+2. **Add the PR to the project board** as a linked item.
+3. **Post an implementor comment** on the PR as the first comment. The comment must:
+   - Include your Warp conversation link (`https://app.warp.dev/conversation/...`).
+   - State that this conversation served as the Implementor for the named sub-issue.
+   - List only activities within the scope of the implemented work (read/confirm, implement, validate, commit).
+   - Be concise — no process discussions, no out-of-scope context.
+
+The conversation link belongs in a **PR comment**, never in the PR body.
+
+## PR→issue linking convention
+
+The PR body's **`Closes` reference must point to the Super-TRD parent only** (e.g. `Closes #930`). Never add `Closes #<child>` lines. Rationale: one branch covers all children; the PR auto-closes the parent on merge; children are closed manually at the developer's direction.
+
+## Closes convention — do not alter
+
+The `Closes #<parent-issue-id>` line in the PR body is written once at PR creation and **must never be changed** by any subsequent Implementor session. Do not add child sub-issue close lines. When updating the PR body to reflect new child completions, leave the `Closes` line untouched and update only prose sections (Summary, Changes, Acceptance Criteria).
+
+## On sub-issue completion — rename the TRD file
+
+Whenever you are asked to mark a child sub-issue as complete, also rename its `.trd/` file to carry a `.complete.md` extension. Do this **together** with closing the sub-issue (do not defer it):
+
+```bash
+git mv .trd/<name>.md .trd/<name>.complete.md
+```
+
+Preserve the full existing filename and only append the extension.
+
+**Fallback:** If `.trd/` is listed in `.gitignore` (exit code 128: "not under version control"), use plain `mv` instead — the rename is still a meaningful local signal regardless of whether it is tracked.
+
+## PR-already-open procedure (subsequent children)
+
+When you are implementing a child on a Super-TRD whose PR is **already open** (Starter has already pushed the branch and opened the PR):
+
+1. **Implement and test** the child on the existing feature branch.
+2. **Commit** the changes.
+3. **Push** to origin.
+4. **Set the child sub-issue to In Review** on the project board.
+
+**Skip** all other Starter-gate steps: do not create a new PR, do not add the PR to the project board again, and do not post an implementor comment unless the developer explicitly requests one.
+
+## Implementor comment convention — same-session continuation
+
+The "skip unless explicitly requested" guidance applies when a **different** Implementor agent takes over a PR already in flight. When the **same session** continues to implement multiple children, a per-child implementor comment is appropriate — each comment contextualizes the distinct scope of work and provides a durable per-child record.
+
+## Orienting on resume — identifying active work
+
+When spun up against an in-flight Super-TRD (branch already exists, some children may be complete):
+
+1. **Read the Super-TRD parent issue** to understand the full child sequence and which children are complete vs. pending.
+2. **Identify the active child** — the lowest-numbered open sub-issue whose status is In Progress or In Review. The developer typically names it; if not, infer from the sub-issue list.
+3. **Determine current state** using two signals:
+   - `git log` / `git status` on the feature branch — confirms which child commits are present and whether uncommitted changes exist.
+   - **PR comments** on the linked PR — read if the sub-issue is In Review, since unresolved review comments are actionable work.
+4. **Act based on sub-issue status:**
+   - *In Progress* — implementation has not yet been pushed. Proceed with implementation.
+   - *In Review* — changes are on origin and the PR is open. Fetch and address all review comments before proceeding.
+
+## Impact analysis for in-flight sibling branches
+
+Before starting a child's implementation, verify the current state of the **in-flight feature branch** — not only recently merged PRs. When a sibling child has just been implemented, confirm:
+
+- The code on the branch reflects the sibling's changes.
+- The current child's TRD prerequisites (§7) are satisfied on the branch.
+- Any constants, factories, or imports the current child depends on already exist on the branch.
+
+Use `git log` and direct file inspection to confirm. If a prerequisite is listed as "Not yet started" in the TRD but is now complete on the branch, treat it as satisfied and proceed.
+
+## PR comment retrieval — when and how
+
+When the active sub-issue is **In Review**, retrieve all review comments before making any edits:
+
+```bash
+# Using pr-comments skill, or:
+gh pr view <pr-number> --repo greatstrength/tiferet --comments
+gh api /repos/greatstrength/tiferet/pulls/<pr-number>/comments
+```
+
+Read every unresolved comment. Address each one in code. Push. Mark comments resolved when available. Do **not** start the next child sub-issue until all review comments on the current child are resolved and the developer signals approval.
+
+## Continuity across token overuse
+
+If model degradation forces a new Implementor agent mid-review, the new agent posts a comment on the PR stating what it has done (in scope of the implemented work only), including its own Warp conversation link.
+
+## Project status — Super-TRD parent
+
+Agents must **not** manually set the Super-TRD parent to In Progress. GitHub automation fires that transition when the PR is linked (`Closes #<parent>`) and the first sub-issue moves to In Review. For all subsequent children, the parent status stays In Progress throughout — agents do not touch it.
+
+Per-child status updates:
+- When a child's work begins: set the child sub-issue to **In Progress**.
+- After the child's implementation is approved and closed: set it to **Done**.

--- a/docs/collab/agents/skills/tiferet-super-trd-reviewer/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-super-trd-reviewer/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: tiferet-super-trd-reviewer
+description: Review a Super-TRD combined PR after all child sub-issues are closed. Primary criterion is always the Acceptance Criteria of the child TRDs — verify named artifacts exist exactly as specified. The prototype branch (origin/v2.x-proto) is optional context restricted to AC-referenced artifacts only. Read after tiferet-super-trd identifies your role as REVIEWER.
+---
+
+# Tiferet Super-TRD — Reviewer
+
+## When to use
+Read this after `tiferet-super-trd` identifies your role as **REVIEWER**. Trigger: Super-TRD project status is In Progress **and** all child GitHub sub-issues are closed. This combination means the Implementor has finished all children on the combined PR branch and the PR is ready for final review.
+
+**Guardrail:** For any Super-TRD PR, read this skill before starting. The `tiferet-pr-code-review` skill provides diff mechanics and comment-posting API that serve the AC-first analysis below — those mechanics do not replace it.
+
+Canonical source of truth:
+- https://github.com/greatstrength/tiferet/blob/main/docs/collab/super_trd_workflow.md
+
+## Review procedure
+
+### 1. Establish inputs
+```bash
+gh pr view <pr-number> --repo greatstrength/tiferet --json number,headRefName,baseRefName,files
+git fetch origin v2.x-proto
+```
+
+Collect the list of changed files and the PR head commit SHA.
+
+### 2. AC-first verification (primary criterion)
+
+The primary review criterion is always the **Acceptance Criteria of each child TRD**. For every child TRD:
+1. Read the child TRD's §5 (Acceptance Criteria).
+2. Identify the named artifact each AC line asserts: section header, constant name, factory function, method, count.
+3. Locate that artifact in the code.
+4. Verify the binary assertion — the AC line is either true or false; no interpretation required.
+
+**Semantic subgroup structure is part of the checklist.** If the AC asserts `# *** constants (ids)` exists with 41 entries, verify the exact section label and entry count. A flat `# *** constants` block where subgroups are asserted is a finding.
+
+Report every AC line that fails as a separate finding. An AC line that passes requires no comment.
+
+### 3. Optional prototype branch context (restricted scope)
+A diff against `origin/v2.x-proto` is **optional additional context** for parity measurement only. When used:
+- Restrict the study area to artifacts **named in the AC** only. Do not report diffs outside the AC-referenced artifact set.
+- Classify each diff: **behind** (branch missing a reference change — actionable if also an AC failure), **ahead** (branch more correct than reference — keep, note once in body).
+- An "ahead" deviation is not a finding unless an AC line also fails.
+
+Mechanics (from `tiferet-pr-code-review`):
+```bash
+git diff origin/v2.x-proto..HEAD -- <path>
+```
+Read both sides when the diff is ambiguous. Map relocated files to their counterparts.
+
+### 4. Present findings first — wait for go-ahead
+Summarize all findings to the developer and **await explicit approval before posting** anything to GitHub.
+
+### 5. Before-posting checklist
+
+Before posting the review to GitHub, confirm **all three** of the following are present in the global review body — all are mandatory, not afterthoughts:
+
+- [ ] **Conversation link** (`https://app.warp.dev/conversation/...`) — the durable record that lets the Closer and future maintainers trace every finding back to its reasoning.
+- [ ] **Findings summary** — all AC failures and actionable behind-diffs listed clearly.
+- [ ] **`Co-Authored-By: Oz <oz-agent@warp.dev>`** line.
+
+### 6. Post one consolidated review
+Use the GitHub reviews API (position-based, **not** line-based — the `line` API returns 422 errors):
+```bash
+gh api --method POST /repos/greatstrength/tiferet/pulls/<pr-number>/reviews \
+  --input review.json
+```
+`review.json` contains `commit_id`, `event: "COMMENT"`, a global `body`, and a `comments[]` array using `path` + `position` (not `line`).
+
+## Reviewer AC Update Authority
+
+When a discrepancy between the code and an AC line is **intentional** (a deliberate developer decision made after the TRD was authored) and the developer confirms this:
+
+1. Edit the relevant AC line(s) in the `.trd/` source file — every section naming the artifact (§1, §4, §5, §6).
+2. Publish the updated body: `gh issue edit <n> --repo greatstrength/tiferet --body-file <path>`.
+3. Add a **"Reviewer AC Updates"** section in the review body with a one-sentence rationale per change. State the updates were applied before posting so the Closer sees only passing AC.
+4. Do **not** leave old AC language in the issue or `.trd/` file. Do **not** flag the deviation as an open finding.
+
+This authority belongs to the Reviewer, not the Implementor. An Implementor that discovers a naming change should note it in its PR comment ("AC deviation") and defer the update to the Reviewer.
+
+## Post-review actions
+
+After posting the review:
+1. **Set the Super-TRD GitHub project status to In Progress.** This is the explicit signal to the next agent that it is the **Closer**. Do **not** set it to In Review — returning to In Progress is the Closer's cue.
+2. **Update `.handoff/ddd-parity-agent-workflow.handoff.md`**: session log, sub-issue state rows, detail blocks, and §6 parent tracking.
+
+The Reviewer does **not** close the Super-TRD issue. Only the Closer does.
+
+## Actionable findings only
+Comment only on AC failures and behind-diffs for AC-referenced artifacts. Do not comment on:
+- Acknowledged out-of-scope differences
+- Code style that already matches standards
+- Cases where the branch is more correct than the reference (note once in body, never recommend reverting)
+
+Include `Co-Authored-By: Oz <oz-agent@warp.dev>` in the review body.

--- a/docs/collab/main.md
+++ b/docs/collab/main.md
@@ -83,6 +83,31 @@ For each issue in the milestone:
 8. **Local cleanup:** pull latest from `main` and delete the local feature branch.
 9. **Repeat** for remaining issues in the milestone.
 
+## Super-TRD Workflow
+
+A **Super-TRD** is an oversized issue (XL or above) decomposed into sequenced child sub-issues, all implemented on a **single combined feature branch** named after the parent issue (e.g. `930-assets-error-id-migration`). This keeps the full migration atomic and avoids cross-branch dependency noise.
+
+### Roles and trigger conditions
+
+| Role | Trigger |
+|---|---|
+| **Starter** | No feature branch exists yet |
+| **Implementor** | Branch exists; active child is In Progress, or In Review with unresolved PR comments |
+| **Reviewer** | All children closed; no unresolved PR comments on the open PR |
+| **Closer** | All children closed; unresolved PR review comments exist |
+
+To self-identify your role, read `tiferet-super-trd` and evaluate its state machine. Then follow the pointer to the matching role skill. For the complete workflow reference — branch strategy, PR gate, status lifecycle, review and closing procedures — see **[docs/collab/super_trd_workflow.md](super_trd_workflow.md)**.
+
+### GitHub automation and parent project status
+The Super-TRD parent project status is managed by **GitHub automation**, not by agents directly:
+- Agents set **only the child sub-issue** status when work begins (never the parent).
+- GitHub automation sets the parent to **In Progress** when the PR is created and linked (`Closes #<parent>`) and the first sub-issue moves to In Review.
+- The parent remains **In Progress** for the entire duration of all child implementations.
+- The parent moves to **Done** automatically when the PR is squash-merged (via the `Closes` line).
+
+### PR→issue linking convention
+The PR body's `Closes` reference points to the **Super-TRD parent only** (e.g. `Closes #930`). Child sub-issues are closed **manually** at the developer's direction after each child's changes are approved — never via PR auto-close. The `Closes #<parent>` line is written once at PR creation and must never be altered by any subsequent session.
+
 ## Closing the Milestone
 
 Once all issues in the milestone are complete and merged, mark the milestone as **closed**.

--- a/docs/collab/super_trd_workflow.md
+++ b/docs/collab/super_trd_workflow.md
@@ -1,0 +1,335 @@
+# Super-TRD Workflow
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet
+
+## Purpose and Scope
+
+A **Super-TRD** is an oversized issue (XL or above) decomposed into sequenced child sub-issues, all implemented on a **single combined feature branch** named after the parent issue. This document is the canonical reference for the full Super-TRD execution workflow — from branch creation through final merge and cleanup.
+
+This document supersedes the process authority previously held by `.handoff/trd-authoring-implementation-process.handoff.md` §2.3–2.6. That handoff remains as a historical archive and session log.
+
+## Single-Branch Strategy
+
+All child implementations land on the same feature branch, cut from `main` at the start of the Starter session and named `<parent-issue-number>-<slug>` (e.g. `930-assets-error-id-migration`). The branch is not merged until all children are complete and the PR is approved. This keeps the full migration atomic and avoids cross-branch dependency noise between sequenced children.
+
+## Role Overview
+
+| Role | Trigger |
+|---|---|
+| **Starter** | No feature branch exists yet |
+| **Implementor** | Branch exists; active child is In Progress, or In Review with unresolved PR comments |
+| **Reviewer** | All children closed; no unresolved PR comments on the open PR |
+| **Closer** | All children closed; unresolved PR review comments exist on the open PR |
+
+To self-identify your role, read `tiferet-super-trd` and evaluate its state machine. Then follow the pointer to the matching role skill.
+
+## State Machine
+
+```
+Parent status = Done?
+  └─ Yes → Exit. Nothing to do.
+
+All children closed?
+  └─ No → Does the feature branch exist?
+           ├─ No  → STARTER → read tiferet-super-trd-implementor
+           └─ Yes → Is the active child's status "In Review"?
+                    ├─ Yes → Does the PR have unresolved review comments?
+                    │        ├─ Yes → IMPLEMENTOR (address comments) → read tiferet-super-trd-implementor
+                    │        └─ No  → ASK HUMAN: await signal before proceeding
+                    └─ No (In Progress) → IMPLEMENTOR → read tiferet-super-trd-implementor
+  └─ Yes → Does the PR have unresolved review comments?
+           ├─ Yes → CLOSER → read tiferet-super-trd-closer
+           └─ No  → REVIEWER → read tiferet-super-trd-reviewer
+```
+
+**Active child** = the lowest-numbered open sub-issue whose project status is In Progress or In Review. The human developer typically names it explicitly; if not, infer from the sub-issue list.
+
+## Starter Responsibilities and PR Gate
+
+When the Starter has no feature branch yet:
+
+1. **Cut the feature branch** from `main`:
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b <parent-issue-number>-<slug>
+   ```
+2. **Set the first child sub-issue to In Progress** on the project board. Do **not** manually set the Super-TRD parent — GitHub automation handles the parent lifecycle.
+3. **Implement and test** the first child on the feature branch.
+4. **Commit** the changes and **stop** — do not push or open a PR without explicit human approval.
+5. After the developer reviews the commits and signals approval, **push the branch** and **open the PR** targeting `main`.
+
+**Note:** The Starter does not manually set the Super-TRD parent status. GitHub automation sets the parent to **In Progress** when the PR is created and linked (`Closes #<parent>`) and the first sub-issue moves to In Review — this is the official project kickoff.
+
+## PR Body as Full Template — Starter-Gate Requirement
+
+The PR body must be written by the **Starter** and must cover **all children up front**:
+
+- A **Changes** sub-section and **Acceptance Criteria** sub-section for every child, in order.
+- Pending children use **unchecked AC boxes** (e.g. `- [ ] AC line`).
+- The `Closes #<parent-issue-number>` line in the PR body's Related Issues section.
+
+As each child is implemented and pushed, the active Implementor:
+- **Checks off that child's AC rows** (changes `- [ ]` to `- [x]`).
+- Marks the Changes section with ✅.
+- Adds its bullet list of changes for that child.
+
+The `Closes` line must never be touched after PR creation. A PR body that covers only Child 1 forces subsequent Implementors to invent the format, introducing inconsistency — this is a **Starter-gate requirement**, not a post-hoc best practice.
+
+## Post-PR Protocol (Starter — First PR Creation)
+
+After pushing the branch and opening the PR:
+
+1. **Set the child sub-issue to In Review** on the project board.
+2. **Add the PR to the project board** as a linked item.
+3. **Post an implementor comment** on the PR as the first comment. The comment must:
+   - Include your Warp conversation link (`https://app.warp.dev/conversation/...`).
+   - State that this conversation served as the Implementor for the named sub-issue.
+   - List only activities within the scope of the implemented work (read/confirm, implement, validate, commit).
+   - Be concise — no process discussions, no out-of-scope context.
+
+The conversation link belongs in a **PR comment**, never in the PR body.
+
+## PR→Issue Linking Convention
+
+The PR body's **`Closes` reference must point to the Super-TRD parent only** (e.g. `Closes #930`). Child sub-issues are closed **manually** at the developer's direction after each child's changes are approved — never via PR auto-close.
+
+The `Closes #<parent-issue-id>` line is written once at PR creation and **must never be changed** by any subsequent Implementor session. Do not add `Closes #<child>` lines. When updating the PR body to reflect new child completions, leave the `Closes` line untouched and update only prose sections (Summary, Changes, Acceptance Criteria).
+
+## Implementation Continuation — PR-Already-Open Procedure
+
+When implementing a child on a Super-TRD whose PR is **already open** (Starter has previously pushed the branch and opened the PR):
+
+1. **Implement and test** the child on the existing feature branch.
+2. **Commit** the changes.
+3. **Push** to origin.
+4. **Set the child sub-issue to In Review** on the project board.
+
+**Skip** all other Starter-gate steps: do not create a new PR, do not add the PR to the project board again, and do not post an implementor comment unless the developer explicitly requests one.
+
+## Implementor Comment Convention — Same-Session Continuation
+
+The "skip unless explicitly requested" guidance applies when a **different** Implementor agent takes over a PR already in flight. When the **same session** continues to implement multiple children, a per-child implementor comment is appropriate — each comment contextualizes the distinct scope of work and provides a durable per-child record.
+
+## Orienting on Resume — Identifying Active Work
+
+When spun up against an in-flight Super-TRD (branch already exists, some children may be complete):
+
+1. **Read the Super-TRD parent issue** to understand the full child sequence and which children are complete vs. pending.
+2. **Identify the active child** — the lowest-numbered open sub-issue whose status is In Progress or In Review. The developer typically names it; if not, infer from the sub-issue list.
+3. **Determine current state** using two signals:
+   - `git log` / `git status` on the feature branch — confirms which child commits are present and whether uncommitted changes exist.
+   - **PR comments** on the linked PR — read if the sub-issue is In Review, since unresolved review comments are actionable work.
+4. **Act based on sub-issue status:**
+   - *In Progress* — implementation has not yet been pushed. Proceed with implementation.
+   - *In Review* — changes are on origin and the PR is open. Fetch and address all review comments before proceeding.
+
+## Impact Analysis for In-Flight Sibling Branches
+
+Before starting a child's implementation, verify the current state of the **in-flight feature branch** — not only recently merged PRs. When a sibling child has just been implemented, confirm that:
+
+- The code on the branch reflects the sibling's changes.
+- The current child's TRD prerequisites (listed in its §7) are satisfied on the branch.
+- Any constants, factories, or imports the current child depends on already exist on the branch.
+
+Use `git log` and direct file inspection to confirm. If a prerequisite is listed as "Not yet started" in the TRD but is now complete on the branch, treat it as satisfied and proceed.
+
+## Child TRD Prerequisite Table Update Recommendation
+
+When a child TRD's §7 Prerequisites table lists a sibling child as "Not yet started," update the table to reflect "Complete (on branch)" once the sibling lands, or add an implementation note confirming readiness via `git log`. This eliminates ambiguity for subsequent Implementors who must mentally translate stale prerequisite language.
+
+## Project Status Lifecycle
+
+### Per-child status updates
+
+- When a child's work begins: set the **child sub-issue** to **In Progress**.
+- After the child's implementation is approved and closed: set it to **Done**.
+
+### Super-TRD parent status
+
+Agents must **not** manually set the Super-TRD parent to In Progress. GitHub automation fires that transition when the PR is linked (`Closes #<parent>`) and the first sub-issue moves to In Review.
+
+| Phase | Parent status | Trigger |
+|---|---|---|
+| Branch cut; child 1 begins | *(unchanged)* | Starter sets only the child sub-issue to In Progress |
+| PR created + sub-issue set to In Review | **In Progress** | GitHub automation (PR linked + sub-issue → In Review) |
+| Each subsequent child approved | **In Progress** | Automation keeps parent In Progress; agents do not touch it |
+| All children closed (pre-review) | **In Progress** | Remains until Reviewer posts review |
+| Reviewer posts review | **In Progress** | Reviewer resets to In Progress as the Closer's cue |
+| PR merged | **Done** | GitHub auto-closes via `Closes` line |
+
+The Super-TRD must **not** move to **In Review** until every child sub-issue is closed; only the Reviewer sets it — but only briefly: after posting the review, the Reviewer resets it to **In Progress** as the explicit signal to the Closer.
+
+## Sub-Issue Completion Procedure
+
+Whenever an Implementor is asked to mark a child sub-issue as complete:
+
+1. Close the child sub-issue on GitHub and set its project status to **Done**.
+2. Rename its `.trd/` file to carry a `.complete.md` extension:
+   ```bash
+   git mv .trd/<name>.md .trd/<name>.complete.md
+   ```
+   **Fallback:** If `.trd/` is listed in `.gitignore` (exit code 128: "not under version control"), use plain `mv` instead — the rename is still a meaningful local signal regardless of whether it is tracked.
+3. Perform the rename **together** with the sub-issue closure — do not defer it.
+4. Preserve the full existing filename and only append the extension: e.g. `m30_931_assets-error-id-migration__S_2_P0.md` → `m30_931_assets-error-id-migration__S_2_P0.complete.md`.
+
+## Review Procedure
+
+### Trigger condition
+
+All child GitHub sub-issues are closed **and** the PR has no unresolved review comments → **REVIEWER** role.
+
+### 1. Establish inputs
+
+```bash
+gh pr view <pr-number> --repo greatstrength/tiferet --json number,headRefName,baseRefName,files
+git fetch origin v2.x-proto
+```
+
+Collect the list of changed files and the PR head commit SHA.
+
+### 2. AC-first verification (primary criterion)
+
+The primary review criterion is always the **Acceptance Criteria of each child TRD**. For every child TRD:
+
+1. Read the child TRD's §5 (Acceptance Criteria).
+2. Identify the named artifact each AC line asserts: section header, constant name, factory function, method, count.
+3. Locate that artifact in the code.
+4. Verify the binary assertion — the AC line is either true or false; no interpretation required.
+
+**Semantic subgroup structure is part of the checklist.** If the AC asserts `# *** constants (ids)` exists with N entries, verify the exact section label and entry count. A flat `# *** constants` block where subgroups are asserted is a finding.
+
+Report every AC line that fails as a separate finding. AC lines that pass require no comment.
+
+### 3. Optional prototype branch context (restricted scope)
+
+A diff against `origin/v2.x-proto` is **optional additional context** for parity measurement only. When used:
+
+- Restrict the study area to artifacts **named in the AC** only. Do not report diffs outside the AC-referenced artifact set.
+- Classify each diff: **behind** (branch missing a reference change — actionable if also an AC failure), **ahead** (branch more correct than reference — keep, note once in body).
+- An "ahead" deviation is not a finding unless an AC line also fails.
+
+```bash
+git diff origin/v2.x-proto..HEAD -- <path>
+```
+
+### 4. Present findings first — wait for go-ahead
+
+Summarize all findings to the developer and **await explicit approval before posting** anything to GitHub.
+
+### 5. Before-posting checklist
+
+Before posting the review to GitHub, confirm **all three** of the following are present in the global review body — all are mandatory, not afterthoughts:
+
+- [ ] **Conversation link** (`https://app.warp.dev/conversation/...`) — the durable record that lets the Closer and future maintainers trace every finding back to its reasoning.
+- [ ] **Findings summary** — all AC failures and actionable behind-diffs listed clearly.
+- [ ] **`Co-Authored-By: Oz <oz-agent@warp.dev>`** line.
+
+### 6. Post one consolidated review
+
+Use the GitHub reviews API (position-based, **not** line-based — the `line` API returns 422 errors):
+
+```bash
+gh api --method POST /repos/greatstrength/tiferet/pulls/<pr-number>/reviews \
+  --input review.json
+```
+
+`review.json` contains `commit_id`, `event: "COMMENT"`, a global `body`, and a `comments[]` array using `path` + `position` (not `line`).
+
+## Reviewer AC Update Authority
+
+When the Reviewer identifies a discrepancy between the implemented code and an AC line, it must first determine whether the deviation is **unintentional** (a genuine implementation gap — actionable finding) or **intentional** (a deliberate naming or design decision made by the developer after the TRD was authored).
+
+If the developer confirms the deviation was **intentional** and approves updating the AC:
+
+1. Edit the relevant AC line(s) in the `.trd/` source file — covering every section that names the artifact: §1 Overview, §4 Detailed Requirements, §5 Acceptance Criteria, and §6 NFR as applicable.
+2. Publish the updated body to the corresponding GitHub issue: `gh issue edit <n> --repo greatstrength/tiferet --body-file <path>`.
+3. Note the update in the PR review body under a dedicated **"Reviewer AC Updates"** section, with a one-sentence rationale for each change. State that the updates were applied before the review was posted so the Closer sees only passing AC.
+4. Do **not** leave the old AC language in the issue or the `.trd/` file — the updated TRD is the new source of truth. Do not flag the deviation as an open finding in the review.
+
+This authority belongs to the **Reviewer**, not the Implementor. An Implementor that discovers a post-authoring naming change should note it in its PR comment ("AC deviation") but defer the AC update to the Reviewer, who evaluates it in the context of the full branch before deciding whether it is intentional.
+
+## Post-Review Actions
+
+After posting the review:
+
+1. **Set the Super-TRD GitHub project status to In Progress.** This is the explicit signal to the next agent that it is the **Closer**. Do **not** set it to In Review — returning to In Progress is the Closer's cue.
+2. **Update `.handoff/ddd-parity-agent-workflow.handoff.md`**: session log, sub-issue state rows, detail blocks, and §6 parent tracking.
+
+The Reviewer does **not** close the Super-TRD issue. Only the Closer does.
+
+## Closing Procedure
+
+### Trigger condition
+
+All child sub-issues are closed **and** the PR has unresolved review comments → **CLOSER** role.
+
+### 1. Retrieve all conversation links before drafting anything
+
+Before drafting any part of the Collaboration Report, explicitly:
+
+1. Retrieve all PR comments: `pr-comments` skill or `gh api /repos/greatstrength/tiferet/pulls/<n>/reviews` + `/comments`.
+2. Extract every `https://app.warp.dev/conversation/...` link present — one per Implementor comment, one in the Reviewer's review body.
+3. Search each conversation for the AI↔Human exchange.
+4. Only then begin drafting any part of the Collaboration Report.
+
+A collaboration log written without consulting these conversations will be incomplete or inaccurate.
+
+### 2. Address review comments
+
+```bash
+git checkout <branch-name> && git pull origin <branch-name>
+```
+
+Read every unresolved comment. Address each one in code. Push:
+
+```bash
+git push origin <branch-name>
+```
+
+### 3. Post a PR comment (optional for trivial fixes)
+
+For non-trivial fixes, post a comment on the PR noting:
+- What was addressed (scope-of-work bullets, no out-of-scope context).
+- Your Warp conversation link (`https://app.warp.dev/conversation/...`).
+
+For trivial fixes (e.g. a single annotation or comment-only change), the commit message on the push is sufficient — omit the PR comment.
+
+### 4. Await user PR approval and merge
+
+Stop here and wait for the developer to approve and squash-merge the PR.
+
+### 5. Post-merge cleanup
+
+```bash
+git checkout main && git pull origin main
+git branch -d <branch-name>
+```
+
+### 6. Post the Collaboration Report
+
+Use the `tiferet-collab-report` skill to post a Collaboration Report as a comment on the Super-TRD parent issue. Consult all implementor and reviewer Warp conversation links extracted in step 1.
+
+### 7. Parent TRD rename after merge
+
+Rename the Super-TRD parent's `.trd/` file to carry the `.complete.md` extension:
+
+```bash
+git mv .trd/<parent-name>.md .trd/<parent-name>.complete.md
+git commit -m "Docs – rename Super-TRD parent TRD to .complete.md after merge"
+```
+
+**Fallback:** If `.trd/` is git-ignored (exit code 128), use plain `mv` instead.
+
+### 8. GitHub issue and project status verification
+
+For Super-TRD PRs that include `Closes #<n>` in the body, GitHub auto-closes the parent issue on squash-merge and typically sets project status to Done.
+
+- Check issue state: `gh issue view <n> --repo greatstrength/tiferet --json state`
+- If already closed: **skip** manual close.
+- If not closed: `gh issue close <n> --repo greatstrength/tiferet`
+- Check project status in the GitHub UI or via GraphQL; if not Done, set it manually and set the End date via `gh project item-edit`.
+
+### 9. Update the handoff
+
+Update `.handoff/ddd-parity-agent-workflow.handoff.md`: session log, §6 parent tracking (all sub-issues `close: done`), and Super-TRD entry in the parents table (status → closed).

--- a/docs/collab/tech_requirements.md
+++ b/docs/collab/tech_requirements.md
@@ -80,6 +80,65 @@ TRDs specify work as **artifacts to add, update, or remove** — never as prose 
 
 The goal: an implementation agent can satisfy the TRD by acting on named artifacts, and a reviewer can verify each one independently.
 
+
+## Operation-Level Artifact Notation in §4
+
+Every requirement in §4 is expressed as an **operation** on an **artifact type**: Add, Update, or Remove applied to a constant, function, method, section header, import, or file. The notation for each combination is standardized and must be **informationally complete** — an agent reading the table must be able to produce the artifact without consulting any other source, and a DSL compiler must be able to parse the same table as input to generate the code directly.
+
+### "Add Constant" Notation
+
+The canonical notation for the **Add Constant** operation is a table, regardless of whether one constant or one hundred are being added. The operation, not the count, determines the form.
+
+There are two primary expressions — use either, or combine both in sequence when a section mixes scalar IDs and factory-built objects:
+
+**Expression 1 — scalar or literal value:**
+```
+| Artifact label | Constant | Value |
+|---|---|---|
+| `# ** constant: tiferet_events_path` | `TIFERET_EVENTS_PATH` | `'events'` |
+| `# ** constant: tiferet_repos_path`  | `TIFERET_REPOS_PATH`  | `'repos'`  |
+```
+
+**Expression 2 — factory-built object:**
+State the shared factory invocation pattern in a prefix sentence; table columns carry only the variable parameters. This keeps the table compact and keeps the factory name out of every row.
+```
+Each constant uses `create_service_registration(ID_CONST, create_service_module_path(TIFERET, <base>, <domain>), 'ClassName')`.
+
+| Constant | ID Constant | base | domain | class_name |
+|---|---|---|---|---|
+| `ADD_FEATURE_EVT` | `ADD_FEATURE_EVT_ID` | `TIFERET_EVENTS_PATH` | `FEATURE_DOMAIN_PATH` | `'AddFeature'` |
+```
+
+**Combining both expressions** — when a code section contains scalar ID constants followed by factory-built object constants (the three-section catalog pattern), produce two tables in sequence under the same `####` heading. The second table references constant names from the first (not bare string values), making the dependency between sections explicit and verifiable.
+
+**Supplementary notes** serve three purposes within an Add Constant block: ordering (which subsection must land before another), naming conventions that apply across all rows (state once rather than repeat per row), and invariants such as optional-field omission rules. Place them as a bold or italic note immediately before or after the table they govern.
+
+### Informational Completeness Requirement
+
+A table row must contain every parameter needed to produce the artifact:
+- For scalar constants: the constant name and its exact value.
+- For factory-built constants: all factory arguments, including which previously-defined constant is passed where. Reference prior constants by their constant name (e.g. `ROOT_LOGGER_ID`), not by their string value (`'root'`), so the dependency chain is derivable.
+- For optional fields: if a field is conditionally included, the condition must be resolvable from the table alone (e.g. a column whose cell is blank when the field is omitted).
+
+This completeness requirement means the same table can serve as the input to a code-generating agent, a test-generating agent, or a future declarative DSL compiler — the notation is the specification, not a summary of it.
+
+### Section-Mirroring in §4
+
+Map each `# *** constants (<name>)` code section directly to a `####` sub-heading in §4, using the exact code section label as the heading text (e.g. `#### Add: # *** constants (ids)`). An implementation agent works section-by-section; the heading correspondence eliminates ambiguity about which part of the file each table governs.
+
+### Constant Section Subgroups
+
+When a module contains many constants of a given type, organize them into named `# *** constants (<subgroup>)` sections — not a flat `# *** constants` block. The subgroup label is semantic: it names what the group *represents*.
+
+Canonical subgroup labels: `(ids)`, `(paths_packages)`, `(paths_domains)`, `(features)`, `(services)`, `(commands)`, `(formatters)`, `(handlers)`, `(loggers)`, `(groups)`, etc.
+
+The section-mirroring rule extends to subgroup level: each `# *** constants (<subgroup>)` code section maps 1:1 to a `#### Add: # *** constants (<subgroup>)` heading in §4. A flat `# *** constants` block where subgroups apply is a defect — assert the correct structure in §5 AC. The Reviewer verifies both the section label and entry count exactly. Issues #935 and #939 are the canonical reference examples of correct subgroup structure.
+
+### "Update Constant" and "Remove Constant"
+
+- **Update**: use a delta table with columns for the current value and the target value (or target expression). Identify each constant by name in the first column. State unchanged fields only if they provide disambiguation context.
+- **Remove**: a plain list of artifact labels is sufficient. Assert removal in §5.
+
 ## Migration and Parity Stories (implementation-source-agnostic)
 
 When a story moves work toward a prototype or other source branch (e.g., a parity milestone), the **dev-facing TRD must be branch-agnostic and written in the target ubiquitous language**. Extract the domain terminology and artifacts from the source and specify them directly.
@@ -118,7 +177,19 @@ A child that is a prerequisite for one or more sibling children carries **P0**. 
 
 ### Super-TRD closing
 
-The parent issue closes when all child sub-issues are closed. When the last child's issue is closed, also rename the parent's TRD file to `.complete.md` and close the parent GitHub issue.
+The parent issue closes when all child sub-issues are closed. The **Closer** agent renames the parent's TRD file to `.complete.md` after posting the Collaboration Report and verifying the PR has been merged. GitHub automation typically closes the parent issue and sets project status to Done when the PR squash-merges via the `Closes #<parent>` line — verify before acting manually.
+
+### Child TRD size cap
+
+A child TRD covers exactly **one primary module**, its test file (if applicable), and at most **1–2 non-testable dependency touches** (e.g. a factory in `core.py` the primary module uses, or an `__init__.py` export). Maximum size is **Medium (3 pts)**.
+
+| Scope | Size |
+|---|---|
+| Single file only | XS (1 pt) |
+| Primary module + tests | S (2 pts) |
+| Primary module + tests + 1–2 dependency touches | M (3 pts) |
+
+If a child would exceed M (3 pts), split it into additional children. Issues #935 and #939 are the canonical reference examples of correct child scoping.
 
 ## Review Checklist
 Before finalizing:
@@ -203,6 +274,8 @@ mv .trd/m30_895_assets-error-catalog-extraction__L_5_P0.md \
 
 For **super-TRD parents**: when the last child issue closes, check if all sibling children are `.complete.md`; if so, also rename the parent and close the parent GitHub issue.
 
+**`git mv` vs `mv`:** When transitioning a TRD file to `.complete.md` during the implementation phase, prefer `git mv` if the file is tracked in a commit. If `.trd/` is listed in `.gitignore` (exit code 128: "not under version control"), use plain `mv` instead — the rename is still a meaningful local signal regardless of whether it is tracked.
+
 ### `.milestones/` — milestone description payloads
 
 `.milestones/` stores Markdown files used as `gh api` description payloads. The milestone number prefix is required:
@@ -225,6 +298,16 @@ gh api repos/greatstrength/tiferet/milestones/<number> \
 ```
 
 ## GitHub Issue Creation
+
+### Impact analysis before creating issues
+
+Before creating GitHub issues from TRD files, verify that no recently merged PRs **and no in-flight feature branches** invalidate the TRD content:
+
+- Check the latest merged PRs: `gh pr list --repo greatstrength/tiferet --state merged --json number,title,mergedAt`
+- Check any active feature branches (e.g. an in-progress Super-TRD): `git branch -r | grep -v HEAD` — read the current state of touched files on those branches, not just on `main`.
+- If a landed PR or a sibling TRD already on an in-flight feature branch has applied changes the TRD expects to find (or removed things the TRD intends to remove), the TRD may need updating before it goes live.
+
+This is especially important for Super-TRDs with sequenced children: the "current state" of a file for Child 2 is the feature branch after Child 1 has landed, not `main`.
 
 ### Creating an issue
 

--- a/docs/core/domain.md
+++ b/docs/core/domain.md
@@ -169,7 +169,7 @@ Domain objects are defined in `tiferet/domain/`:
 - `logging.py` – `Formatter`, `Handler`, `Logger`, `LoggingSettings`.
 - `__init__.py` – Public exports for all domain objects.
 
-Tests live in `tiferet/domain/tests/`.
+Tests live in `tests/domain/`.
 
 ## Conclusion
 
@@ -178,4 +178,4 @@ Domain objects provide the **structural foundation** for the entire Tiferet fram
 - Reliable persistent configuration via Aggregate and TransferObject extensions.
 - A single source of truth shared across all layers.
 
-Explore source in `tiferet/domain/` and tests in `tiferet/domain/tests/` for implementation details.
+Explore source in `tiferet/domain/` and tests in `tests/domain/` for implementation details.

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -292,7 +292,7 @@ class TestGetError(ServiceEventTestBase):
 
 #### Conftest Hook
 
-The `pytest_generate_tests` hook in `tiferet/events/tests/conftest.py` dynamically parametrizes `test_missing_required_params` over the `required_params` list for any `DomainEventTestBase` subclass:
+The `pytest_generate_tests` hook in `tests/events/conftest.py` dynamically parametrizes `test_missing_required_params` over the `required_params` list for any `DomainEventTestBase` subclass:
 
 ```python
 def pytest_generate_tests(metafunc):
@@ -419,8 +419,8 @@ The test harness lives in `tiferet/testing/`:
 - `tiferet/testing/mappers.py` – `AggregateTestBase`, `TransferObjectTestBase`, `MapperAssertions`.
 - `tiferet/testing/domain.py` – `DomainEventTestBase`, `ServiceEventTestBase`.
 - `tiferet/testing/hooks.py` – `register_mapper_hooks`, `register_event_hooks`.
-- Per-module test suites live in `tiferet/events/tests/` (e.g., `test_app.py`, `test_cli.py`, etc.).
+- Per-module test suites live in `tests/events/` (e.g., `test_app.py`, `test_cli.py`, etc.).
 
 ## Conclusion
 
-Domain events are the operational core of Tiferet applications, providing validated, injectable domain operations. Their structured design ensures consistency, testability, and extensibility. The test harness (`DomainEventTestBase` / `ServiceEventTestBase`) eliminates boilerplate while enforcing consistent coverage of required-parameter validation and not-found error paths. Developers can create new events by following the artifact pattern and new tests by extending the harness. Explore `tiferet/events/` for source and `tiferet/events/tests/` for test examples.
+Domain events are the operational core of Tiferet applications, providing validated, injectable domain operations. Their structured design ensures consistency, testability, and extensibility. The test harness (`DomainEventTestBase` / `ServiceEventTestBase`) eliminates boilerplate while enforcing consistent coverage of required-parameter validation and not-found error paths. Developers can create new events by following the artifact pattern and new tests by extending the harness. Explore `tiferet/events/` for source and `tests/events/` for test examples.

--- a/docs/core/mappers.md
+++ b/docs/core/mappers.md
@@ -423,7 +423,7 @@ Mappers are defined in `tiferet/mappers/`:
 - `logging.py` — `FormatterAggregate`, `HandlerAggregate`, `LoggerAggregate`, and their ConfigObject counterparts.
 - `__init__.py` — Public exports.
 
-Tests live in `tiferet/mappers/tests/`.
+Tests live in `tests/mappers/`.
 
 ## Conclusion
 
@@ -431,4 +431,4 @@ The mappers layer provides the structural bridge between persistent configuratio
 - Validated, mutation-safe domain updates.
 - Role-based serialization for multiple output formats.
 
-Explore source in `tiferet/mappers/` and tests in `tiferet/mappers/tests/` for implementation details.
+Explore source in `tiferet/mappers/` and tests in `tests/mappers/` for implementation details.


### PR DESCRIPTION
## Summary

Adds a dedicated `docs/collab/super_trd_workflow.md` as the canonical Super-TRD execution reference, incorporates process improvement notes from completed Super-TRD exercise sessions into the role skills and collaboration docs, adds a keyword argument rule for optional parameters to the code style reference, and corrects stale test-path references across five documentation files.

## Changes

### New
- **`docs/collab/super_trd_workflow.md`** — Dedicated canonical reference for the Super-TRD execution workflow. Covers single-branch strategy, four-role model (Starter / Implementor / Reviewer / Closer), state machine, PR body template Starter-gate requirement, sibling branch impact analysis, before-posting checklist, Reviewer AC update authority, and the conversation link retrieval step required before drafting a Collaboration Report.

### Updated — Collaboration docs
- **`docs/collab/main.md`** — Super-TRD Workflow section trimmed to a brief role table and pointer to the new `super_trd_workflow.md`; GitHub automation and PR→issue convention paragraphs retained.
- **`docs/collab/tech_requirements.md`** — Two additions: a `git mv` fallback note for git-ignored `.trd/` directories; a new "Impact analysis before creating issues" subsection covering in-flight sibling feature branches.

### Updated — Skills
- **`tiferet-super-trd-implementor`** — Adds PR body template Starter-gate requirement; `git mv` fallback for `.trd/` rename; same-session implementor comment convention clarification; sibling branch impact analysis guidance; canonical source pointer updated.
- **`tiferet-super-trd-reviewer`** — Adds before-posting checklist (conversation link, findings summary, and `Co-Authored-By` line are all mandatory); Reviewer AC update authority procedure for intentional developer-approved deviations; canonical source pointer updated.
- **`tiferet-super-trd-closer`** — Adds explicit conversation link retrieval step before drafting the Collaboration Report; canonical source pointer updated.
- **`tiferet-author-trd`** — Verbose operation-level notation tables trimmed; replaced with a 3-sentence summary and pointer to `docs/collab/tech_requirements.md`.
- **`tiferet-code-style`** — Adds keyword argument rule: optional parameters in function/factory calls must be passed as keyword arguments, not positionally.
- **`tiferet-code-assets`** — Adds optional parameter factory call note; cross-references `tiferet-code-style`.

### Updated — Code style doc
- **`docs/core/code_style.md`** — New "Keyword Arguments for Optional Parameters" subsection with correct/incorrect examples.

### Fixed — Stale test paths
- **`AGENTS.md`**, **`docs/core/domain.md`**, **`docs/core/events.md`**, **`docs/core/mappers.md`** — Updated from co-located `tiferet/<component>/tests/` to `tests/<component>/` at the repository root; `pytest tiferet/` updated to `pytest tests/`.

### Updated — Navigation
- **`CONTRIBUTING.md`** — Working with AI Agents section now includes Super-TRD skills block and pointer to `docs/collab/super_trd_workflow.md`.

Co-Authored-By: Oz <oz-agent@warp.dev>