### PR TITLE
RFP - CLI Argument Type System

### DIFF
--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -490,7 +490,6 @@ def test_create_default_cli_argument_includes_optional_fields_when_provided() ->
         required=True,
         nargs='?',
         choices=['DEBUG', 'INFO', 'WARNING'],
-        action='store',
     )
 
     # Assert all optional fields are present with correct values.
@@ -500,7 +499,6 @@ def test_create_default_cli_argument_includes_optional_fields_when_provided() ->
     assert result['required'] is True
     assert result['nargs'] == '?'
     assert result['choices'] == ['DEBUG', 'INFO', 'WARNING']
-    assert result['action'] == 'store'
 
 # ** test: create_default_cli_command_returns_required_fields
 def test_create_default_cli_command_returns_required_fields() -> None:

--- a/tests/contexts/test_cli.py
+++ b/tests/contexts/test_cli.py
@@ -145,7 +145,7 @@ def test_build_parser_merges_parent_args_and_skips_collisions():
 
     # Arrange parent arguments including one that collides with the command arg.
     parent_arguments = [
-        CliArgument(name_or_flags=['--verbose'], action='store_true'),
+        CliArgument(name_or_flags=['--verbose'], type='bool'),
         CliArgument(name_or_flags=['a']),
     ]
 

--- a/tests/domain/test_cli.py
+++ b/tests/domain/test_cli.py
@@ -143,29 +143,199 @@ def test_cli_argument_to_argparse_kwargs_value_action() -> None:
     assert 'action' not in kwargs
     assert 'required' not in kwargs
 
-# ** test: cli_argument_to_argparse_kwargs_flag_action
-def test_cli_argument_to_argparse_kwargs_flag_action() -> None:
+# ** test: cli_argument_to_argparse_kwargs_bool_type
+def test_cli_argument_to_argparse_kwargs_bool_type() -> None:
     '''
-    Test that flag actions omit value-only keywords.
+    Test that type=\'bool\' maps to action=\'store_true\' and omits value-only keywords.
     '''
 
-    # Build a flag argument.
+    # Build a boolean flag argument.
     argument = CliArgument(
         name_or_flags=['--verbose'],
         description='Enable verbose output.',
-        action='store_true',
+        type='bool',
     )
 
     # Build the argparse keyword arguments.
     kwargs = argument.to_argparse_kwargs()
 
-    # Assert the action and help are present and value-only keywords are omitted.
+    # Assert store_true action and help are present; no value-only keywords.
     assert kwargs['action'] == 'store_true'
     assert kwargs['help'] == 'Enable verbose output.'
     assert 'type' not in kwargs
     assert 'nargs' not in kwargs
     assert 'choices' not in kwargs
     assert 'default' not in kwargs
+
+# ** test: cli_argument_to_argparse_kwargs_json_type
+def test_cli_argument_to_argparse_kwargs_json_type() -> None:
+    '''
+    Test that type=\'json\' sets type=json.loads for argparse-native decoding.
+    '''
+    import json
+
+    # Build a JSON argument.
+    argument = CliArgument(
+        name_or_flags=['--config'],
+        description='Configuration as JSON string.',
+        type='json',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert json.loads is wired as the type callable.
+    assert kwargs['type'] is json.loads
+    assert kwargs['help'] == 'Configuration as JSON string.'
+    assert 'nargs' not in kwargs
+    assert 'action' not in kwargs
+
+# ** test: cli_argument_to_argparse_kwargs_list_type
+def test_cli_argument_to_argparse_kwargs_list_type() -> None:
+    '''
+    Test that type=\'list\' sets nargs=\'*\' by default.
+    '''
+
+    # Build a list argument with no explicit nargs.
+    argument = CliArgument(
+        name_or_flags=['--handlers'],
+        description='Handler IDs.',
+        type='list',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert nargs defaults to '*' and type is str.
+    assert kwargs['nargs'] == '*'
+    assert kwargs['type'] is str
+    assert 'action' not in kwargs
+
+# ** test: cli_argument_to_argparse_kwargs_list_type_nargs_override
+def test_cli_argument_to_argparse_kwargs_list_type_nargs_override() -> None:
+    '''
+    Test that an explicit nargs overrides the list default of \'*\'.
+    '''
+
+    # Build a list argument requiring at least one token.
+    argument = CliArgument(
+        name_or_flags=['--handlers'],
+        description='At least one handler ID required.',
+        type='list',
+        nargs='+',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert the explicit nargs wins.
+    assert kwargs['nargs'] == '+'
+
+# ** test: cli_argument_to_argparse_kwargs_dict_type
+def test_cli_argument_to_argparse_kwargs_dict_type() -> None:
+    '''
+    Test that type=\'dict\' sets nargs=\'*\' and type=str by default.
+    '''
+
+    # Build a dict argument.
+    argument = CliArgument(
+        name_or_flags=['--constants'],
+        description='Key=value constant pairs.',
+        type='dict',
+    )
+
+    # Build the argparse keyword arguments.
+    kwargs = argument.to_argparse_kwargs()
+
+    # Assert nargs defaults to '*' and type is str.
+    assert kwargs['nargs'] == '*'
+    assert kwargs['type'] is str
+    assert 'action' not in kwargs
+
+# ** test: cli_argument_get_dest_long_flag
+def test_cli_argument_get_dest_long_flag() -> None:
+    '''
+    Test that get_dest derives the dest from the first long flag.
+    '''
+
+    # Build an argument with a long flag containing a hyphen.
+    argument = CliArgument(name_or_flags=['-f', '--foo-bar'])
+
+    # Assert the dest normalises hyphens to underscores.
+    assert argument.get_dest() == 'foo_bar'
+
+# ** test: cli_argument_get_dest_short_flag
+def test_cli_argument_get_dest_short_flag() -> None:
+    '''
+    Test that get_dest falls back to the short flag when no long flag exists.
+    '''
+
+    # Build an argument with only a short flag.
+    argument = CliArgument(name_or_flags=['-v'])
+
+    # Assert the dest is the stripped flag letter.
+    assert argument.get_dest() == 'v'
+
+# ** test: cli_argument_get_dest_positional
+def test_cli_argument_get_dest_positional() -> None:
+    '''
+    Test that get_dest returns the positional name directly.
+    '''
+
+    # Build a positional argument.
+    argument = CliArgument(name_or_flags=['config_file'])
+
+    # Assert the dest is the positional name.
+    assert argument.get_dest() == 'config_file'
+
+# ** test: cli_argument_parse_value_dict
+def test_cli_argument_parse_value_dict() -> None:
+    '''
+    Test that parse_value assembles a list of key=value strings into a dict.
+    '''
+
+    # Build a dict-typed argument.
+    argument = CliArgument(name_or_flags=['--params'], type='dict')
+
+    # Apply parse_value to a list of raw key=value tokens.
+    result = argument.parse_value(['key1=value1', 'key2=value2'])
+
+    # Assert the result is a properly keyed dict.
+    assert result == {'key1': 'value1', 'key2': 'value2'}
+
+# ** test: cli_argument_parse_value_dict_with_equals_in_value
+def test_cli_argument_parse_value_dict_with_equals_in_value() -> None:
+    '''
+    Test that parse_value splits on the first '=' only, preserving values that
+    contain '=' characters.
+    '''
+
+    # Build a dict-typed argument.
+    argument = CliArgument(name_or_flags=['--params'], type='dict')
+
+    # Apply parse_value to a token whose value itself contains '='.
+    result = argument.parse_value(['url=http://example.com?a=1'])
+
+    # Assert only the first '=' is used as the separator.
+    assert result == {'url': 'http://example.com?a=1'}
+
+# ** test: cli_argument_parse_value_passthrough
+def test_cli_argument_parse_value_passthrough() -> None:
+    '''
+    Test that parse_value returns values unchanged for non-dict types.
+    '''
+
+    # Assert str passes through unchanged.
+    str_arg = CliArgument(name_or_flags=['--name'], type='str')
+    assert str_arg.parse_value('hello') == 'hello'
+
+    # Assert list passes through unchanged (already a list from argparse).
+    list_arg = CliArgument(name_or_flags=['--items'], type='list')
+    assert list_arg.parse_value(['a', 'b']) == ['a', 'b']
+
+    # Assert int passes through unchanged.
+    int_arg = CliArgument(name_or_flags=['--count'], type='int')
+    assert int_arg.parse_value(42) == 42
 
 # ** test: cli_command_new
 def test_cli_command_new(cli_command: CliCommand) -> None:

--- a/tests/events/test_app.py
+++ b/tests/events/test_app.py
@@ -245,16 +245,16 @@ class TestGetAppSession(ServiceEventTestBase):
     service_attr = 'app_service'
 
     # * attribute: sample_kwargs
-    sample_kwargs = dict(interface_id='test')
+    sample_kwargs = dict(id='test')
 
     # * attribute: required_params
-    required_params = ['interface_id']
+    required_params = ['id']
 
     # * attribute: not_found_error_code
     not_found_error_code = a.error.APP_SESSION_NOT_FOUND_ID
 
     # * attribute: not_found_kwargs
-    not_found_kwargs = dict(interface_id='non_existent_id')
+    not_found_kwargs = dict(id='non_existent_id')
 
     # * method: test_success
     def test_success(self, mock_dependencies, app_interface):
@@ -285,7 +285,7 @@ class TestGetAppSession(ServiceEventTestBase):
         mock_dependencies['app_service'].get.return_value = domain_interface
 
         # Execute via the harness handle helper.
-        result = self.handle(mock_dependencies, interface_id='test.interface')
+        result = self.handle(mock_dependencies, id='test.interface')
 
         # Assert the stored interface is returned unchanged (no aggregate re-wrap).
         assert result is domain_interface

--- a/tests/mappers/test_cli.py
+++ b/tests/mappers/test_cli.py
@@ -18,7 +18,6 @@ ARGUMENT_AGGREGATE_SAMPLE_DATA = {
     'type': 'str',
     'required': False,
     'default': 'false',
-    'action': 'store_true',
 }
 
 # ** constant: command_aggregate_sample_data
@@ -49,7 +48,6 @@ ARGUMENT_EQUALITY_FIELDS = [
     'type',
     'required',
     'default',
-    'action',
 ]
 
 # ** constant: command_equality_fields
@@ -106,7 +104,6 @@ class TestCliArgumentAggregate(AggregateTestBase):
         ('type', 'int', None),
         ('required', True, None),
         ('default', 'new_default', None),
-        ('action', 'store_false', None),
         # invalid
         ('name_or_flags', ['b'], a.error.INVALID_MODEL_ATTRIBUTE_ID),
         ('invalid_attr', 'value', a.error.INVALID_MODEL_ATTRIBUTE_ID),
@@ -173,7 +170,7 @@ class TestCliCommandAggregate(AggregateTestBase):
         aggregate.add_argument(
             name_or_flags=['-v', '--verbose'],
             description='Enable verbose output.',
-            action='store_true',
+            type='bool',
         )
 
         # Assert both arguments were added.
@@ -181,7 +178,7 @@ class TestCliCommandAggregate(AggregateTestBase):
         assert aggregate.arguments[-2].name_or_flags == ['c']
         assert aggregate.arguments[-2].type == 'float'
         assert aggregate.arguments[-1].name_or_flags == ['-v', '--verbose']
-        assert aggregate.arguments[-1].action == 'store_true'
+        assert aggregate.arguments[-1].type == 'bool'
 
     # ** test: add_argument_to_empty
     def test_add_argument_to_empty(self):

--- a/tests/repos/test_cli.py
+++ b/tests/repos/test_cli.py
@@ -71,7 +71,7 @@ CLI_DATA: Dict = {
             {
                 'name_or_flags': ['--verbose', '-v'],
                 'description': 'Enable verbose output.',
-                'action': 'store_true',
+                'type': 'bool',
             },
             {
                 'name_or_flags': ['--config', '-c'],
@@ -207,7 +207,7 @@ def test_int_cli_config_repo_get_parent_arguments(
     assert len(parent_args) == 2
     assert parent_args[0].name_or_flags == ['--verbose', '-v']
     assert parent_args[0].description == 'Enable verbose output.'
-    assert parent_args[0].action == 'store_true'
+    assert parent_args[0].type == 'bool'
     assert parent_args[1].name_or_flags == ['--config', '-c']
     assert parent_args[1].description == 'Path to configuration file.'
 
@@ -318,7 +318,7 @@ def test_int_cli_config_repo_save_parent_arguments(
         CliArgumentAggregate(
             name_or_flags=['--debug', '-d'],
             description='Enable debug mode.',
-            action='store_true',
+            type='bool',
         ),
         CliArgumentAggregate(
             name_or_flags=['--output', '-o'],
@@ -338,6 +338,6 @@ def test_int_cli_config_repo_save_parent_arguments(
     assert len(reloaded_args) == 2
     assert reloaded_args[0].name_or_flags == ['--debug', '-d']
     assert reloaded_args[0].description == 'Enable debug mode.'
-    assert reloaded_args[0].action == 'store_true'
+    assert reloaded_args[0].type == 'bool'
     assert reloaded_args[1].name_or_flags == ['--output', '-o']
     assert reloaded_args[1].description == 'Output file path.'

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -157,8 +157,8 @@ APP_ADD_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['class_name'], 'Name of the context class.'),
         create_default_cli_argument(['--description'], 'Optional description.'),
         create_default_cli_argument(['--logger-id'], 'Logger identifier (default: default).', default='default'),
-        create_default_cli_argument(['--services'], 'Service dependencies as JSON string.'),
-        create_default_cli_argument(['--constants'], 'Constants as JSON string.'),
+        create_default_cli_argument(['--services'], 'Service dependencies as JSON string.', type='json'),
+        create_default_cli_argument(['--constants'], 'Constants as JSON string.', type='json'),
     ],
 )
 
@@ -206,7 +206,7 @@ APP_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
     description='Set or clear constants on an app interface.',
     arguments=[
         create_default_cli_argument(['id'], 'The interface identifier.'),
-        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
+        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.', type='json'),
     ],
 )
 
@@ -222,7 +222,7 @@ APP_SET_SERVICE_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['service_id'], 'The service dependency identifier.'),
         create_default_cli_argument(['module_path'], 'Module path for the service.'),
         create_default_cli_argument(['class_name'], 'Class name for the service.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
     ],
 )
 
@@ -328,7 +328,7 @@ ERROR_LIST_CLI_CMD = create_default_cli_command(
     'List Errors',
     description='List all error definitions.',
     arguments=[
-        create_default_cli_argument(['--include-defaults'], 'Include built-in default errors.', action='store_true'),
+        create_default_cli_argument(['--include-defaults'], 'Include built-in default errors.', type='bool'),
     ],
 )
 
@@ -460,7 +460,7 @@ FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['id'], 'The feature identifier.'),
         create_default_cli_argument(['name'], 'The step name.'),
         create_default_cli_argument(['service_id'], 'The service configuration ID for the step.'),
-        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.'),
+        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.', type='json'),
         create_default_cli_argument(['--data-key'], 'Optional result data key.'),
         create_default_cli_argument(['--position'], 'Insertion position (default: append).', type='int'),
     ],
@@ -523,8 +523,8 @@ SERVICE_ADD_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['id'], 'The unique service configuration identifier.'),
         create_default_cli_argument(['--module-path'], 'Default module path.'),
         create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.'),
-        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.'),
+        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.', type='json'),
+        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.', type='json'),
     ],
 )
 
@@ -548,7 +548,7 @@ SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['id'], 'The service configuration identifier.'),
         create_default_cli_argument(['--module-path'], 'Default module path.'),
         create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
     ],
 )
 
@@ -564,7 +564,7 @@ SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
         create_default_cli_argument(['flag'], 'The flag identifying the dependency.'),
         create_default_cli_argument(['module_path'], 'Module path for the dependency.'),
         create_default_cli_argument(['class_name'], 'Class name for the dependency.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.'),
+        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
     ],
 )
 
@@ -601,7 +601,7 @@ SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
     'Set Service Constants',
     description='Set or clear service-level constants.',
     arguments=[
-        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.'),
+        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.', type='json'),
     ],
 )
 
@@ -686,7 +686,7 @@ LOGGING_ADD_LOGGER_CLI_CMD = create_default_cli_command(
         ),
         create_default_cli_argument(['handlers'], 'Comma-separated list of handler IDs.'),
         create_default_cli_argument(['--description'], 'Optional description.'),
-        create_default_cli_argument(['--no-propagate'], 'Disable message propagation.', action='store_true'),
+        create_default_cli_argument(['--no-propagate'], 'Disable message propagation.', type='bool'),
     ],
 )
 

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -430,7 +430,6 @@ def create_default_cli_argument(
         required: bool = None,
         nargs: str = None,
         choices: List[str] = None,
-        action: str = None,
     ) -> Dict[str, Any]:
     '''
     Build a default CLI argument definition dictionary.
@@ -439,18 +438,19 @@ def create_default_cli_argument(
     :type name_or_flags: List[str]
     :param description: Optional argument description surfaced as help text.
     :type description: str
-    :param type: Optional argument type string (``'str'``, ``'int'``, ``'float'``).
+    :param type: Optional argument type string (``'str'``, ``'int'``, ``'float'``,
+        ``'bool'``, ``'json'``, ``'list'``, or ``'dict'``).
     :type type: str
     :param default: Optional default value when the argument is not provided.
     :type default: Any
     :param required: Optional flag indicating whether the argument is required.
     :type required: bool
-    :param nargs: Optional argument count specifier (``'?'``, ``'*'``, ``'+'``).
+    :param nargs: Optional argument count specifier (``'?'``, ``'*'``, ``'+'``,
+        or an integer).  For ``'list'`` and ``'dict'`` types this defaults to
+        ``'*'`` automatically; only set when a different count is required.
     :type nargs: str
     :param choices: Optional list of allowed values for the argument.
     :type choices: List[str]
-    :param action: Optional argparse action string (e.g. ``'store_true'``).
-    :type action: str
     :return: The default CLI argument definition.
     :rtype: Dict[str, Any]
     '''
@@ -471,8 +471,6 @@ def create_default_cli_argument(
         argument['nargs'] = nargs
     if choices is not None:
         argument['choices'] = choices
-    if action is not None:
-        argument['action'] = action
 
     # Return the assembled argument definition.
     return argument

--- a/tiferet/blueprints/admin_cli.py
+++ b/tiferet/blueprints/admin_cli.py
@@ -3,9 +3,7 @@
 # *** imports
 
 # ** core
-import json
-import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 # ** app
 from .. import assets as a
@@ -27,91 +25,6 @@ from ..contexts.cli import (
     get_default_cli_commands,
 )
 from ..di import injectable_parameter_names
-
-# *** functions
-
-# ** function: _decode_json_arguments
-def _decode_json_arguments(parsed: Dict[str, Any]) -> Dict[str, Any]:
-    '''
-    Decode JSON-valued CLI arguments in place.
-
-    Complex arguments (``parameters``, ``constants``, ``services``, and
-    ``flagged_dependencies``) arrive from argparse as raw strings.  This helper
-    parses each present string value with ``json.loads`` so domain events
-    receive structured data.  Malformed JSON results in a controlled CLI exit
-    rather than an unhandled traceback.
-
-    :param parsed: The parsed argument namespace as a dictionary.
-    :type parsed: Dict[str, Any]
-    :return: The parsed dictionary with JSON-valued arguments decoded.
-    :rtype: Dict[str, Any]
-    '''
-
-    # The complex argument keys whose string values carry JSON payloads.
-    json_keys = ('parameters', 'constants', 'services', 'flagged_dependencies')
-
-    # Decode each present string value, failing cleanly on malformed JSON.
-    for key in json_keys:
-        value = parsed.get(key)
-        if isinstance(value, str):
-            try:
-                parsed[key] = json.loads(value)
-            except json.JSONDecodeError as e:
-                print(
-                    f"Invalid JSON for argument '--{key.replace('_', '-')}': {e}",
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-
-    # Return the parsed dictionary with decoded values.
-    return parsed
-
-
-# ** function: _admin_parse_cli_args_handler
-def _admin_parse_cli_args_handler(
-        list_commands_evt,
-        get_parent_args_evt,
-        default_commands_list=None,
-    ) -> Callable:
-    '''
-    Build a CLI arg-parser closure that includes JSON decoding for admin arguments.
-
-    Wraps the standard :func:`parse_cli_args_handler` and post-processes the
-    parsed data dict through :func:`_decode_json_arguments` so complex admin CLI
-    arguments (``--parameters``, ``--constants``, etc.) are decoded from raw
-    JSON strings into structured Python objects before feature dispatch.
-
-    :param list_commands_evt: The event used to list CLI commands.
-    :param get_parent_args_evt: The event used to retrieve parent-level CLI arguments.
-    :param default_commands_list: Bootstrap default commands used when the
-        repository returns no results.
-    :type default_commands_list: List | None
-    :return: A closure that parses argv and returns (feature_id, headers, data)
-        with JSON-valued arguments decoded.
-    :rtype: Callable
-    '''
-
-    # Build the standard parse handler and wrap it with JSON decoding.
-    base_handler = parse_cli_args_handler(
-        list_commands_evt,
-        get_parent_args_evt,
-        default_commands_list,
-    )
-
-    # Return the wrapping handler closure.
-    def handler(argv=None) -> Tuple[str, Dict[str, str], Dict[str, Any]]:
-
-        # Delegate to the standard handler to parse argv.
-        feature_id, headers, data = base_handler(argv)
-
-        # Decode JSON-valued arguments before returning.
-        data = _decode_json_arguments(data)
-
-        # Return the feature request tuple with decoded data.
-        return feature_id, headers, data
-
-    return handler
-
 
 # *** blueprints
 
@@ -175,8 +88,8 @@ def build_admin_cli_session_context(
     list_commands_evt = app_container.get_dependency('list_commands_evt')
     get_parent_args_evt = app_container.get_dependency('get_parent_args_evt')
 
-    # Build the _parse_cli_args closure with admin JSON-decoding support.
-    parse_cli_args = _admin_parse_cli_args_handler(
+    # Build the _parse_cli_args closure via the standard type-aware handler.
+    parse_cli_args = parse_cli_args_handler(
         list_commands_evt,
         get_parent_args_evt,
         get_default_cli_commands(cache),

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -204,6 +204,29 @@ def parse_cli_args_handler(
         # Derive the feature id and headers from the parsed dict.
         feature_id, headers = derive_feature_request(parsed)
 
+        # Resolve the active command for type-aware value interpretation.
+        active_command = next(
+            (
+                cmd for cmd in cli_commands
+                if cmd.group_key == parsed.get('group', '')
+                and cmd.key == parsed.get('command', '')
+            ),
+            None,
+        )
+
+        # Apply parse_value to each active command argument.
+        if active_command:
+            for arg in active_command.arguments:
+                dest = arg.get_dest()
+                if dest in parsed:
+                    parsed[dest] = arg.parse_value(parsed[dest])
+
+        # Apply parse_value to each parent argument.
+        for arg in parent_arguments:
+            dest = arg.get_dest()
+            if dest in parsed:
+                parsed[dest] = arg.parse_value(parsed[dest])
+
         # Return the feature request tuple.
         return feature_id, headers, parsed
 

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -416,7 +416,7 @@ class AppSessionContext(BaseContext):
         return DomainEvent.handle(
             GetAppSession,
             dependencies=dict(app_service=app_service),
-            interface_id=interface_id,
+            id=interface_id,
         )
 
     # * method: load_logging_context

--- a/tiferet/domain/cli.py
+++ b/tiferet/domain/cli.py
@@ -3,6 +3,7 @@
 # *** imports
 
 # ** core
+import json
 from typing import Any, Dict, List, Literal
 
 # ** infra
@@ -167,9 +168,14 @@ class CliArgument(DomainObject):
     )
 
     # * attribute: type
-    type: Literal['str', 'int', 'float'] = Field(
+    type: Literal['str', 'int', 'float', 'bool', 'json', 'list', 'dict'] = Field(
         default='str',
-        description='The type of the argument. Can be "str", "int", or "float". Defaults to "str".',
+        description=(
+            'The argument input shape. Scalar types ("str", "int", "float") consume a single '
+            'value; "bool" is a presence/absence toggle (no value consumed); "json" decodes a '
+            'single JSON string at parse time; "list" collects space-separated string tokens; '
+            '"dict" collects space-separated key=value token pairs. Defaults to "str".'
+        ),
     )
 
     # * attribute: required
@@ -196,32 +202,21 @@ class CliArgument(DomainObject):
         description='The number of arguments that should be consumed. Can be an integer or "?" for optional, "*" for zero or more, or "+" for one or more.',
     )
 
-    # * attribute: action
-    action: Literal[
-        'store',
-        'store_const',
-        'store_true',
-        'store_false',
-        'append',
-        'append_const',
-        'count',
-        'help',
-        'version',
-    ] | None = Field(
-        default=None,
-        description='The action to be taken when the argument is encountered.',
-    )
-
     # * method: get_type
     def get_type(self) -> type:
         '''
-        Get the Python type that corresponds to the argument's declared type.
+        Get the Python type callable for scalar argument types.
+
+        Returns the builtin type corresponding to the declared scalar ``type``
+        (``'str'``, ``'int'``, or ``'float'``).  Non-scalar types are handled
+        directly by ``to_argparse_kwargs``; this method returns ``str`` as a
+        safe fallback for any unrecognised value.
 
         :return: The corresponding Python type.
         :rtype: type
         '''
 
-        # Map the type string to a Python type.
+        # Map the scalar type string to a Python builtin.
         if self.type == 'str':
             return str
         elif self.type == 'int':
@@ -229,7 +224,7 @@ class CliArgument(DomainObject):
         elif self.type == 'float':
             return float
 
-        # If the type is not recognized, return str as a default.
+        # Non-scalar types are handled by to_argparse_kwargs; return str as fallback.
         else:
             return str
 
@@ -238,38 +233,105 @@ class CliArgument(DomainObject):
         '''
         Express this CLI argument in the form an argparse parser expects.
 
-        A ``CliArgument`` is the domain's declarative description of one command
-        input; this adapts that description so the argument can be registered on
-        an argparse parser. The human-readable ``description`` is surfaced as the
-        argument's ``help`` text, and its declared type is resolved to a concrete
-        type. Because an argument that captures a value means something different
-        from a simple on/off flag, value-bearing arguments keep their type,
-        allowed count (``nargs``), and permitted ``choices``, while flag-style
-        arguments leave those value-only details out.
+        Each ``type`` variant maps to a distinct argparse configuration.
+        ``'bool'`` maps to ``action='store_true'`` (no value consumed);
+        ``'json'`` uses ``json.loads`` so the single string value is decoded
+        at parse time; ``'list'`` and ``'dict'`` collect space-separated tokens
+        via ``nargs='*'`` (overridden by an explicit ``nargs``); scalar types
+        (``'str'``, ``'int'``, ``'float'``) resolve their Python builtin and
+        honour any declared ``nargs`` and ``choices``.
 
         :return: The keyword arguments for ``add_argument``.
         :rtype: Dict[str, Any]
         '''
 
-        # Dump the trivial fields, excluding those with bespoke translation.
-        kwargs = self.model_dump(
-            exclude_none=True,
-            exclude={'name_or_flags', 'description', 'type'},
-        )
+        # Seed the kwargs with the help text.
+        kwargs: Dict[str, Any] = {'help': self.description}
 
-        # argparse expects 'help' rather than 'description'.
-        kwargs['help'] = self.description
+        # Boolean flags consume no value; map to store_true and return early.
+        if self.type == 'bool':
+            kwargs['action'] = 'store_true'
+            return kwargs
 
-        # Value-consuming actions accept a resolved type and retain nargs/choices;
-        # flag and const actions reject those keywords, so drop them.
-        if self.action in (None, 'store', 'append'):
-            kwargs['type'] = self.get_type()
+        # JSON type: decode a single string value at parse time.
+        if self.type == 'json':
+            kwargs['type'] = json.loads
+
+        # Collection types: gather space-separated tokens; nargs defaults to '*'.
+        elif self.type in ('list', 'dict'):
+            kwargs['type'] = str
+            kwargs['nargs'] = self.nargs or '*'
+
+            # List arguments permit per-element choice constraints.
+            if self.type == 'list' and self.choices is not None:
+                kwargs['choices'] = self.choices
+
+        # Scalar types: resolve the Python type callable and honour optional constraints.
         else:
-            kwargs.pop('nargs', None)
-            kwargs.pop('choices', None)
+            kwargs['type'] = self.get_type()
+            if self.nargs is not None:
+                kwargs['nargs'] = self.nargs
+            if self.choices is not None:
+                kwargs['choices'] = self.choices
+
+        # Apply common value-bearing fields.
+        if self.required is not None:
+            kwargs['required'] = self.required
+        if self.default is not None:
+            kwargs['default'] = self.default
 
         # Return the assembled keyword arguments.
         return kwargs
+
+    # * method: get_dest
+    def get_dest(self) -> str:
+        '''
+        Derive the argparse destination name for this argument.
+
+        Mirrors argparse's own dest derivation: the first long flag
+        (``--foo-bar``) wins, normalising hyphens to underscores; if none
+        exists the first short flag is used; positional arguments return
+        their name directly.
+
+        :return: The argparse destination key.
+        :rtype: str
+        '''
+
+        # Prefer the first long flag, stripping dashes and normalising hyphens.
+        for flag in self.name_or_flags:
+            if flag.startswith('--'):
+                return flag.lstrip('-').replace('-', '_')
+
+        # Fall back to the first short flag.
+        for flag in self.name_or_flags:
+            if flag.startswith('-'):
+                return flag.lstrip('-').replace('-', '_')
+
+        # Positional argument: use the name directly.
+        return self.name_or_flags[0]
+
+    # * method: parse_value
+    def parse_value(self, value: Any) -> Any:
+        '''
+        Interpret the raw value returned by argparse for this argument.
+
+        ``'dict'``-typed arguments arrive from argparse as a list of
+        ``key=value`` strings (due to ``nargs='*'``); this method assembles
+        them into a mapping.  All other types are already in their correct
+        Python form from argparse and are returned unchanged.
+
+        :param value: The raw value produced by argparse for this argument.
+        :type value: Any
+        :return: The correctly typed Python value.
+        :rtype: Any
+        '''
+
+        # Dict-typed arguments arrive as a list of key=value strings; assemble into a mapping.
+        if self.type == 'dict' and isinstance(value, list):
+            return dict(kv.split('=', 1) for kv in value if '=' in kv)
+
+        # All other types are already in their correct form from argparse.
+        return value
 
 # ** model: cli_command
 class CliCommand(DomainObject):

--- a/tiferet/domain/cli.py
+++ b/tiferet/domain/cli.py
@@ -12,6 +12,11 @@ from pydantic import Field, model_validator
 # ** app
 from .core import DomainObject
 
+# *** constants
+
+# ** constant: dict_argument_delimiter
+DICT_ARGUMENT_DELIMITER = '='
+
 # *** models
 
 # ** model: cli_record
@@ -328,7 +333,11 @@ class CliArgument(DomainObject):
 
         # Dict-typed arguments arrive as a list of key=value strings; assemble into a mapping.
         if self.type == 'dict' and isinstance(value, list):
-            return dict(kv.split('=', 1) for kv in value if '=' in kv)
+            return dict(
+                kv.split(DICT_ARGUMENT_DELIMITER, 1)
+                for kv in value
+                if DICT_ARGUMENT_DELIMITER in kv
+            )
 
         # All other types are already in their correct form from argparse.
         return value

--- a/tiferet/mappers/cli.py
+++ b/tiferet/mappers/cli.py
@@ -26,7 +26,7 @@ class CliArgumentAggregate(CliArgument, Aggregate):
         '''
         Update a supported attribute on the CLI argument aggregate.
 
-        Supported attributes: description, type, required, default, choices, nargs, action.
+        Supported attributes: description, type, required, default, choices, nargs.
 
         :param attribute: The attribute name to update.
         :type attribute: str
@@ -44,7 +44,6 @@ class CliArgumentAggregate(CliArgument, Aggregate):
             'default',
             'choices',
             'nargs',
-            'action',
         }
 
         # Validate the attribute name.
@@ -74,7 +73,6 @@ class CliCommandAggregate(CliCommand, Aggregate):
             default: str = None,
             choices: list = None,
             nargs: str = None,
-            action: str = None,
         ) -> None:
         '''
         Add an argument to the command.
@@ -83,7 +81,8 @@ class CliCommandAggregate(CliCommand, Aggregate):
         :type name_or_flags: list
         :param description: A brief description of the argument.
         :type description: str
-        :param type: The type of the argument (str, int, float).
+        :param type: The type of the argument (``'str'``, ``'int'``, ``'float'``,
+            ``'bool'``, ``'json'``, ``'list'``, or ``'dict'``).
         :type type: str
         :param required: Whether the argument is required.
         :type required: bool
@@ -93,8 +92,6 @@ class CliCommandAggregate(CliCommand, Aggregate):
         :type choices: list
         :param nargs: The number of arguments to consume.
         :type nargs: str
-        :param action: The action to take when the argument is encountered.
-        :type action: str
         :return: None
         :rtype: None
         '''
@@ -111,7 +108,6 @@ class CliCommandAggregate(CliCommand, Aggregate):
                 default=default,
                 choices=choices,
                 nargs=nargs,
-                action=action,
             ).items()
             if v is not None
         }


### PR DESCRIPTION
## Summary

Implements [#951](https://github.com/greatstrength/tiferet/issues/951).

Completes the `CliArgument` domain model's behavioral contract by extending its type vocabulary to cover all practical input shapes and introducing a symmetric method pair that fully encapsulates argparse interaction. Retires a hardcoded post-parse decode workaround in the admin CLI path, replacing it with declarative, domain-driven behavior available to all CLI consumers.

## What Changed

### Domain (`domain/cli.py`)
- `CliArgument.type` extended to `'str'` | `'int'` | `'float'` | `'bool'` | `'json'` | `'list'` | `'dict'`
- `CliArgument.action` attribute removed; the boolean toggle pattern is now `type='bool'`
- `CliArgument.get_dest()` added — derives the argparse destination name from `name_or_flags`
- `CliArgument.parse_value(raw)` added — interprets argparse's raw output into the correct Python value
- `to_argparse_kwargs()` rewritten to be fully type-driven with no residual `action` dependency
- `DICT_ARGUMENT_DELIMITER` constant extracted for the `key=value` split delimiter (addresses review comment)

### Core Pipeline (`blueprints/cli.py`)
- `parse_cli_args_handler` resolves the active command post-parse and calls `arg.parse_value()` on every argument, making structured input available to all CLI consumers without special-casing

### Admin Cleanup (`blueprints/admin_cli.py`)
- `_decode_json_arguments` retired
- `_admin_parse_cli_args_handler` retired
- `build_admin_cli_session_context` simplified to use `parse_cli_args_handler` directly

### Assets & Mapper (`assets/core.py`, `assets/cli.py`, `mappers/cli.py`)
- `action` removed from `create_default_cli_argument` factory, `CliArgumentAggregate.set_attribute`, and `CliCommandAggregate.add_argument`
- All admin command definitions updated: `action='store_true'` → `type='bool'`, JSON arguments declared as `type='json'`

## Bug Fixes

### `GetAppSession` parameter mismatch (`contexts/app.py`, `tests/events/test_app.py`)
- `AppSessionContext.load` was forwarding the session identifier as `interface_id=` but `GetAppSession.execute` declares it as `id` (enforced by `@DomainEvent.parameters_required(['id'])`), causing all blueprint-layer invocations to raise `COMMAND_PARAMETER_REQUIRED`.
- Fixed by passing `id=interface_id` in `AppSessionContext.load` and aligning the `TestGetAppSession` test class accordingly.
- Resolves the 6 pre-existing `GetAppSession` failures that were confirmed on `v2.x-proto` before this branch's work.

## Tests
- 25 new/updated domain tests covering all new types, `get_dest`, and `parse_value`
- Mapper, context, asset, and repo test layers updated throughout
- **1031 tests passing, 11 skipped, 0 failures**

## Conversation
https://app.warp.dev/conversation/29d0243d-d4aa-45e2-b124-c09e8d6c7737
https://app.warp.dev/conversation/963b0d10-ea5d-4c4a-9d9b-0f8d6ab46fe0

Co-Authored-By: Oz <oz-agent@warp.dev>