### PR TITLE
Assets – Error Catalog Tiered Group Structure (#947)

### DIFF
--- a/tests/assets/test_error.py
+++ b/tests/assets/test_error.py
@@ -1,0 +1,118 @@
+"""Tests for Error Assets"""
+
+# *** imports
+
+# ** app
+from tiferet.assets.error import (
+    ADMIN_DEFAULT_ERRORS,
+    CORE_DEFAULT_ERRORS,
+    CSV_DEFAULT_ERRORS,
+    DEFAULT_ERRORS,
+    SQLITE_DEFAULT_ERRORS,
+    TOML_DEFAULT_ERRORS,
+)
+
+# *** tests
+
+# ** test: default_errors_is_union_of_all_tiers
+def test_default_errors_is_union_of_all_tiers():
+    '''
+    Verify DEFAULT_ERRORS is exactly the union of the five capability tiers.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Assemble the union of every tier's key set.
+    union = (
+        set(CORE_DEFAULT_ERRORS)
+        | set(ADMIN_DEFAULT_ERRORS)
+        | set(SQLITE_DEFAULT_ERRORS)
+        | set(TOML_DEFAULT_ERRORS)
+        | set(CSV_DEFAULT_ERRORS)
+    )
+
+    # Verify the composite catalog adds and omits nothing.
+    assert set(DEFAULT_ERRORS) == union
+
+# ** test: core_default_errors_is_strict_subset
+def test_core_default_errors_is_strict_subset():
+    '''
+    Verify CORE_DEFAULT_ERRORS is a strict subset of the full catalog.
+
+    Guards against the retired ``CORE_DEFAULT_ERRORS = DEFAULT_ERRORS`` stopgap
+    alias returning, which would silently re-seed every error into the app cache.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Verify the core tier is contained by, and smaller than, the full catalog.
+    assert set(CORE_DEFAULT_ERRORS) < set(DEFAULT_ERRORS)
+
+    # Verify the two are not the same object, as the retired alias made them.
+    assert CORE_DEFAULT_ERRORS is not DEFAULT_ERRORS
+
+# ** test: admin_default_errors_extends_core
+def test_admin_default_errors_extends_core():
+    '''
+    Verify ADMIN_DEFAULT_ERRORS layers the admin tier on top of the core tier.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Verify the admin catalog is a strict superset of the core tier.
+    assert set(ADMIN_DEFAULT_ERRORS) > set(CORE_DEFAULT_ERRORS)
+
+    # Verify every core entry survives the merge unchanged.
+    for error_id, definition in CORE_DEFAULT_ERRORS.items():
+        assert ADMIN_DEFAULT_ERRORS[error_id] is definition
+
+# ** test: utility_tiers_are_disjoint_from_core
+def test_utility_tiers_are_disjoint_from_core():
+    '''
+    Verify the optional utility tiers share no keys with the core tier.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Verify each utility tier is fully outside the core runtime tier.
+    assert not set(SQLITE_DEFAULT_ERRORS) & set(CORE_DEFAULT_ERRORS)
+    assert not set(TOML_DEFAULT_ERRORS) & set(CORE_DEFAULT_ERRORS)
+    assert not set(CSV_DEFAULT_ERRORS) & set(CORE_DEFAULT_ERRORS)
+
+# ** test: tier_sizes
+def test_tier_sizes():
+    '''
+    Verify each capability tier holds its expected number of entries.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Verify the core tier and the admin-only remainder.
+    assert len(CORE_DEFAULT_ERRORS) == 42
+    assert len(set(ADMIN_DEFAULT_ERRORS) - set(CORE_DEFAULT_ERRORS)) == 18
+
+    # Verify the three optional utility tiers.
+    assert len(SQLITE_DEFAULT_ERRORS) == 6
+    assert len(TOML_DEFAULT_ERRORS) == 3
+    assert len(CSV_DEFAULT_ERRORS) == 6
+
+    # Verify the composite catalog preserves the full pre-tiering key count.
+    assert len(DEFAULT_ERRORS) == 75
+
+# ** test: every_entry_id_matches_its_key
+def test_every_entry_id_matches_its_key():
+    '''
+    Verify each catalog entry carries an id equal to its dict key.
+
+    :return: None
+    :rtype: None
+    '''
+
+    # Verify no entry was filed under a mismatched key during the restructure.
+    for error_id, definition in DEFAULT_ERRORS.items():
+        assert definition['id'] == error_id

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -1,4 +1,4 @@
-"""Tiferet Error Catalog (Assets)
+"""Tiferet Assets Error
 
 Default error catalog mapping each error-code constant to its name and
 multilingual message templates, consumed by ErrorContext and the error
@@ -12,38 +12,162 @@ from .core import EN_US, create_default_error
 
 # *** constants (ids)
 
-# ** constant: command_parameter_required_id
-COMMAND_PARAMETER_REQUIRED_ID = 'COMMAND_PARAMETER_REQUIRED'
+# ** constant: app_config_loading_failed_id
+APP_CONFIG_LOADING_FAILED_ID = 'APP_CONFIG_LOADING_FAILED'
 
-# ** constant: parameter_parsing_failed_id
-PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
+# ** constant: app_error_id
+APP_ERROR_ID = 'APP_ERROR'
 
-# ** constant: import_dependency_failed_id
-IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
+# ** constant: app_repository_import_failed_id
+APP_REPOSITORY_IMPORT_FAILED_ID = 'APP_REPOSITORY_IMPORT_FAILED'
 
 # ** constant: app_service_import_failed_id
 APP_SERVICE_IMPORT_FAILED_ID = 'APP_SERVICE_IMPORT_FAILED'
 
-# ** constant: middleware_loading_failed_id
-MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
+# ** constant: app_service_not_loaded_id
+APP_SERVICE_NOT_LOADED_ID = 'APP_SERVICE_NOT_LOADED'
+
+# ** constant: app_session_not_found_id
+APP_SESSION_NOT_FOUND_ID = 'APP_SESSION_NOT_FOUND'
+
+# ** constant: attribute_already_exists_id
+ATTRIBUTE_ALREADY_EXISTS_ID = 'ATTRIBUTE_ALREADY_EXISTS'
+
+# ** constant: command_parameter_required_id
+COMMAND_PARAMETER_REQUIRED_ID = 'COMMAND_PARAMETER_REQUIRED'
+
+# ** constant: config_file_not_found_id
+CONFIG_FILE_NOT_FOUND_ID = 'CONFIG_FILE_NOT_FOUND'
+
+# ** constant: container_config_loading_failed_id
+CONTAINER_CONFIG_LOADING_FAILED_ID = 'CONTAINER_CONFIG_LOADING_FAILED'
+
+# ** constant: context_not_found_id
+CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
+
+# ** constant: dependency_type_not_found_id
+DEPENDENCY_TYPE_NOT_FOUND_ID = 'DEPENDENCY_TYPE_NOT_FOUND'
+
+# ** constant: di_service_not_configured_id
+DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
+
+# ** constant: error_config_loading_failed_id
+ERROR_CONFIG_LOADING_FAILED_ID = 'ERROR_CONFIG_LOADING_FAILED'
 
 # ** constant: error_not_found_id
 ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
 
-# ** constant: error_already_exists_id
-ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
-
-# ** constant: no_error_messages_id
-NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
+# ** constant: feature_config_loading_failed_id
+FEATURE_CONFIG_LOADING_FAILED_ID = 'FEATURE_CONFIG_LOADING_FAILED'
 
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
+# ** constant: feature_step_loading_failed_id
+FEATURE_STEP_LOADING_FAILED_ID = 'FEATURE_STEP_LOADING_FAILED'
+
+# ** constant: file_already_open_id
+FILE_ALREADY_OPEN_ID = 'FILE_ALREADY_OPEN'
+
+# ** constant: file_not_found_id
+FILE_NOT_FOUND_ID = 'FILE_NOT_FOUND'
+
+# ** constant: import_dependency_failed_id
+IMPORT_DEPENDENCY_FAILED_ID = 'IMPORT_DEPENDENCY_FAILED'
+
+# ** constant: invalid_app_session_type_id
+INVALID_APP_SESSION_TYPE_ID = 'INVALID_APP_SESSION_TYPE'
+
+# ** constant: invalid_dependency_error_id
+INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
+
+# ** constant: invalid_encoding_id
+INVALID_ENCODING_ID = 'INVALID_ENCODING'
+
+# ** constant: invalid_file_id
+INVALID_FILE_ID = 'INVALID_FILE'
+
+# ** constant: invalid_file_mode_id
+INVALID_FILE_MODE_ID = 'INVALID_FILE_MODE'
+
+# ** constant: invalid_json_file_id
+INVALID_JSON_FILE_ID = 'INVALID_JSON_FILE'
+
+# ** constant: invalid_json_path_id
+INVALID_JSON_PATH_ID = 'INVALID_JSON_PATH'
+
+# ** constant: invalid_model_attribute_id
+INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
+
+# ** constant: invalid_yaml_file_id
+INVALID_YAML_FILE_ID = 'INVALID_YAML_FILE'
+
+# ** constant: json_file_load_error_id
+JSON_FILE_LOAD_ERROR_ID = 'JSON_FILE_LOAD_ERROR'
+
+# ** constant: json_file_not_found_id
+JSON_FILE_NOT_FOUND_ID = 'JSON_FILE_NOT_FOUND'
+
+# ** constant: logger_creation_failed_id
+LOGGER_CREATION_FAILED_ID = 'LOGGER_CREATION_FAILED'
+
+# ** constant: logging_config_failed_id
+LOGGING_CONFIG_FAILED_ID = 'LOGGING_CONFIG_FAILED'
+
+# ** constant: middleware_loading_failed_id
+MIDDLEWARE_LOADING_FAILED_ID = 'MIDDLEWARE_LOADING_FAILED'
+
+# ** constant: parameter_not_found_id
+PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
+
+# ** constant: parameter_parsing_failed_id
+PARAMETER_PARSING_FAILED_ID = 'PARAMETER_PARSING_FAILED'
+
+# ** constant: request_not_found_id
+REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
+
+# ** constant: request_validation_failed_id
+REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
+
+# ** constant: unsupported_config_file_type_id
+UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
+
+# ** constant: yaml_file_load_error_id
+YAML_FILE_LOAD_ERROR_ID = 'YAML_FILE_LOAD_ERROR'
+
+# ** constant: yaml_file_not_found_id
+YAML_FILE_NOT_FOUND_ID = 'YAML_FILE_NOT_FOUND'
+
+# *** constants (ids_admin)
+
+# ** constant: app_interface_not_found_id
+# -- obsolete: Retire in Parity V Story 13.
+APP_INTERFACE_NOT_FOUND_ID = 'APP_INTERFACE_NOT_FOUND'
+
+# ** constant: cli_command_already_exists_id
+CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
+
+# ** constant: cli_command_not_found_id
+CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
+
+# ** constant: cli_config_loading_failed_id
+CLI_CONFIG_LOADING_FAILED_ID = 'CLI_CONFIG_LOADING_FAILED'
+
+# ** constant: error_already_exists_id
+ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
+
 # ** constant: feature_already_exists_id
 FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
 
+# ** constant: feature_command_not_found_id
+FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
+
 # ** constant: feature_name_required_id
 FEATURE_NAME_REQUIRED_ID = 'FEATURE_NAME_REQUIRED'
+
+# ** constant: invalid_app_interface_type_id
+# -- obsolete: Retire in Parity V Story 13.
+INVALID_APP_INTERFACE_TYPE_ID = 'INVALID_APP_INTERFACE_TYPE'
 
 # ** constant: invalid_feature_attribute_id
 INVALID_FEATURE_ATTRIBUTE_ID = 'INVALID_FEATURE_ATTRIBUTE'
@@ -51,140 +175,73 @@ INVALID_FEATURE_ATTRIBUTE_ID = 'INVALID_FEATURE_ATTRIBUTE'
 # ** constant: invalid_feature_command_attribute_id
 INVALID_FEATURE_COMMAND_ATTRIBUTE_ID = 'INVALID_FEATURE_COMMAND_ATTRIBUTE'
 
-# ** constant: feature_command_not_found_id
-FEATURE_COMMAND_NOT_FOUND_ID = 'FEATURE_COMMAND_NOT_FOUND'
-
-# ** constant: feature_step_loading_failed_id
-FEATURE_STEP_LOADING_FAILED_ID = 'FEATURE_STEP_LOADING_FAILED'
-
-# ** constant: app_session_not_found_id
-APP_SESSION_NOT_FOUND_ID = 'APP_SESSION_NOT_FOUND'
-
-# ** constant: invalid_app_session_type_id
-INVALID_APP_SESSION_TYPE_ID = 'INVALID_APP_SESSION_TYPE'
-
-# ** constant: app_error_id
-APP_ERROR_ID = 'APP_ERROR'
-
-# ** constant: di_service_not_configured_id
-DI_SERVICE_NOT_CONFIGURED_ID = 'DI_SERVICE_NOT_CONFIGURED'
+# ** constant: invalid_flagged_dependency_id
+INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
 
 # ** constant: invalid_service_registration_id
 INVALID_SERVICE_REGISTRATION_ID = 'INVALID_SERVICE_REGISTRATION'
 
-# ** constant: service_registration_not_found_id
-SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
+# ** constant: json_file_save_error_id
+JSON_FILE_SAVE_ERROR_ID = 'JSON_FILE_SAVE_ERROR'
+
+# ** constant: no_error_messages_id
+NO_ERROR_MESSAGES_ID = 'NO_ERROR_MESSAGES'
 
 # ** constant: service_registration_already_exists_id
 SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
 
-# ** constant: invalid_flagged_dependency_id
-INVALID_FLAGGED_DEPENDENCY_ID = 'INVALID_FLAGGED_DEPENDENCY'
-
-# ** constant: context_not_found_id
-CONTEXT_NOT_FOUND_ID = 'CONTEXT_NOT_FOUND'
-
-# ** constant: request_not_found_id
-REQUEST_NOT_FOUND_ID = 'REQUEST_NOT_FOUND'
-
-# ** constant: parameter_not_found_id
-PARAMETER_NOT_FOUND_ID = 'PARAMETER_NOT_FOUND'
-
-# ** constant: request_validation_failed_id
-REQUEST_VALIDATION_FAILED_ID = 'REQUEST_VALIDATION_FAILED'
-
-# ** constant: invalid_model_attribute_id
-INVALID_MODEL_ATTRIBUTE_ID = 'INVALID_MODEL_ATTRIBUTE'
-
-# ** constant: logging_config_failed_id
-LOGGING_CONFIG_FAILED_ID = 'LOGGING_CONFIG_FAILED'
-
-# ** constant: logger_creation_failed_id
-LOGGER_CREATION_FAILED_ID = 'LOGGER_CREATION_FAILED'
-
-# ** constant: file_not_found_id
-FILE_NOT_FOUND_ID = 'FILE_NOT_FOUND'
-
-# ** constant: invalid_file_id
-INVALID_FILE_ID = 'INVALID_FILE'
-
-# ** constant: file_already_open_id
-FILE_ALREADY_OPEN_ID = 'FILE_ALREADY_OPEN'
-
-# ** constant: invalid_file_mode_id
-INVALID_FILE_MODE_ID = 'INVALID_FILE_MODE'
-
-# ** constant: invalid_encoding_id
-INVALID_ENCODING_ID = 'INVALID_ENCODING'
-
-# ** constant: config_file_not_found_id
-CONFIG_FILE_NOT_FOUND_ID = 'CONFIG_FILE_NOT_FOUND'
-
-# ** constant: app_config_loading_failed_id
-APP_CONFIG_LOADING_FAILED_ID = 'APP_CONFIG_LOADING_FAILED'
-
-# ** constant: container_config_loading_failed_id
-CONTAINER_CONFIG_LOADING_FAILED_ID = 'CONTAINER_CONFIG_LOADING_FAILED'
-
-# ** constant: feature_config_loading_failed_id
-FEATURE_CONFIG_LOADING_FAILED_ID = 'FEATURE_CONFIG_LOADING_FAILED'
-
-# ** constant: error_config_loading_failed_id
-ERROR_CONFIG_LOADING_FAILED_ID = 'ERROR_CONFIG_LOADING_FAILED'
-
-# ** constant: cli_config_loading_failed_id
-CLI_CONFIG_LOADING_FAILED_ID = 'CLI_CONFIG_LOADING_FAILED'
-
-# ** constant: unsupported_config_file_type_id
-UNSUPPORTED_CONFIG_FILE_TYPE_ID = 'UNSUPPORTED_CONFIG_FILE_TYPE'
-
-# ** constant: cli_command_not_found_id
-CLI_COMMAND_NOT_FOUND_ID = 'CLI_COMMAND_NOT_FOUND'
-
-# ** constant: cli_command_already_exists_id
-CLI_COMMAND_ALREADY_EXISTS_ID = 'CLI_COMMAND_ALREADY_EXISTS'
-
-# ** constant: invalid_yaml_file_id
-INVALID_YAML_FILE_ID = 'INVALID_YAML_FILE'
-
-# ** constant: yaml_file_not_found_id
-YAML_FILE_NOT_FOUND_ID = 'YAML_FILE_NOT_FOUND'
-
-# ** constant: yaml_file_load_error_id
-YAML_FILE_LOAD_ERROR_ID = 'YAML_FILE_LOAD_ERROR'
+# ** constant: service_registration_not_found_id
+SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
 # ** constant: yaml_file_save_error_id
 YAML_FILE_SAVE_ERROR_ID = 'YAML_FILE_SAVE_ERROR'
 
-# ** constant: invalid_json_file_id
-INVALID_JSON_FILE_ID = 'INVALID_JSON_FILE'
+# *** constants (ids_sqlite)
 
-# ** constant: json_file_not_found_id
-JSON_FILE_NOT_FOUND_ID = 'JSON_FILE_NOT_FOUND'
+# ** constant: sqlite_backup_failed_id
+SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
 
-# ** constant: json_file_load_error_id
-JSON_FILE_LOAD_ERROR_ID = 'JSON_FILE_LOAD_ERROR'
+# ** constant: sqlite_conn_already_open_id
+SQLITE_CONN_ALREADY_OPEN_ID = 'SQLITE_CONN_ALREADY_OPEN'
 
-# ** constant: json_file_save_error_id
-JSON_FILE_SAVE_ERROR_ID = 'JSON_FILE_SAVE_ERROR'
+# ** constant: sqlite_conn_failed_id
+SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
 
-# ** constant: invalid_json_path_id
-INVALID_JSON_PATH_ID = 'INVALID_JSON_PATH'
+# ** constant: sqlite_conn_not_initialized_id
+SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
 
-# ** constant: toml_file_not_found_id
-TOML_FILE_NOT_FOUND_ID = 'TOML_FILE_NOT_FOUND'
+# Legacy constants — present on main pending rename or retirement in later parity stories.
 
-# ** constant: toml_file_load_error_id
-TOML_FILE_LOAD_ERROR_ID = 'TOML_FILE_LOAD_ERROR'
+# ** constant: sqlite_file_not_found_or_readonly_id
+SQLITE_FILE_NOT_FOUND_OR_READONLY_ID = 'SQLITE_FILE_NOT_FOUND_OR_READONLY'
+
+# ** constant: sqlite_invalid_mode_id
+SQLITE_INVALID_MODE_ID = 'SQLITE_INVALID_MODE'
+
+# *** constants (ids_toml)
 
 # ** constant: invalid_toml_file_id
 INVALID_TOML_FILE_ID = 'INVALID_TOML_FILE'
 
-# ** constant: csv_invalid_mode_id
-CSV_INVALID_MODE_ID = 'CSV_INVALID_MODE'
+# ** constant: toml_file_load_error_id
+TOML_FILE_LOAD_ERROR_ID = 'TOML_FILE_LOAD_ERROR'
+
+# ** constant: toml_file_not_found_id
+TOML_FILE_NOT_FOUND_ID = 'TOML_FILE_NOT_FOUND'
+
+# *** constants (ids_csv)
+
+# ** constant: csv_dict_no_header_id
+CSV_DICT_NO_HEADER_ID = 'CSV_DICT_NO_HEADER'
+
+# ** constant: csv_fieldnames_required_id
+CSV_FIELDNAMES_REQUIRED_ID = 'CSV_FIELDNAMES_REQUIRED'
 
 # ** constant: csv_handle_not_initialized_id
 CSV_HANDLE_NOT_INITIALIZED_ID = 'CSV_HANDLE_NOT_INITIALIZED'
+
+# ** constant: csv_invalid_mode_id
+CSV_INVALID_MODE_ID = 'CSV_INVALID_MODE'
 
 # ** constant: csv_invalid_read_mode_id
 CSV_INVALID_READ_MODE_ID = 'CSV_INVALID_READ_MODE'
@@ -192,249 +249,20 @@ CSV_INVALID_READ_MODE_ID = 'CSV_INVALID_READ_MODE'
 # ** constant: csv_invalid_write_mode_id
 CSV_INVALID_WRITE_MODE_ID = 'CSV_INVALID_WRITE_MODE'
 
-# ** constant: csv_fieldnames_required_id
-CSV_FIELDNAMES_REQUIRED_ID = 'CSV_FIELDNAMES_REQUIRED'
-
-# ** constant: csv_dict_no_header_id
-CSV_DICT_NO_HEADER_ID = 'CSV_DICT_NO_HEADER'
-
-# ** constant: sqlite_conn_already_open_id
-SQLITE_CONN_ALREADY_OPEN_ID = 'SQLITE_CONN_ALREADY_OPEN'
-
-# ** constant: sqlite_invalid_mode_id
-SQLITE_INVALID_MODE_ID = 'SQLITE_INVALID_MODE'
-
-# ** constant: sqlite_file_not_found_or_readonly_id
-SQLITE_FILE_NOT_FOUND_OR_READONLY_ID = 'SQLITE_FILE_NOT_FOUND_OR_READONLY'
-
-# ** constant: sqlite_conn_failed_id
-SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
-
-# ** constant: sqlite_backup_failed_id
-SQLITE_BACKUP_FAILED_ID = 'SQLITE_BACKUP_FAILED'
-
-# ** constant: sqlite_conn_not_initialized_id
-SQLITE_CONN_NOT_INITIALIZED_ID = 'SQLITE_CONN_NOT_INITIALIZED'
-
-# Legacy constants — present on main pending rename or retirement in later parity stories.
-
-# ** constant: invalid_app_interface_type_id
-# -- obsolete: Retire in Parity V Story 13 (#911)
-INVALID_APP_INTERFACE_TYPE_ID = 'INVALID_APP_INTERFACE_TYPE'
-
-# ** constant: app_interface_not_found_id
-# -- obsolete: Retire in Parity V Story 13 (#911)
-APP_INTERFACE_NOT_FOUND_ID = 'APP_INTERFACE_NOT_FOUND'
-
-# ** constant: app_repository_import_failed_id
-APP_REPOSITORY_IMPORT_FAILED_ID = 'APP_REPOSITORY_IMPORT_FAILED'
-
-# ** constant: app_service_not_loaded_id
-APP_SERVICE_NOT_LOADED_ID = 'APP_SERVICE_NOT_LOADED'
-
-# ** constant: attribute_already_exists_id
-ATTRIBUTE_ALREADY_EXISTS_ID = 'ATTRIBUTE_ALREADY_EXISTS'
-
-# ** constant: dependency_type_not_found_id
-DEPENDENCY_TYPE_NOT_FOUND_ID = 'DEPENDENCY_TYPE_NOT_FOUND'
-
-# ** constant: invalid_dependency_error_id
-INVALID_DEPENDENCY_ERROR_ID = 'INVALID_DEPENDENCY_ERROR'
-
 # *** constants (models)
 
-# ** constant: command_parameter_required
-COMMAND_PARAMETER_REQUIRED = create_default_error(
-    COMMAND_PARAMETER_REQUIRED_ID,
-    'Command Parameter Required',
-    [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
+# ** constant: app_config_loading_failed
+APP_CONFIG_LOADING_FAILED = create_default_error(
+    APP_CONFIG_LOADING_FAILED_ID,
+    'App Configuration Loading Failed',
+    [(EN_US, 'Unable to load app configuration file {file_path}: {exception}.')],
 )
 
-# ** constant: error_not_found
-ERROR_NOT_FOUND = create_default_error(
-    ERROR_NOT_FOUND_ID,
-    'Error Not Found',
-    [(EN_US, 'Error not found: {id}.')],
-)
-
-# ** constant: error_already_exists
-ERROR_ALREADY_EXISTS = create_default_error(
-    ERROR_ALREADY_EXISTS_ID,
-    'Error Already Exists',
-    [(EN_US, 'An error with ID {id} already exists.')],
-)
-
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
-    'Feature Not Found',
-    [(EN_US, 'Feature not found: {feature_id}.')],
-)
-
-# ** constant: feature_already_exists
-FEATURE_ALREADY_EXISTS = create_default_error(
-    FEATURE_ALREADY_EXISTS_ID,
-    'Feature Already Exists',
-    [(EN_US, 'Feature with ID {id} already exists.')],
-)
-
-# ** constant: feature_name_required
-FEATURE_NAME_REQUIRED = create_default_error(
-    FEATURE_NAME_REQUIRED_ID,
-    'Feature Name Required',
-    [(EN_US, 'A feature name is required when updating the name attribute.')],
-)
-
-# ** constant: invalid_feature_attribute
-INVALID_FEATURE_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_ATTRIBUTE_ID,
-    'Invalid Feature Attribute',
-    [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
-)
-
-# ** constant: invalid_feature_command_attribute
-INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
-    'Invalid Feature Command Attribute',
-    [(EN_US,
-      'Invalid feature command attribute: {attribute}. Supported attributes are '
-      'name, attribute_id, data_key, pass_on_error, and parameters.')],
-)
-
-# ** constant: feature_command_not_found
-FEATURE_COMMAND_NOT_FOUND = create_default_error(
-    FEATURE_COMMAND_NOT_FOUND_ID,
-    'Feature Command Not Found',
-    [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
-)
-
-# ** constant: feature_step_loading_failed
-FEATURE_STEP_LOADING_FAILED = create_default_error(
-    FEATURE_STEP_LOADING_FAILED_ID,
-    'Feature Step Loading Failed',
-    [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
-)
-
-# ** constant: invalid_model_attribute
-INVALID_MODEL_ATTRIBUTE = create_default_error(
-    INVALID_MODEL_ATTRIBUTE_ID,
-    'Invalid Model Attribute',
-    [(EN_US, 'Invalid attribute: {attribute}. Supported attributes are {supported}.')],
-)
-
-# ** constant: invalid_app_interface_type
-# -- obsolete: Retire in Parity V Story 13 (#911)
-INVALID_APP_INTERFACE_TYPE = create_default_error(
-    INVALID_APP_INTERFACE_TYPE_ID,
-    'Invalid App Interface Type',
-    [(EN_US, '{attribute} must be a non-empty string.')],
-)
-
-# ** constant: attribute_already_exists
-ATTRIBUTE_ALREADY_EXISTS = create_default_error(
-    ATTRIBUTE_ALREADY_EXISTS_ID,
-    'Attribute Already Exists',
-    [(EN_US, 'A container attribute with ID {id} already exists.')],
-)
-
-# ** constant: di_service_not_configured
-DI_SERVICE_NOT_CONFIGURED = create_default_error(
-    DI_SERVICE_NOT_CONFIGURED_ID,
-    'DI Service Not Configured',
-    [(EN_US, 'No di_service dependency is configured for interface {interface_id}.')],
-)
-
-# ** constant: dependency_type_not_found
-DEPENDENCY_TYPE_NOT_FOUND = create_default_error(
-    DEPENDENCY_TYPE_NOT_FOUND_ID,
-    'Dependency Type Not Found',
-    [(EN_US, 'No dependency type found for service configuration {configuration_id} with flags {flags}.')],
-)
-
-# ** constant: invalid_service_registration
-INVALID_SERVICE_REGISTRATION = create_default_error(
-    INVALID_SERVICE_REGISTRATION_ID,
-    'Invalid Service Registration',
-    [(EN_US,
-      'A service registration must define either a default type '
-      '(module_path/class_name) or at least one flagged dependency.')],
-)
-
-# ** constant: service_registration_not_found
-SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
-    SERVICE_REGISTRATION_NOT_FOUND_ID,
-    'Service Registration Not Found',
-    [(EN_US, 'Service registration with ID {id} not found.')],
-)
-
-# ** constant: service_registration_already_exists
-SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
-    'Service Registration Already Exists',
-    [(EN_US, 'A service registration with ID {id} already exists.')],
-)
-
-# ** constant: invalid_flagged_dependency
-INVALID_FLAGGED_DEPENDENCY = create_default_error(
-    INVALID_FLAGGED_DEPENDENCY_ID,
-    'Invalid Flagged Dependency',
-    [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
-)
-
-# ** constant: invalid_dependency_error
-INVALID_DEPENDENCY_ERROR = create_default_error(
-    INVALID_DEPENDENCY_ERROR_ID,
-    'Invalid Dependency Error',
-    [(EN_US, 'Dependency {dependency} could not be resolved: {reason}.')],
-)
-
-# ** constant: parameter_parsing_failed
-PARAMETER_PARSING_FAILED = create_default_error(
-    PARAMETER_PARSING_FAILED_ID,
-    'Parameter Parsing Failed',
-    [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
-)
-
-# ** constant: parameter_not_found
-PARAMETER_NOT_FOUND = create_default_error(
-    PARAMETER_NOT_FOUND_ID,
-    'Parameter Not Found',
-    [(EN_US, 'Parameter {parameter} not found in request data.')],
-)
-
-# ** constant: import_dependency_failed
-IMPORT_DEPENDENCY_FAILED = create_default_error(
-    IMPORT_DEPENDENCY_FAILED_ID,
-    'Import Dependency Failed',
-    [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
-)
-
-# ** constant: request_not_found
-REQUEST_NOT_FOUND = create_default_error(
-    REQUEST_NOT_FOUND_ID,
-    'Request Not Found',
-    [(EN_US, 'Request data is not available for parameter parsing.')],
-)
-
-# ** constant: request_validation_failed
-REQUEST_VALIDATION_FAILED = create_default_error(
-    REQUEST_VALIDATION_FAILED_ID,
-    'Request Validation Failed',
-    [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
-)
-
-# ** constant: no_error_messages
-NO_ERROR_MESSAGES = create_default_error(
-    NO_ERROR_MESSAGES_ID,
-    'No Error Messages',
-    [(EN_US, 'No error messages are defined for error ID {id}.')],
-)
-
-# ** constant: middleware_loading_failed
-MIDDLEWARE_LOADING_FAILED = create_default_error(
-    MIDDLEWARE_LOADING_FAILED_ID,
-    'Middleware Loading Failed',
-    [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
+# ** constant: app_error
+APP_ERROR = create_default_error(
+    APP_ERROR_ID,
+    'App Error',
+    [(EN_US, 'An error occurred in the app: {error_message}.')],
 )
 
 # ** constant: app_repository_import_failed
@@ -465,26 +293,18 @@ APP_SESSION_NOT_FOUND = create_default_error(
     [(EN_US, 'App session with ID {interface_id} not found.')],
 )
 
-# ** constant: invalid_app_session_type
-INVALID_APP_SESSION_TYPE = create_default_error(
-    INVALID_APP_SESSION_TYPE_ID,
-    'Invalid App Session Type',
-    [(EN_US, 'App context for interface is not valid: {interface_id}.')],
+# ** constant: attribute_already_exists
+ATTRIBUTE_ALREADY_EXISTS = create_default_error(
+    ATTRIBUTE_ALREADY_EXISTS_ID,
+    'Attribute Already Exists',
+    [(EN_US, 'A container attribute with ID {id} already exists.')],
 )
 
-# ** constant: app_interface_not_found
-# -- obsolete: Retire in Parity V Story 13 (#911)
-APP_INTERFACE_NOT_FOUND = create_default_error(
-    APP_INTERFACE_NOT_FOUND_ID,
-    'App Interface Not Found',
-    [(EN_US, 'App interface with ID {interface_id} not found.')],
-)
-
-# ** constant: app_error
-APP_ERROR = create_default_error(
-    APP_ERROR_ID,
-    'App Error',
-    [(EN_US, 'An error occurred in the app: {error_message}.')],
+# ** constant: command_parameter_required
+COMMAND_PARAMETER_REQUIRED = create_default_error(
+    COMMAND_PARAMETER_REQUIRED_ID,
+    'Command Parameter Required',
+    [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
 )
 
 # ** constant: config_file_not_found
@@ -494,13 +314,6 @@ CONFIG_FILE_NOT_FOUND = create_default_error(
     [(EN_US, 'Configuration file {file_path} not found.')],
 )
 
-# ** constant: app_config_loading_failed
-APP_CONFIG_LOADING_FAILED = create_default_error(
-    APP_CONFIG_LOADING_FAILED_ID,
-    'App Configuration Loading Failed',
-    [(EN_US, 'Unable to load app configuration file {file_path}: {exception}.')],
-)
-
 # ** constant: container_config_loading_failed
 CONTAINER_CONFIG_LOADING_FAILED = create_default_error(
     CONTAINER_CONFIG_LOADING_FAILED_ID,
@@ -508,11 +321,25 @@ CONTAINER_CONFIG_LOADING_FAILED = create_default_error(
     [(EN_US, 'Unable to load container configuration file {file_path}: {exception}.')],
 )
 
-# ** constant: feature_config_loading_failed
-FEATURE_CONFIG_LOADING_FAILED = create_default_error(
-    FEATURE_CONFIG_LOADING_FAILED_ID,
-    'Feature Configuration Loading Failed',
-    [(EN_US, 'Unable to load feature configuration file {file_path}: {exception}.')],
+# ** constant: context_not_found
+CONTEXT_NOT_FOUND = create_default_error(
+    CONTEXT_NOT_FOUND_ID,
+    'Context Not Found',
+    [(EN_US, 'No context registered for domain type: {domain_type}.')],
+)
+
+# ** constant: dependency_type_not_found
+DEPENDENCY_TYPE_NOT_FOUND = create_default_error(
+    DEPENDENCY_TYPE_NOT_FOUND_ID,
+    'Dependency Type Not Found',
+    [(EN_US, 'No dependency type found for service configuration {configuration_id} with flags {flags}.')],
+)
+
+# ** constant: di_service_not_configured
+DI_SERVICE_NOT_CONFIGURED = create_default_error(
+    DI_SERVICE_NOT_CONFIGURED_ID,
+    'DI Service Not Configured',
+    [(EN_US, 'No di_service dependency is configured for interface {interface_id}.')],
 )
 
 # ** constant: error_config_loading_failed
@@ -522,53 +349,32 @@ ERROR_CONFIG_LOADING_FAILED = create_default_error(
     [(EN_US, 'Unable to load error configuration file {file_path}: {exception}.')],
 )
 
-# ** constant: cli_config_loading_failed
-CLI_CONFIG_LOADING_FAILED = create_default_error(
-    CLI_CONFIG_LOADING_FAILED_ID,
-    'CLI Configuration Loading Failed',
-    [(EN_US, 'Unable to load CLI configuration file {file_path}: {exception}.')],
+# ** constant: error_not_found
+ERROR_NOT_FOUND = create_default_error(
+    ERROR_NOT_FOUND_ID,
+    'Error Not Found',
+    [(EN_US, 'Error not found: {id}.')],
 )
 
-# ** constant: cli_command_not_found
-CLI_COMMAND_NOT_FOUND = create_default_error(
-    CLI_COMMAND_NOT_FOUND_ID,
-    'CLI Command Not Found',
-    [(EN_US, 'CLI command {command_id} not found.')],
+# ** constant: feature_config_loading_failed
+FEATURE_CONFIG_LOADING_FAILED = create_default_error(
+    FEATURE_CONFIG_LOADING_FAILED_ID,
+    'Feature Configuration Loading Failed',
+    [(EN_US, 'Unable to load feature configuration file {file_path}: {exception}.')],
 )
 
-# ** constant: cli_command_already_exists
-CLI_COMMAND_ALREADY_EXISTS = create_default_error(
-    CLI_COMMAND_ALREADY_EXISTS_ID,
-    'CLI Command Already Exists',
-    [(EN_US, 'CLI command with ID {id} already exists.')],
+# ** constant: feature_not_found
+FEATURE_NOT_FOUND = create_default_error(
+    FEATURE_NOT_FOUND_ID,
+    'Feature Not Found',
+    [(EN_US, 'Feature not found: {feature_id}.')],
 )
 
-# ** constant: logging_config_failed
-LOGGING_CONFIG_FAILED = create_default_error(
-    LOGGING_CONFIG_FAILED_ID,
-    'Logging Configuration Failed',
-    [(EN_US, 'Failed to configure logging: {exception}.')],
-)
-
-# ** constant: logger_creation_failed
-LOGGER_CREATION_FAILED = create_default_error(
-    LOGGER_CREATION_FAILED_ID,
-    'Logger Creation Failed',
-    [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
-)
-
-# ** constant: file_not_found
-FILE_NOT_FOUND = create_default_error(
-    FILE_NOT_FOUND_ID,
-    'File Not Found',
-    [(EN_US, 'File not found: {path}.')],
-)
-
-# ** constant: invalid_file
-INVALID_FILE = create_default_error(
-    INVALID_FILE_ID,
-    'Invalid File',
-    [(EN_US, 'Path is not a file: {path}.')],
+# ** constant: feature_step_loading_failed
+FEATURE_STEP_LOADING_FAILED = create_default_error(
+    FEATURE_STEP_LOADING_FAILED_ID,
+    'Feature Step Loading Failed',
+    [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
 )
 
 # ** constant: file_already_open
@@ -578,11 +384,32 @@ FILE_ALREADY_OPEN = create_default_error(
     [(EN_US, 'File is already open: {path}.')],
 )
 
-# ** constant: invalid_file_mode
-INVALID_FILE_MODE = create_default_error(
-    INVALID_FILE_MODE_ID,
-    'Invalid File Mode',
-    [(EN_US, 'Invalid file mode: {mode}. Valid modes include {modes}')],
+# ** constant: file_not_found
+FILE_NOT_FOUND = create_default_error(
+    FILE_NOT_FOUND_ID,
+    'File Not Found',
+    [(EN_US, 'File not found: {path}.')],
+)
+
+# ** constant: import_dependency_failed
+IMPORT_DEPENDENCY_FAILED = create_default_error(
+    IMPORT_DEPENDENCY_FAILED_ID,
+    'Import Dependency Failed',
+    [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
+)
+
+# ** constant: invalid_app_session_type
+INVALID_APP_SESSION_TYPE = create_default_error(
+    INVALID_APP_SESSION_TYPE_ID,
+    'Invalid App Session Type',
+    [(EN_US, 'App context for interface is not valid: {interface_id}.')],
+)
+
+# ** constant: invalid_dependency_error
+INVALID_DEPENDENCY_ERROR = create_default_error(
+    INVALID_DEPENDENCY_ERROR_ID,
+    'Invalid Dependency Error',
+    [(EN_US, 'Dependency {dependency} could not be resolved: {reason}.')],
 )
 
 # ** constant: invalid_encoding
@@ -592,67 +419,25 @@ INVALID_ENCODING = create_default_error(
     [(EN_US, 'Invalid encoding: {encoding}. Supported encodings are: utf-8, ascii, latin-1.')],
 )
 
+# ** constant: invalid_file
+INVALID_FILE = create_default_error(
+    INVALID_FILE_ID,
+    'Invalid File',
+    [(EN_US, 'Path is not a file: {path}.')],
+)
+
+# ** constant: invalid_file_mode
+INVALID_FILE_MODE = create_default_error(
+    INVALID_FILE_MODE_ID,
+    'Invalid File Mode',
+    [(EN_US, 'Invalid file mode: {mode}. Valid modes include {modes}')],
+)
+
 # ** constant: invalid_json_file
 INVALID_JSON_FILE = create_default_error(
     INVALID_JSON_FILE_ID,
     'Invalid JSON File',
     [(EN_US, 'File is not a valid JSON file: {path}.')],
-)
-
-# ** constant: invalid_yaml_file
-INVALID_YAML_FILE = create_default_error(
-    INVALID_YAML_FILE_ID,
-    'Invalid YAML File',
-    [(EN_US, 'File is not a valid YAML file: {path}.')],
-)
-
-# ** constant: unsupported_config_file_type
-UNSUPPORTED_CONFIG_FILE_TYPE = create_default_error(
-    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
-    'Unsupported Configuration File Type',
-    [(EN_US, 'Unsupported configuration file type: {file_extension}.')],
-)
-
-# ** constant: yaml_file_not_found
-YAML_FILE_NOT_FOUND = create_default_error(
-    YAML_FILE_NOT_FOUND_ID,
-    'YAML File Not Found',
-    [(EN_US, 'The specified YAML file could not be found at {path}.')],
-)
-
-# ** constant: yaml_file_load_error
-YAML_FILE_LOAD_ERROR = create_default_error(
-    YAML_FILE_LOAD_ERROR_ID,
-    'YAML Load Failure',
-    [(EN_US, 'Failed to parse YAML file: {error}. Path: {path}.')],
-)
-
-# ** constant: yaml_file_save_error
-YAML_FILE_SAVE_ERROR = create_default_error(
-    YAML_FILE_SAVE_ERROR_ID,
-    'YAML Save Failure',
-    [(EN_US, 'Failed to write YAML file: {error}. Path: {path}.')],
-)
-
-# ** constant: json_file_not_found
-JSON_FILE_NOT_FOUND = create_default_error(
-    JSON_FILE_NOT_FOUND_ID,
-    'JSON File Not Found',
-    [(EN_US, 'The specified JSON file could not be found at {path}.')],
-)
-
-# ** constant: json_file_load_error
-JSON_FILE_LOAD_ERROR = create_default_error(
-    JSON_FILE_LOAD_ERROR_ID,
-    'JSON Load Failure',
-    [(EN_US, 'Failed to parse JSON: {error}. Path: {path}.')],
-)
-
-# ** constant: json_file_save_error
-JSON_FILE_SAVE_ERROR = create_default_error(
-    JSON_FILE_SAVE_ERROR_ID,
-    'JSON Save Failure',
-    [(EN_US, 'Failed to serialize/write JSON: {error}. Path: {path}.')],
 )
 
 # ** constant: invalid_json_path
@@ -662,11 +447,321 @@ INVALID_JSON_PATH = create_default_error(
     [(EN_US, 'Invalid JSON path: {path}. Failed at segment: {part}.')],
 )
 
-# ** constant: csv_invalid_mode
-CSV_INVALID_MODE = create_default_error(
-    CSV_INVALID_MODE_ID,
-    'Invalid CSV Mode',
-    [(EN_US, 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.')],
+# ** constant: invalid_model_attribute
+INVALID_MODEL_ATTRIBUTE = create_default_error(
+    INVALID_MODEL_ATTRIBUTE_ID,
+    'Invalid Model Attribute',
+    [(EN_US, 'Invalid attribute: {attribute}. Supported attributes are {supported}.')],
+)
+
+# ** constant: invalid_yaml_file
+INVALID_YAML_FILE = create_default_error(
+    INVALID_YAML_FILE_ID,
+    'Invalid YAML File',
+    [(EN_US, 'File is not a valid YAML file: {path}.')],
+)
+
+# ** constant: json_file_load_error
+JSON_FILE_LOAD_ERROR = create_default_error(
+    JSON_FILE_LOAD_ERROR_ID,
+    'JSON Load Failure',
+    [(EN_US, 'Failed to parse JSON: {error}. Path: {path}.')],
+)
+
+# ** constant: json_file_not_found
+JSON_FILE_NOT_FOUND = create_default_error(
+    JSON_FILE_NOT_FOUND_ID,
+    'JSON File Not Found',
+    [(EN_US, 'The specified JSON file could not be found at {path}.')],
+)
+
+# ** constant: logger_creation_failed
+LOGGER_CREATION_FAILED = create_default_error(
+    LOGGER_CREATION_FAILED_ID,
+    'Logger Creation Failed',
+    [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
+)
+
+# ** constant: logging_config_failed
+LOGGING_CONFIG_FAILED = create_default_error(
+    LOGGING_CONFIG_FAILED_ID,
+    'Logging Configuration Failed',
+    [(EN_US, 'Failed to configure logging: {exception}.')],
+)
+
+# ** constant: middleware_loading_failed
+MIDDLEWARE_LOADING_FAILED = create_default_error(
+    MIDDLEWARE_LOADING_FAILED_ID,
+    'Middleware Loading Failed',
+    [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
+)
+
+# ** constant: parameter_not_found
+PARAMETER_NOT_FOUND = create_default_error(
+    PARAMETER_NOT_FOUND_ID,
+    'Parameter Not Found',
+    [(EN_US, 'Parameter {parameter} not found in request data.')],
+)
+
+# ** constant: parameter_parsing_failed
+PARAMETER_PARSING_FAILED = create_default_error(
+    PARAMETER_PARSING_FAILED_ID,
+    'Parameter Parsing Failed',
+    [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
+)
+
+# ** constant: request_not_found
+REQUEST_NOT_FOUND = create_default_error(
+    REQUEST_NOT_FOUND_ID,
+    'Request Not Found',
+    [(EN_US, 'Request data is not available for parameter parsing.')],
+)
+
+# ** constant: request_validation_failed
+REQUEST_VALIDATION_FAILED = create_default_error(
+    REQUEST_VALIDATION_FAILED_ID,
+    'Request Validation Failed',
+    [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
+)
+
+# ** constant: unsupported_config_file_type
+UNSUPPORTED_CONFIG_FILE_TYPE = create_default_error(
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID,
+    'Unsupported Configuration File Type',
+    [(EN_US, 'Unsupported configuration file type: {file_extension}.')],
+)
+
+# ** constant: yaml_file_load_error
+YAML_FILE_LOAD_ERROR = create_default_error(
+    YAML_FILE_LOAD_ERROR_ID,
+    'YAML Load Failure',
+    [(EN_US, 'Failed to parse YAML file: {error}. Path: {path}.')],
+)
+
+# ** constant: yaml_file_not_found
+YAML_FILE_NOT_FOUND = create_default_error(
+    YAML_FILE_NOT_FOUND_ID,
+    'YAML File Not Found',
+    [(EN_US, 'The specified YAML file could not be found at {path}.')],
+)
+
+# *** constants (models_admin)
+
+# ** constant: app_interface_not_found
+# -- obsolete: Retire in Parity V Story 13.
+APP_INTERFACE_NOT_FOUND = create_default_error(
+    APP_INTERFACE_NOT_FOUND_ID,
+    'App Interface Not Found',
+    [(EN_US, 'App interface with ID {interface_id} not found.')],
+)
+
+# ** constant: cli_command_already_exists
+CLI_COMMAND_ALREADY_EXISTS = create_default_error(
+    CLI_COMMAND_ALREADY_EXISTS_ID,
+    'CLI Command Already Exists',
+    [(EN_US, 'CLI command with ID {id} already exists.')],
+)
+
+# ** constant: cli_command_not_found
+CLI_COMMAND_NOT_FOUND = create_default_error(
+    CLI_COMMAND_NOT_FOUND_ID,
+    'CLI Command Not Found',
+    [(EN_US, 'CLI command {command_id} not found.')],
+)
+
+# ** constant: cli_config_loading_failed
+CLI_CONFIG_LOADING_FAILED = create_default_error(
+    CLI_CONFIG_LOADING_FAILED_ID,
+    'CLI Configuration Loading Failed',
+    [(EN_US, 'Unable to load CLI configuration file {file_path}: {exception}.')],
+)
+
+# ** constant: error_already_exists
+ERROR_ALREADY_EXISTS = create_default_error(
+    ERROR_ALREADY_EXISTS_ID,
+    'Error Already Exists',
+    [(EN_US, 'An error with ID {id} already exists.')],
+)
+
+# ** constant: feature_already_exists
+FEATURE_ALREADY_EXISTS = create_default_error(
+    FEATURE_ALREADY_EXISTS_ID,
+    'Feature Already Exists',
+    [(EN_US, 'Feature with ID {id} already exists.')],
+)
+
+# ** constant: feature_command_not_found
+FEATURE_COMMAND_NOT_FOUND = create_default_error(
+    FEATURE_COMMAND_NOT_FOUND_ID,
+    'Feature Command Not Found',
+    [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
+)
+
+# ** constant: feature_name_required
+FEATURE_NAME_REQUIRED = create_default_error(
+    FEATURE_NAME_REQUIRED_ID,
+    'Feature Name Required',
+    [(EN_US, 'A feature name is required when updating the name attribute.')],
+)
+
+# ** constant: invalid_app_interface_type
+# -- obsolete: Retire in Parity V Story 13.
+INVALID_APP_INTERFACE_TYPE = create_default_error(
+    INVALID_APP_INTERFACE_TYPE_ID,
+    'Invalid App Interface Type',
+    [(EN_US, '{attribute} must be a non-empty string.')],
+)
+
+# ** constant: invalid_feature_attribute
+INVALID_FEATURE_ATTRIBUTE = create_default_error(
+    INVALID_FEATURE_ATTRIBUTE_ID,
+    'Invalid Feature Attribute',
+    [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
+)
+
+# ** constant: invalid_feature_command_attribute
+INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+    'Invalid Feature Command Attribute',
+    [(EN_US,
+      'Invalid feature command attribute: {attribute}. Supported attributes are '
+      'name, attribute_id, data_key, pass_on_error, and parameters.')],
+)
+
+# ** constant: invalid_flagged_dependency
+INVALID_FLAGGED_DEPENDENCY = create_default_error(
+    INVALID_FLAGGED_DEPENDENCY_ID,
+    'Invalid Flagged Dependency',
+    [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
+)
+
+# ** constant: invalid_service_registration
+INVALID_SERVICE_REGISTRATION = create_default_error(
+    INVALID_SERVICE_REGISTRATION_ID,
+    'Invalid Service Registration',
+    [(EN_US,
+      'A service registration must define either a default type '
+      '(module_path/class_name) or at least one flagged dependency.')],
+)
+
+# ** constant: json_file_save_error
+JSON_FILE_SAVE_ERROR = create_default_error(
+    JSON_FILE_SAVE_ERROR_ID,
+    'JSON Save Failure',
+    [(EN_US, 'Failed to serialize/write JSON: {error}. Path: {path}.')],
+)
+
+# ** constant: no_error_messages
+NO_ERROR_MESSAGES = create_default_error(
+    NO_ERROR_MESSAGES_ID,
+    'No Error Messages',
+    [(EN_US, 'No error messages are defined for error ID {id}.')],
+)
+
+# ** constant: service_registration_already_exists
+SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+    'Service Registration Already Exists',
+    [(EN_US, 'A service registration with ID {id} already exists.')],
+)
+
+# ** constant: service_registration_not_found
+SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
+    SERVICE_REGISTRATION_NOT_FOUND_ID,
+    'Service Registration Not Found',
+    [(EN_US, 'Service registration with ID {id} not found.')],
+)
+
+# ** constant: yaml_file_save_error
+YAML_FILE_SAVE_ERROR = create_default_error(
+    YAML_FILE_SAVE_ERROR_ID,
+    'YAML Save Failure',
+    [(EN_US, 'Failed to write YAML file: {error}. Path: {path}.')],
+)
+
+# *** constants (models_sqlite)
+
+# ** constant: sqlite_backup_failed
+SQLITE_BACKUP_FAILED = create_default_error(
+    SQLITE_BACKUP_FAILED_ID,
+    'SQLite Backup Failed',
+    [(EN_US, 'Backup to {target_path} failed: {original_error}')],
+)
+
+# ** constant: sqlite_conn_already_open
+SQLITE_CONN_ALREADY_OPEN = create_default_error(
+    SQLITE_CONN_ALREADY_OPEN_ID,
+    'SQLite Connection Already Open',
+    [(EN_US, 'Connection already open for path: {path}.')],
+)
+
+# ** constant: sqlite_conn_failed
+SQLITE_CONN_FAILED = create_default_error(
+    SQLITE_CONN_FAILED_ID,
+    'SQLite Connection Failed',
+    [(EN_US, 'Failed to connect to SQLite database at {path}: {original_error}')],
+)
+
+# ** constant: sqlite_conn_not_initialized
+SQLITE_CONN_NOT_INITIALIZED = create_default_error(
+    SQLITE_CONN_NOT_INITIALIZED_ID,
+    'SQLite Connection Not Initialized',
+    [(EN_US, 'SQLite connection not initialized. Must be used within a "with" block.')],
+)
+
+# ** constant: sqlite_file_not_found_or_readonly
+SQLITE_FILE_NOT_FOUND_OR_READONLY = create_default_error(
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
+    'SQLite File Not Found or Read-Only',
+    [(EN_US,
+      'Unable to open SQLite database at {path}: {original_error}. '
+      'Check path exists and is writable (use mode=rwc to create).')],
+)
+
+# ** constant: sqlite_invalid_mode
+SQLITE_INVALID_MODE = create_default_error(
+    SQLITE_INVALID_MODE_ID,
+    'Invalid SQLite Mode',
+    [(EN_US, 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).')],
+)
+
+# *** constants (models_toml)
+
+# ** constant: invalid_toml_file
+INVALID_TOML_FILE = create_default_error(
+    INVALID_TOML_FILE_ID,
+    'Invalid TOML File',
+    [(EN_US, 'File is not a valid TOML file: {path}.')],
+)
+
+# ** constant: toml_file_load_error
+TOML_FILE_LOAD_ERROR = create_default_error(
+    TOML_FILE_LOAD_ERROR_ID,
+    'TOML Load Failure',
+    [(EN_US, 'Failed to parse TOML file: {error}. Path: {path}.')],
+)
+
+# ** constant: toml_file_not_found
+TOML_FILE_NOT_FOUND = create_default_error(
+    TOML_FILE_NOT_FOUND_ID,
+    'TOML File Not Found',
+    [(EN_US, 'The specified TOML file could not be found at {path}.')],
+)
+
+# *** constants (models_csv)
+
+# ** constant: csv_dict_no_header
+CSV_DICT_NO_HEADER = create_default_error(
+    CSV_DICT_NO_HEADER_ID,
+    'CSV Dict Reader Without Header',
+    [(EN_US, 'Dict reader expects header row; file appears to lack one or was not read correctly.')],
+)
+
+# ** constant: csv_fieldnames_required
+CSV_FIELDNAMES_REQUIRED = create_default_error(
+    CSV_FIELDNAMES_REQUIRED_ID,
+    'CSV Fieldnames Required',
+    [(EN_US, 'Fieldnames must be provided when writing dict-based CSV rows.')],
 )
 
 # ** constant: csv_handle_not_initialized
@@ -674,6 +769,13 @@ CSV_HANDLE_NOT_INITIALIZED = create_default_error(
     CSV_HANDLE_NOT_INITIALIZED_ID,
     'CSV Handle Not Initialized',
     [(EN_US, 'CSV file must be opened before reading/writing.')],
+)
+
+# ** constant: csv_invalid_mode
+CSV_INVALID_MODE = create_default_error(
+    CSV_INVALID_MODE_ID,
+    'Invalid CSV Mode',
+    [(EN_US, 'Invalid file mode for CSV operation: {mode}. Expected r, w, a, etc.')],
 )
 
 # ** constant: csv_invalid_read_mode
@@ -690,177 +792,109 @@ CSV_INVALID_WRITE_MODE = create_default_error(
     [(EN_US, 'File not opened in writable mode for CSV writing.')],
 )
 
-# ** constant: csv_fieldnames_required
-CSV_FIELDNAMES_REQUIRED = create_default_error(
-    CSV_FIELDNAMES_REQUIRED_ID,
-    'CSV Fieldnames Required',
-    [(EN_US, 'Fieldnames must be provided when writing dict-based CSV rows.')],
-)
-
-# ** constant: csv_dict_no_header
-CSV_DICT_NO_HEADER = create_default_error(
-    CSV_DICT_NO_HEADER_ID,
-    'CSV Dict Reader Without Header',
-    [(EN_US, 'Dict reader expects header row; file appears to lack one or was not read correctly.')],
-)
-
-# ** constant: toml_file_not_found
-TOML_FILE_NOT_FOUND = create_default_error(
-    TOML_FILE_NOT_FOUND_ID,
-    'TOML File Not Found',
-    [(EN_US, 'The specified TOML file could not be found at {path}.')],
-)
-
-# ** constant: toml_file_load_error
-TOML_FILE_LOAD_ERROR = create_default_error(
-    TOML_FILE_LOAD_ERROR_ID,
-    'TOML Load Failure',
-    [(EN_US, 'Failed to parse TOML file: {error}. Path: {path}.')],
-)
-
-# ** constant: invalid_toml_file
-INVALID_TOML_FILE = create_default_error(
-    INVALID_TOML_FILE_ID,
-    'Invalid TOML File',
-    [(EN_US, 'File is not a valid TOML file: {path}.')],
-)
-
-# ** constant: sqlite_conn_already_open
-SQLITE_CONN_ALREADY_OPEN = create_default_error(
-    SQLITE_CONN_ALREADY_OPEN_ID,
-    'SQLite Connection Already Open',
-    [(EN_US, 'Connection already open for path: {path}.')],
-)
-
-# ** constant: sqlite_invalid_mode
-SQLITE_INVALID_MODE = create_default_error(
-    SQLITE_INVALID_MODE_ID,
-    'Invalid SQLite Mode',
-    [(EN_US, 'Invalid SQLite mode: {mode}. Supported: ro, rw, rwc (or None for default auto-create).')],
-)
-
-# ** constant: sqlite_file_not_found_or_readonly
-SQLITE_FILE_NOT_FOUND_OR_READONLY = create_default_error(
-    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID,
-    'SQLite File Not Found or Read-Only',
-    [(EN_US,
-      'Unable to open SQLite database at {path}: {original_error}. '
-      'Check path exists and is writable (use mode=rwc to create).')],
-)
-
-# ** constant: sqlite_conn_failed
-SQLITE_CONN_FAILED = create_default_error(
-    SQLITE_CONN_FAILED_ID,
-    'SQLite Connection Failed',
-    [(EN_US, 'Failed to connect to SQLite database at {path}: {original_error}')],
-)
-
-# ** constant: sqlite_backup_failed
-SQLITE_BACKUP_FAILED = create_default_error(
-    SQLITE_BACKUP_FAILED_ID,
-    'SQLite Backup Failed',
-    [(EN_US, 'Backup to {target_path} failed: {original_error}')],
-)
-
-# ** constant: sqlite_conn_not_initialized
-SQLITE_CONN_NOT_INITIALIZED = create_default_error(
-    SQLITE_CONN_NOT_INITIALIZED_ID,
-    'SQLite Connection Not Initialized',
-    [(EN_US, 'SQLite connection not initialized. Must be used within a "with" block.')],
-)
-
-# ** constant: context_not_found
-CONTEXT_NOT_FOUND = create_default_error(
-    CONTEXT_NOT_FOUND_ID,
-    'Context Not Found',
-    [(EN_US, 'No context registered for domain type: {domain_type}.')],
-)
-
 # *** constants (groups)
 
-# ** constant: default_errors
-DEFAULT_ERRORS = {
-    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
-    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
-    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
-    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
-    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
-    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
-    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
-    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED,
-    INVALID_MODEL_ATTRIBUTE_ID: INVALID_MODEL_ATTRIBUTE,
-    INVALID_APP_INTERFACE_TYPE_ID: INVALID_APP_INTERFACE_TYPE,
-    ATTRIBUTE_ALREADY_EXISTS_ID: ATTRIBUTE_ALREADY_EXISTS,
-    DI_SERVICE_NOT_CONFIGURED_ID: DI_SERVICE_NOT_CONFIGURED,
-    DEPENDENCY_TYPE_NOT_FOUND_ID: DEPENDENCY_TYPE_NOT_FOUND,
-    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
-    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
-    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
-    INVALID_DEPENDENCY_ERROR_ID: INVALID_DEPENDENCY_ERROR,
-    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
-    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
-    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
-    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
-    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
-    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
-    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
+# ** constant: core_default_errors
+CORE_DEFAULT_ERRORS = {
+    APP_CONFIG_LOADING_FAILED_ID: APP_CONFIG_LOADING_FAILED,
+    APP_ERROR_ID: APP_ERROR,
     APP_REPOSITORY_IMPORT_FAILED_ID: APP_REPOSITORY_IMPORT_FAILED,
     APP_SERVICE_IMPORT_FAILED_ID: APP_SERVICE_IMPORT_FAILED,
     APP_SERVICE_NOT_LOADED_ID: APP_SERVICE_NOT_LOADED,
     APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND,
-    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
-    APP_INTERFACE_NOT_FOUND_ID: APP_INTERFACE_NOT_FOUND,
-    APP_ERROR_ID: APP_ERROR,
+    ATTRIBUTE_ALREADY_EXISTS_ID: ATTRIBUTE_ALREADY_EXISTS,
+    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
     CONFIG_FILE_NOT_FOUND_ID: CONFIG_FILE_NOT_FOUND,
-    APP_CONFIG_LOADING_FAILED_ID: APP_CONFIG_LOADING_FAILED,
     CONTAINER_CONFIG_LOADING_FAILED_ID: CONTAINER_CONFIG_LOADING_FAILED,
-    FEATURE_CONFIG_LOADING_FAILED_ID: FEATURE_CONFIG_LOADING_FAILED,
-    ERROR_CONFIG_LOADING_FAILED_ID: ERROR_CONFIG_LOADING_FAILED,
-    CLI_CONFIG_LOADING_FAILED_ID: CLI_CONFIG_LOADING_FAILED,
-    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
-    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
-    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
-    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
-    FILE_NOT_FOUND_ID: FILE_NOT_FOUND,
-    INVALID_FILE_ID: INVALID_FILE,
-    FILE_ALREADY_OPEN_ID: FILE_ALREADY_OPEN,
-    INVALID_FILE_MODE_ID: INVALID_FILE_MODE,
-    INVALID_ENCODING_ID: INVALID_ENCODING,
-    INVALID_JSON_FILE_ID: INVALID_JSON_FILE,
-    INVALID_YAML_FILE_ID: INVALID_YAML_FILE,
-    UNSUPPORTED_CONFIG_FILE_TYPE_ID: UNSUPPORTED_CONFIG_FILE_TYPE,
-    YAML_FILE_NOT_FOUND_ID: YAML_FILE_NOT_FOUND,
-    YAML_FILE_LOAD_ERROR_ID: YAML_FILE_LOAD_ERROR,
-    YAML_FILE_SAVE_ERROR_ID: YAML_FILE_SAVE_ERROR,
-    JSON_FILE_NOT_FOUND_ID: JSON_FILE_NOT_FOUND,
-    JSON_FILE_LOAD_ERROR_ID: JSON_FILE_LOAD_ERROR,
-    JSON_FILE_SAVE_ERROR_ID: JSON_FILE_SAVE_ERROR,
-    INVALID_JSON_PATH_ID: INVALID_JSON_PATH,
-    CSV_INVALID_MODE_ID: CSV_INVALID_MODE,
-    CSV_HANDLE_NOT_INITIALIZED_ID: CSV_HANDLE_NOT_INITIALIZED,
-    CSV_INVALID_READ_MODE_ID: CSV_INVALID_READ_MODE,
-    CSV_INVALID_WRITE_MODE_ID: CSV_INVALID_WRITE_MODE,
-    CSV_FIELDNAMES_REQUIRED_ID: CSV_FIELDNAMES_REQUIRED,
-    CSV_DICT_NO_HEADER_ID: CSV_DICT_NO_HEADER,
-    TOML_FILE_NOT_FOUND_ID: TOML_FILE_NOT_FOUND,
-    TOML_FILE_LOAD_ERROR_ID: TOML_FILE_LOAD_ERROR,
-    INVALID_TOML_FILE_ID: INVALID_TOML_FILE,
-    SQLITE_CONN_ALREADY_OPEN_ID: SQLITE_CONN_ALREADY_OPEN,
-    SQLITE_INVALID_MODE_ID: SQLITE_INVALID_MODE,
-    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: SQLITE_FILE_NOT_FOUND_OR_READONLY,
-    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
-    SQLITE_BACKUP_FAILED_ID: SQLITE_BACKUP_FAILED,
-    SQLITE_CONN_NOT_INITIALIZED_ID: SQLITE_CONN_NOT_INITIALIZED,
     CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND,
+    DEPENDENCY_TYPE_NOT_FOUND_ID: DEPENDENCY_TYPE_NOT_FOUND,
+    DI_SERVICE_NOT_CONFIGURED_ID: DI_SERVICE_NOT_CONFIGURED,
+    ERROR_CONFIG_LOADING_FAILED_ID: ERROR_CONFIG_LOADING_FAILED,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
+    FEATURE_CONFIG_LOADING_FAILED_ID: FEATURE_CONFIG_LOADING_FAILED,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED,
+    FILE_ALREADY_OPEN_ID: FILE_ALREADY_OPEN,
+    FILE_NOT_FOUND_ID: FILE_NOT_FOUND,
+    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
+    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
+    INVALID_DEPENDENCY_ERROR_ID: INVALID_DEPENDENCY_ERROR,
+    INVALID_ENCODING_ID: INVALID_ENCODING,
+    INVALID_FILE_ID: INVALID_FILE,
+    INVALID_FILE_MODE_ID: INVALID_FILE_MODE,
+    INVALID_JSON_FILE_ID: INVALID_JSON_FILE,
+    INVALID_JSON_PATH_ID: INVALID_JSON_PATH,
+    INVALID_MODEL_ATTRIBUTE_ID: INVALID_MODEL_ATTRIBUTE,
+    INVALID_YAML_FILE_ID: INVALID_YAML_FILE,
+    JSON_FILE_LOAD_ERROR_ID: JSON_FILE_LOAD_ERROR,
+    JSON_FILE_NOT_FOUND_ID: JSON_FILE_NOT_FOUND,
+    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
+    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
+    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
+    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
+    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
+    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
+    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
+    UNSUPPORTED_CONFIG_FILE_TYPE_ID: UNSUPPORTED_CONFIG_FILE_TYPE,
+    YAML_FILE_LOAD_ERROR_ID: YAML_FILE_LOAD_ERROR,
+    YAML_FILE_NOT_FOUND_ID: YAML_FILE_NOT_FOUND,
 }
 
-# ** constant: core_default_errors
-# ++ todo: Stopgap alias only. CORE_DEFAULT_ERRORS is intended to be the core
-# tier of a tiered catalog, with DEFAULT_ERRORS derived from it alongside the
-# admin/sqlite/toml/csv tiers. Aliasing it to the full catalog here inverts that
-# relationship and seeds every error into the core app cache. Retire this alias
-# when the tiered restructure lands in #947.
-CORE_DEFAULT_ERRORS = DEFAULT_ERRORS
+# ** constant: admin_default_errors
+ADMIN_DEFAULT_ERRORS = {
+    **CORE_DEFAULT_ERRORS,
+    APP_INTERFACE_NOT_FOUND_ID: APP_INTERFACE_NOT_FOUND,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
+    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
+    CLI_CONFIG_LOADING_FAILED_ID: CLI_CONFIG_LOADING_FAILED,
+    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
+    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
+    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
+    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
+    INVALID_APP_INTERFACE_TYPE_ID: INVALID_APP_INTERFACE_TYPE,
+    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
+    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
+    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
+    JSON_FILE_SAVE_ERROR_ID: JSON_FILE_SAVE_ERROR,
+    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
+    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
+    YAML_FILE_SAVE_ERROR_ID: YAML_FILE_SAVE_ERROR,
+}
+
+# ** constant: sqlite_default_errors
+SQLITE_DEFAULT_ERRORS = {
+    SQLITE_BACKUP_FAILED_ID: SQLITE_BACKUP_FAILED,
+    SQLITE_CONN_ALREADY_OPEN_ID: SQLITE_CONN_ALREADY_OPEN,
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+    SQLITE_CONN_NOT_INITIALIZED_ID: SQLITE_CONN_NOT_INITIALIZED,
+    SQLITE_FILE_NOT_FOUND_OR_READONLY_ID: SQLITE_FILE_NOT_FOUND_OR_READONLY,
+    SQLITE_INVALID_MODE_ID: SQLITE_INVALID_MODE,
+}
+
+# ** constant: toml_default_errors
+TOML_DEFAULT_ERRORS = {
+    INVALID_TOML_FILE_ID: INVALID_TOML_FILE,
+    TOML_FILE_LOAD_ERROR_ID: TOML_FILE_LOAD_ERROR,
+    TOML_FILE_NOT_FOUND_ID: TOML_FILE_NOT_FOUND,
+}
+
+# ** constant: csv_default_errors
+CSV_DEFAULT_ERRORS = {
+    CSV_DICT_NO_HEADER_ID: CSV_DICT_NO_HEADER,
+    CSV_FIELDNAMES_REQUIRED_ID: CSV_FIELDNAMES_REQUIRED,
+    CSV_HANDLE_NOT_INITIALIZED_ID: CSV_HANDLE_NOT_INITIALIZED,
+    CSV_INVALID_MODE_ID: CSV_INVALID_MODE,
+    CSV_INVALID_READ_MODE_ID: CSV_INVALID_READ_MODE,
+    CSV_INVALID_WRITE_MODE_ID: CSV_INVALID_WRITE_MODE,
+}
+
+# ** constant: default_errors
+DEFAULT_ERRORS = {
+    **CORE_DEFAULT_ERRORS,
+    **ADMIN_DEFAULT_ERRORS,
+    **SQLITE_DEFAULT_ERRORS,
+    **TOML_DEFAULT_ERRORS,
+    **CSV_DEFAULT_ERRORS,
+}


### PR DESCRIPTION
Closes #947

Adopts the five-capability-group tiered composition pattern from `v2.x-proto` in `tiferet/assets/error.py`, replacing two flat constant sections and a single monolithic `DEFAULT_ERRORS` dict.

**Implementor conversation:** https://app.warp.dev/conversation/ee1fecd0-45b5-4eb2-9b7b-0c9698328819

## Changes

- Split `(ids)` and `(models)` into ten alphabetized sub-group sections: core, admin, sqlite, toml, csv.
- Added five named group dicts (`CORE_`/`ADMIN_`/`SQLITE_`/`TOML_`/`CSV_DEFAULT_ERRORS`), with `DEFAULT_ERRORS` derived from them as the backward-compatible full-catalog re-export.
- **Retired the `CORE_DEFAULT_ERRORS = DEFAULT_ERRORS` stopgap alias** and its `# ++ todo`.
- Re-targeted four stale `# -- obsolete: ... (#911)` annotations.
- Normalized the module docstring to `"Tiferet Assets Error"`.
- Added `tests/assets/test_error.py` — six tier-boundary regression tests.

## Acceptance Criteria

- [x] 1. Module docstring is `"Tiferet Assets Error"`
- [x] 2. Ten `# *** constants (...)` sub-group sections in the specified order
- [x] 3. Entries alphabetized within each sub-group
- [x] 4. `FEATURE_STEP_LOADING_FAILED_ID` / `FEATURE_STEP_LOADING_FAILED` in core — *already satisfied by ST3 #913; verified in place*
- [x] 5. `INVALID_APP_SESSION_TYPE_ID` / `INVALID_APP_SESSION_TYPE` in core — *amended, see Amendment 1*
- [x] 6. Five group dicts defined in `# *** constants (groups)` in order
- [x] 7. `DEFAULT_ERRORS` redefined as the five-way spread
- [x] 8. All pre-story keys remain present
- [x] 9. Four `# -- obsolete:` annotations retained and re-targeted — *amended, see Amendment 2*
- [x] 10. No constants outside `tiferet/assets/error.py` modified
- [x] 11. Stopgap alias and its `# ++ todo` removed — *added, see Amendment 3*
- [x] 12. `tiferet/blueprints/core.py` unchanged
- [x] 13. `tests/assets/test_error.py` covers the six tier-boundary assertions
- [x] 14. Suite matches baseline plus the new tests

## TRD amendments

The TRD was dated 2026-07-29, before ST3, ST4, and ST5 landed. Four assumptions were re-verified against `main@5c6e034` and `origin/v2.x-proto` before any code was written; three were amended under explicit developer ruling and the TRD/issue body republished (see §9 Amendment Log on #947).

**Amendment 1 — AC 5 message text.** The TRD specified `'{attribute} must be a non-empty string.'`, copied from the prototype catalog. The prototype's raise site passes an *explicit inline message* to `RaiseError.execute`, so that catalog text never surfaces there. `main`'s raise site (`blueprints/core.py:618`) passes none, so the catalog text **is** user-facing — adopting the TRD text would emit an unfilled `{attribute}` placeholder at the only call site. **Ruled: keep `main`'s wording.**

**Amendment 2 — AC 9 annotations.** AC 9 required preserving the `(#911)` annotations verbatim, but #911 is now closed, so the marker points at a passed milestone. Six sibling annotations in `events/app.py` use the bare `Retire in Parity V Story 13.` form — the `(#911)` suffix is the anomaly. **Ruled: re-target in this PR.** Four annotations were affected, not the two AC 9 named — both ID *and* both model constants carry the suffix.

**Amendment 3 — tier inversion.** The TRD never mentions `CORE_DEFAULT_ERRORS = DEFAULT_ERRORS`, added after authoring by ST4 review finding DI-4 (`2dfcb2e`); its own `# ++ todo` names this story as its retirement point. **Ruled: retire it, and `build_cache` keeps `CORE_DEFAULT_ERRORS`.**

## Behavioural change — reviewer attention

Retiring the alias narrows what `build_cache` seeds. `blueprints/core.py:176` decorates with `@add_default_errors(a.error.CORE_DEFAULT_ERRORS)`; while the alias stood that seeded all 75 errors, and it now seeds the 42-error core tier. The 33 admin/sqlite/toml/csv errors fall through `get_error` to a repository lookup that raises `ERROR_NOT_FOUND` when absent from consumer config.

This is intended: the prototype's `build_cache` uses the same decorator argument, and selective seeding by capability is the entire purpose of the tiering. `blueprints/core.py` is deliberately unchanged, and `tests/assets/test_error.py` locks the boundary so the relationship cannot silently re-invert.

## Group membership

Determined by diffing `main`'s flat catalog (75 keys) against the prototype's five tiers (68). The prototype is a strict subset; `main` carries 7 extra IDs. Two are named in TRD §4.3's admin roster; the other five (`APP_REPOSITORY_IMPORT_FAILED_ID`, `APP_SERVICE_NOT_LOADED_ID`, `ATTRIBUTE_ALREADY_EXISTS_ID`, `DEPENDENCY_TYPE_NOT_FOUND_ID`, `INVALID_DEPENDENCY_ERROR_ID`) fall to core by §4.3's residual rule.

core 42 · admin 18 · sqlite 6 · toml 3 · csv 6 = **75**

## Validation

`pytest tiferet/ tests/` → **1094 passed, 12 skipped, 0 errors** against the `main@5c6e034` baseline of 1088/12/0. The delta is exactly the six new tests.

AC 8 was verified mechanically rather than by inspection: the pre-story `DEFAULT_ERRORS` was serialized to disk before the restructure and compared afterwards — **identical key-set, zero value diffs** across all 75 entries. The restructure itself was performed by a parser/generator over the artifact blocks rather than by hand, so no constant could be dropped or reworded in transit.

## Flagged, out of scope

- `tiferet/events/app.py:353` carries the same stale `(#911)` suffix, but lies outside this story's single-file scope. Suggest folding into a later annotation story.
- `docs/core/assets.md` is broadly stale — it still documents `constants.py` and `blueprints.py`, both superseded by earlier stories, and shows the flat `DEFAULT_ERRORS` form. This predates #947 and is much wider than the error catalog. Note the `tiferet-code-assets` skill already documents the tiered pattern correctly.

Co-Authored-By: Oz <oz-agent@warp.dev>
