### PR TITLE
Assets – App Catalog Multi-line Constants Normalization (#948)

### DIFF
--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -114,7 +114,9 @@ DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(
 DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
 
 # ** constant: default_app_service_parameters
-DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+DEFAULT_APP_SERVICE_PARAMETERS = {
+    'app_config': DEFAULT_APP_CONFIG_FILE,
+}
 
 # *** constants (sessions)
 
@@ -262,11 +264,16 @@ CORE_DEFAULT_CONSTANTS: Dict[str, str] = {
 }
 
 # ** constant: admin_default_services
-ADMIN_DEFAULT_SERVICES = {**CORE_DEFAULT_SERVICES}
+ADMIN_DEFAULT_SERVICES = {
+    **CORE_DEFAULT_SERVICES,
+}
 
 # ** constant: admin_default_constants
 # Core constants plus the app_config key that the admin layer exposes directly.
-ADMIN_DEFAULT_CONSTANTS = {**CORE_DEFAULT_CONSTANTS, 'app_config': DEFAULT_CONFIG_FILE}
+ADMIN_DEFAULT_CONSTANTS = {
+    **CORE_DEFAULT_CONSTANTS,
+    'app_config': DEFAULT_CONFIG_FILE,
+}
 
 # ** constant: core_default_app_sessions
 # Built-in session definitions seeded into the cache by build_cache.


### PR DESCRIPTION
Closes #948

Applies the SD-1 multi-line hanging-indent standard to the three dict-typed constants in `tiferet/assets/app.py` still using the prohibited single-line form.

**Implementor conversation:** https://app.warp.dev/conversation/ee1fecd0-45b5-4eb2-9b7b-0c9698328819

## Changes

| Constant | Line |
|---|---|
| `DEFAULT_APP_SERVICE_PARAMETERS` | 117 |
| `ADMIN_DEFAULT_SERVICES` | 265 |
| `ADMIN_DEFAULT_CONSTANTS` | 269 |

Pure formatting. No behavioural or semantic change.

## Acceptance Criteria

- [x] 1. `DEFAULT_APP_SERVICE_PARAMETERS` uses multi-line hanging indent with a trailing comma
- [x] 2. `ADMIN_DEFAULT_SERVICES` uses multi-line hanging indent with a trailing comma
- [x] 3. `ADMIN_DEFAULT_CONSTANTS` uses multi-line hanging indent with a trailing comma
- [x] 4. No other lines in `tiferet/assets/app.py` are modified

## TRD drift

**None.** All three targets were exactly as the TRD describes — no re-verification adjustments were needed, in contrast to the sibling #947.

## Validation

The diff is **10 insertions, 3 deletions in a single file** — precisely the three constants expanded, nothing else, satisfying AC 4 literally. The explanatory comment above `ADMIN_DEFAULT_CONSTANTS` is preserved in place.

Evaluated values confirmed identical after the change:

```
DEFAULT_APP_SERVICE_PARAMETERS: {'app_config': 'config.yml'}
ADMIN_DEFAULT_SERVICES == CORE_DEFAULT_SERVICES: True
ADMIN_DEFAULT_CONSTANTS: {'cli_config': ..., 'di_config': ..., 'error_config': ...,
                          'logging_config': ..., 'feature_config': ..., 'app_config': 'config.yml'}
```

`pytest tiferet/ tests/` → **1088 passed, 12 skipped, 0 errors** — identical to the `main@5c6e034` baseline. `DEFAULT_APP_SERVICE_PARAMETERS` is consumed at `blueprints/core.py:341` and asserted in `tests/blueprints/test_core.py:389,430`; those assertions remain green and untouched.

## Relationship to #947

Separate issue, separate TRD, separate branch and PR — deliberately not bundled with #947 despite both being XS assets cleanup. Both were cut from `main@5c6e034` and touch different modules (`error.py` vs `app.py`), so they carry no conflict and may merge in either order.

These two are the last open issues on milestone 31.

Co-Authored-By: Oz <oz-agent@warp.dev>
