### PR TITLE
Hotfix – Post-Parity-IV Proto Convergence (HF-1–HF-24)

### DIFF
--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -950,15 +950,17 @@ def test_build_logging_context_uses_defaults_when_evt_returns_empty():
     assert len(result.domain.loggers) > 0
 
 
-# ** test: build_logging_context_uses_repo_data_when_provided
-def test_build_logging_context_uses_repo_data_when_provided():
+# ** test: build_logging_context_merges_repo_data_over_defaults_by_id
+def test_build_logging_context_merges_repo_data_over_defaults_by_id():
     '''
-    Test that build_logging_context uses repo-supplied sections over cache
-    defaults when the event returns non-empty data.
+    Test that build_logging_context merges repo-supplied sections over the
+    cache-seeded defaults by id: an entry sharing a default's id replaces it,
+    while defaults the repo does not redeclare survive.
     '''
     from tiferet.domain.logging import Formatter, Handler, Logger
 
-    # Arrange cache and an event that returns concrete domain objects.
+    # Arrange cache and an event returning one new formatter, one new handler,
+    # and a logger whose id collides with the seeded 'root' default.
     cache = build_cache()
     repo_formatter = Formatter(
         id='repo', name='Repo Formatter', format='%(message)s'
@@ -980,10 +982,41 @@ def test_build_logging_context_uses_repo_data_when_provided():
     # Build the logging context.
     result = build_logging_context(cache, get_dependency, logger_id='default')
 
-    # Assert the domain uses the repo-supplied data, not the defaults.
-    assert result.domain.formatters == [repo_formatter]
-    assert result.domain.handlers == [repo_handler]
-    assert result.domain.loggers == [repo_logger]
+    # Assert the repo entries are present alongside the surviving defaults.
+    assert repo_formatter in result.domain.formatters
+    assert repo_handler in result.domain.handlers
+    assert {'default', 'repo'} == {f.id for f in result.domain.formatters}
+    assert {'default_root', 'default', 'debug', 'repo_h'} == {h.id for h in result.domain.handlers}
+
+    # Assert the id collision replaced only the matching default logger.
+    assert {'root', 'default', 'debug'} == {l.id for l in result.domain.loggers}
+    assert next(l for l in result.domain.loggers if l.id == 'root') is repo_logger
+
+
+# ** test: build_logging_context_tolerates_unseeded_cache
+def test_build_logging_context_tolerates_unseeded_cache():
+    '''
+    Test that build_logging_context does not fail when the cache carries no
+    seeded logging defaults, using the repo-supplied sections alone.
+    '''
+    from tiferet.domain.logging import Formatter
+
+    # Arrange a bare cache with no seeded logging settings.
+    cache = CacheContext()
+    repo_formatter = Formatter(
+        id='repo', name='Repo Formatter', format='%(message)s'
+    )
+    logging_evt = mock.Mock()
+    logging_evt.execute.return_value = ([repo_formatter], [], [])
+    get_dependency = mock.Mock(return_value=logging_evt)
+
+    # Build the logging context against the unseeded cache.
+    result = build_logging_context(cache, get_dependency, logger_id='default')
+
+    # Assert only the repo-supplied formatter is present and no error was raised.
+    assert [f.id for f in result.domain.formatters] == ['repo']
+    assert result.domain.handlers == []
+    assert result.domain.loggers == []
 
 
 # ** test: build_app_session_context_returns_app_session_context

--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -563,6 +563,28 @@ def test_parse_parameter_resolves_env(monkeypatch):
     assert parse_parameter('$env.TIFERET_TEST_VAR') == 'resolved_value'
 
 
+# ** test: parse_parameter_missing_env_raises
+def test_parse_parameter_missing_env_raises(monkeypatch):
+    '''
+    Test that parse_parameter raises PARAMETER_PARSING_FAILED when the referenced
+    environment variable is unset.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :type monkeypatch: pytest.MonkeyPatch
+    '''
+
+    # Ensure the environment variable is absent.
+    monkeypatch.delenv('TIFERET_NONEXISTENT_VAR', raising=False)
+
+    # Attempt to resolve the missing reference and capture the structured error.
+    with pytest.raises(TiferetError) as exc_info:
+        parse_parameter('$env.TIFERET_NONEXISTENT_VAR')
+
+    # Assert the error code and parameter context are reported.
+    assert exc_info.value.error_code == a.error.PARAMETER_PARSING_FAILED_ID
+    assert exc_info.value.kwargs.get('parameter') == '$env.TIFERET_NONEXISTENT_VAR'
+
+
 # ** test: load_cache_returns_root_snapshot_callable
 def test_load_cache_returns_root_snapshot_callable():
     '''
@@ -633,6 +655,9 @@ def test_create_feature_context_with_preloaded_feature():
     assert feature_context.get_dependency is get_dependency
     assert feature_context.cache is cache
     get_dependency.assert_not_called()
+
+    # Assert the blueprint-owned parameter parser was injected.
+    assert feature_context.parse_parameter is parse_parameter
 
 
 # ** test: create_feature_context_loads_by_feature_id

--- a/tests/contexts/test_app.py
+++ b/tests/contexts/test_app.py
@@ -31,6 +31,7 @@ from tiferet.contexts.app import (
 )
 from tiferet.contexts.cache import CacheContext
 from tiferet.contexts.error import ErrorContext, ERROR_CACHE_PREFIX
+from tiferet.contexts.feature import FEATURE_CACHE_PREFIX
 
 # *** fixtures
 
@@ -648,6 +649,74 @@ def test_app_session_context_build_response_fallback(app_interface):
     # Assert build_response returns the request's handled response.
     result = context.build_response(request)
     assert result == 'the_result'
+
+
+# ** test: app_session_context_execute_feature_fallback_reads_feature_namespace
+def test_app_session_context_execute_feature_fallback_reads_feature_namespace(app_interface):
+    """
+    Test that the legacy execute_feature fallback resolves the feature from the
+    feature cache namespace rather than the cache root namespace.
+
+    :param app_interface: The test AppSessionAggregate.
+    :type app_interface: AppSessionAggregate
+    """
+
+    # Seed a feature into the shared cache under the feature namespace.
+    feature = Feature(
+        id='group.feat',
+        group_id='group',
+        feature_key='feat',
+        name='Test Feature',
+    )
+    cache = CacheContext()
+    cache.set('group.feat', feature, *FEATURE_CACHE_PREFIX)
+
+    # Construct the hub without an execute_feature_handler to force the fallback.
+    context = AppSessionContext.from_domain(
+        app_interface,
+        get_dependency=mock.Mock(),
+        cache=cache,
+    )
+
+    # Drive the fallback with the real FeatureContext execution patched out.
+    request = RequestContext(data={})
+    with mock.patch.object(FeatureContext, 'execute_feature') as execute_mock:
+        context.execute_feature('group.feat', request)
+
+    # Assert the seeded feature was resolved and forwarded rather than None.
+    assert execute_mock.call_args.args[0] is feature
+
+
+# ** test: app_session_context_handle_error_fallback_preserves_error_kwargs
+def test_app_session_context_handle_error_fallback_preserves_error_kwargs(app_interface):
+    """
+    Test that the legacy handle_error fallback propagates the structured error
+    kwargs onto the raised TiferetAPIError.
+
+    :param app_interface: The test AppSessionAggregate.
+    :type app_interface: AppSessionAggregate
+    """
+
+    # Construct the hub without a raise_error_handler to force the fallback.
+    context = AppSessionContext.from_domain(
+        app_interface,
+        get_dependency=mock.Mock(),
+    )
+
+    # Arrange a structured error carrying additional context kwargs.
+    error = TiferetError(
+        'TEST_ERROR',
+        'Test error message.',
+        feature_id='group.feat',
+    )
+
+    # Invoke the fallback and capture the raised API error.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.handle_error(error)
+
+    # Assert the structured context survived onto the raised API error.
+    assert exc_info.value.error_code == 'TEST_ERROR'
+    assert exc_info.value.kwargs.get('feature_id') == 'group.feat'
 
 
 # ** test: app_interface_context_handle_response

--- a/tests/contexts/test_feature.py
+++ b/tests/contexts/test_feature.py
@@ -20,7 +20,6 @@ from tiferet.contexts.feature import (
     merge_step_kwargs,
     build_step_chain,
     compose_step_middleware,
-    parse_request_parameter,
     evaluate_condition,
     validate_request,
 )
@@ -1055,31 +1054,31 @@ def test_build_step_chain_with_middleware(test_command):
     assert order == ['pre', 'post']
 
 # ** test: parse_request_parameter_request_ref_success
-def test_parse_request_parameter_request_ref_success():
+def test_parse_request_parameter_request_ref_success(feature_context):
     """Test that parse_request_parameter extracts a $r.-prefixed value from request data."""
 
     # Create a request containing the referenced key.
     request = RequestContext(data={'key': 'value'})
 
     # Parse the request-backed parameter.
-    result = parse_request_parameter('$r.key', request)
+    result = feature_context.parse_request_parameter('$r.key', request)
 
     # Assert the extracted value is returned.
     assert result == 'value'
 
 # ** test: parse_request_parameter_request_not_found
-def test_parse_request_parameter_request_not_found():
+def test_parse_request_parameter_request_not_found(feature_context):
     """Test that parse_request_parameter raises REQUEST_NOT_FOUND when no request is given."""
 
     # Assert the structured error is raised when no request is provided.
     with pytest.raises(TiferetError) as exc_info:
-        parse_request_parameter('$r.key', None)
+        feature_context.parse_request_parameter('$r.key', None)
 
     assert exc_info.value.error_code == 'REQUEST_NOT_FOUND'
     assert exc_info.value.kwargs.get('parameter') == '$r.key'
 
 # ** test: parse_request_parameter_key_missing
-def test_parse_request_parameter_key_missing():
+def test_parse_request_parameter_key_missing(feature_context):
     """Test that parse_request_parameter raises PARAMETER_NOT_FOUND when the key is absent."""
 
     # Create a request that does not contain the referenced key.
@@ -1087,30 +1086,40 @@ def test_parse_request_parameter_key_missing():
 
     # Assert the structured error is raised when the key is missing.
     with pytest.raises(TiferetError) as exc_info:
-        parse_request_parameter('$r.missing', request)
+        feature_context.parse_request_parameter('$r.missing', request)
 
     assert exc_info.value.error_code == 'PARAMETER_NOT_FOUND'
     assert exc_info.value.kwargs.get('parameter') == '$r.missing'
 
-# ** test: parse_request_parameter_delegates_to_parse_parameter
-def test_parse_request_parameter_delegates_to_parse_parameter(monkeypatch):
-    """Test that non-$r. parameters are forwarded to ParseParameter.execute."""
+# ** test: parse_request_parameter_delegates_to_injected_parser
+def test_parse_request_parameter_delegates_to_injected_parser(services_context):
+    """Test that non-$r. parameters are forwarded to the injected parse_parameter callable."""
 
-    from tiferet.events import static as static_events
-
+    # Arrange a spy parser to capture the delegated parameter.
     called = {}
 
-    def fake_execute(parameter: str):
+    def spy_parser(parameter: str) -> str:
         called['parameter'] = parameter
         return 'parsed-value'
 
-    monkeypatch.setattr(static_events.ParseParameter, 'execute', staticmethod(fake_execute))
+    # Build a context wired with the spy parser.
+    ctx = FeatureContext(
+        get_dependency=services_context.get_dependency,
+        parse_parameter=spy_parser,
+    )
 
-    # A non-$r. parameter should delegate to ParseParameter.execute.
-    result = parse_request_parameter('$env.MY_VAR', RequestContext(data={}))
+    # A non-$r. parameter should delegate to the injected parser.
+    result = ctx.parse_request_parameter('$env.MY_VAR', RequestContext(data={}))
 
     assert result == 'parsed-value'
     assert called['parameter'] == '$env.MY_VAR'
+
+# ** test: parse_request_parameter_defaults_to_identity
+def test_parse_request_parameter_defaults_to_identity(feature_context):
+    """Test that a context built without a parser passes non-$r. values through unchanged."""
+
+    # Assert the identity default returns the parameter verbatim.
+    assert feature_context.parse_request_parameter('plain_value', RequestContext(data={})) == 'plain_value'
 
 # ** test: evaluate_condition_none_returns_true
 def test_evaluate_condition_none_returns_true():

--- a/tests/events/test_static.py
+++ b/tests/events/test_static.py
@@ -7,7 +7,7 @@ import pytest
 import os
 
 # ** app
-from tiferet.events.static import ParseParameter, ImportDependency, RaiseError
+from tiferet.events.static import ParseParameter, RaiseError
 from tiferet.events.core import TiferetError, a
 
 # *** tests
@@ -58,33 +58,6 @@ def test_parse_parameter_non_env_string():
 
     # Verify the value is returned unchanged.
     assert result == 'plain_value', 'Should return the plain string unchanged'
-
-# ** test: test_import_dependency_success
-def test_import_dependency_success():
-    '''
-    Test that ImportDependency successfully imports a known class.
-    '''
-
-    # Import os.getenv via ImportDependency.
-    result = ImportDependency.execute('os', 'getenv')
-
-    # Verify the imported attribute is os.getenv.
-    assert result is os.getenv, 'Should import os.getenv successfully'
-
-# ** test: test_import_dependency_failure
-def test_import_dependency_failure():
-    '''
-    Test that ImportDependency raises on an invalid module/class.
-    '''
-
-    # Attempt to import a nonexistent module, expect TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        ImportDependency.execute('nonexistent.module', 'FakeClass')
-
-    # Verify error code and kwargs.
-    assert exc_info.value.error_code == a.error.IMPORT_DEPENDENCY_FAILED_ID, 'Should raise IMPORT_DEPENDENCY_FAILED'
-    assert exc_info.value.kwargs.get('module_path') == 'nonexistent.module', 'Should include module_path'
-    assert exc_info.value.kwargs.get('class_name') == 'FakeClass', 'Should include class_name'
 
 # ** test: test_raise_error_basic
 def test_raise_error_basic():

--- a/tests/events/test_static.py
+++ b/tests/events/test_static.py
@@ -4,60 +4,12 @@
 
 # ** infra
 import pytest
-import os
 
 # ** app
-from tiferet.events.static import ParseParameter, RaiseError
-from tiferet.events.core import TiferetError, a
+from tiferet.events.static import RaiseError
+from tiferet.events.core import TiferetError
 
 # *** tests
-
-# ** test: test_parse_parameter_env_variable
-def test_parse_parameter_env_variable():
-    '''
-    Test that ParseParameter resolves an existing environment variable.
-    '''
-
-    # Set a test environment variable.
-    os.environ['TIFERET_TEST_VAR'] = 'hello_world'
-
-    # Parse the environment variable parameter.
-    result = ParseParameter.execute('$env.TIFERET_TEST_VAR')
-
-    # Verify the resolved value.
-    assert result == 'hello_world', 'Should resolve the environment variable value'
-
-    # Clean up.
-    del os.environ['TIFERET_TEST_VAR']
-
-# ** test: test_parse_parameter_missing_env_variable
-def test_parse_parameter_missing_env_variable():
-    '''
-    Test that ParseParameter raises on a missing environment variable.
-    '''
-
-    # Ensure the variable does not exist.
-    os.environ.pop('TIFERET_NONEXISTENT_VAR', None)
-
-    # Attempt to parse a missing env variable, expect TiferetError.
-    with pytest.raises(TiferetError) as exc_info:
-        ParseParameter.execute('$env.TIFERET_NONEXISTENT_VAR')
-
-    # Verify error code and kwargs.
-    assert exc_info.value.error_code == a.error.PARAMETER_PARSING_FAILED_ID, 'Should raise PARAMETER_PARSING_FAILED'
-    assert exc_info.value.kwargs.get('parameter') == '$env.TIFERET_NONEXISTENT_VAR', 'Should include the parameter'
-
-# ** test: test_parse_parameter_non_env_string
-def test_parse_parameter_non_env_string():
-    '''
-    Test that ParseParameter passes through a plain string unchanged.
-    '''
-
-    # Parse a non-environment variable string.
-    result = ParseParameter.execute('plain_value')
-
-    # Verify the value is returned unchanged.
-    assert result == 'plain_value', 'Should return the plain string unchanged'
 
 # ** test: test_raise_error_basic
 def test_raise_error_basic():

--- a/tests/mappers/test_app.py
+++ b/tests/mappers/test_app.py
@@ -237,6 +237,47 @@ class TestAppSessionAggregate(AggregateTestBase):
         # Verify the remaining services.
         assert [s.service_id for s in aggr.services] == expected_remaining
 
+    # ** test: add_service_appends_with_service_id_first
+    def test_add_service_appends_with_service_id_first(self, aggregate):
+        '''
+        Test that add_service appends a dependency, taking service_id first so
+        its positional order matches set_service.
+        '''
+
+        # Verify the service does not exist yet.
+        assert aggregate.get_service('added_svc') is None
+
+        # Add the service positionally to pin the parameter order.
+        aggregate.add_service(
+            'added_svc',
+            'pkg.added.module',
+            'AddedService',
+            parameters={'p1': 'v1'},
+        )
+
+        # Verify the dependency was appended with each value in the right field.
+        svc = aggregate.get_service('added_svc')
+        assert svc is not None
+        assert svc.module_path == 'pkg.added.module'
+        assert svc.class_name == 'AddedService'
+        assert svc.parameters == {'p1': 'v1'}
+
+    # ** test: add_service_defaults_parameters_to_empty
+    def test_add_service_defaults_parameters_to_empty(self, aggregate):
+        '''
+        Test that add_service defaults parameters to an empty dict when omitted.
+        '''
+
+        # Add a service without parameters.
+        aggregate.add_service(
+            service_id='no_params_svc',
+            module_path='pkg.noparams',
+            class_name='NoParamsService',
+        )
+
+        # Verify parameters defaulted to an empty dict.
+        assert aggregate.get_service('no_params_svc').parameters == {}
+
     # ** test: set_service_update_existing_merge_params
     def test_set_service_update_existing_merge_params(self, aggregate):
         '''

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -10,7 +10,6 @@ __all__ = [
     'DomainObject',
     'DomainEvent',
     'AsyncDomainEvent',
-    'ParseParameter',
     'Service',
     'MiddlewareService',
     'Aggregate',
@@ -44,7 +43,6 @@ try:
     from .events import (
         DomainEvent,
         AsyncDomainEvent,
-        ParseParameter,
     )
     from .interfaces import Service, MiddlewareService
     from .mappers import (

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -119,7 +119,9 @@ DEFAULT_APP_SERVICE_MODULE_PATH = create_service_module_path(
 DEFAULT_APP_SERVICE_CLASS_NAME = 'AppConfigRepository'
 
 # ** constant: default_app_service_parameters
-DEFAULT_APP_SERVICE_PARAMETERS = {'app_config': DEFAULT_APP_CONFIG_FILE}
+DEFAULT_APP_SERVICE_PARAMETERS = {
+    'app_config': DEFAULT_APP_CONFIG_FILE,
+}
 
 # *** constants (sessions)
 

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -547,7 +547,7 @@ FEATURE_NAME_REQUIRED = create_default_error(
 INVALID_FEATURE_ATTRIBUTE = create_default_error(
     INVALID_FEATURE_ATTRIBUTE_ID,
     'Invalid Feature Attribute',
-    [(EN_US, 'Invalid feature attribute: {attribute}')],
+    [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
 )
 
 # ** constant: invalid_feature_command_attribute

--- a/tiferet/assets/logging.py
+++ b/tiferet/assets/logging.py
@@ -130,6 +130,6 @@ DEBUG_LOGGER = create_default_logger(
 # ** constant: core_default_logging_settings
 CORE_DEFAULT_LOGGING_SETTINGS: Dict[str, Any] = {
     'formatters': [DEFAULT_FORMATTER],
-    'handlers':   [DEFAULT_ROOT_HANDLER, DEFAULT_HANDLER, DEBUG_HANDLER],
-    'loggers':    [ROOT_LOGGER, DEFAULT_LOGGER, DEBUG_LOGGER],
+    'handlers': [DEFAULT_ROOT_HANDLER, DEFAULT_HANDLER, DEBUG_HANDLER],
+    'loggers': [ROOT_LOGGER, DEFAULT_LOGGER, DEBUG_LOGGER],
 }

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -12,14 +12,10 @@ from . import core
 from ..contexts.cli import (
     CliArgument,
     CliCommand,
-    CliRecord,
-    CliOutputRecord,
-    CliRecordList,
     CliRequestContext,
     CliSessionContext,
     add_default_cli_commands,
     get_default_cli_commands,
-    CLI_COMMAND_CACHE_PREFIX,
 )
 from ..contexts.cache import CacheContext
 from ..contexts.request import RequestContext

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -3,6 +3,7 @@
 # *** imports
 
 # ** core
+import os
 from typing import Any, Callable, Dict
 
 # ** app
@@ -37,7 +38,6 @@ from ..contexts.app import (
 from ..di import DIAppServiceContainer, DIDynamicServiceContainer, injectable_parameter_names
 from ..di.core import ServiceResolver
 from ..di.dependency_injector import DIDynamicServiceResolver
-from ..events import ParseParameter
 from .. import assets as a
 
 # *** blueprints
@@ -379,9 +379,10 @@ def parse_parameter(parameter: str) -> Any:
     '''
     Parse a configuration parameter value, resolving environment references.
 
-    Thin blueprint-layer wrapper over the ParseParameter static event so the DI
-    resolver receives its parser from the blueprint layer rather than importing
-    the event directly.
+    Resolves ``$env.``-prefixed values from the process environment and returns
+    any other value unchanged. Parameter parsing is owned by the blueprint layer
+    and injected into both the DI resolver and the FeatureContext, so neither
+    reaches into the events layer to parse a parameter.
 
     :param parameter: The parameter value to parse.
     :type parameter: str
@@ -389,8 +390,30 @@ def parse_parameter(parameter: str) -> Any:
     :rtype: Any
     '''
 
-    # Delegate to the ParseParameter static event.
-    return ParseParameter.execute(parameter)
+    # Resolve the parameter, wrapping any failure in a structured error.
+    try:
+
+        # Resolve an environment reference from the process environment.
+        if parameter.startswith('$env.'):
+            result = os.getenv(parameter[5:])
+
+            # Treat an unset or empty environment variable as a failure.
+            if not result:
+                raise Exception('Environment variable not found.')
+
+            # Return the resolved environment value.
+            return result
+
+        # Return any non-environment parameter unchanged.
+        return parameter
+
+    # Raise a structured error when parsing fails.
+    except Exception as e:
+        RaiseError.execute(
+            a.error.PARAMETER_PARSING_FAILED_ID,
+            parameter=parameter,
+            exception=str(e),
+        )
 
 # ** blueprint: build_service_resolver
 def build_service_resolver(
@@ -521,8 +544,13 @@ def create_feature_context(
     if feature is None:
         feature = get_feature(cache, get_dependency)(feature_id)
 
-    # Compose the feature context with the resolver handler and shared cache.
-    feature_context = FeatureContext(get_dependency=get_dependency, cache=cache)
+    # Compose the feature context with the resolver handler, shared cache, and
+    # the blueprint-owned parameter parser.
+    feature_context = FeatureContext(
+        get_dependency=get_dependency,
+        cache=cache,
+        parse_parameter=parse_parameter,
+    )
 
     # Return the feature and its composed context.
     return feature, feature_context

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -14,7 +14,6 @@ from ..contexts.feature import (
     Feature,
     FeatureContext,
     FEATURE_CACHE_PREFIX,
-    add_default_features,
 )
 from ..contexts.logging import (
     add_default_logging_settings,

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -19,6 +19,7 @@ from ..contexts.logging import (
     add_default_logging_settings,
     get_default_logging_settings,
     LoggingContext,
+    LoggingSettings,
 )
 from ..contexts.request import RequestContext
 from ..contexts.core import BaseContext
@@ -267,10 +268,11 @@ def build_logging_context(
 
     Resolves the ``logging_list_all_evt`` from the app-scoped service container,
     calls it once to fetch any repository-specific logging configurations, merges
-    the result over the cache-seeded ``LoggingSettings`` defaults (empty sections
-    fall back to defaults), and constructs a ``LoggingContext`` via
+    the result over the cache-seeded ``LoggingSettings`` defaults **by id** (a
+    repository entry overrides the default sharing its id, while unmatched
+    defaults survive), and constructs a ``LoggingContext`` via
     ``LoggingContext.from_domain`` with the assembled ``LoggingSettings`` bound
-    as the domain object.
+    as the domain object. A cache with no seeded defaults is tolerated.
 
     :param cache: The shared cache context pre-seeded with default LoggingSettings.
     :type cache: CacheContext
@@ -288,15 +290,26 @@ def build_logging_context(
     # Fetch repo-specific configs; empty sections signal no config file present.
     formatters, handlers, loggers = logging_list_all_evt.execute()
 
-    # Load the cache-seeded defaults as the fallback for any missing section.
+    # Load the cache-seeded defaults, tolerating a cache with none seeded.
     defaults = get_default_logging_settings(cache)
+    default_formatters = defaults.formatters if defaults else []
+    default_handlers = defaults.handlers if defaults else []
+    default_loggers = defaults.loggers if defaults else []
 
-    # Build the LoggingSettings domain object, merging repo data over defaults.
-    from ..domain import LoggingSettings
+    # Merge the retrieved configs over the defaults keyed by id, so a repository
+    # entry overrides only the default sharing its id.
+    merged_formatters = {formatter.id: formatter for formatter in default_formatters}
+    merged_formatters.update({formatter.id: formatter for formatter in (formatters or [])})
+    merged_handlers = {handler.id: handler for handler in default_handlers}
+    merged_handlers.update({handler.id: handler for handler in (handlers or [])})
+    merged_loggers = {logger.id: logger for logger in default_loggers}
+    merged_loggers.update({logger.id: logger for logger in (loggers or [])})
+
+    # Build the merged LoggingSettings domain object.
     settings = LoggingSettings(
-        formatters=formatters or defaults.formatters,
-        handlers=handlers or defaults.handlers,
-        loggers=loggers or defaults.loggers,
+        formatters=list(merged_formatters.values()),
+        handlers=list(merged_handlers.values()),
+        loggers=list(merged_loggers.values()),
     )
 
     # Construct the LoggingContext via the BaseContext factory, injecting logger_id.

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -33,9 +33,10 @@ from ..contexts.app import (
     get_default_app_constants,
     get_default_app_session,
 )
-from ..di import DIAppServiceContainer, DIDynamicServiceContainer, injectable_parameter_names, ParseParameter
+from ..di import DIAppServiceContainer, DIDynamicServiceContainer, injectable_parameter_names
 from ..di.core import ServiceResolver
 from ..di.dependency_injector import DIDynamicServiceResolver
+from ..events import ParseParameter
 from .. import assets as a
 
 # *** blueprints

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -17,7 +17,7 @@ from ..events.app import GetAppSession
 from ..interfaces import AppService
 from .core import BaseContext
 from .cache import CacheContext
-from .feature import FeatureContext
+from .feature import FeatureContext, FEATURE_CACHE_PREFIX
 from .logging import LoggingContext
 from .request import RequestContext
 
@@ -489,11 +489,18 @@ class AppSessionContext(BaseContext):
 
         # Fallback: execute directly (should not normally be reached when blueprints wire handlers).
         feature_context_cls = BaseContext.for_domain(Feature)
-        feature_context = feature_context_cls(
+
+        # Resolve the feature from the shared cache under the feature namespace.
+        feature = self.cache.get(feature_id, *FEATURE_CACHE_PREFIX)
+
+        # Bind the resolved feature to the context via the registry factory.
+        feature_context = feature_context_cls.from_domain(
+            feature,
             get_dependency=self.get_dependency,
             cache=self.cache,
         )
-        feature = self.cache.get(feature_id)
+
+        # Drive execution against the resolved feature.
         feature_context.execute_feature(feature, request, **kwargs)
 
     # * method: handle_error
@@ -523,12 +530,15 @@ class AppSessionContext(BaseContext):
             error = TiferetError(
                 'APP_ERROR',
                 f'An error occurred in the app: {str(error)}',
-                error=str(error)
+                error=str(error),
             )
+
+        # Raise the structured API error, propagating the error's context kwargs.
         raise TiferetAPIError(
             error_code=error.error_code,
             name=error.error_code,
             message=str(error),
+            **error.kwargs,
         )
 
     # * method: build_response

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -313,31 +313,37 @@ def get_default_app_session(cache: CacheContext, session_id: str) -> AppSession 
 # ** context: app_session_context
 class AppSessionContext(BaseContext):
     '''
-    The application session context is a minimal hub that builds operational
-    sub-contexts on demand from a loaded ``AppSession`` domain object and
-    orchestrates feature execution, error handling, and logging.
+    The application session hub binds a loaded ``AppSession`` domain object
+    and delegates feature execution, error handling, request construction,
+    and response building to four injected FE4 template-method handlers.
+
+    The legacy fallback paths build operational sub-contexts on demand; they
+    are reached only when a handler is not wired.
     '''
 
     # * attribute: domain_type
     domain_type = AppSession
-
-    # * attribute: _execute_feature
-    _execute_feature: Callable
-
-    # * attribute: _create_request
-    _create_request: Callable
-
-    # * attribute: _raise_error
-    _raise_error: Callable
-
-    # * attribute: _build_response
-    _build_response: Callable
 
     # * attribute: get_dependency
     get_dependency: Callable
 
     # * attribute: cache
     cache: CacheContext
+
+    # * attribute: logging (private)
+    _logging: LoggingContext
+
+    # * attribute: execute_feature (private)
+    _execute_feature: Callable
+
+    # * attribute: create_request (private)
+    _create_request: Callable
+
+    # * attribute: raise_error (private)
+    _raise_error: Callable
+
+    # * attribute: build_response (private)
+    _build_response: Callable
 
     # * init
     def __init__(self,
@@ -572,7 +578,7 @@ class AppSessionContext(BaseContext):
             data: Dict[str, Any] = {},
             **kwargs) -> Any:
         '''
-        Run the application interface by executing the feature.
+        Run the application session by executing the feature.
 
         Pure orchestrator that calls the four template methods in order:
         ``build_request`` → ``execute_feature`` → ``handle_error`` (on error)
@@ -593,7 +599,7 @@ class AppSessionContext(BaseContext):
         # Start timing immediately.
         start_time = time.perf_counter()
 
-        # Create the logger for the app interface context.
+        # Build the logger for this session run.
         logger = self.load_logging_context().build_logger()
 
         # Build request via the template method.

--- a/tiferet/contexts/cache.py
+++ b/tiferet/contexts/cache.py
@@ -1,3 +1,5 @@
+"""Tiferet Cache Contexts"""
+
 # *** imports
 
 # ** core

--- a/tiferet/contexts/cli.py
+++ b/tiferet/contexts/cli.py
@@ -4,7 +4,7 @@
 
 # ** core
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 # ** app
 from ..assets import TiferetAPIError
@@ -18,6 +18,7 @@ from ..domain import (
 )
 from .app import AppSessionContext
 from .cache import CacheContext
+from .logging import LoggingContext
 from .request import RequestContext
 
 # *** constants
@@ -197,7 +198,7 @@ class CliSessionContext(AppSessionContext):
     # * init
     def __init__(self,
             get_dependency: Callable,
-            logging_context = None,
+            logging_context: LoggingContext = None,
             parse_cli_args: Callable = None,
             cache: CacheContext = None,
             execute_feature_handler: Callable = None,
@@ -277,7 +278,7 @@ class CliSessionContext(AppSessionContext):
         return model
 
     # * method: run
-    def run(self, argv=None, **kwargs) -> Any:
+    def run(self, argv: List[str] = None, **kwargs) -> Any:
         '''
         Parse CLI arguments and dispatch execution through the inherited run.
 
@@ -287,7 +288,7 @@ class CliSessionContext(AppSessionContext):
 
         :param argv: Optional argument list; defaults to ``sys.argv[1:]`` when
             ``None``.
-        :type argv: Optional[List[str]]
+        :type argv: List[str]
         :param kwargs: Not used; present for signature compatibility.
         :type kwargs: dict
         :return: The feature response.

--- a/tiferet/contexts/error.py
+++ b/tiferet/contexts/error.py
@@ -60,7 +60,7 @@ def add_default_errors(errors: Dict[str, Any]) -> Callable:
 class ErrorContext(BaseContext):
     '''
     The error context formats structured error responses from loaded ``Error``
-    domain objects. Error retrieval is owned by the application interface hub.
+    domain objects. Error retrieval is owned by the application session hub.
     '''
 
     # * attribute: domain_type

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -19,8 +19,7 @@ from ..assets.error import (
 )
 from ..events import (
     DomainEvent,
-    RaiseError,
-    ParseParameter
+    RaiseError
 )
 from ..domain import Feature, EventFeatureStep
 
@@ -249,50 +248,6 @@ def compose_step_middleware(
     # Concatenate feature-level (outer) and step-level (inner) middleware.
     return (feature_middleware or []) + (step_middleware or [])
 
-# ** function: parse_request_parameter
-def parse_request_parameter(parameter: str, request: RequestContext = None) -> str:
-    '''
-    Parse a request-aware parameter value.
-
-    Delegates non-prefixed parameters to :func:`ParseParameter.execute`. For
-    ``$r.``-prefixed references, extracts the value keyed by the suffix from
-    ``request.data``, raising a structured error when the request is absent or
-    the key is missing.
-
-    :param parameter: The parameter value to parse.
-    :type parameter: str
-    :param request: The request context object containing data for parameter parsing.
-    :type request: RequestContext
-    :return: The parsed parameter value.
-    :rtype: str
-    '''
-
-    # Delegate non-prefixed parameters to the ParseParameter static event.
-    if not parameter.startswith('$r.'):
-        return ParseParameter.execute(parameter)
-
-    # Raise an error if the request is not provided for a request-backed parameter.
-    if not request:
-        RaiseError.execute(
-            REQUEST_NOT_FOUND_ID,
-            'Request data is not available for parameter parsing.',
-            parameter=parameter
-        )
-
-    # Extract the value from the request data using the key after the $r. prefix.
-    result = request.data.get(parameter[3:], None)
-
-    # Raise an error if the parameter key is not found in the request data.
-    if result is None:
-        RaiseError.execute(
-            PARAMETER_NOT_FOUND_ID,
-            f'Parameter {parameter} not found in request data.',
-            parameter=parameter
-        )
-
-    # Return the parsed parameter value.
-    return result
-
 # ** function: evaluate_condition
 def evaluate_condition(condition: str, request: RequestContext) -> bool:
     '''
@@ -390,11 +345,15 @@ class FeatureContext(BaseContext):
     # * attribute: context_data
     context_data: Dict[str, Any]
 
+    # * attribute: parse_parameter
+    parse_parameter: Callable
+
     # * init
     def __init__(self,
             get_dependency: Callable,
             cache: CacheContext = None,
-            context_data: Dict[str, Any] = None):
+            context_data: Dict[str, Any] = None,
+            parse_parameter: Callable = None):
         '''
         Initialize the feature context.
 
@@ -406,6 +365,10 @@ class FeatureContext(BaseContext):
         :param context_data: Lowest-priority context defaults merged into every
             command execution.
         :type context_data: Dict[str, Any]
+        :param parse_parameter: The injected parameter parser applied to
+            non-request-backed step parameters; defaults to an identity pass-through
+            so the context stays usable without a blueprint-supplied parser.
+        :type parse_parameter: Callable
         '''
 
         # Initialize the base context.
@@ -419,6 +382,9 @@ class FeatureContext(BaseContext):
 
         # Store the context-level execution defaults.
         self.context_data = context_data if context_data is not None else {}
+
+        # Store the injected parameter parser, defaulting to identity.
+        self.parse_parameter = parse_parameter if parse_parameter is not None else lambda parameter: parameter
 
     # * method: resolve_step_event
     def resolve_step_event(self, step: EventFeatureStep, feature_flags: List[str] = None) -> DomainEvent:
@@ -489,6 +455,50 @@ class FeatureContext(BaseContext):
 
         # Return the resolved middleware instances.
         return middleware
+
+    # * method: parse_request_parameter
+    def parse_request_parameter(self, parameter: str, request: RequestContext = None) -> str:
+        '''
+        Parse a request-aware parameter value.
+
+        Delegates non-prefixed parameters to the injected ``parse_parameter``
+        callable. For ``$r.``-prefixed references, extracts the value keyed by
+        the suffix from ``request.data``, raising a structured error when the
+        request is absent or the key is missing.
+
+        :param parameter: The parameter value to parse.
+        :type parameter: str
+        :param request: The request context object containing data for parameter parsing.
+        :type request: RequestContext
+        :return: The parsed parameter value.
+        :rtype: str
+        '''
+
+        # Delegate non-prefixed parameters to the injected parameter parser.
+        if not parameter.startswith('$r.'):
+            return self.parse_parameter(parameter)
+
+        # Raise an error if the request is not provided for a request-backed parameter.
+        if not request:
+            RaiseError.execute(
+                REQUEST_NOT_FOUND_ID,
+                'Request data is not available for parameter parsing.',
+                parameter=parameter
+            )
+
+        # Extract the value from the request data using the key after the $r. prefix.
+        result = request.data.get(parameter[3:], None)
+
+        # Raise an error if the parameter key is not found in the request data.
+        if result is None:
+            RaiseError.execute(
+                PARAMETER_NOT_FOUND_ID,
+                f'Parameter {parameter} not found in request data.',
+                parameter=parameter
+            )
+
+        # Return the parsed parameter value.
+        return result
 
     # * method: execute_step
     def execute_step(self,
@@ -683,7 +693,7 @@ class FeatureContext(BaseContext):
 
             # Parse the step parameters.
             params = {
-                param: parse_request_parameter(value, request)
+                param: self.parse_request_parameter(value, request)
                 for param, value in step.parameters.items()
             }
 

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -4,6 +4,7 @@
 
 # ** core
 import asyncio
+import re
 import threading
 from typing import Any, Callable, Generator, List, Tuple, Dict
 
@@ -266,8 +267,6 @@ def evaluate_condition(condition: str, request: RequestContext) -> bool:
     :return: The boolean result of the evaluated expression.
     :rtype: bool
     '''
-
-    import re
 
     # Return True if condition is None or empty (unconditional step).
     if not condition or not condition.strip():

--- a/tiferet/contexts/logging.py
+++ b/tiferet/contexts/logging.py
@@ -58,14 +58,14 @@ def add_default_logging_settings(settings: Dict[str, Any]) -> Callable:
     return decorator
 
 # ** function: get_default_logging_settings
-def get_default_logging_settings(cache: CacheContext) -> LoggingSettings:
+def get_default_logging_settings(cache: CacheContext) -> LoggingSettings | None:
     '''
     Return the default LoggingSettings seeded on the cache.
 
     :param cache: The cache context to read.
     :type cache: CacheContext
-    :return: The default LoggingSettings domain object.
-    :rtype: LoggingSettings
+    :return: The default LoggingSettings domain object, or None when absent.
+    :rtype: LoggingSettings | None
     '''
 
     # Retrieve the default LoggingSettings from the logging namespace.

--- a/tiferet/di/__init__.py
+++ b/tiferet/di/__init__.py
@@ -8,10 +8,8 @@ __all__ = [
     'DIDynamicServiceResolver',
     'injectable_parameter_names',
     'normalize_flags',
-    'ParseParameter',
 ]
 
 # ** app
 from .core import ServiceContainer, ServiceResolver, injectable_parameter_names, normalize_flags
 from .dependency_injector import DIAppServiceContainer, DIDynamicServiceContainer, DIDynamicServiceResolver
-from ..events.static import ParseParameter

--- a/tiferet/domain/core.py
+++ b/tiferet/domain/core.py
@@ -35,7 +35,8 @@ class DomainObject(BaseModel):
 # ** model: service_dependency
 class ServiceDependency(DomainObject):
     '''
-    A core service dependency that defines the module, class, and parameters for a service.
+    A core service dependency that defines the module, class, and parameters
+    for a service implementation.
     '''
 
     # * attribute: module_path
@@ -59,11 +60,11 @@ class ServiceDependency(DomainObject):
     # * method: get_service_type
     def get_service_type(self) -> type:
         '''
-        Get the service type for this service dependency.
+        Import and return the service class identified by this dependency.
 
-        :return: The service type.
+        :return: The service class type.
         :rtype: type
         '''
 
-        # Import and return the service class type.
+        # Import the module and return the named class.
         return getattr(import_module(self.module_path), self.class_name)

--- a/tiferet/domain/di.py
+++ b/tiferet/domain/di.py
@@ -96,9 +96,9 @@ class ServiceRegistration(DomainObject):
         '''
         Gets the service type based on the provided flags.
 
-        Delegates to ``resolve_service`` so the flagged-override -> default
-        precedence lives in exactly one place, then imports the effective
-        dependency's service type.
+        Delegates to :meth:`resolve_service` so the flagged-override
+        → default precedence lives in exactly one place, then imports
+        the effective service type.
 
         :param flags: The flags for the flagged dependency.
         :type flags: Tuple[str, ...]
@@ -115,9 +115,9 @@ class ServiceRegistration(DomainObject):
         '''
         Resolve the effective core service dependency for the given flags.
 
-        Prefers a matching flagged override (in flag priority order), then falls
-        back to the registration's own default definition, and returns None when
-        no service is defined.
+        Prefers a matching flagged override (in flag priority order), then
+        falls back to the registration's own default definition, and returns
+        ``None`` when no service is defined.
 
         :param flags: The flags to match against flagged dependencies.
         :type flags: Tuple[str, ...]

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -3,7 +3,7 @@
 # *** imports
 
 # ** core
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 # ** infra
 from pydantic import ConfigDict, Field, ValidationError, create_model, model_validator
@@ -110,7 +110,7 @@ class ParameterSpecification(DomainObject):
     choices: List[Any] | None = Field(default=None, description='Enumerated set of valid values.')
 
     # * method: get_type
-    def get_type(self) -> Type:
+    def get_type(self) -> type:
         '''
         Map the declared type string to a Python type.
 

--- a/tiferet/events/__init__.py
+++ b/tiferet/events/__init__.py
@@ -7,10 +7,9 @@ __all__ = [
     'AsyncDomainEvent',
     'TiferetError',
     'a',
-    'ParseParameter',
     'RaiseError',
 ]
 
 # ** app
 from .core import DomainEvent, AsyncDomainEvent, TiferetError, a
-from .static import ParseParameter, RaiseError
+from .static import RaiseError

--- a/tiferet/events/__init__.py
+++ b/tiferet/events/__init__.py
@@ -8,10 +8,9 @@ __all__ = [
     'TiferetError',
     'a',
     'ParseParameter',
-    'ImportDependency',
     'RaiseError',
 ]
 
 # ** app
 from .core import DomainEvent, AsyncDomainEvent, TiferetError, a
-from .static import ParseParameter, ImportDependency, RaiseError
+from .static import ParseParameter, RaiseError

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -169,7 +169,7 @@ class UpdateAppSession(AppEvent):
             expression=interface is not None,
             error_code=a.error.APP_SESSION_NOT_FOUND_ID,
             message=f'App session with ID {id} not found.',
-            interface_id=id,
+            id=id,
         )
 
         # Update the attribute via the model method.
@@ -216,7 +216,7 @@ class SetAppConstants(AppEvent):
             expression=interface is not None,
             error_code=a.error.APP_SESSION_NOT_FOUND_ID,
             message=f'App session with ID {id} not found.',
-            interface_id=id,
+            id=id,
         )
 
         # Update constants via the model method.
@@ -292,7 +292,7 @@ class SetServiceDependency(AppEvent):
             expression=interface is not None,
             error_code=a.error.APP_SESSION_NOT_FOUND_ID,
             message=f'App session with ID {id} not found.',
-            interface_id=id,
+            id=id,
         )
 
         # Set or update the service dependency on the session.
@@ -339,7 +339,7 @@ class RemoveServiceDependency(AppEvent):
             expression=interface is not None,
             error_code=a.error.APP_SESSION_NOT_FOUND_ID,
             message=f'App session with ID {id} not found.',
-            interface_id=id,
+            id=id,
         )
 
         # Remove the service dependency idempotently from the session.

--- a/tiferet/events/static.py
+++ b/tiferet/events/static.py
@@ -2,59 +2,7 @@
 
 # *** imports
 
-# ** core
-from typing import Any
-import os
-
 # ** app
-from .core import DomainEvent, TiferetError, a
-
-# *** events
-
-# ** event: parse_parameter
-class ParseParameter(DomainEvent):
-    '''
-    A static domain event to parse a parameter from a string.
-    '''
-
-    # * method: execute (static)
-    @staticmethod
-    def execute(parameter: str) -> Any:
-        '''
-        Parse a parameter string, resolving environment variable references.
-
-        :param parameter: The parameter to parse.
-        :type parameter: str
-        :return: The parsed parameter.
-        :rtype: Any
-        '''
-
-        # Parse the parameter.
-        try:
-
-            # If the parameter is an environment variable, get the value.
-            if parameter.startswith('$env.'):
-                result = os.getenv(parameter[5:])
-
-                # Raise an exception if the environment variable is not found.
-                if not result:
-                    raise Exception('Environment variable not found.')
-
-                # Return the result if the environment variable is found.
-                return result
-
-            # Return the parameter as is if it is not an environment variable.
-            return parameter
-
-        # Raise an error if the parameter parsing fails.
-        except Exception as e:
-            raise TiferetError(
-                a.error.PARAMETER_PARSING_FAILED_ID,
-                parameter=parameter,
-                exception=str(e),
-            )
-
-# ** event: raise_error
-# Re-export from assets.exceptions so blueprints can import RaiseError from
+# Re-export RaiseError from assets.exceptions so consumers can import it from
 # either the events or assets layer without circular imports.
 from ..assets.exceptions import RaiseError

--- a/tiferet/events/static.py
+++ b/tiferet/events/static.py
@@ -5,7 +5,6 @@
 # ** core
 from typing import Any
 import os
-from importlib import import_module
 
 # ** app
 from .core import DomainEvent, TiferetError, a
@@ -52,41 +51,6 @@ class ParseParameter(DomainEvent):
             raise TiferetError(
                 a.error.PARAMETER_PARSING_FAILED_ID,
                 parameter=parameter,
-                exception=str(e),
-            )
-
-# ** event: import_dependency
-class ImportDependency(DomainEvent):
-    '''
-    A static domain event to import a dependency from a module.
-    '''
-
-    # * method: execute (static)
-    @staticmethod
-    def execute(module_path: str, class_name: str, **kwargs) -> Any:
-        '''
-        Import a class from a module path.
-
-        :param module_path: The module path to import from.
-        :type module_path: str
-        :param class_name: The class name to import.
-        :type class_name: str
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The imported class.
-        :rtype: Any
-        '''
-
-        # Import module.
-        try:
-            return getattr(import_module(module_path), class_name)
-
-        # Raise an error if the dependency import fails.
-        except Exception as e:
-            raise TiferetError(
-                a.error.IMPORT_DEPENDENCY_FAILED_ID,
-                module_path=module_path,
-                class_name=class_name,
                 exception=str(e),
             )
 

--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -30,20 +30,20 @@ class AppSessionAggregate(AppSession, Aggregate):
     # * method: add_service
     def add_service(
         self,
+        service_id: str,
         module_path: str,
         class_name: str,
-        service_id: str,
         parameters: Dict[str, str] | None = None,
     ) -> None:
         '''
-        Add a service dependency to the app interface.
+        Add a service dependency to the app session.
 
+        :param service_id: The id for the service dependency.
+        :type service_id: str
         :param module_path: The module path for the service dependency.
         :type module_path: str
         :param class_name: The class name for the service dependency.
         :type class_name: str
-        :param service_id: The id for the service dependency.
-        :type service_id: str
         :param parameters: Additional parameters for the service dependency.
         :type parameters: Dict[str, str] | None
         :return: None
@@ -52,9 +52,9 @@ class AppSessionAggregate(AppSession, Aggregate):
 
         # Create a new AppServiceDependency object.
         dependency = AppServiceDependency(
+            service_id=service_id,
             module_path=module_path,
             class_name=class_name,
-            service_id=service_id,
             parameters=parameters or {},
         )
 

--- a/tiferet/mappers/app.py
+++ b/tiferet/mappers/app.py
@@ -130,7 +130,6 @@ class AppSessionAggregate(AppSession, Aggregate):
                     for key, value in merged.items()
                     if value is not None
                 }
-            return
 
             # Return early after in-place update.
             return
@@ -175,8 +174,7 @@ class AppSessionAggregate(AppSession, Aggregate):
         '''
         Update a supported scalar attribute on the app session aggregate.
 
-        Supported attributes: name, description, module_path, class_name,
-        logger_id, flags.
+        Supported attributes: name, description, logger_id, flags.
 
         :param attribute: The attribute name to update.
         :type attribute: str
@@ -205,7 +203,6 @@ class AppSessionAggregate(AppSession, Aggregate):
 
         # Apply the update; validate_assignment=True handles re-validation.
         setattr(self, attribute, value)
-
 
 
 # ** mapper: app_service_dependency_config_object


### PR DESCRIPTION
## Summary

Batched hotfix pass against `v2.x-proto`, resolving the Hotfix RFP candidates from `.handoff/main-proto-full-artifact-diff.handoff.md`. Per the RFP convention these get no individual GitHub issues — one branch, one PR, one commit per item (trivia consolidated).

**14 commits, 24 items.** 1033 tests passing (+2 net new), clean working tree.

## Correctness bugs

| Item | Fix |
|---|---|
| **HF-1** | `AppSessionContext.execute_feature` legacy fallback read the cache **root** namespace instead of `('app','features')`, so it resolved `feature = None` unconditionally. Also now builds the context via `from_domain` per the `BaseContext` convention. |
| **HF-2** | `handle_error` fallback omitted `**error.kwargs`, silently dropping all structured error context. |
| **HF-3** | `di/__init__.py` re-exported `ParseParameter` from `events.static`, violating the DI layer's event-free constraint. |
| **HF-4** | `build_logging_context` discarded **all** default formatters/handlers/loggers for a section as soon as the repo returned one entry. Plus an unguarded `defaults.formatters` dereference (AttributeError on an unseeded cache) and a function-local import. |

Both HF-1 and HF-2 lived in fallback branches that had **no test coverage at all** — only the `build_response` fallback was exercised. That gap is why they survived. Regression tests added for both, verified red-before/green-after.

HF-4's replace-semantics bug was **enshrined in a test** asserting `formatters == [repo_formatter]`. That test now asserts merge semantics, using a repo logger that collides on `root` while the formatter/handler are new, so it exercises both override and survive.

## Refactors

- **HF-24** (subsumes HF-3): promotes `ParseParameter` from a static-only `DomainEvent` to the blueprint-owned `parse_parameter`, injected into both the DI resolver and `FeatureContext`. `parse_request_parameter` becomes a `FeatureContext` method (it now depends on injected state, so it no longer qualifies for the side-effect-free `# *** functions` section). Removes `ParseParameter` from `events/`, `di/`, and the root package.
- **HF-23**: removes the dead `ImportDependency` event.

## Remaining items

HF-5–HF-22: `add_service` parameter order, dead `return`, stale docstrings and terminology, `interface_id=id` → `id=id`, missing `_logging` declaration, function-local `import re`, lost type annotations, SD-1 constant style, dead imports, and a consolidated docstring/typing/whitespace batch. See individual commit messages.

## Scope corrections found during implementation

Three findings changed shape once checked against actual code — worth reviewer attention:

1. **The proposed `blueprints`→`domain` layering item was reversed and dropped.** `tiferet-code-architecture` states blueprints must access domain models *via contexts*, never importing `domain` directly. Proto's `from ..contexts.error import Error` is therefore **canonical**; it is `main` that violates the rule at `blueprints/core.py:29`. This inverts into a `main`-side Cleanup TRD. It also changed HF-4's fix: hoisting `LoggingSettings` to `from ..domain import` would have *introduced* proto's only blueprints→domain violation, so it routes through `..contexts.logging`.
2. **AU-7 was split out, not folded in.** Dropping `FeatureContext`'s redundant `feature` parameter is a public API change spanning ~30 call sites and needs to land symmetrically on `main`. HF-1 instead applies the minimal correct fix (cache prefix + `from_domain` binding) with no signature change.
3. **HF-6's stated rationale was inverted.** The *second* `return` is the unreachable one, not the first; deleting the bare first return is still correct.

## Follow-ups deliberately not actioned

- `IMPORT_DEPENDENCY_FAILED_ID` is now orphaned in `assets/error.py`. Left in place — that catalog is shared with `main`, so pruning it unilaterally would create an unmirrored divergence. Belongs with main's CT-8.
- Removing `tiferet.ParseParameter` is a **public API removal**; coordinate with main's CT-15 root-export work.
- `docs/core/di.md` still documents the removed `ParseParameter` re-export. Docs were out of scope for this pass.
- **Pre-existing, unrelated:** `examples/basic_calculator` does not run on proto — `app/repos/formula.py` imports `tiferet.repos.settings`, which does not exist (it is `repos/core.py`). Confirmed present on the untouched base; neither `tiferet/repos/` nor `examples/` was touched by this branch.

## Verification

- `pytest tests/` — 1033 passed, 11 skipped.
- Confirmed the root package still imports cleanly. `tiferet/__init__.py` swallows import errors in a `try/except`, so a green suite alone would **not** catch a broken export; all 27 `__all__` symbols were asserted to resolve.
- Exercised the real `build_cache → container → resolver → create_feature_context` chain to confirm the parser reaches both the DI resolver and `FeatureContext`, with `$env.`, `$r.` and literal parameters all resolving.

Co-Authored-By: Oz <oz-agent@warp.dev>