### PR TITLE
Hotfix – Main Convergence Proto (HF-25–HF-28)

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -2,7 +2,7 @@
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
-**Module:** `tiferet/utils/middleware.py`  
+**Module:** `tiferet/utils/core.py`  
 **Version:** 2.0.0
 
 ## Overview
@@ -15,14 +15,14 @@ See the [Middleware Support](../core/events.md#middleware-support) section of th
 
 ## Built-in Middleware
 
-Two infrastructure middleware ship in `tiferet.utils.middleware`. Each is a `MiddlewareService` subclass that takes a single `logger_id: str` parameter (default `'root'`) and resolves the matching stdlib logger via `logging.getLogger(logger_id)`. They rely on `LoggingContext` having configured Python logging at application startup; on their own they emit records to whichever logger `logger_id` names.
+Two infrastructure middleware ship in `tiferet.utils.core`. Each is a `MiddlewareService` subclass that takes a single `logger_id: str` parameter (default `'root'`) and resolves the matching stdlib logger via `logging.getLogger(logger_id)`. They rely on `LoggingContext` having configured Python logging at application startup; on their own they emit records to whichever logger `logger_id` names.
 
 - **`LoggingMiddleware`** — emits a `DEBUG` record before execution and after success, and an `ERROR` record (with traceback via `exc_info=True`) when the chain raises. The exception is always re-raised.
 - **`TimingMiddleware`** — measures elapsed wall-clock time with `time.perf_counter` and emits a single `DEBUG` record reporting the duration in milliseconds on both the success and exception paths. The exception is always re-raised.
 
 ```python
 from tiferet.events import DomainEvent
-from tiferet.utils.middleware import LoggingMiddleware, TimingMiddleware
+from tiferet.utils.core import LoggingMiddleware, TimingMiddleware
 
 result = DomainEvent.handle(
     GetError,
@@ -126,17 +126,17 @@ When middleware is resolved from configuration, feature-level middleware is comp
 
 ## Registering Middleware in config.yml
 
-Middleware can also be declared in `config.yml` and resolved from the DI container by `FeatureContext` during `execute_feature` / `execute_feature_async`. First register the middleware as a service, pointing `module_path` at `tiferet.utils.middleware` (or your own module):
+Middleware can also be declared in `config.yml` and resolved from the DI container by `FeatureContext` during `execute_feature` / `execute_feature_async`. First register the middleware as a service, pointing `module_path` at `tiferet.utils.core` (or your own module):
 
 ```yaml
 services:
   logging_middleware:
-    module_path: tiferet.utils.middleware
+    module_path: tiferet.utils.core
     class_name: LoggingMiddleware
     parameters:
       logger_id: root
   timing_middleware:
-    module_path: tiferet.utils.middleware
+    module_path: tiferet.utils.core
     class_name: TimingMiddleware
     parameters:
       logger_id: root
@@ -240,7 +240,7 @@ import pytest
 from unittest import mock
 
 # ** app
-from tiferet.utils.middleware import LoggingMiddleware
+from tiferet.utils.core import LoggingMiddleware
 
 # *** tests
 

--- a/examples/basic_calculator/app/repos/formula.py
+++ b/examples/basic_calculator/app/repos/formula.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List
 
 # ** app
-from tiferet.repos.settings import ConfigurationRepository
+from tiferet.repos.core import ConfigurationRepository
 from ..interfaces.formula import FormulaService
 from ..mappers.formula import FormulaAggregate, FormulaConfigObject
 

--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -606,28 +606,54 @@ def test_load_cache_returns_root_snapshot_callable():
     assert snapshot == {'root_key': 'root_value'}
 
 
-# ** test: create_request_context_seeds_feature_id
-def test_create_request_context_seeds_feature_id():
+# ** test: create_request_context_stamps_interface_id
+def test_create_request_context_stamps_interface_id():
     '''
-    Test that create_request_context builds a RequestContext seeded with the
-    feature id and the supplied data and headers.
+    Test that create_request_context stamps the interface id onto the request
+    headers and seeds the feature id, headers, and data.
     '''
 
-    # Build a feature and compose a request context around it.
-    feature = Feature(
-        id='group.feat', group_id='group', feature_key='feat', name='Feat'
-    )
+    # Compose a request context from the scalar session and feature ids.
     request = create_request_context(
-        feature,
-        data={'a': 1},
+        'test_interface',
+        'group.feat',
         headers={'h': 'v'},
+        data={'a': 1},
     )
 
-    # Assert the request is shaped from the feature and inputs.
+    # Assert the request is shaped from the supplied scalars and inputs.
     assert isinstance(request, RequestContext)
     assert request.feature_id == 'group.feat'
+    assert request.headers.get('interface_id') == 'test_interface'
+    assert request.headers.get('h') == 'v'
     assert request.data == {'a': 1}
-    assert request.headers == {'h': 'v'}
+
+
+# ** test: create_session_request_delegates_to_create_request_context
+def test_create_session_request_delegates_to_create_request_context():
+    '''
+    Test that create_session_request is a backward-compatible alias producing
+    a request context identical to create_request_context's.
+    '''
+
+    # Compose the same request through both entry points.
+    canonical = create_request_context(
+        'iface',
+        'g.f',
+        headers={'h': 'v'},
+        data={'a': 1},
+    )
+    aliased = create_session_request(
+        'iface',
+        'g.f',
+        headers={'h': 'v'},
+        data={'a': 1},
+    )
+
+    # Assert both produce equivalent request state.
+    assert aliased.headers == canonical.headers
+    assert aliased.data == canonical.data
+    assert aliased.feature_id == canonical.feature_id
 
 
 # ** test: create_feature_context_with_preloaded_feature

--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -35,7 +35,7 @@ from tiferet.contexts.logging import LoggingContext, LoggingSettings, LOGGING_CA
 from tiferet.contexts.request import RequestContext
 from tiferet.contexts.app import APP_SERVICE_CACHE_PREFIX, APP_CONSTANT_CACHE_PREFIX, AppSessionContext
 from tiferet.domain import Error, Feature, AppSession, AppServiceDependency
-from tiferet.utils.middleware import CacheMiddleware
+from tiferet.utils.core import CacheMiddleware
 from tiferet.repos.app import AppConfigRepository
 from tiferet.repos.di import DIConfigRepository
 from tiferet.repos.error import ErrorConfigRepository

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -1,4 +1,4 @@
-"""Tiferet Middleware Utility Tests"""
+"""Tiferet Utils Core Tests"""
 
 # *** imports
 
@@ -10,7 +10,7 @@ import re
 import pytest
 
 # ** app
-from tiferet.utils.middleware import LoggingMiddleware, TimingMiddleware, CacheMiddleware
+from tiferet.utils.core import LoggingMiddleware, TimingMiddleware, CacheMiddleware
 from tiferet.interfaces.middleware import MiddlewareService
 
 

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -30,7 +30,7 @@ from .core import (
     APP_DOMAIN_PATH,
     LOGGING_DOMAIN_PATH,
     CLI_DOMAIN_PATH,
-    MIDDLEWARE_DOMAIN_PATH,
+    CORE_DOMAIN_PATH,
 )
 
 # *** constants (ids)
@@ -221,21 +221,21 @@ DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
 # ** constant: logging_middleware
 LOGGING_MIDDLEWARE = create_app_service_dependency(
     LOGGING_MIDDLEWARE_ID,
-    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'LoggingMiddleware',
 )
 
 # ** constant: timing_middleware
 TIMING_MIDDLEWARE = create_app_service_dependency(
     TIMING_MIDDLEWARE_ID,
-    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'TimingMiddleware',
 )
 
 # ** constant: cache_middleware
 CACHE_MIDDLEWARE = create_app_service_dependency(
     CACHE_MIDDLEWARE_ID,
-    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, MIDDLEWARE_DOMAIN_PATH),
+    create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'CacheMiddleware',
 )
 

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -44,8 +44,8 @@ LOGGING_DOMAIN_PATH = 'logging'
 # ** constant: cli_domain_path
 CLI_DOMAIN_PATH = 'cli'
 
-# ** constant: middleware_domain_path
-MIDDLEWARE_DOMAIN_PATH = 'middleware'
+# ** constant: core_domain_path
+CORE_DOMAIN_PATH = 'core'
 
 # *** functions
 

--- a/tiferet/blueprints/admin.py
+++ b/tiferet/blueprints/admin.py
@@ -20,7 +20,6 @@ from ..contexts.app import (
     get_default_admin_services,
     get_default_admin_constants,
 )
-from ..di import injectable_parameter_names
 from ..di.dependency_injector import DIAppServiceContainer, DIDynamicServiceResolver
 from ..di.core import ServiceResolver
 from .. import assets as a
@@ -149,21 +148,7 @@ def build_admin_app_session_context(
     context_cls = AppSessionContext
 
     # Resolve the context's collaborators from the app container by id.
-    reserved = {
-        'get_dependency',
-        'cache',
-        'execute_feature_handler',
-        'create_request_handler',
-        'raise_error_handler',
-        'response_handler',
-    }
-    collaborators = {
-        name: app_container.get_dependency(name)
-        for name in injectable_parameter_names(context_cls)
-        if name not in reserved
-        and not name.startswith('default_')
-        and app_container.has_dependency(name)
-    }
+    collaborators = core.resolve_collaborators(context_cls, app_container)
 
     # Build the four FE4 template-method handlers.
     handlers = dict(

--- a/tiferet/blueprints/admin_cli.py
+++ b/tiferet/blueprints/admin_cli.py
@@ -24,7 +24,6 @@ from ..contexts.cli import (
     add_default_cli_commands,
     get_default_cli_commands,
 )
-from ..di import injectable_parameter_names
 
 # *** blueprints
 
@@ -95,25 +94,10 @@ def build_admin_cli_session_context(
         get_default_cli_commands(cache),
     )
 
-    # Resolve the context's other collaborators from the app container by id,
-    # skipping the explicitly supplied handler params, resolver, cache, and
-    # the CLI arg-parser (injected separately below).
-    reserved = {
-        'get_dependency',
-        'cache',
-        'execute_feature_handler',
-        'create_request_handler',
-        'raise_error_handler',
-        'response_handler',
-        'parse_cli_args',
-    }
-    collaborators = {
-        name: app_container.get_dependency(name)
-        for name in injectable_parameter_names(CliSessionContext)
-        if name not in reserved
-        and not name.startswith('default_')
-        and app_container.has_dependency(name)
-    }
+    # Resolve the context's other collaborators from the app container by id;
+    # the resolver, cache, handler params, and the CLI arg-parser are all
+    # reserved and supplied explicitly.
+    collaborators = core.resolve_collaborators(CliSessionContext, app_container)
 
     # Build the four FE4 handlers, overriding the request and response slots
     # with CLI-specific implementations.

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -19,7 +19,6 @@ from ..contexts.cli import (
 )
 from ..contexts.cache import CacheContext
 from ..contexts.request import RequestContext
-from ..di import injectable_parameter_names
 
 # *** functions
 
@@ -327,26 +326,10 @@ def build_cli_session_context(
         get_default_cli_commands(cache),
     )
 
-    # Resolve the context's other collaborators from the app container by id,
-    # skipping the explicitly supplied handler params, resolver, cache,
-    # the pre-built logging context, and the CLI arg-parser (injected separately below).
-    reserved = {
-        'get_dependency',
-        'cache',
-        'logging_context',
-        'execute_feature_handler',
-        'create_request_handler',
-        'raise_error_handler',
-        'response_handler',
-        'parse_cli_args',
-    }
-    collaborators = {
-        name: app_container.get_dependency(name)
-        for name in injectable_parameter_names(CliSessionContext)
-        if name not in reserved
-        and not name.startswith('default_')
-        and app_container.has_dependency(name)
-    }
+    # Resolve the context's other collaborators from the app container by id;
+    # the resolver, cache, logging context, handler params, and the CLI
+    # arg-parser are all reserved and supplied explicitly.
+    collaborators = core.resolve_collaborators(CliSessionContext, app_container)
 
     # Build the four FE4 handlers, overriding the request and response slots
     # with CLI-specific implementations.

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -526,36 +526,37 @@ def load_cache(cache: CacheContext) -> Callable[[], Dict[str, Any]]:
 
 # ** blueprint: create_request_context
 def create_request_context(
-    feature: Feature,
-    data: Dict[str, Any] = None,
+    interface_id: str,
+    feature_id: str,
     headers: Dict[str, str] = None,
-    **kwargs,
+    data: Dict[str, Any] = None,
 ) -> RequestContext:
     '''
     Compose a request context for a feature execution.
 
-    Pure, side-effect-free constructor that seeds the request's ``feature_id``
-    from the feature and wires in the supplied data and headers. Suitable as
-    the hub's injected request-context factory.
+    Pure, side-effect-free constructor that stamps the ``interface_id`` onto the
+    request headers and seeds the request with the supplied ``feature_id`` and
+    data. Takes string scalars so it can be called before the feature is
+    loaded, matching the hub's construction order. Suitable as the hub's
+    injected request-context factory.
 
-    :param feature: The feature being executed; supplies the feature id.
-    :type feature: Feature
-    :param data: The request data payload.
-    :type data: Dict[str, Any] | None
-    :param headers: The request headers.
+    :param interface_id: The id of the app session issuing the request.
+    :type interface_id: str
+    :param feature_id: The id of the feature to execute.
+    :type feature_id: str
+    :param headers: Optional request headers to merge with the interface id.
     :type headers: Dict[str, str] | None
-    :param kwargs: Additional request context constructor arguments.
-    :type kwargs: dict
+    :param data: Optional request data payload.
+    :type data: Dict[str, Any] | None
     :return: The composed request context.
     :rtype: RequestContext
     '''
 
-    # Compose and return the request context, seeding feature_id from the feature.
+    # Compose and return the request context, stamping the interface id onto the headers.
     return RequestContext(
-        headers=headers,
-        data=data,
-        feature_id=feature.id,
-        **kwargs,
+        headers={**(headers or {}), 'interface_id': interface_id},
+        data=data or {},
+        feature_id=feature_id,
     )
 
 # ** blueprint: create_feature_context
@@ -611,11 +612,8 @@ def create_session_request(
     '''
     Compose a session request context for the hub's ``run`` method.
 
-    Pure, side-effect-free constructor that enriches the supplied headers with
-    the ``interface_id`` and constructs a ``RequestContext`` seeded with the
-    ``feature_id``. Unlike :func:`create_request_context`, this variant takes
-    string scalars so it can be called before the feature is loaded, matching
-    the hub's current construction order.
+    Backward-compatible alias for :func:`create_request_context`, retained as
+    the name the hub's ``create_request_handler`` slot is wired to.
 
     :param interface_id: The interface id to inject into the request headers.
     :type interface_id: str
@@ -629,12 +627,8 @@ def create_session_request(
     :rtype: RequestContext
     '''
 
-    # Compose and return the request context, enriching headers with the interface id.
-    return RequestContext(
-        headers={**(headers or {}), 'interface_id': interface_id},
-        data=data,
-        feature_id=feature_id,
-    )
+    # Delegate to the canonical request context factory.
+    return create_request_context(interface_id, feature_id, headers, data)
 
 # ** blueprint: execute_feature_handler
 def execute_feature_handler(

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -39,6 +39,53 @@ from ..di.core import ServiceResolver
 from ..di.dependency_injector import DIDynamicServiceResolver
 from .. import assets as a
 
+# *** constants
+
+# ** constant: reserved_context_parameters
+# Constructor parameters supplied explicitly by the session context builders,
+# and therefore excluded from generic collaborator resolution.
+RESERVED_CONTEXT_PARAMETERS = (
+    'get_dependency',
+    'cache',
+    'logging_context',
+    'parse_cli_args',
+    'execute_feature_handler',
+    'create_request_handler',
+    'raise_error_handler',
+    'response_handler',
+)
+
+# *** functions
+
+# ** function: resolve_collaborators
+def resolve_collaborators(context_cls: type, app_container: DIAppServiceContainer) -> Dict[str, Any]:
+    '''
+    Resolve a context class's remaining injectable collaborators from the app container.
+
+    Inspects the realized context class's constructor and resolves every
+    injectable parameter that is registered on the app container, skipping the
+    parameters the session context builders supply explicitly
+    (``RESERVED_CONTEXT_PARAMETERS``) and the bootstrap ``default_*``
+    parameters. This is the seam that lets a context subclass declare extra
+    collaborators and have them wired declaratively.
+
+    :param context_cls: The realized context class to inspect.
+    :type context_cls: type
+    :param app_container: The built app service container to resolve against.
+    :type app_container: DIAppServiceContainer
+    :return: A mapping of collaborator name to resolved instance.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Resolve each injectable parameter that is neither reserved nor a bootstrap default.
+    return {
+        name: app_container.get_dependency(name)
+        for name in injectable_parameter_names(context_cls)
+        if name not in RESERVED_CONTEXT_PARAMETERS
+        and not name.startswith('default_')
+        and app_container.has_dependency(name)
+    }
+
 # *** blueprints
 
 # ** blueprint: build_cache
@@ -737,24 +784,7 @@ def build_app_session_context(
     context_cls = AppSessionContext
 
     # Resolve the context's collaborators from the app container by id.
-    # Skip the explicitly supplied resolver, cache, logging_context, handler
-    # params, and bootstrap defaults.
-    reserved = {
-        'get_dependency',
-        'cache',
-        'logging_context',
-        'execute_feature_handler',
-        'create_request_handler',
-        'raise_error_handler',
-        'response_handler',
-    }
-    collaborators = {
-        name: app_container.get_dependency(name)
-        for name in injectable_parameter_names(context_cls)
-        if name not in reserved
-        and not name.startswith('default_')
-        and app_container.has_dependency(name)
-    }
+    collaborators = resolve_collaborators(context_cls, app_container)
 
     # Build the four FE4 template-method handlers.
     handlers = dict(

--- a/tiferet/utils/__init__.py
+++ b/tiferet/utils/__init__.py
@@ -29,4 +29,4 @@ from .yaml import YamlLoader, YamlLoader as Yaml
 from .toml import TomlLoader, TomlLoader as Toml
 from .csv import CsvLoader, CsvLoader as Csv, CsvDictLoader, CsvDictLoader as CsvDict
 from .sqlite import SqliteClient, SqliteClient as Sqlite
-from .middleware import LoggingMiddleware, TimingMiddleware, CacheMiddleware
+from .core import LoggingMiddleware, TimingMiddleware, CacheMiddleware

--- a/tiferet/utils/core.py
+++ b/tiferet/utils/core.py
@@ -1,4 +1,4 @@
-"""Tiferet Middleware Utilities"""
+"""Tiferet Utils Core"""
 
 # *** imports
 


### PR DESCRIPTION
## Summary

Second batched hotfix pass against `v2.x-proto`, following PR #971. Resolves the three items reclassified out of the Feature RFP backlog on 2026-08-04 (former FR-1/FR-2/FR-3 → HF-25/HF-26/HF-27), plus one pre-existing example-app breakage recorded but never scoped in #971 (HF-28). Per the Hotfix RFP convention these get no individual GitHub issues — one branch, one PR, one commit per item.

**5 commits, 4 items.** 1047 passed / 11 skipped, clean working tree.

All three reclassified items ported `main`'s established form back to proto, so each is a convergence rather than a new design.

## Items

| Item | Change |
|---|---|
| **HF-25** | `utils/middleware.py` → `utils/core.py` and `MIDDLEWARE_DOMAIN_PATH` → `CORE_DOMAIN_PATH`, adopting the Evans DDD Core Module framing `main` established in #967. Test module renamed to match. |
| **HF-26** | Extracts `RESERVED_CONTEXT_PARAMETERS` + `resolve_collaborators` into `blueprints/core.py`, replacing four inline duplicate copies. Zero behavior change. |
| **HF-27** | Consolidates `create_request_context` onto the scalar-based canonical form; `create_session_request` becomes a delegating alias. |
| **HF-28** | Repoints the `basic_calculator` example at `tiferet.repos.core` — `tiferet.repos.settings` does not exist on proto. |

## Reviewer attention

**HF-25 is an import-path-visible rename.** `tiferet.utils.middleware` ceases to exist. No public export references the module path (`LoggingMiddleware` / `TimingMiddleware` / `CacheMiddleware` are re-exported from `tiferet.utils`), and the DI-visible `module_path` strings in `assets/app.py` were updated with it — but any consumer importing the submodule directly breaks. Flagged explicitly rather than buried in a commit message.

**HF-26 covers all four sites, including the two admin blueprints** (`core.py`, `cli.py`, `admin.py`, `admin_cli.py`). This is a deliberate, user-approved exception to the parity analysis's admin-scope exclusion: the extracted helper serves them mechanically, and leaving two of four inline would defeat the point. `main` has no admin blueprints, so its helper only ever served two sites.

## Scope corrections found during implementation

Continuing #971's practice of recording findings that changed shape once checked against code:

1. **HF-26 was four duplication sites, not two.** The parity analysis recorded two.
2. **HF-26's `parse_cli_args` caveat was already moot.** `main`'s `RESERVED_CONTEXT_PARAMETERS` is the *union* of proto's two variant sets, so no parameterization or `extra_reserved` seam is needed.
3. **The two admin reserved sets omitted `logging_context`**, which made adopting the union look like a behavior change. It is not: neither `logging_context` nor `parse_cli_args` is ever a registered container id, so the pre-existing `has_dependency` guard already excluded them. Confirmed by inspection — `AppSessionContext`'s injectable parameters are *exactly* the 7 reserved names and `CliSessionContext`'s exactly the 8, so `resolve_collaborators` returns `{}` for both built-in contexts today. Its value is purely the declarative seam for subclasses.
4. **HF-25 broke `docs/guides/middleware.md`**, including two `module_path:` entries inside a copy-paste config example — i.e. the doc would have handed readers a config that fails DI resolution. Fixed in a separate docs commit per the functional/docs commit convention.
5. **HF-28 was broader than recorded.** #971 described it as breaking the example's formula features. Because `app/repos/__init__.py` eagerly imports the module, DI resolution of the package raised `ModuleNotFoundError` and **every** feature failed with `FEATURE_STEP_LOADING_FAILED`, including the arithmetic ones. The documented onboarding example was fully non-functional.

## Verification

- `pytest` — 1047 passed, 11 skipped (+1 net new test).
- As in #971, a green suite would **not** catch a broken root export, since `tiferet/__init__.py` swallows import errors. Explicitly asserted all 27 `__all__` symbols resolve; that `tiferet.utils.middleware` no longer imports while `tiferet.utils.core` exports all three middleware; and that the real `build_cache → build_app_service_container` chain resolves all three middleware services out of `tiferet.utils.core`, proving the `CORE_DOMAIN_PATH` change reaches DI.
- Asserted `resolve_collaborators` returns `{}` for both built-in contexts, and that the consolidated request factory and its alias produce identical state including `None` normalization.
- **HF-28 verified by running the example, not just importing it:** `basic_calc.py` end-to-end (seven arithmetic cases, history listing, formula save/list/eval round trip) plus the example's own 23-test suite, both green.

## Follow-up noted, not actioned

Running the example mutates the tracked seed file `examples/basic_calculator/formulas.yml` and writes an untracked `history.json`, neither covered by `.gitignore` — so anyone who runs the onboarding example gets a dirty tree. Left alone deliberately: `formulas.yml` is tracked seed data, so this needs a design decision (relocate example runtime state, or seed to a temp path) rather than a `.gitignore` line.

Co-Authored-By: Oz <oz-agent@warp.dev>
