### PR TITLE
Hotfix – APP_ERROR formatting defect (proto)

### DIFF
--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -898,6 +898,58 @@ def test_raise_error_handler_wraps_plain_exception(monkeypatch):
     get_error_mock.assert_called_once_with('APP_ERROR')
 
 
+# ** test: raise_error_handler_formats_wrapped_app_error_end_to_end
+def test_raise_error_handler_formats_wrapped_app_error_end_to_end():
+    '''
+    Test that a plain Exception wrapped as APP_ERROR formats through the real
+    ErrorContext against the cache-seeded catalog definition, rather than
+    raising KeyError on an unsupplied message-template placeholder.
+    '''
+
+    # Build the seeded cache and the handler over the real error retrieval path;
+    # APP_ERROR resolves from the cache, so the resolver is never consulted.
+    cache = build_cache()
+    handler = raise_error_handler(get_error(cache, mock.Mock()))
+
+    # Invoke the handler with a plain exception.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        handler(Exception('something went wrong'))
+
+    # Assert the catalog template formatted with the supplied error message.
+    assert exc_info.value.error_code == a.error.APP_ERROR_ID
+    assert exc_info.value.name == 'App Error'
+    assert exc_info.value.message == 'An error occurred in the app: something went wrong.'
+
+
+# ** test: raise_error_handler_formats_event_raised_app_error
+def test_raise_error_handler_formats_event_raised_app_error():
+    '''
+    Test that an APP_ERROR raised as a genuine TiferetError by a domain event
+    formats through the real ErrorContext. This is the reachable arm: the
+    SQLite events raise APP_ERROR, AppSessionContext.run catches it, and the
+    handler must format rather than fail on the template placeholder.
+    '''
+
+    # Build the seeded cache and the handler over the real error retrieval path.
+    cache = build_cache()
+    handler = raise_error_handler(get_error(cache, mock.Mock()))
+
+    # Arrange an APP_ERROR shaped exactly as the SQLite events raise it.
+    error = TiferetError(
+        a.error.APP_ERROR_ID,
+        'SQLite execution failed: no such table: users',
+        error_message='no such table: users',
+    )
+
+    # Invoke the handler with the event-raised error.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        handler(error)
+
+    # Assert the catalog template formatted with the event's error message.
+    assert exc_info.value.error_code == a.error.APP_ERROR_ID
+    assert exc_info.value.message == 'An error occurred in the app: no such table: users.'
+
+
 # ** test: response_handler_delegates_to_request
 def test_response_handler_delegates_to_request():
     '''

--- a/tests/events/test_sqlite.py
+++ b/tests/events/test_sqlite.py
@@ -267,9 +267,9 @@ class TestQuerySql(SqliteEventTestBase):
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, query="SELECT * FROM invalid_table")
 
-        # Assert the error code and original error.
-        assert exc_info.value.error_code == 'APP_ERROR'
-        assert exc_info.value.kwargs.get('original_error') == "no such table: invalid_table"
+        # Assert the error code and the formatting-ready error message.
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
+        assert exc_info.value.kwargs.get('error_message') == "no such table: invalid_table"
 
 
 # ** test: TestMutateSql
@@ -388,7 +388,7 @@ class TestMutateSql(SqliteEventTestBase):
             self.handle(mock_dependencies, statement="INSERT INTO users VALUES (1)")
 
         # Assert the error code.
-        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
 
 
 # ** test: TestBulkMutateSql
@@ -490,7 +490,7 @@ class TestBulkMutateSql(SqliteEventTestBase):
             self.handle(mock_dependencies)
 
         # Assert the error code.
-        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
 
 
 # ** test: TestExecuteScriptSql
@@ -551,7 +551,7 @@ class TestExecuteScriptSql(SqliteEventTestBase):
             self.handle(mock_dependencies, script="INVALID SQL;")
 
         # Assert the error code.
-        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
 
 
 # ** test: TestBackupSql
@@ -736,7 +736,7 @@ class TestCreateTableSql(SqliteEventTestBase):
             )
 
         # Assert the error code.
-        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
 
     # * method: test_invalid_table_name
     def test_invalid_table_name(self, mock_dependencies):
@@ -812,7 +812,7 @@ class TestCreateTableSql(SqliteEventTestBase):
             self.handle(mock_dependencies, columns={'id': 'INVALID_TYPE'})
 
         # Assert the error code.
-        assert exc_info.value.error_code == 'APP_ERROR'
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
 
 
 # ** test: TestDropTableSql
@@ -889,9 +889,9 @@ class TestDropTableSql(SqliteEventTestBase):
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, table_name='non_existent_table', if_exists=False)
 
-        # Assert the error code and original error.
-        assert exc_info.value.error_code == 'APP_ERROR'
-        assert exc_info.value.kwargs.get('original_error') == "no such table: non_existent_table"
+        # Assert the error code and the formatting-ready error message.
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
+        assert exc_info.value.kwargs.get('error_message') == "no such table: non_existent_table"
 
     # * method: test_invalid_table_name
     def test_invalid_table_name(self, mock_dependencies):
@@ -936,6 +936,6 @@ class TestDropTableSql(SqliteEventTestBase):
         with pytest.raises(TiferetError) as exc_info:
             self.handle(mock_dependencies, table_name='test_table')
 
-        # Assert the error code and original error.
-        assert exc_info.value.error_code == 'APP_ERROR'
-        assert exc_info.value.kwargs.get('original_error') == "database is locked"
+        # Assert the error code and the formatting-ready error message.
+        assert exc_info.value.error_code == a.error.APP_ERROR_ID
+        assert exc_info.value.kwargs.get('error_message') == "database is locked"

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -693,9 +693,9 @@ def raise_error_handler(
         # Wrap plain exceptions in a TiferetError before formatting.
         if not isinstance(error, TiferetError):
             error = TiferetError(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'An error occurred: {str(error)}',
-                error=str(error),
+                error_message=str(error),
             )
 
         # Retrieve the error domain object via the error retrieval handler.

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -11,6 +11,7 @@ from ..assets import (
     TiferetError,
     TiferetAPIError,
 )
+from ..assets.error import APP_ERROR_ID
 from ..domain import AppSession, AppServiceDependency, Feature
 from ..events import DomainEvent
 from ..events.app import GetAppSession
@@ -534,9 +535,9 @@ class AppSessionContext(BaseContext):
         # Fallback: wrap plain exceptions and raise a generic API error.
         if not isinstance(error, TiferetError):
             error = TiferetError(
-                'APP_ERROR',
+                APP_ERROR_ID,
                 f'An error occurred in the app: {str(error)}',
-                error=str(error),
+                error_message=str(error),
             )
 
         # Raise the structured API error, propagating the error's context kwargs.

--- a/tiferet/events/sqlite.py
+++ b/tiferet/events/sqlite.py
@@ -100,9 +100,9 @@ class MutateSql(SqliteEvent):
                 }
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )
 
 # ** event: query_sql
@@ -151,9 +151,9 @@ class QuerySql(SqliteEvent):
                     return sql.fetch_all(query, parameters)
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )
 
 # ** event: bulk_mutate_sql
@@ -212,9 +212,9 @@ class BulkMutateSql(SqliteEvent):
                 }
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )
 
 # ** event: execute_script_sql
@@ -251,9 +251,9 @@ class ExecuteScriptSql(SqliteEvent):
                 }
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )
 
 # ** event: backup_sql
@@ -407,9 +407,9 @@ class CreateTableSql(SqliteEvent):
                 }
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )
 
 # ** event: drop_table_sql
@@ -467,7 +467,7 @@ class DropTableSql(SqliteEvent):
                 }
         except sqlite3.Error as e:
             self.raise_error(
-                'APP_ERROR',
+                a.error.APP_ERROR_ID,
                 f'SQLite execution failed: {str(e)}',
-                original_error=str(e)
+                error_message=str(e)
             )


### PR DESCRIPTION
## Problem

`APP_ERROR`'s message template is `'An error occurred in the app: {error_message}.'`, but all **8** raise sites passed `error=` or `original_error=` instead. `ErrorMessage.format` does a bare `self.text.format(**kwargs)`, so `ErrorContext.format_response` raised `KeyError: 'error_message'` rather than returning a `TiferetAPIError`.

**The path is live, not theoretical.** The SQLite events raise `APP_ERROR` as a genuine `TiferetError`; `AppSessionContext.run` catches it at `contexts/app.py:615` and routes it through `handle_error` → `raise_error_handler` → `format_response`, where formatting dies. Reproduced directly before fixing.

Separately, `APP_ERROR_ID` had **zero references anywhere** — the code was live purely through string literals.

## Change

Normalize the kwarg to `error_message` and replace the `'APP_ERROR'` literals with the constant, at all 8 sites:

- `blueprints/core.py:696` — `raise_error_handler`, plain-exception wrap
- `contexts/app.py:537` — `handle_error` legacy fallback
- `events/sqlite.py:103,154,215,254,410,470` — SQLite driver failures

`BackupSql`'s raiser at `events/sqlite.py:297` deliberately keeps `original_error=`, matching its own `SQLITE_BACKUP_FAILED` template.

## Tests

- Updated the 8 affected assertions in `tests/events/test_sqlite.py`.
- **Added two end-to-end regression tests** in `tests/blueprints/test_core.py` that format through the real `ErrorContext` against the cache-seeded catalog, covering both the wrapped-plain-exception arm and the event-raised arm. The pre-existing test mocked `format_response`, which is how the defect went unnoticed.

**1049 passed / 11 skipped** (baseline 1047 + 2).

## Scope note

The six `events/sqlite.py` sites are an **interim** fix. Investigating this defect showed `SqliteClient` leaves 7 of its 9 methods' driver calls unwrapped, so those `except sqlite3.Error` blocks are compensating for raw `sqlite3` exceptions one layer down. That is now folded into **#976** (Service Error Protocol) as scope item 5, which deletes the blocks and the six raises outright. The two generic wrap sites are **permanent** — they are `APP_ERROR`'s actual purpose.

Co-Authored-By: Oz <oz-agent@warp.dev>