### PR TITLE
RFP: Catalog Data/ID Redundancy Elimination

### DIFF
--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -36,15 +36,17 @@ Artifact labels:
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
 # *** constants (models)            ← assembled default definition constants (core group)
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(...)
+# ** constant: feature_not_found_data
+FEATURE_NOT_FOUND_DATA = create_default_error_data(...)  # no id — see below
 
 # *** constants (groups)            ← catalog dicts aggregating the above
 # ** constant: core_default_errors
 CORE_DEFAULT_ERRORS = {
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND_DATA,
 }
 ```
+
+The `_DATA` suffix on the leaf constant signals that the id was factored out: the factory (`create_default_error_data` and its siblings) does not take an `id`/`service_id` parameter, since the definition is always stored under its owning `*_ID` constant as the group-dict key above. Embedding the id a second time inside the value would restate it. The consuming `add_default_*` decorator (e.g. `add_default_errors`) reinjects the id from that key when reconstituting the domain object.
 
 **Multi-group catalogs** — when a module defines additional capability groups (e.g., `admin`, `sqlite`, `csv`), each group name is a shared key across all three layers: `(ids_<group>)`, `(models_<group>)`, and a named dict entry in `(groups)`. Adding an entry to a capability group always requires touching all three locations:
 ```python
@@ -53,9 +55,8 @@ CORE_DEFAULT_ERRORS = {
 SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
 
 # *** constants (models_sqlite)
-# ** constant: sqlite_conn_failed
-SQLITE_CONN_FAILED = create_default_error(
-    SQLITE_CONN_FAILED_ID,
+# ** constant: sqlite_conn_failed_data
+SQLITE_CONN_FAILED_DATA = create_default_error_data(
     'SQLite Connection Failed',
     [(EN_US, 'Failed to connect: {original_error}')],
 )
@@ -63,7 +64,7 @@ SQLITE_CONN_FAILED = create_default_error(
 # *** constants (groups)
 # ** constant: sqlite_default_errors
 SQLITE_DEFAULT_ERRORS = {
-    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED,
+    SQLITE_CONN_FAILED_ID: SQLITE_CONN_FAILED_DATA,
 }
 ```
 
@@ -73,9 +74,9 @@ The plain `(ids)` / `(models)` sub-groups (no suffix) hold the core/baseline gro
 
 - **Layer boundary — valid `# ** app` imports:** none. `assets` is the root layer; it has no framework imports. Only `# ** core` (stdlib) and `# ** infra` (minimal third-party, e.g. `json`) are valid. Never import from any other framework layer.
 - **Constants:** `SCREAMING_SNAKE_CASE`. Each constant has its own `# ** constant: <snake_case>` label. Do not group multiple constants under a single `# ** constants: <group>` mid-level label — use a top-level sub-group instead.
-- **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error`), not inline dicts. Define each entry as a named constant, then assemble the catalog dict as a separate constant.
+- **Structured defaults:** Build structured default data from a factory function (e.g. `create_default_error_data`), not inline dicts. Define each entry as a named constant with a `_DATA` suffix (it is raw data, not an id-keyed model), then assemble the catalog dict as a separate constant keyed by the corresponding `_ID` constant.
 - **Constant declaration style:** All list- and dictionary-typed constants use the multi-line hanging-indent style with a trailing comma everywhere. This is especially important in `assets/` modules: unlike `# *** events`, `# *** mappers`, and other construct groups, the assets layer has no unique construct-level section designation — it is a pure repository of constants, functions, and classes, making constant formatting the primary quality signal. Never `{ **OTHER_DICT }` inline — always expand to multi-line.
-- **Factory function constants:** Constants whose value is a factory function call (e.g. `create_default_error`, `create_app_service_dependency`) must list each argument on its own line with hanging indent and a trailing comma. Never collapse a factory call to a single line.
+- **Factory function constants:** Constants whose value is a factory function call (e.g. `create_default_error_data`, `create_app_service_dependency_data`) must list each argument on its own line with hanging indent and a trailing comma. Never collapse a factory call to a single line. These id-adjacent factories intentionally omit an `id`/`service_id` parameter — the group-dict key is the sole source of the id, and the consuming `add_default_*` decorator reinjects it.
 - **Optional parameters in factory calls:** must always be passed as keyword arguments. Required positional parameters may be passed positionally. See `tiferet-code-style` for the general keyword-argument rule and example.
 - **Functions:** Small, stateless, no framework dependencies. Use RST docstrings.
 - **Classes:** Plain standalone classes (exception types, data primitives). Use `# *** classes` / `# ** class: <name>`, `# * attribute: <name>`, `# * init`.
@@ -101,9 +102,8 @@ FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
 
 # *** constants (models)
 
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
+# ** constant: feature_not_found_data
+FEATURE_NOT_FOUND_DATA = create_default_error_data(
     'Feature Not Found',
     [('en_US', 'Feature not found: {feature_id}.')],
 )
@@ -112,31 +112,27 @@ FEATURE_NOT_FOUND = create_default_error(
 
 # ** constant: default_errors
 DEFAULT_ERRORS = {
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND_DATA,
 }
 
 # *** functions
 
-# ** function: create_default_error
-def create_default_error(id: str,
-        name: str,
+# ** function: create_default_error_data
+def create_default_error_data(name: str,
         messages: List[Tuple[str, str]]) -> Dict[str, Any]:
     '''
     Build a default error definition dictionary.
 
-    :param id: The unique error identifier.
-    :type id: str
     :param name: The human-readable error name.
     :type name: str
     :param messages: Ordered (lang, text) message pairs.
     :type messages: List[Tuple[str, str]]
-    :return: The error definition dictionary.
+    :return: The error definition dictionary, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble and return the error definition.
     return {
-        'id': id,
         'name': name,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }

--- a/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-assets/SKILL.md
@@ -35,7 +35,7 @@ Artifact labels:
 # ** constant: feature_not_found_id
 FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 
-# *** constants (models)            ← assembled default definition constants (core group)
+# *** constants (data)              ← assembled default definition constants (core group)
 # ** constant: feature_not_found_data
 FEATURE_NOT_FOUND_DATA = create_default_error_data(...)  # no id — see below
 
@@ -48,13 +48,13 @@ CORE_DEFAULT_ERRORS = {
 
 The `_DATA` suffix on the leaf constant signals that the id was factored out: the factory (`create_default_error_data` and its siblings) does not take an `id`/`service_id` parameter, since the definition is always stored under its owning `*_ID` constant as the group-dict key above. Embedding the id a second time inside the value would restate it. The consuming `add_default_*` decorator (e.g. `add_default_errors`) reinjects the id from that key when reconstituting the domain object.
 
-**Multi-group catalogs** — when a module defines additional capability groups (e.g., `admin`, `sqlite`, `csv`), each group name is a shared key across all three layers: `(ids_<group>)`, `(models_<group>)`, and a named dict entry in `(groups)`. Adding an entry to a capability group always requires touching all three locations:
+**Multi-group catalogs** — when a module defines additional capability groups (e.g., `admin`, `sqlite`, `csv`), each group name is a shared key across all three layers: `(ids_<group>)`, `(data_<group>)`, and a named dict entry in `(groups)`. Adding an entry to a capability group always requires touching all three locations:
 ```python
 # *** constants (ids_sqlite)
 # ** constant: sqlite_conn_failed_id
 SQLITE_CONN_FAILED_ID = 'SQLITE_CONN_FAILED'
 
-# *** constants (models_sqlite)
+# *** constants (data_sqlite)
 # ** constant: sqlite_conn_failed_data
 SQLITE_CONN_FAILED_DATA = create_default_error_data(
     'SQLite Connection Failed',
@@ -68,7 +68,7 @@ SQLITE_DEFAULT_ERRORS = {
 }
 ```
 
-The plain `(ids)` / `(models)` sub-groups (no suffix) hold the core/baseline group. All additional groups use the `_<group>` suffix consistently.
+The plain `(ids)` / `(data)` sub-groups (no suffix) hold the core/baseline group. All additional groups use the `_<group>` suffix consistently.
 
 ## Key conventions
 
@@ -100,7 +100,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
 # ** constant: feature_already_exists_id
 FEATURE_ALREADY_EXISTS_ID = 'FEATURE_ALREADY_EXISTS'
 
-# *** constants (models)
+# *** constants (data)
 
 # ** constant: feature_not_found_data
 FEATURE_NOT_FOUND_DATA = create_default_error_data(

--- a/docs/collab/agents/skills/tiferet-code-style/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-code-style/SKILL.md
@@ -64,7 +64,7 @@ FEATURE_NOT_FOUND_ID = 'FEATURE_NOT_FOUND'
   - `# -- obsolete: <reason>` — deprecated artifact; remove with the artifact. Shorthand: `# * method: foo (obsolete)`.
 - **Pre-session scan:** Before editing, run `grep -rn "# ++\|# --" tiferet/` to find open annotations.
 - **Constant declaration style:** All list- and dictionary-typed constants use the multi-line hanging-indent style with a trailing comma, wherever they appear. Short constants are just as mandatory as long ones. Never `{ **OTHER_DICT }` inline.
-- **Optional parameters in function/factory calls:** must be passed as keyword arguments — not positionally. Required positional parameters may continue to be passed positionally. Correct: `create_default_app_session(TIFERET_ADMIN_ID, 'Admin App', description='...')`. Incorrect: `create_default_app_session(TIFERET_ADMIN_ID, 'Admin App', '...')` (the optional `description` passed positionally loses its self-documenting value).
+- **Optional parameters in function/factory calls:** must be passed as keyword arguments — not positionally. Required positional parameters may continue to be passed positionally. Correct: `create_default_app_session_data('Admin App', description='...')`. Incorrect: `create_default_app_session_data('Admin App', '...')` (the optional `description` passed positionally loses its self-documenting value).
 
 ## Example
 

--- a/docs/collab/tech_requirements.md
+++ b/docs/collab/tech_requirements.md
@@ -102,11 +102,11 @@ There are two primary expressions — use either, or combine both in sequence wh
 **Expression 2 — factory-built object:**
 State the shared factory invocation pattern in a prefix sentence; table columns carry only the variable parameters. This keeps the table compact and keeps the factory name out of every row.
 ```
-Each constant uses `create_service_registration(ID_CONST, create_service_module_path(TIFERET, <base>, <domain>), 'ClassName')`.
+Each constant uses `create_service_registration_data(create_service_module_path(TIFERET, <base>, <domain>), 'ClassName')`. The factory omits an `id` parameter — the group-dict key (the ID Constant column) is the sole source of the id, reinjected by the consuming `add_default_*` decorator.
 
 | Constant | ID Constant | base | domain | class_name |
 |---|---|---|---|---|
-| `ADD_FEATURE_EVT` | `ADD_FEATURE_EVT_ID` | `TIFERET_EVENTS_PATH` | `FEATURE_DOMAIN_PATH` | `'AddFeature'` |
+| `ADD_FEATURE_EVT_DATA` | `ADD_FEATURE_EVT_ID` | `TIFERET_EVENTS_PATH` | `FEATURE_DOMAIN_PATH` | `'AddFeature'` |
 ```
 
 **Combining both expressions** — when a code section contains scalar ID constants followed by factory-built object constants (the three-section catalog pattern), produce two tables in sequence under the same `####` heading. The second table references constant names from the first (not bare string values), making the dependency between sections explicit and verifiable.

--- a/docs/core/assets.md
+++ b/docs/core/assets.md
@@ -67,47 +67,46 @@ EN_US = 'en_US'
 ERROR_NOT_FOUND_ID = 'ERROR_NOT_FOUND'
 ```
 
-Structured data is built from a factory rather than annotated inline. `DEFAULT_ERRORS` keys each error-id constant to a definition produced by `create_default_error`, and each definition is itself a named constant:
+Structured data is built from a factory rather than annotated inline. `DEFAULT_ERRORS` keys each error-id constant to a definition produced by `create_default_error_data`, and each definition is itself a named constant. The factory deliberately does not take an `id` parameter: the definition is always stored under its owning `*_ID` constant as the group-dict key, so embedding the id a second time inside the value would restate it. The consuming `add_default_errors` decorator reinjects the id from that key when reconstituting the `Error` domain object:
 
 ```python
-# ** constant: error_not_found
-ERROR_NOT_FOUND = create_default_error(
-    ERROR_NOT_FOUND_ID,
+# ** constant: error_not_found_data
+ERROR_NOT_FOUND_DATA = create_default_error_data(
     'Error Not Found',
     [(EN_US, 'Error not found: {id}.')],
 )
 
 # ** constant: default_errors
 DEFAULT_ERRORS = {
-    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND_DATA,
 }
 ```
 
 ### Functions
 
-Assets functions are small, stateless helpers with no framework dependencies. For example, `create_default_error` (in `constants.py`) builds a default error definition from ordered `(lang, text)` message pairs:
+Assets functions are small, stateless helpers with no framework dependencies. For example, `create_default_error_data` (in `core.py`) builds a default error definition from ordered `(lang, text)` message pairs, without an `id` parameter:
 
 ```python
 # *** functions
 
-# ** function: create_default_error
-def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) -> Dict[str, Any]:
+# ** function: create_default_error_data
+def create_default_error_data(
+        name: str,
+        messages: List[Tuple[str, str]],
+    ) -> Dict[str, Any]:
     '''
     Build a default error definition dictionary.
 
-    :param id: The unique identifier of the error.
-    :type id: str
     :param name: The human-readable error name.
     :type name: str
     :param messages: Ordered (lang, text) message pairs.
     :type messages: List[Tuple[str, str]]
-    :return: The default error definition.
+    :return: The default error definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble and return the default error definition dictionary.
     return {
-        'id': id,
         'name': name,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -104,9 +104,8 @@ ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
 
 # *** constants (models_admin)
 
-# ** constant: error_already_exists
-ERROR_ALREADY_EXISTS = create_default_error(
-    ERROR_ALREADY_EXISTS_ID,
+# ** constant: error_already_exists_data
+ERROR_ALREADY_EXISTS_DATA = create_default_error_data(
     'Error Already Exists',
     [(EN_US, 'An error with ID {id} already exists.')],
 )
@@ -116,9 +115,11 @@ ERROR_ALREADY_EXISTS = create_default_error(
 # ** constant: admin_default_errors
 ADMIN_DEFAULT_ERRORS = {
     **CORE_DEFAULT_ERRORS,
-    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
+    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS_DATA,
 }
 ```
+
+The factory omits `id`: the definition is always stored under its owning `*_ID` constant as the group-dict key, so embedding the id a second time inside the value would restate it. The `_DATA` suffix on the leaf constant signals this — it is raw data, not an id-keyed model. The consuming `add_default_*` decorator reinjects the id from the group-dict key when reconstituting the domain object.
 
 The plain `(ids)` and `(models)` sub-groups (no suffix) hold the core/baseline group. All additional capability groups use the `_<group>` suffix consistently.
 
@@ -186,15 +187,13 @@ When calling a function or factory that has optional parameters, those parameter
 
 ```python
 # Correct — optional 'description' passed as keyword argument
-DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
-    TIFERET_ADMIN_ID,
+DEFAULT_ADMIN_APP_SESSION_DATA = create_default_app_session_data(
     'Admin App',
     description='Default built-in admin application session',
 )
 
 # Incorrect — optional 'description' passed positionally; do not use
-DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
-    TIFERET_ADMIN_ID,
+DEFAULT_ADMIN_APP_SESSION_DATA = create_default_app_session_data(
     'Admin App',
     'Default built-in admin application session',
 )

--- a/docs/core/code_style.md
+++ b/docs/core/code_style.md
@@ -91,10 +91,10 @@ The most common use is grouping unit tests by the class or method under test, so
 **Multi-group asset catalogs** — When an `assets/` module defines multiple capability groups (e.g., `admin`, `sqlite`, `csv`), apply a three-layer sub-group structure. Each capability group name is a shared key across all three layers:
 
 1. `# *** constants (ids_<group>)` — raw string ID constants for the group.
-2. `# *** constants (models_<group>)` — assembled model constants (e.g., via `create_default_error`) in the same order as the corresponding `(ids_<group>)` section.
-3. A named dict entry under `# *** constants (groups)` — aggregates the group's models.
+2. `# *** constants (data_<group>)` — assembled data constants (e.g., via `create_default_error_data`) in the same order as the corresponding `(ids_<group>)` section.
+3. A named dict entry under `# *** constants (groups)` — aggregates the group's data.
 
-When adding an entry to a capability group, touch all three locations: `(ids_<group>)`, `(models_<group>)`, and the group dict in `(groups)`. See `tiferet/assets/error.py` for the canonical reference.
+When adding an entry to a capability group, touch all three locations: `(ids_<group>)`, `(data_<group>)`, and the group dict in `(groups)`. See `tiferet/assets/error.py` for the canonical reference.
 
 ```python
 # *** constants (ids_admin)
@@ -102,7 +102,7 @@ When adding an entry to a capability group, touch all three locations: `(ids_<gr
 # ** constant: error_already_exists_id
 ERROR_ALREADY_EXISTS_ID = 'ERROR_ALREADY_EXISTS'
 
-# *** constants (models_admin)
+# *** constants (data_admin)
 
 # ** constant: error_already_exists_data
 ERROR_ALREADY_EXISTS_DATA = create_default_error_data(
@@ -121,7 +121,7 @@ ADMIN_DEFAULT_ERRORS = {
 
 The factory omits `id`: the definition is always stored under its owning `*_ID` constant as the group-dict key, so embedding the id a second time inside the value would restate it. The `_DATA` suffix on the leaf constant signals this — it is raw data, not an id-keyed model. The consuming `add_default_*` decorator reinjects the id from the group-dict key when reconstituting the domain object.
 
-The plain `(ids)` and `(models)` sub-groups (no suffix) hold the core/baseline group. All additional capability groups use the `_<group>` suffix consistently.
+The plain `(ids)` and `(data)` sub-groups (no suffix) hold the core/baseline group. All additional capability groups use the `_<group>` suffix consistently.
 
 **A catalogued code must have a raiser.** The error catalog holds **domain** codes only — outcomes a consumer can act on. An infrastructural failure raises a `ServiceError` whose code is a plain `_ID` constant in the module that raises it, and a model defect raises a `ModelError` against the constants in `domain/core.py`; neither is catalogued. Do not pre-create a catalog entry in anticipation of a future raiser: `assets/error.py` previously accumulated 15 codes with no raiser anywhere in the framework, and they were deleted rather than kept.
 

--- a/tests/assets/test_app.py
+++ b/tests/assets/test_app.py
@@ -76,19 +76,18 @@ def test_core_default_services_keys_match_service_ids() -> None:
 # ** test: core_default_services_entries_have_expected_shape
 def test_core_default_services_entries_have_expected_shape() -> None:
     '''
-    Test that each CORE_DEFAULT_SERVICES value carries the four dependency keys
-    and that its key matches the embedded service_id.
+    Test that each CORE_DEFAULT_SERVICES value carries the three base
+    dependency keys, with no embedded service_id — the group-dict key is the
+    sole source of the service id.
     '''
 
-    # Assert each entry carries the four expected keys with a matching service_id.
-    for service_id, record in CORE_DEFAULT_SERVICES.items():
+    # Assert each entry carries only the three base dependency keys.
+    for record in CORE_DEFAULT_SERVICES.values():
         assert set(record.keys()) == {
-            'service_id',
             'module_path',
             'class_name',
             'parameters',
         }
-        assert record['service_id'] == service_id
 
 # ** test: core_default_constants_keys_match_config_ids
 def test_core_default_constants_keys_match_config_ids() -> None:

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -8,17 +8,17 @@ import pytest
 # ** app
 from tiferet.assets.core import (
     create_service_dependency,
-    create_app_service_dependency,
-    create_service_registration,
+    create_app_service_dependency_data,
+    create_service_registration_data,
     create_service_module_path,
-    create_default_feature,
-    create_default_app_session,
+    create_default_feature_data,
+    create_default_app_session_data,
     create_params_schema,
     create_default_formatter,
     create_default_handler,
     create_default_logger,
     create_default_cli_argument,
-    create_default_cli_command,
+    create_default_cli_command_data,
     TiferetError,
     TiferetAPIError,
     TIFERET,
@@ -93,91 +93,89 @@ def test_create_service_dependency_with_parameters() -> None:
     # Assert parameters are preserved.
     assert result['parameters'] == params
 
-# ** test: create_app_service_dependency_returns_expected_shape
-def test_create_app_service_dependency_returns_expected_shape() -> None:
+# ** test: create_app_service_dependency_data_returns_expected_shape
+def test_create_app_service_dependency_data_returns_expected_shape() -> None:
     '''
-    Test that create_app_service_dependency returns a dict with the four
-    dependency keys and that service_id matches the first argument.
+    Test that create_app_service_dependency_data returns a dict with the
+    three base dependency keys and no id (dropped in favor of the owning
+    group-dict key).
 
     :return: None
     :rtype: None
     '''
 
     # Build the app service dependency dict.
-    result = create_app_service_dependency(
-        'error_service',
+    result = create_app_service_dependency_data(
         'tiferet.repos.error',
         'ErrorConfigRepository',
     )
 
     # Assert the shape and values.
-    assert set(result.keys()) == {'service_id', 'module_path', 'class_name', 'parameters'}
-    assert result['service_id'] == 'error_service'
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
     assert result['module_path'] == 'tiferet.repos.error'
     assert result['class_name'] == 'ErrorConfigRepository'
     assert result['parameters'] == {}
 
-# ** test: create_app_service_dependency_omitting_parameters_yields_empty_dict
-def test_create_app_service_dependency_omitting_parameters_yields_empty_dict() -> None:
+# ** test: create_app_service_dependency_data_omitting_parameters_yields_empty_dict
+def test_create_app_service_dependency_data_omitting_parameters_yields_empty_dict() -> None:
     '''
-    Test that omitting parameters in create_app_service_dependency yields an
-    empty dict rather than None.
+    Test that omitting parameters in create_app_service_dependency_data yields
+    an empty dict rather than None.
 
     :return: None
     :rtype: None
     '''
 
     # Build without explicit parameters.
-    result = create_app_service_dependency('svc', 'tiferet.mod', 'Cls')
+    result = create_app_service_dependency_data('tiferet.mod', 'Cls')
 
     # Assert parameters default to an empty dict.
     assert result['parameters'] == {}
 
-# ** test: create_service_registration_returns_expected_shape
-def test_create_service_registration_returns_expected_shape() -> None:
+# ** test: create_service_registration_data_returns_expected_shape
+def test_create_service_registration_data_returns_expected_shape() -> None:
     '''
-    Test that create_service_registration returns a dict with the four
-    registration keys and that id matches the first argument.
+    Test that create_service_registration_data returns a dict with the three
+    base registration keys and no id (dropped in favor of the owning
+    group-dict key).
 
     :return: None
     :rtype: None
     '''
 
     # Build the service registration dict.
-    result = create_service_registration(
-        'add_feature_evt',
+    result = create_service_registration_data(
         'tiferet.events.feature',
         'AddFeature',
     )
 
     # Assert the shape and values.
-    assert set(result.keys()) == {'id', 'module_path', 'class_name', 'parameters'}
-    assert result['id'] == 'add_feature_evt'
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
     assert result['module_path'] == 'tiferet.events.feature'
     assert result['class_name'] == 'AddFeature'
     assert result['parameters'] == {}
 
-# ** test: create_service_registration_omitting_parameters_yields_empty_dict
-def test_create_service_registration_omitting_parameters_yields_empty_dict() -> None:
+# ** test: create_service_registration_data_omitting_parameters_yields_empty_dict
+def test_create_service_registration_data_omitting_parameters_yields_empty_dict() -> None:
     '''
-    Test that omitting parameters in create_service_registration yields an
-    empty dict rather than None.
+    Test that omitting parameters in create_service_registration_data yields
+    an empty dict rather than None.
 
     :return: None
     :rtype: None
     '''
 
     # Build without explicit parameters.
-    result = create_service_registration('svc', 'tiferet.mod', 'Cls')
+    result = create_service_registration_data('tiferet.mod', 'Cls')
 
     # Assert parameters default to an empty dict.
     assert result['parameters'] == {}
 
-# ** test: create_default_feature_returns_required_fields
-def test_create_default_feature_returns_required_fields() -> None:
+# ** test: create_default_feature_data_returns_required_fields
+def test_create_default_feature_data_returns_required_fields() -> None:
     '''
-    Test that create_default_feature returns a dict with all five required
-    fields populated and no optional fields when omitted.
+    Test that create_default_feature_data returns a dict with all four base
+    fields populated (no id) and no optional fields when omitted.
 
     :return: None
     :rtype: None
@@ -185,8 +183,7 @@ def test_create_default_feature_returns_required_fields() -> None:
 
     # Build a minimal feature with no optional arguments.
     steps = [{'service_id': 'get_feature_evt', 'name': 'Get feature'}]
-    result = create_default_feature(
-        'feature.get',
+    result = create_default_feature_data(
         'Get Feature',
         'feature',
         'get',
@@ -194,21 +191,21 @@ def test_create_default_feature_returns_required_fields() -> None:
     )
 
     # Assert required fields are present.
-    assert result['id'] == 'feature.get'
     assert result['name'] == 'Get Feature'
     assert result['group_id'] == 'feature'
     assert result['feature_key'] == 'get'
     assert result['steps'] == steps
 
-    # Assert optional fields are absent when not provided.
+    # Assert id and optional fields are absent.
+    assert 'id' not in result
     assert 'description' not in result
     assert 'params_schema' not in result
 
-# ** test: create_default_feature_includes_optional_fields_when_provided
-def test_create_default_feature_includes_optional_fields_when_provided() -> None:
+# ** test: create_default_feature_data_includes_optional_fields_when_provided
+def test_create_default_feature_data_includes_optional_fields_when_provided() -> None:
     '''
-    Test that create_default_feature includes description and params_schema
-    when they are supplied.
+    Test that create_default_feature_data includes description and
+    params_schema when they are supplied.
 
     :return: None
     :rtype: None
@@ -216,8 +213,7 @@ def test_create_default_feature_includes_optional_fields_when_provided() -> None
 
     # Build with optional arguments.
     schema = {'id': 'str'}
-    result = create_default_feature(
-        'feature.get',
+    result = create_default_feature_data(
         'Get Feature',
         'feature',
         'get',
@@ -230,22 +226,22 @@ def test_create_default_feature_includes_optional_fields_when_provided() -> None
     assert result['description'] == 'Retrieve a feature by ID.'
     assert result['params_schema'] == schema
 
-# ** test: create_default_app_session_returns_required_fields
-def test_create_default_app_session_returns_required_fields() -> None:
+# ** test: create_default_app_session_data_returns_required_fields
+def test_create_default_app_session_data_returns_required_fields() -> None:
     '''
-    Test that create_default_app_session returns a dict with id and name and
-    no description field when omitted.
+    Test that create_default_app_session_data returns a dict with only name
+    (no id) and no description field when omitted.
 
     :return: None
     :rtype: None
     '''
 
     # Build a minimal session with no optional arguments.
-    result = create_default_app_session('admin', 'Admin App')
+    result = create_default_app_session_data('Admin App')
 
-    # Assert required fields are present.
-    assert result['id'] == 'admin'
+    # Assert required fields are present and id is absent.
     assert result['name'] == 'Admin App'
+    assert 'id' not in result
 
     # Assert optional description is absent when not provided.
     assert 'description' not in result
@@ -275,19 +271,18 @@ def test_create_params_schema_returns_expected_dict() -> None:
         'description': {'type': 'str', 'required': False},
     }
 
-# ** test: create_default_app_session_includes_description_when_provided
-def test_create_default_app_session_includes_description_when_provided() -> None:
+# ** test: create_default_app_session_data_includes_description_when_provided
+def test_create_default_app_session_data_includes_description_when_provided() -> None:
     '''
-    Test that create_default_app_session includes the description field when
-    it is supplied.
+    Test that create_default_app_session_data includes the description field
+    when it is supplied.
 
     :return: None
     :rtype: None
     '''
 
     # Build with an optional description.
-    result = create_default_app_session(
-        'admin_cli',
+    result = create_default_app_session_data(
         'Admin CLI',
         description='Built-in CLI for managing Tiferet application configurations',
     )
@@ -505,39 +500,38 @@ def test_create_default_cli_argument_includes_optional_fields_when_provided() ->
     assert result['nargs'] == '?'
     assert result['choices'] == ['DEBUG', 'INFO', 'WARNING']
 
-# ** test: create_default_cli_command_returns_required_fields
-def test_create_default_cli_command_returns_required_fields() -> None:
+# ** test: create_default_cli_command_data_returns_required_fields
+def test_create_default_cli_command_data_returns_required_fields() -> None:
     '''
-    Test that create_default_cli_command returns a dict with the four required
-    fields and no optional fields when they are omitted.
+    Test that create_default_cli_command_data returns a dict with the three
+    base fields (no id) and no optional fields when they are omitted.
 
     :return: None
     :rtype: None
     '''
 
     # Build a minimal command with no optional arguments.
-    result = create_default_cli_command(
-        'feature.list',
+    result = create_default_cli_command_data(
         'list',
         'feature',
         'List Features',
     )
 
     # Assert required fields are present.
-    assert result['id'] == 'feature.list'
     assert result['key'] == 'list'
     assert result['group_key'] == 'feature'
     assert result['name'] == 'List Features'
 
-    # Assert optional fields are absent when not provided.
+    # Assert id and optional fields are absent when not provided.
+    assert 'id' not in result
     assert 'description' not in result
     assert 'arguments' not in result
 
-# ** test: create_default_cli_command_includes_optional_fields_when_provided
-def test_create_default_cli_command_includes_optional_fields_when_provided() -> None:
+# ** test: create_default_cli_command_data_includes_optional_fields_when_provided
+def test_create_default_cli_command_data_includes_optional_fields_when_provided() -> None:
     '''
-    Test that create_default_cli_command includes description and arguments
-    when they are supplied.
+    Test that create_default_cli_command_data includes description and
+    arguments when they are supplied.
 
     :return: None
     :rtype: None
@@ -545,8 +539,7 @@ def test_create_default_cli_command_includes_optional_fields_when_provided() -> 
 
     # Build with optional arguments.
     args = [create_default_cli_argument(['id'], 'The feature identifier.')]
-    result = create_default_cli_command(
-        'feature.get',
+    result = create_default_cli_command_data(
         'get',
         'feature',
         'Get Feature',

--- a/tests/contexts/test_error.py
+++ b/tests/contexts/test_error.py
@@ -78,8 +78,9 @@ def error() -> Error:
     :rtype: Error
     '''
 
-    # Build and return the ERROR_NOT_FOUND error.
-    return Error(**CORE_DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
+    # Build and return the ERROR_NOT_FOUND error, re-injecting its id since
+    # the catalog entry no longer embeds it.
+    return Error(id=ERROR_NOT_FOUND_ID, **CORE_DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
 
 # *** tests
 

--- a/tests/di/test_dependency_injector.py
+++ b/tests/di/test_dependency_injector.py
@@ -560,10 +560,11 @@ def test_app_container_from_dependencies_core_catalog_resolves():
     Test that the full core service catalog resolves through the app container.
     '''
 
-    # Reconstitute the core catalog into app service dependencies and constants.
+    # Reconstitute the core catalog into app service dependencies (re-injecting
+    # service_id from the group-dict key) and constants.
     services = [
-        AppServiceDependency.model_validate(record)
-        for record in a.app.CORE_DEFAULT_SERVICES.values()
+        AppServiceDependency.model_validate({**record, 'service_id': service_id})
+        for service_id, record in a.app.CORE_DEFAULT_SERVICES.items()
     ]
     constants = dict(a.app.CORE_DEFAULT_CONSTANTS)
 

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -4,7 +4,7 @@ Provides the default interface definitions plus the core service-dependency and
 bootstrap-constant catalogs for the built-in Tiferet application.
 
 The service and constant catalogs mirror the default-error catalog in
-``assets/error.py``: id constants, model constants (services built via
+``assets/error.py``: id constants, data constants (services built via
 ``create_app_service_dependency_data``), and group mappings
 (``CORE_DEFAULT_SERVICES`` / ``CORE_DEFAULT_CONSTANTS``) consumed during
 application bootstrapping and cache seeding.

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -5,7 +5,7 @@ bootstrap-constant catalogs for the built-in Tiferet application.
 
 The service and constant catalogs mirror the default-error catalog in
 ``assets/error.py``: id constants, model constants (services built via
-``create_app_service_dependency``), and group mappings
+``create_app_service_dependency_data``), and group mappings
 (``CORE_DEFAULT_SERVICES`` / ``CORE_DEFAULT_CONSTANTS``) consumed during
 application bootstrapping and cache seeding.
 """
@@ -17,8 +17,8 @@ from typing import Any, Dict
 
 # ** app
 from .core import (
-    create_app_service_dependency,
-    create_default_app_session,
+    create_app_service_dependency_data,
+    create_default_app_session_data,
     create_service_module_path,
     TIFERET,
     TIFERET_EVENTS_PATH,
@@ -125,116 +125,100 @@ DEFAULT_APP_SERVICE_PARAMETERS = {
 
 # *** constants (sessions)
 
-# ** constant: default_admin_app_session
-DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
-    TIFERET_ADMIN_ID,
+# ** constant: default_admin_app_session_data
+DEFAULT_ADMIN_APP_SESSION_DATA = create_default_app_session_data(
     'Admin App',
     description='Default built-in admin application session',
 )
 
-# ** constant: default_admin_cli_session
-DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
-    TIFERET_ADMIN_CLI_ID,
+# ** constant: default_admin_cli_session_data
+DEFAULT_ADMIN_CLI_SESSION_DATA = create_default_app_session_data(
     'Admin CLI',
     description='Built-in CLI for managing Tiferet application configurations',
 )
 
 # *** constants (services)
 
-# ** constant: di_service
-DI_SERVICE = create_app_service_dependency(
-    DI_SERVICE_ID,
+# ** constant: di_service_data
+DI_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
     'DIConfigRepository',
 )
 
-# ** constant: error_service
-ERROR_SERVICE = create_app_service_dependency(
-    ERROR_SERVICE_ID,
+# ** constant: error_service_data
+ERROR_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
     'ErrorConfigRepository',
 )
 
-# ** constant: logging_service
-LOGGING_SERVICE = create_app_service_dependency(
-    LOGGING_SERVICE_ID,
+# ** constant: logging_service_data
+LOGGING_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
     'LoggingConfigRepository',
 )
 
-# ** constant: feature_service
-FEATURE_SERVICE = create_app_service_dependency(
-    FEATURE_SERVICE_ID,
+# ** constant: feature_service_data
+FEATURE_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
     'FeatureConfigRepository',
 )
 
-# ** constant: get_error_evt
-GET_ERROR_EVT = create_app_service_dependency(
-    GET_ERROR_EVT_ID,
+# ** constant: get_error_evt_data
+GET_ERROR_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'GetError',
 )
 
-# ** constant: get_feature_evt
-GET_FEATURE_EVT = create_app_service_dependency(
-    GET_FEATURE_EVT_ID,
+# ** constant: get_feature_evt_data
+GET_FEATURE_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'GetFeature',
 )
 
-# ** constant: logging_list_all_evt
-LOGGING_LIST_ALL_EVT = create_app_service_dependency(
-    LOGGING_LIST_ALL_EVT_ID,
+# ** constant: logging_list_all_evt_data
+LOGGING_LIST_ALL_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'ListAllLoggingConfigs',
 )
 
-# ** constant: cli_service
-CLI_SERVICE = create_app_service_dependency(
-    CLI_SERVICE_ID,
+# ** constant: cli_service_data
+CLI_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
     'CliConfigRepository',
 )
 
-# ** constant: list_commands_evt
-LIST_COMMANDS_EVT = create_app_service_dependency(
-    LIST_COMMANDS_EVT_ID,
+# ** constant: list_commands_evt_data
+LIST_COMMANDS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'ListCliCommands',
 )
 
-# ** constant: get_parent_args_evt
-GET_PARENT_ARGS_EVT = create_app_service_dependency(
-    GET_PARENT_ARGS_EVT_ID,
+# ** constant: get_parent_args_evt_data
+GET_PARENT_ARGS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'GetParentArguments',
 )
 
-# ** constant: di_list_all_configs_evt
-DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
-    DI_LIST_ALL_CONFIGS_EVT_ID,
+# ** constant: di_list_all_configs_evt_data
+DI_LIST_ALL_CONFIGS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'ListAllSettings',
 )
 
-# ** constant: logging_middleware
-LOGGING_MIDDLEWARE = create_app_service_dependency(
-    LOGGING_MIDDLEWARE_ID,
+# ** constant: logging_middleware_data
+LOGGING_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'LoggingMiddleware',
 )
 
-# ** constant: timing_middleware
-TIMING_MIDDLEWARE = create_app_service_dependency(
-    TIMING_MIDDLEWARE_ID,
+# ** constant: timing_middleware_data
+TIMING_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'TimingMiddleware',
 )
 
-# ** constant: cache_middleware
-CACHE_MIDDLEWARE = create_app_service_dependency(
-    CACHE_MIDDLEWARE_ID,
+# ** constant: cache_middleware_data
+CACHE_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'CacheMiddleware',
 )
@@ -243,20 +227,20 @@ CACHE_MIDDLEWARE = create_app_service_dependency(
 
 # ** constant: core_default_services
 CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
-    DI_SERVICE_ID: DI_SERVICE,
-    ERROR_SERVICE_ID: ERROR_SERVICE,
-    LOGGING_SERVICE_ID: LOGGING_SERVICE,
-    FEATURE_SERVICE_ID: FEATURE_SERVICE,
-    GET_ERROR_EVT_ID: GET_ERROR_EVT,
-    GET_FEATURE_EVT_ID: GET_FEATURE_EVT,
-    LOGGING_LIST_ALL_EVT_ID: LOGGING_LIST_ALL_EVT,
-    CLI_SERVICE_ID: CLI_SERVICE,
-    LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT,
-    GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT,
-    DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT,
-    LOGGING_MIDDLEWARE_ID: LOGGING_MIDDLEWARE,
-    TIMING_MIDDLEWARE_ID: TIMING_MIDDLEWARE,
-    CACHE_MIDDLEWARE_ID: CACHE_MIDDLEWARE,
+    DI_SERVICE_ID: DI_SERVICE_DATA,
+    ERROR_SERVICE_ID: ERROR_SERVICE_DATA,
+    LOGGING_SERVICE_ID: LOGGING_SERVICE_DATA,
+    FEATURE_SERVICE_ID: FEATURE_SERVICE_DATA,
+    GET_ERROR_EVT_ID: GET_ERROR_EVT_DATA,
+    GET_FEATURE_EVT_ID: GET_FEATURE_EVT_DATA,
+    LOGGING_LIST_ALL_EVT_ID: LOGGING_LIST_ALL_EVT_DATA,
+    CLI_SERVICE_ID: CLI_SERVICE_DATA,
+    LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT_DATA,
+    GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT_DATA,
+    DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT_DATA,
+    LOGGING_MIDDLEWARE_ID: LOGGING_MIDDLEWARE_DATA,
+    TIMING_MIDDLEWARE_ID: TIMING_MIDDLEWARE_DATA,
+    CACHE_MIDDLEWARE_ID: CACHE_MIDDLEWARE_DATA,
 }
 
 # ** constant: core_default_constants
@@ -284,6 +268,6 @@ ADMIN_DEFAULT_CONSTANTS = {
 # Built-in session definitions seeded into the cache by build_cache so the admin
 # paths can resolve them without a config-file entry or a separate fallback.
 CORE_DEFAULT_APP_SESSIONS = {
-    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION,
-    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION,
+    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION_DATA,
+    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION_DATA,
 }

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -14,7 +14,7 @@ at startup — they are not loaded from the consumer's config file.
 from typing import Any, Dict, List
 
 # ** app
-from .core import create_default_cli_argument, create_default_cli_command
+from .core import create_default_cli_argument, create_default_cli_command_data
 
 # *** constants (ids)
 
@@ -143,9 +143,8 @@ LOGGING_LIST_CLI_CMD_ID = 'logging.list'
 
 # *** constants (commands)
 
-# ** constant: app_add_cli_cmd
-APP_ADD_CLI_CMD = create_default_cli_command(
-    APP_ADD_CLI_CMD_ID,
+# ** constant: app_add_cli_cmd_data
+APP_ADD_CLI_CMD_DATA = create_default_cli_command_data(
     'add',
     'app',
     'Add App Interface',
@@ -162,9 +161,8 @@ APP_ADD_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_get_cli_cmd
-APP_GET_CLI_CMD = create_default_cli_command(
-    APP_GET_CLI_CMD_ID,
+# ** constant: app_get_cli_cmd_data
+APP_GET_CLI_CMD_DATA = create_default_cli_command_data(
     'get',
     'app',
     'Get App Interface',
@@ -174,18 +172,16 @@ APP_GET_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_list_cli_cmd
-APP_LIST_CLI_CMD = create_default_cli_command(
-    APP_LIST_CLI_CMD_ID,
+# ** constant: app_list_cli_cmd_data
+APP_LIST_CLI_CMD_DATA = create_default_cli_command_data(
     'list',
     'app',
     'List App Interfaces',
     description='List all configured app interfaces.',
 )
 
-# ** constant: app_update_cli_cmd
-APP_UPDATE_CLI_CMD = create_default_cli_command(
-    APP_UPDATE_CLI_CMD_ID,
+# ** constant: app_update_cli_cmd_data
+APP_UPDATE_CLI_CMD_DATA = create_default_cli_command_data(
     'update',
     'app',
     'Update App Interface',
@@ -197,9 +193,8 @@ APP_UPDATE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_constants_cli_cmd
-APP_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
-    APP_SET_CONSTANTS_CLI_CMD_ID,
+# ** constant: app_set_constants_cli_cmd_data
+APP_SET_CONSTANTS_CLI_CMD_DATA = create_default_cli_command_data(
     'set-constants',
     'app',
     'Set App Constants',
@@ -210,9 +205,8 @@ APP_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_service_cli_cmd
-APP_SET_SERVICE_CLI_CMD = create_default_cli_command(
-    APP_SET_SERVICE_CLI_CMD_ID,
+# ** constant: app_set_service_cli_cmd_data
+APP_SET_SERVICE_CLI_CMD_DATA = create_default_cli_command_data(
     'set-service',
     'app',
     'Set App Service Dependency',
@@ -226,9 +220,8 @@ APP_SET_SERVICE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_service_cli_cmd
-APP_REMOVE_SERVICE_CLI_CMD = create_default_cli_command(
-    APP_REMOVE_SERVICE_CLI_CMD_ID,
+# ** constant: app_remove_service_cli_cmd_data
+APP_REMOVE_SERVICE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-service',
     'app',
     'Remove App Service Dependency',
@@ -239,9 +232,8 @@ APP_REMOVE_SERVICE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_cli_cmd
-APP_REMOVE_CLI_CMD = create_default_cli_command(
-    APP_REMOVE_CLI_CMD_ID,
+# ** constant: app_remove_cli_cmd_data
+APP_REMOVE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove',
     'app',
     'Remove App Interface',
@@ -251,9 +243,8 @@ APP_REMOVE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_add_command_cli_cmd
-CLI_ADD_COMMAND_CLI_CMD = create_default_cli_command(
-    CLI_ADD_COMMAND_CLI_CMD_ID,
+# ** constant: cli_add_command_cli_cmd_data
+CLI_ADD_COMMAND_CLI_CMD_DATA = create_default_cli_command_data(
     'add-command',
     'cli',
     'Add CLI Command',
@@ -267,18 +258,16 @@ CLI_ADD_COMMAND_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_list_commands_cli_cmd
-CLI_LIST_COMMANDS_CLI_CMD = create_default_cli_command(
-    CLI_LIST_COMMANDS_CLI_CMD_ID,
+# ** constant: cli_list_commands_cli_cmd_data
+CLI_LIST_COMMANDS_CLI_CMD_DATA = create_default_cli_command_data(
     'list-commands',
     'cli',
     'List CLI Commands',
     description='List all CLI command definitions.',
 )
 
-# ** constant: cli_add_argument_cli_cmd
-CLI_ADD_ARGUMENT_CLI_CMD = create_default_cli_command(
-    CLI_ADD_ARGUMENT_CLI_CMD_ID,
+# ** constant: cli_add_argument_cli_cmd_data
+CLI_ADD_ARGUMENT_CLI_CMD_DATA = create_default_cli_command_data(
     'add-argument',
     'cli',
     'Add CLI Argument',
@@ -293,9 +282,8 @@ CLI_ADD_ARGUMENT_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_add_cli_cmd
-ERROR_ADD_CLI_CMD = create_default_cli_command(
-    ERROR_ADD_CLI_CMD_ID,
+# ** constant: error_add_cli_cmd_data
+ERROR_ADD_CLI_CMD_DATA = create_default_cli_command_data(
     'add',
     'error',
     'Add Error',
@@ -308,9 +296,8 @@ ERROR_ADD_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_get_cli_cmd
-ERROR_GET_CLI_CMD = create_default_cli_command(
-    ERROR_GET_CLI_CMD_ID,
+# ** constant: error_get_cli_cmd_data
+ERROR_GET_CLI_CMD_DATA = create_default_cli_command_data(
     'get',
     'error',
     'Get Error',
@@ -320,18 +307,16 @@ ERROR_GET_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_list_cli_cmd
-ERROR_LIST_CLI_CMD = create_default_cli_command(
-    ERROR_LIST_CLI_CMD_ID,
+# ** constant: error_list_cli_cmd_data
+ERROR_LIST_CLI_CMD_DATA = create_default_cli_command_data(
     'list',
     'error',
     'List Errors',
     description='List all error definitions.',
 )
 
-# ** constant: error_rename_cli_cmd
-ERROR_RENAME_CLI_CMD = create_default_cli_command(
-    ERROR_RENAME_CLI_CMD_ID,
+# ** constant: error_rename_cli_cmd_data
+ERROR_RENAME_CLI_CMD_DATA = create_default_cli_command_data(
     'rename',
     'error',
     'Rename Error',
@@ -342,9 +327,8 @@ ERROR_RENAME_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_set_message_cli_cmd
-ERROR_SET_MESSAGE_CLI_CMD = create_default_cli_command(
-    ERROR_SET_MESSAGE_CLI_CMD_ID,
+# ** constant: error_set_message_cli_cmd_data
+ERROR_SET_MESSAGE_CLI_CMD_DATA = create_default_cli_command_data(
     'set-message',
     'error',
     'Set Error Message',
@@ -356,9 +340,8 @@ ERROR_SET_MESSAGE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_message_cli_cmd
-ERROR_REMOVE_MESSAGE_CLI_CMD = create_default_cli_command(
-    ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
+# ** constant: error_remove_message_cli_cmd_data
+ERROR_REMOVE_MESSAGE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-message',
     'error',
     'Remove Error Message',
@@ -369,9 +352,8 @@ ERROR_REMOVE_MESSAGE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_cli_cmd
-ERROR_REMOVE_CLI_CMD = create_default_cli_command(
-    ERROR_REMOVE_CLI_CMD_ID,
+# ** constant: error_remove_cli_cmd_data
+ERROR_REMOVE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove',
     'error',
     'Remove Error',
@@ -381,9 +363,8 @@ ERROR_REMOVE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_add_cli_cmd
-FEATURE_ADD_CLI_CMD = create_default_cli_command(
-    FEATURE_ADD_CLI_CMD_ID,
+# ** constant: feature_add_cli_cmd_data
+FEATURE_ADD_CLI_CMD_DATA = create_default_cli_command_data(
     'add',
     'feature',
     'Add Feature',
@@ -396,9 +377,8 @@ FEATURE_ADD_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_get_cli_cmd
-FEATURE_GET_CLI_CMD = create_default_cli_command(
-    FEATURE_GET_CLI_CMD_ID,
+# ** constant: feature_get_cli_cmd_data
+FEATURE_GET_CLI_CMD_DATA = create_default_cli_command_data(
     'get',
     'feature',
     'Get Feature',
@@ -408,9 +388,8 @@ FEATURE_GET_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_list_cli_cmd
-FEATURE_LIST_CLI_CMD = create_default_cli_command(
-    FEATURE_LIST_CLI_CMD_ID,
+# ** constant: feature_list_cli_cmd_data
+FEATURE_LIST_CLI_CMD_DATA = create_default_cli_command_data(
     'list',
     'feature',
     'List Features',
@@ -420,9 +399,8 @@ FEATURE_LIST_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_cli_cmd
-FEATURE_REMOVE_CLI_CMD = create_default_cli_command(
-    FEATURE_REMOVE_CLI_CMD_ID,
+# ** constant: feature_remove_cli_cmd_data
+FEATURE_REMOVE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove',
     'feature',
     'Remove Feature',
@@ -432,9 +410,8 @@ FEATURE_REMOVE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_cli_cmd
-FEATURE_UPDATE_CLI_CMD = create_default_cli_command(
-    FEATURE_UPDATE_CLI_CMD_ID,
+# ** constant: feature_update_cli_cmd_data
+FEATURE_UPDATE_CLI_CMD_DATA = create_default_cli_command_data(
     'update',
     'feature',
     'Update Feature',
@@ -446,9 +423,8 @@ FEATURE_UPDATE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_add_step_cli_cmd
-FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_ADD_STEP_CLI_CMD_ID,
+# ** constant: feature_add_step_cli_cmd_data
+FEATURE_ADD_STEP_CLI_CMD_DATA = create_default_cli_command_data(
     'add-step',
     'feature',
     'Add Feature Step',
@@ -463,9 +439,8 @@ FEATURE_ADD_STEP_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_step_cli_cmd
-FEATURE_UPDATE_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_UPDATE_STEP_CLI_CMD_ID,
+# ** constant: feature_update_step_cli_cmd_data
+FEATURE_UPDATE_STEP_CLI_CMD_DATA = create_default_cli_command_data(
     'update-step',
     'feature',
     'Update Feature Step',
@@ -482,9 +457,8 @@ FEATURE_UPDATE_STEP_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_step_cli_cmd
-FEATURE_REMOVE_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_REMOVE_STEP_CLI_CMD_ID,
+# ** constant: feature_remove_step_cli_cmd_data
+FEATURE_REMOVE_STEP_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-step',
     'feature',
     'Remove Feature Step',
@@ -495,9 +469,8 @@ FEATURE_REMOVE_STEP_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_reorder_step_cli_cmd
-FEATURE_REORDER_STEP_CLI_CMD = create_default_cli_command(
-    FEATURE_REORDER_STEP_CLI_CMD_ID,
+# ** constant: feature_reorder_step_cli_cmd_data
+FEATURE_REORDER_STEP_CLI_CMD_DATA = create_default_cli_command_data(
     'reorder-step',
     'feature',
     'Reorder Feature Step',
@@ -509,9 +482,8 @@ FEATURE_REORDER_STEP_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_add_cli_cmd
-SERVICE_ADD_CLI_CMD = create_default_cli_command(
-    SERVICE_ADD_CLI_CMD_ID,
+# ** constant: service_add_cli_cmd_data
+SERVICE_ADD_CLI_CMD_DATA = create_default_cli_command_data(
     'add',
     'service',
     'Add Service Configuration',
@@ -525,18 +497,16 @@ SERVICE_ADD_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_list_cli_cmd
-SERVICE_LIST_CLI_CMD = create_default_cli_command(
-    SERVICE_LIST_CLI_CMD_ID,
+# ** constant: service_list_cli_cmd_data
+SERVICE_LIST_CLI_CMD_DATA = create_default_cli_command_data(
     'list',
     'service',
     'List All Settings',
     description='List all service configurations and constants.',
 )
 
-# ** constant: service_set_default_cli_cmd
-SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_DEFAULT_CLI_CMD_ID,
+# ** constant: service_set_default_cli_cmd_data
+SERVICE_SET_DEFAULT_CLI_CMD_DATA = create_default_cli_command_data(
     'set-default',
     'service',
     'Set Default Service Configuration',
@@ -549,9 +519,8 @@ SERVICE_SET_DEFAULT_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_dependency_cli_cmd
-SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
+# ** constant: service_set_dependency_cli_cmd_data
+SERVICE_SET_DEPENDENCY_CLI_CMD_DATA = create_default_cli_command_data(
     'set-dependency',
     'service',
     'Set Service Dependency',
@@ -565,9 +534,8 @@ SERVICE_SET_DEPENDENCY_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_dependency_cli_cmd
-SERVICE_REMOVE_DEPENDENCY_CLI_CMD = create_default_cli_command(
-    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
+# ** constant: service_remove_dependency_cli_cmd_data
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-dependency',
     'service',
     'Remove Service Dependency',
@@ -578,9 +546,8 @@ SERVICE_REMOVE_DEPENDENCY_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_cli_cmd
-SERVICE_REMOVE_CLI_CMD = create_default_cli_command(
-    SERVICE_REMOVE_CLI_CMD_ID,
+# ** constant: service_remove_cli_cmd_data
+SERVICE_REMOVE_CLI_CMD_DATA = create_default_cli_command_data(
     'remove',
     'service',
     'Remove Service Configuration',
@@ -590,9 +557,8 @@ SERVICE_REMOVE_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_constants_cli_cmd
-SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
-    SERVICE_SET_CONSTANTS_CLI_CMD_ID,
+# ** constant: service_set_constants_cli_cmd_data
+SERVICE_SET_CONSTANTS_CLI_CMD_DATA = create_default_cli_command_data(
     'set-constants',
     'service',
     'Set Service Constants',
@@ -602,9 +568,8 @@ SERVICE_SET_CONSTANTS_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_formatter_cli_cmd
-LOGGING_ADD_FORMATTER_CLI_CMD = create_default_cli_command(
-    LOGGING_ADD_FORMATTER_CLI_CMD_ID,
+# ** constant: logging_add_formatter_cli_cmd_data
+LOGGING_ADD_FORMATTER_CLI_CMD_DATA = create_default_cli_command_data(
     'add-formatter',
     'logging',
     'Add Formatter',
@@ -618,9 +583,8 @@ LOGGING_ADD_FORMATTER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_formatter_cli_cmd
-LOGGING_REMOVE_FORMATTER_CLI_CMD = create_default_cli_command(
-    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID,
+# ** constant: logging_remove_formatter_cli_cmd_data
+LOGGING_REMOVE_FORMATTER_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-formatter',
     'logging',
     'Remove Formatter',
@@ -630,9 +594,8 @@ LOGGING_REMOVE_FORMATTER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_handler_cli_cmd
-LOGGING_ADD_HANDLER_CLI_CMD = create_default_cli_command(
-    LOGGING_ADD_HANDLER_CLI_CMD_ID,
+# ** constant: logging_add_handler_cli_cmd_data
+LOGGING_ADD_HANDLER_CLI_CMD_DATA = create_default_cli_command_data(
     'add-handler',
     'logging',
     'Add Handler',
@@ -654,9 +617,8 @@ LOGGING_ADD_HANDLER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_handler_cli_cmd
-LOGGING_REMOVE_HANDLER_CLI_CMD = create_default_cli_command(
-    LOGGING_REMOVE_HANDLER_CLI_CMD_ID,
+# ** constant: logging_remove_handler_cli_cmd_data
+LOGGING_REMOVE_HANDLER_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-handler',
     'logging',
     'Remove Handler',
@@ -666,9 +628,8 @@ LOGGING_REMOVE_HANDLER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_logger_cli_cmd
-LOGGING_ADD_LOGGER_CLI_CMD = create_default_cli_command(
-    LOGGING_ADD_LOGGER_CLI_CMD_ID,
+# ** constant: logging_add_logger_cli_cmd_data
+LOGGING_ADD_LOGGER_CLI_CMD_DATA = create_default_cli_command_data(
     'add-logger',
     'logging',
     'Add Logger',
@@ -687,9 +648,8 @@ LOGGING_ADD_LOGGER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_logger_cli_cmd
-LOGGING_REMOVE_LOGGER_CLI_CMD = create_default_cli_command(
-    LOGGING_REMOVE_LOGGER_CLI_CMD_ID,
+# ** constant: logging_remove_logger_cli_cmd_data
+LOGGING_REMOVE_LOGGER_CLI_CMD_DATA = create_default_cli_command_data(
     'remove-logger',
     'logging',
     'Remove Logger',
@@ -699,9 +659,8 @@ LOGGING_REMOVE_LOGGER_CLI_CMD = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_list_cli_cmd
-LOGGING_LIST_CLI_CMD = create_default_cli_command(
-    LOGGING_LIST_CLI_CMD_ID,
+# ** constant: logging_list_cli_cmd_data
+LOGGING_LIST_CLI_CMD_DATA = create_default_cli_command_data(
     'list',
     'logging',
     'List Logging Configs',
@@ -712,46 +671,46 @@ LOGGING_LIST_CLI_CMD = create_default_cli_command(
 
 # ** constant: admin_default_commands
 ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
-    APP_ADD_CLI_CMD_ID:               APP_ADD_CLI_CMD,
-    APP_GET_CLI_CMD_ID:               APP_GET_CLI_CMD,
-    APP_LIST_CLI_CMD_ID:              APP_LIST_CLI_CMD,
-    APP_UPDATE_CLI_CMD_ID:            APP_UPDATE_CLI_CMD,
-    APP_SET_CONSTANTS_CLI_CMD_ID:     APP_SET_CONSTANTS_CLI_CMD,
-    APP_SET_SERVICE_CLI_CMD_ID:       APP_SET_SERVICE_CLI_CMD,
-    APP_REMOVE_SERVICE_CLI_CMD_ID:    APP_REMOVE_SERVICE_CLI_CMD,
-    APP_REMOVE_CLI_CMD_ID:            APP_REMOVE_CLI_CMD,
-    CLI_ADD_COMMAND_CLI_CMD_ID:       CLI_ADD_COMMAND_CLI_CMD,
-    CLI_LIST_COMMANDS_CLI_CMD_ID:     CLI_LIST_COMMANDS_CLI_CMD,
-    CLI_ADD_ARGUMENT_CLI_CMD_ID:      CLI_ADD_ARGUMENT_CLI_CMD,
-    ERROR_ADD_CLI_CMD_ID:             ERROR_ADD_CLI_CMD,
-    ERROR_GET_CLI_CMD_ID:             ERROR_GET_CLI_CMD,
-    ERROR_LIST_CLI_CMD_ID:            ERROR_LIST_CLI_CMD,
-    ERROR_RENAME_CLI_CMD_ID:          ERROR_RENAME_CLI_CMD,
-    ERROR_SET_MESSAGE_CLI_CMD_ID:     ERROR_SET_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_MESSAGE_CLI_CMD_ID:  ERROR_REMOVE_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_CLI_CMD_ID:          ERROR_REMOVE_CLI_CMD,
-    FEATURE_ADD_CLI_CMD_ID:           FEATURE_ADD_CLI_CMD,
-    FEATURE_GET_CLI_CMD_ID:           FEATURE_GET_CLI_CMD,
-    FEATURE_LIST_CLI_CMD_ID:          FEATURE_LIST_CLI_CMD,
-    FEATURE_REMOVE_CLI_CMD_ID:        FEATURE_REMOVE_CLI_CMD,
-    FEATURE_UPDATE_CLI_CMD_ID:        FEATURE_UPDATE_CLI_CMD,
-    FEATURE_ADD_STEP_CLI_CMD_ID:      FEATURE_ADD_STEP_CLI_CMD,
-    FEATURE_UPDATE_STEP_CLI_CMD_ID:   FEATURE_UPDATE_STEP_CLI_CMD,
-    FEATURE_REMOVE_STEP_CLI_CMD_ID:   FEATURE_REMOVE_STEP_CLI_CMD,
-    FEATURE_REORDER_STEP_CLI_CMD_ID:  FEATURE_REORDER_STEP_CLI_CMD,
-    SERVICE_ADD_CLI_CMD_ID:           SERVICE_ADD_CLI_CMD,
-    SERVICE_LIST_CLI_CMD_ID:          SERVICE_LIST_CLI_CMD,
-    SERVICE_SET_DEFAULT_CLI_CMD_ID:   SERVICE_SET_DEFAULT_CLI_CMD,
-    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
-    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
-    SERVICE_REMOVE_CLI_CMD_ID:        SERVICE_REMOVE_CLI_CMD,
-    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
-    LOGGING_ADD_FORMATTER_CLI_CMD_ID:    LOGGING_ADD_FORMATTER_CLI_CMD,
-    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD,
-    LOGGING_ADD_HANDLER_CLI_CMD_ID:      LOGGING_ADD_HANDLER_CLI_CMD,
-    LOGGING_REMOVE_HANDLER_CLI_CMD_ID:   LOGGING_REMOVE_HANDLER_CLI_CMD,
-    LOGGING_ADD_LOGGER_CLI_CMD_ID:       LOGGING_ADD_LOGGER_CLI_CMD,
-    LOGGING_REMOVE_LOGGER_CLI_CMD_ID:    LOGGING_REMOVE_LOGGER_CLI_CMD,
-    LOGGING_LIST_CLI_CMD_ID:             LOGGING_LIST_CLI_CMD,
+    APP_ADD_CLI_CMD_ID:               APP_ADD_CLI_CMD_DATA,
+    APP_GET_CLI_CMD_ID:               APP_GET_CLI_CMD_DATA,
+    APP_LIST_CLI_CMD_ID:              APP_LIST_CLI_CMD_DATA,
+    APP_UPDATE_CLI_CMD_ID:            APP_UPDATE_CLI_CMD_DATA,
+    APP_SET_CONSTANTS_CLI_CMD_ID:     APP_SET_CONSTANTS_CLI_CMD_DATA,
+    APP_SET_SERVICE_CLI_CMD_ID:       APP_SET_SERVICE_CLI_CMD_DATA,
+    APP_REMOVE_SERVICE_CLI_CMD_ID:    APP_REMOVE_SERVICE_CLI_CMD_DATA,
+    APP_REMOVE_CLI_CMD_ID:            APP_REMOVE_CLI_CMD_DATA,
+    CLI_ADD_COMMAND_CLI_CMD_ID:       CLI_ADD_COMMAND_CLI_CMD_DATA,
+    CLI_LIST_COMMANDS_CLI_CMD_ID:     CLI_LIST_COMMANDS_CLI_CMD_DATA,
+    CLI_ADD_ARGUMENT_CLI_CMD_ID:      CLI_ADD_ARGUMENT_CLI_CMD_DATA,
+    ERROR_ADD_CLI_CMD_ID:             ERROR_ADD_CLI_CMD_DATA,
+    ERROR_GET_CLI_CMD_ID:             ERROR_GET_CLI_CMD_DATA,
+    ERROR_LIST_CLI_CMD_ID:            ERROR_LIST_CLI_CMD_DATA,
+    ERROR_RENAME_CLI_CMD_ID:          ERROR_RENAME_CLI_CMD_DATA,
+    ERROR_SET_MESSAGE_CLI_CMD_ID:     ERROR_SET_MESSAGE_CLI_CMD_DATA,
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID:  ERROR_REMOVE_MESSAGE_CLI_CMD_DATA,
+    ERROR_REMOVE_CLI_CMD_ID:          ERROR_REMOVE_CLI_CMD_DATA,
+    FEATURE_ADD_CLI_CMD_ID:           FEATURE_ADD_CLI_CMD_DATA,
+    FEATURE_GET_CLI_CMD_ID:           FEATURE_GET_CLI_CMD_DATA,
+    FEATURE_LIST_CLI_CMD_ID:          FEATURE_LIST_CLI_CMD_DATA,
+    FEATURE_REMOVE_CLI_CMD_ID:        FEATURE_REMOVE_CLI_CMD_DATA,
+    FEATURE_UPDATE_CLI_CMD_ID:        FEATURE_UPDATE_CLI_CMD_DATA,
+    FEATURE_ADD_STEP_CLI_CMD_ID:      FEATURE_ADD_STEP_CLI_CMD_DATA,
+    FEATURE_UPDATE_STEP_CLI_CMD_ID:   FEATURE_UPDATE_STEP_CLI_CMD_DATA,
+    FEATURE_REMOVE_STEP_CLI_CMD_ID:   FEATURE_REMOVE_STEP_CLI_CMD_DATA,
+    FEATURE_REORDER_STEP_CLI_CMD_ID:  FEATURE_REORDER_STEP_CLI_CMD_DATA,
+    SERVICE_ADD_CLI_CMD_ID:           SERVICE_ADD_CLI_CMD_DATA,
+    SERVICE_LIST_CLI_CMD_ID:          SERVICE_LIST_CLI_CMD_DATA,
+    SERVICE_SET_DEFAULT_CLI_CMD_ID:   SERVICE_SET_DEFAULT_CLI_CMD_DATA,
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD_DATA,
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD_DATA,
+    SERVICE_REMOVE_CLI_CMD_ID:        SERVICE_REMOVE_CLI_CMD_DATA,
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD_DATA,
+    LOGGING_ADD_FORMATTER_CLI_CMD_ID:    LOGGING_ADD_FORMATTER_CLI_CMD_DATA,
+    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD_DATA,
+    LOGGING_ADD_HANDLER_CLI_CMD_ID:      LOGGING_ADD_HANDLER_CLI_CMD_DATA,
+    LOGGING_REMOVE_HANDLER_CLI_CMD_ID:   LOGGING_REMOVE_HANDLER_CLI_CMD_DATA,
+    LOGGING_ADD_LOGGER_CLI_CMD_ID:       LOGGING_ADD_LOGGER_CLI_CMD_DATA,
+    LOGGING_REMOVE_LOGGER_CLI_CMD_ID:    LOGGING_REMOVE_LOGGER_CLI_CMD_DATA,
+    LOGGING_LIST_CLI_CMD_ID:             LOGGING_LIST_CLI_CMD_DATA,
 }
 

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -50,24 +50,30 @@ CORE_DOMAIN_PATH = 'core'
 
 # *** functions
 
-# ** function: create_default_error
-def create_default_error(id: str, name: str, messages: List[Tuple[str, str]]) -> Dict[str, Any]:
+# ** function: create_default_error_data
+def create_default_error_data(
+        name: str,
+        messages: List[Tuple[str, str]],
+    ) -> Dict[str, Any]:
     '''
     Build a default error definition dictionary.
 
-    :param id: The unique identifier of the error.
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict is
+    always stored under its owning ``*_ID`` constant as a group-dict key, so
+    embedding the id a second time inside the value would restate it. The
+    consuming ``add_default_errors`` decorator reinjects the id from that key
+    when reconstituting the ``Error`` domain object.
+
     :param name: The human-readable error name.
     :type name: str
     :param messages: Ordered (lang, text) message pairs.
     :type messages: List[Tuple[str, str]]
-    :return: The default error definition.
+    :return: The default error definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble and return the default error definition dictionary.
     return {
-        'id': id,
         'name': name,
         'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
@@ -117,9 +123,8 @@ def create_service_dependency(
         'parameters': parameters or {},
     }
 
-# ** function: create_app_service_dependency
-def create_app_service_dependency(
-        service_id: str,
+# ** function: create_app_service_dependency_data
+def create_app_service_dependency_data(
         module_path: str,
         class_name: str,
         parameters: Dict[str, Any] = None,
@@ -127,27 +132,28 @@ def create_app_service_dependency(
     '''
     Build a default app service dependency definition dictionary.
 
-    :param service_id: The unique service identifier for the dependency.
-    :type service_id: str
+    The ``service_id`` is intentionally not a parameter here: the returned
+    dict is always stored under its owning ``*_ID`` constant as a group-dict
+    key, so embedding the id a second time inside the value would restate it.
+    The consuming ``add_default_app_services`` / ``add_default_admin_services``
+    decorators reinject ``service_id`` from that key when reconstituting the
+    ``AppServiceDependency`` domain object.
+
     :param module_path: The module path of the service implementation.
     :type module_path: str
     :param class_name: The class name of the service implementation.
     :type class_name: str
     :param parameters: Optional DI parameters for the dependency.
     :type parameters: Dict[str, Any]
-    :return: The default app service dependency definition.
+    :return: The default app service dependency definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble and return the app service dependency definition dictionary.
-    return {
-        'service_id': service_id,
-        **create_service_dependency(module_path, class_name, parameters),
-    }
+    return create_service_dependency(module_path, class_name, parameters)
 
-# ** function: create_service_registration
-def create_service_registration(
-        id: str,
+# ** function: create_service_registration_data
+def create_service_registration_data(
         module_path: str,
         class_name: str,
         parameters: Dict[str, Any] = None,
@@ -155,27 +161,25 @@ def create_service_registration(
     '''
     Build a default service registration definition dictionary.
 
-    :param id: The unique service registration identifier.
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict is
+    always stored under its owning ``*_ID`` constant as a group-dict key, so
+    embedding the id a second time inside the value would restate it.
+
     :param module_path: The module path of the service implementation.
     :type module_path: str
     :param class_name: The class name of the service implementation.
     :type class_name: str
     :param parameters: Optional DI parameters for the registration.
     :type parameters: Dict[str, Any]
-    :return: The default service registration definition.
+    :return: The default service registration definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble and return the service registration definition dictionary.
-    return {
-        'id': id,
-        **create_service_dependency(module_path, class_name, parameters),
-    }
+    return create_service_dependency(module_path, class_name, parameters)
 
-# ** function: create_default_feature
-def create_default_feature(
-        id: str,
+# ** function: create_default_feature_data
+def create_default_feature_data(
         name: str,
         group_id: str,
         feature_key: str,
@@ -186,8 +190,12 @@ def create_default_feature(
     '''
     Build a default feature workflow definition dictionary.
 
-    :param id: The unique feature identifier (e.g. ``'feature.add'``).
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict is
+    always stored under its owning ``*_ID`` constant as a group-dict key, so
+    embedding the id a second time inside the value would restate it. The
+    consuming ``add_default_features`` decorator reinjects the id from that
+    key when reconstituting the ``Feature`` domain object.
+
     :param name: The human-readable feature name.
     :type name: str
     :param group_id: The group this feature belongs to.
@@ -200,13 +208,12 @@ def create_default_feature(
     :type description: str
     :param params_schema: Optional request parameter schema dict.
     :type params_schema: Dict[str, Any]
-    :return: The default feature workflow definition.
+    :return: The default feature workflow definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble the base feature definition.
     feature = {
-        'id': id,
         'name': name,
         'group_id': group_id,
         'feature_key': feature_key,
@@ -243,28 +250,30 @@ def create_params_schema(**params: Any) -> Dict[str, Any]:
     # Return the assembled parameter schema dict.
     return dict(params)
 
-# ** function: create_default_app_session
-def create_default_app_session(
-        id: str,
+# ** function: create_default_app_session_data
+def create_default_app_session_data(
         name: str,
         description: str = None,
     ) -> Dict[str, Any]:
     '''
     Build a default application session definition dictionary.
 
-    :param id: The unique session identifier.
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict is
+    always stored under its owning ``*_ID`` constant as a group-dict key, so
+    embedding the id a second time inside the value would restate it. The
+    consuming ``add_default_app_sessions`` decorator reinjects the id from
+    that key when reconstituting the ``AppSession`` domain object.
+
     :param name: The human-readable session name.
     :type name: str
     :param description: Optional session description.
     :type description: str
-    :return: The default application session definition.
+    :return: The default application session definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble the base session definition.
     session = {
-        'id': id,
         'name': name,
     }
 
@@ -476,9 +485,8 @@ def create_default_cli_argument(
     # Return the assembled argument definition.
     return argument
 
-# ** function: create_default_cli_command
-def create_default_cli_command(
-        id: str,
+# ** function: create_default_cli_command_data
+def create_default_cli_command_data(
         key: str,
         group_key: str,
         name: str,
@@ -488,8 +496,12 @@ def create_default_cli_command(
     '''
     Build a default CLI command definition dictionary.
 
-    :param id: The unique command identifier (e.g. ``'feature.add'``).
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict is
+    always stored under its owning ``*_ID`` constant as a group-dict key, so
+    embedding the id a second time inside the value would restate it. The
+    consuming ``add_default_cli_commands`` decorator reinjects the id from
+    that key when reconstituting the ``CliCommand`` domain object.
+
     :param key: The command key used in CLI invocation.
     :type key: str
     :param group_key: The group key for the command.
@@ -500,13 +512,12 @@ def create_default_cli_command(
     :type description: str
     :param arguments: Optional ordered list of argument definition dicts.
     :type arguments: List[Dict[str, Any]]
-    :return: The default CLI command definition.
+    :return: The default CLI command definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble the base command definition.
     command = {
-        'id': id,
         'key': key,
         'group_key': group_key,
         'name': name,

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -2,7 +2,7 @@
 
 Provides the default service registration catalog for the built-in Tiferet CLI
 management application. Each entry maps a service ID constant to a registration
-definition built via ``create_service_registration``.
+definition built via ``create_service_registration_data``.
 
 Services already defined in ``app.CORE_DEFAULT_SERVICES`` (e.g.
 ``get_error_evt``, ``get_feature_evt``, ``list_all_settings_evt``) are
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 # ** app
 from .core import (
-    create_service_registration,
+    create_service_registration_data,
     create_service_module_path,
     TIFERET,
     TIFERET_EVENTS_PATH,
@@ -144,261 +144,224 @@ REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
 
 # *** constants (services)
 
-# ** constant: app_service
-APP_SERVICE = create_service_registration(
-    APP_SERVICE_ID,
+# ** constant: app_service_data
+APP_SERVICE_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
     'AppConfigRepository',
 )
 
-# ** constant: add_feature_evt
-ADD_FEATURE_EVT = create_service_registration(
-    ADD_FEATURE_EVT_ID,
+# ** constant: add_feature_evt_data
+ADD_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeature',
 )
 
-# ** constant: list_features_evt
-LIST_FEATURES_EVT = create_service_registration(
-    LIST_FEATURES_EVT_ID,
+# ** constant: list_features_evt_data
+LIST_FEATURES_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ListFeatures',
 )
 
-# ** constant: remove_feature_evt
-REMOVE_FEATURE_EVT = create_service_registration(
-    REMOVE_FEATURE_EVT_ID,
+# ** constant: remove_feature_evt_data
+REMOVE_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeature',
 )
 
-# ** constant: update_feature_evt
-UPDATE_FEATURE_EVT = create_service_registration(
-    UPDATE_FEATURE_EVT_ID,
+# ** constant: update_feature_evt_data
+UPDATE_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeature',
 )
 
-# ** constant: add_feature_step_evt
-ADD_FEATURE_STEP_EVT = create_service_registration(
-    ADD_FEATURE_STEP_EVT_ID,
+# ** constant: add_feature_step_evt_data
+ADD_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeatureStep',
 )
 
-# ** constant: update_feature_step_evt
-UPDATE_FEATURE_STEP_EVT = create_service_registration(
-    UPDATE_FEATURE_STEP_EVT_ID,
+# ** constant: update_feature_step_evt_data
+UPDATE_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeatureStep',
 )
 
-# ** constant: remove_feature_step_evt
-REMOVE_FEATURE_STEP_EVT = create_service_registration(
-    REMOVE_FEATURE_STEP_EVT_ID,
+# ** constant: remove_feature_step_evt_data
+REMOVE_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeatureStep',
 )
 
-# ** constant: reorder_feature_step_evt
-REORDER_FEATURE_STEP_EVT = create_service_registration(
-    REORDER_FEATURE_STEP_EVT_ID,
+# ** constant: reorder_feature_step_evt_data
+REORDER_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ReorderFeatureStep',
 )
 
-# ** constant: add_error_evt
-ADD_ERROR_EVT = create_service_registration(
-    ADD_ERROR_EVT_ID,
+# ** constant: add_error_evt_data
+ADD_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'AddError',
 )
 
-# ** constant: list_errors_evt
-LIST_ERRORS_EVT = create_service_registration(
-    LIST_ERRORS_EVT_ID,
+# ** constant: list_errors_evt_data
+LIST_ERRORS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'ListErrors',
 )
 
-# ** constant: rename_error_evt
-RENAME_ERROR_EVT = create_service_registration(
-    RENAME_ERROR_EVT_ID,
+# ** constant: rename_error_evt_data
+RENAME_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RenameError',
 )
 
-# ** constant: set_error_message_evt
-SET_ERROR_MESSAGE_EVT = create_service_registration(
-    SET_ERROR_MESSAGE_EVT_ID,
+# ** constant: set_error_message_evt_data
+SET_ERROR_MESSAGE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'SetErrorMessage',
 )
 
-# ** constant: remove_error_message_evt
-REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
-    REMOVE_ERROR_MESSAGE_EVT_ID,
+# ** constant: remove_error_message_evt_data
+REMOVE_ERROR_MESSAGE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveErrorMessage',
 )
 
-# ** constant: remove_error_evt
-REMOVE_ERROR_EVT = create_service_registration(
-    REMOVE_ERROR_EVT_ID,
+# ** constant: remove_error_evt_data
+REMOVE_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveError',
 )
 
-# ** constant: add_service_registration_evt
-ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
-    ADD_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: add_service_registration_evt_data
+ADD_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'AddServiceRegistration',
 )
 
-# ** constant: set_default_service_registration_evt
-SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: set_default_service_registration_evt_data
+SET_DEFAULT_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetDefaultServiceRegistration',
 )
 
-# ** constant: set_di_service_dependency_evt
-SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: set_di_service_dependency_evt_data
+SET_DI_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
-# ** constant: remove_di_service_dependency_evt
-REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: remove_di_service_dependency_evt_data
+REMOVE_DI_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
-# ** constant: remove_service_registration_evt
-REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
-    REMOVE_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: remove_service_registration_evt_data
+REMOVE_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceRegistration',
 )
 
-# ** constant: set_service_constants_evt
-SET_SERVICE_CONSTANTS_EVT = create_service_registration(
-    SET_SERVICE_CONSTANTS_EVT_ID,
+# ** constant: set_service_constants_evt_data
+SET_SERVICE_CONSTANTS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceConstants',
 )
 
-# ** constant: add_app_session_evt
-ADD_APP_SESSION_EVT = create_service_registration(
-    ADD_APP_SESSION_EVT_ID,
+# ** constant: add_app_session_evt_data
+ADD_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'AddAppSession',
 )
 
-# ** constant: get_app_session_evt
-GET_APP_SESSION_EVT = create_service_registration(
-    GET_APP_SESSION_EVT_ID,
+# ** constant: get_app_session_evt_data
+GET_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'GetAppSession',
 )
 
-# ** constant: update_app_session_evt
-UPDATE_APP_SESSION_EVT = create_service_registration(
-    UPDATE_APP_SESSION_EVT_ID,
+# ** constant: update_app_session_evt_data
+UPDATE_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'UpdateAppSession',
 )
 
-# ** constant: set_app_constants_evt
-SET_APP_CONSTANTS_EVT = create_service_registration(
-    SET_APP_CONSTANTS_EVT_ID,
+# ** constant: set_app_constants_evt_data
+SET_APP_CONSTANTS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetAppConstants',
 )
 
-# ** constant: list_app_sessions_evt
-LIST_APP_SESSIONS_EVT = create_service_registration(
-    LIST_APP_SESSIONS_EVT_ID,
+# ** constant: list_app_sessions_evt_data
+LIST_APP_SESSIONS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'ListAppSessions',
 )
 
-# ** constant: set_app_service_dependency_evt
-SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: set_app_service_dependency_evt_data
+SET_APP_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
-# ** constant: remove_app_service_dependency_evt
-REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: remove_app_service_dependency_evt_data
+REMOVE_APP_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
-# ** constant: remove_app_session_evt
-REMOVE_APP_SESSION_EVT = create_service_registration(
-    REMOVE_APP_SESSION_EVT_ID,
+# ** constant: remove_app_session_evt_data
+REMOVE_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveAppSession',
 )
 
-# ** constant: add_cli_command_evt
-ADD_CLI_COMMAND_EVT = create_service_registration(
-    ADD_CLI_COMMAND_EVT_ID,
+# ** constant: add_cli_command_evt_data
+ADD_CLI_COMMAND_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliCommand',
 )
 
-# ** constant: add_cli_argument_evt
-ADD_CLI_ARGUMENT_EVT = create_service_registration(
-    ADD_CLI_ARGUMENT_EVT_ID,
+# ** constant: add_cli_argument_evt_data
+ADD_CLI_ARGUMENT_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliArgument',
 )
 
-# ** constant: add_formatter_evt
-ADD_FORMATTER_EVT = create_service_registration(
-    ADD_FORMATTER_EVT_ID,
+# ** constant: add_formatter_evt_data
+ADD_FORMATTER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddFormatter',
 )
 
-# ** constant: remove_formatter_evt
-REMOVE_FORMATTER_EVT = create_service_registration(
-    REMOVE_FORMATTER_EVT_ID,
+# ** constant: remove_formatter_evt_data
+REMOVE_FORMATTER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveFormatter',
 )
 
-# ** constant: add_handler_evt
-ADD_HANDLER_EVT = create_service_registration(
-    ADD_HANDLER_EVT_ID,
+# ** constant: add_handler_evt_data
+ADD_HANDLER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddHandler',
 )
 
-# ** constant: remove_handler_evt
-REMOVE_HANDLER_EVT = create_service_registration(
-    REMOVE_HANDLER_EVT_ID,
+# ** constant: remove_handler_evt_data
+REMOVE_HANDLER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveHandler',
 )
 
-# ** constant: add_logger_evt
-ADD_LOGGER_EVT = create_service_registration(
-    ADD_LOGGER_EVT_ID,
+# ** constant: add_logger_evt_data
+ADD_LOGGER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddLogger',
 )
 
-# ** constant: remove_logger_evt
-REMOVE_LOGGER_EVT = create_service_registration(
-    REMOVE_LOGGER_EVT_ID,
+# ** constant: remove_logger_evt_data
+REMOVE_LOGGER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveLogger',
 )
@@ -407,41 +370,41 @@ REMOVE_LOGGER_EVT = create_service_registration(
 
 # ** constant: default_tiferet_cli_services
 DEFAULT_TIFERET_CLI_SERVICES: Dict[str, Dict[str, Any]] = {
-    APP_SERVICE_ID: APP_SERVICE,
-    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
-    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
-    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
-    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
-    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
-    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
-    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
-    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
-    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
-    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
-    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
-    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
-    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
-    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
-    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
-    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
-    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
-    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
-    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
-    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
-    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
-    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
-    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
-    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
-    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
-    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
-    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
+    APP_SERVICE_ID: APP_SERVICE_DATA,
+    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT_DATA,
+    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT_DATA,
+    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT_DATA,
+    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT_DATA,
+    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT_DATA,
+    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT_DATA,
+    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT_DATA,
+    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT_DATA,
+    ADD_ERROR_EVT_ID: ADD_ERROR_EVT_DATA,
+    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT_DATA,
+    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT_DATA,
+    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT_DATA,
+    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT_DATA,
+    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT_DATA,
+    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT_DATA,
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT_DATA,
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT_DATA,
+    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT_DATA,
+    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT_DATA,
+    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT_DATA,
+    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT_DATA,
+    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT_DATA,
+    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT_DATA,
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT_DATA,
+    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT_DATA,
+    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT_DATA,
+    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT_DATA,
+    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT_DATA,
+    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT_DATA,
+    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT_DATA,
+    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT_DATA,
+    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT_DATA,
 }

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -19,7 +19,7 @@ localized, or formatted into an API response.
 # ** app
 from .core import (
     EN_US,
-    create_default_error,
+    create_default_error_data,
 )
 
 # *** constants (ids)
@@ -112,200 +112,172 @@ SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
 # *** constants (models)
 
-# ** constant: app_error
-APP_ERROR = create_default_error(
-    APP_ERROR_ID,
+# ** constant: app_error_data
+APP_ERROR_DATA = create_default_error_data(
     'App Error',
     [(EN_US, 'An error occurred in the app: {error_message}.')],
 )
 
-# ** constant: app_session_not_found
-APP_SESSION_NOT_FOUND = create_default_error(
-    APP_SESSION_NOT_FOUND_ID,
+# ** constant: app_session_not_found_data
+APP_SESSION_NOT_FOUND_DATA = create_default_error_data(
     'App Session Not Found',
     [(EN_US, 'App session with ID {interface_id} not found.')],
 )
 
-# ** constant: command_parameter_required
-COMMAND_PARAMETER_REQUIRED = create_default_error(
-    COMMAND_PARAMETER_REQUIRED_ID,
+# ** constant: command_parameter_required_data
+COMMAND_PARAMETER_REQUIRED_DATA = create_default_error_data(
     'Command Parameter Required',
     [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
 )
 
-# ** constant: context_not_found
-CONTEXT_NOT_FOUND = create_default_error(
-    CONTEXT_NOT_FOUND_ID,
+# ** constant: context_not_found_data
+CONTEXT_NOT_FOUND_DATA = create_default_error_data(
     'Context Not Found',
     [(EN_US, 'No context registered for domain type: {domain_type}.')],
 )
 
-# ** constant: error_not_found
-ERROR_NOT_FOUND = create_default_error(
-    ERROR_NOT_FOUND_ID,
+# ** constant: error_not_found_data
+ERROR_NOT_FOUND_DATA = create_default_error_data(
     'Error Not Found',
     [(EN_US, 'Error not found: {id}.')],
 )
 
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
+# ** constant: feature_not_found_data
+FEATURE_NOT_FOUND_DATA = create_default_error_data(
     'Feature Not Found',
     [(EN_US, 'Feature not found: {feature_id}.')],
 )
 
-# ** constant: feature_step_loading_failed
-FEATURE_STEP_LOADING_FAILED = create_default_error(
-    FEATURE_STEP_LOADING_FAILED_ID,
+# ** constant: feature_step_loading_failed_data
+FEATURE_STEP_LOADING_FAILED_DATA = create_default_error_data(
     'Feature Step Loading Failed',
     [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
 )
 
-# ** constant: invalid_app_session_type
-INVALID_APP_SESSION_TYPE = create_default_error(
-    INVALID_APP_SESSION_TYPE_ID,
+# ** constant: invalid_app_session_type_data
+INVALID_APP_SESSION_TYPE_DATA = create_default_error_data(
     'Invalid App Session Type',
     [(EN_US, '{attribute} must be a non-empty string.')],
 )
 
-# ** constant: logger_creation_failed
-LOGGER_CREATION_FAILED = create_default_error(
-    LOGGER_CREATION_FAILED_ID,
+# ** constant: logger_creation_failed_data
+LOGGER_CREATION_FAILED_DATA = create_default_error_data(
     'Logger Creation Failed',
     [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
 )
 
-# ** constant: logging_config_failed
-LOGGING_CONFIG_FAILED = create_default_error(
-    LOGGING_CONFIG_FAILED_ID,
+# ** constant: logging_config_failed_data
+LOGGING_CONFIG_FAILED_DATA = create_default_error_data(
     'Logging Configuration Failed',
     [(EN_US, 'Failed to configure logging: {exception}.')],
 )
 
-# ** constant: middleware_loading_failed
-MIDDLEWARE_LOADING_FAILED = create_default_error(
-    MIDDLEWARE_LOADING_FAILED_ID,
+# ** constant: middleware_loading_failed_data
+MIDDLEWARE_LOADING_FAILED_DATA = create_default_error_data(
     'Middleware Loading Failed',
     [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
 )
 
-# ** constant: parameter_not_found
-PARAMETER_NOT_FOUND = create_default_error(
-    PARAMETER_NOT_FOUND_ID,
+# ** constant: parameter_not_found_data
+PARAMETER_NOT_FOUND_DATA = create_default_error_data(
     'Parameter Not Found',
     [(EN_US, 'Parameter {parameter} not found in request data.')],
 )
 
-# ** constant: parameter_parsing_failed
-PARAMETER_PARSING_FAILED = create_default_error(
-    PARAMETER_PARSING_FAILED_ID,
+# ** constant: parameter_parsing_failed_data
+PARAMETER_PARSING_FAILED_DATA = create_default_error_data(
     'Parameter Parsing Failed',
     [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
 )
 
-# ** constant: request_not_found
-REQUEST_NOT_FOUND = create_default_error(
-    REQUEST_NOT_FOUND_ID,
+# ** constant: request_not_found_data
+REQUEST_NOT_FOUND_DATA = create_default_error_data(
     'Request Not Found',
     [(EN_US, 'Request data is not available for parameter parsing.')],
 )
 
-# ** constant: request_validation_failed
-REQUEST_VALIDATION_FAILED = create_default_error(
-    REQUEST_VALIDATION_FAILED_ID,
+# ** constant: request_validation_failed_data
+REQUEST_VALIDATION_FAILED_DATA = create_default_error_data(
     'Request Validation Failed',
     [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
 )
 
 # *** constants (models_admin)
 
-# ** constant: cli_command_already_exists
-CLI_COMMAND_ALREADY_EXISTS = create_default_error(
-    CLI_COMMAND_ALREADY_EXISTS_ID,
+# ** constant: cli_command_already_exists_data
+CLI_COMMAND_ALREADY_EXISTS_DATA = create_default_error_data(
     'CLI Command Already Exists',
     [(EN_US, 'CLI command with ID {id} already exists.')],
 )
 
-# ** constant: cli_command_not_found
-CLI_COMMAND_NOT_FOUND = create_default_error(
-    CLI_COMMAND_NOT_FOUND_ID,
+# ** constant: cli_command_not_found_data
+CLI_COMMAND_NOT_FOUND_DATA = create_default_error_data(
     'CLI Command Not Found',
     [(EN_US, 'CLI command {command_id} not found.')],
 )
 
-# ** constant: error_already_exists
-ERROR_ALREADY_EXISTS = create_default_error(
-    ERROR_ALREADY_EXISTS_ID,
+# ** constant: error_already_exists_data
+ERROR_ALREADY_EXISTS_DATA = create_default_error_data(
     'Error Already Exists',
     [(EN_US, 'An error with ID {id} already exists.')],
 )
 
-# ** constant: feature_already_exists
-FEATURE_ALREADY_EXISTS = create_default_error(
-    FEATURE_ALREADY_EXISTS_ID,
+# ** constant: feature_already_exists_data
+FEATURE_ALREADY_EXISTS_DATA = create_default_error_data(
     'Feature Already Exists',
     [(EN_US, 'Feature with ID {id} already exists.')],
 )
 
-# ** constant: feature_command_not_found
-FEATURE_COMMAND_NOT_FOUND = create_default_error(
-    FEATURE_COMMAND_NOT_FOUND_ID,
+# ** constant: feature_command_not_found_data
+FEATURE_COMMAND_NOT_FOUND_DATA = create_default_error_data(
     'Feature Command Not Found',
     [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
 )
 
-# ** constant: feature_name_required
-FEATURE_NAME_REQUIRED = create_default_error(
-    FEATURE_NAME_REQUIRED_ID,
+# ** constant: feature_name_required_data
+FEATURE_NAME_REQUIRED_DATA = create_default_error_data(
     'Feature Name Required',
     [(EN_US, 'A feature name is required when updating the name attribute.')],
 )
 
-# ** constant: invalid_feature_attribute
-INVALID_FEATURE_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_ATTRIBUTE_ID,
+# ** constant: invalid_feature_attribute_data
+INVALID_FEATURE_ATTRIBUTE_DATA = create_default_error_data(
     'Invalid Feature Attribute',
     [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
 )
 
-# ** constant: invalid_feature_command_attribute
-INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+# ** constant: invalid_feature_command_attribute_data
+INVALID_FEATURE_COMMAND_ATTRIBUTE_DATA = create_default_error_data(
     'Invalid Feature Command Attribute',
     [(EN_US, 'Invalid feature command attribute: {attribute}. Supported attributes are name, attribute_id, data_key, pass_on_error, and parameters.')],
 )
 
-# ** constant: invalid_flagged_dependency
-INVALID_FLAGGED_DEPENDENCY = create_default_error(
-    INVALID_FLAGGED_DEPENDENCY_ID,
+# ** constant: invalid_flagged_dependency_data
+INVALID_FLAGGED_DEPENDENCY_DATA = create_default_error_data(
     'Invalid Flagged Dependency',
     [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
 )
 
-# ** constant: invalid_service_registration
-INVALID_SERVICE_REGISTRATION = create_default_error(
-    INVALID_SERVICE_REGISTRATION_ID,
+# ** constant: invalid_service_registration_data
+INVALID_SERVICE_REGISTRATION_DATA = create_default_error_data(
     'Invalid Service Registration',
     [(EN_US, 'A service registration must define either a default type (module_path/class_name) or at least one flagged dependency.')],
 )
 
-# ** constant: no_error_messages
-NO_ERROR_MESSAGES = create_default_error(
-    NO_ERROR_MESSAGES_ID,
+# ** constant: no_error_messages_data
+NO_ERROR_MESSAGES_DATA = create_default_error_data(
     'No Error Messages',
     [(EN_US, 'No error messages are defined for error ID {id}.')],
 )
 
-# ** constant: service_registration_already_exists
-SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+# ** constant: service_registration_already_exists_data
+SERVICE_REGISTRATION_ALREADY_EXISTS_DATA = create_default_error_data(
     'Service Registration Already Exists',
     [(EN_US, 'A service registration with ID {id} already exists.')],
 )
 
-# ** constant: service_registration_not_found
-SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
-    SERVICE_REGISTRATION_NOT_FOUND_ID,
+# ** constant: service_registration_not_found_data
+SERVICE_REGISTRATION_NOT_FOUND_DATA = create_default_error_data(
     'Service Registration Not Found',
     [(EN_US, 'Service registration with ID {id} not found.')],
 )
@@ -314,37 +286,37 @@ SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
 
 # ** constant: core_default_errors
 CORE_DEFAULT_ERRORS = {
-    APP_ERROR_ID: APP_ERROR,
-    APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND,
-    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
-    CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND,
-    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
-    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED,
-    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
-    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
-    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
-    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
-    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
-    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
-    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
-    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
+    APP_ERROR_ID: APP_ERROR_DATA,
+    APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND_DATA,
+    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED_DATA,
+    CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND_DATA,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND_DATA,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND_DATA,
+    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED_DATA,
+    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE_DATA,
+    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED_DATA,
+    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED_DATA,
+    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED_DATA,
+    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND_DATA,
+    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED_DATA,
+    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND_DATA,
+    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED_DATA,
 }
 
 # ** constant: admin_default_errors
 ADMIN_DEFAULT_ERRORS = {
     **CORE_DEFAULT_ERRORS,
-    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
-    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
-    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
-    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
-    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
-    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
-    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
-    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
-    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
-    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
-    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS_DATA,
+    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND_DATA,
+    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS_DATA,
+    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS_DATA,
+    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND_DATA,
+    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED_DATA,
+    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE_DATA,
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE_DATA,
+    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY_DATA,
+    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION_DATA,
+    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES_DATA,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS_DATA,
+    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND_DATA,
 }

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -110,7 +110,7 @@ SERVICE_REGISTRATION_ALREADY_EXISTS_ID = 'SERVICE_REGISTRATION_ALREADY_EXISTS'
 # ** constant: service_registration_not_found_id
 SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
-# *** constants (models)
+# *** constants (data)
 
 # ** constant: app_error_data
 APP_ERROR_DATA = create_default_error_data(
@@ -202,7 +202,7 @@ REQUEST_VALIDATION_FAILED_DATA = create_default_error_data(
     [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
 )
 
-# *** constants (models_admin)
+# *** constants (data_admin)
 
 # ** constant: cli_command_already_exists_data
 CLI_COMMAND_ALREADY_EXISTS_DATA = create_default_error_data(

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -14,7 +14,7 @@ at startup — they are not loaded from the consumer's config file.
 from typing import Any, Dict
 
 # ** app
-from .core import create_default_feature, create_params_schema
+from .core import create_default_feature_data, create_params_schema
 
 # *** constants (ids)
 
@@ -143,9 +143,8 @@ LOGGING_LIST_ID = 'logging.list'
 
 # *** constants (features)
 
-# ** constant: app_add
-APP_ADD = create_default_feature(
-    APP_ADD_ID,
+# ** constant: app_add_data
+APP_ADD_DATA = create_default_feature_data(
     'Add App Session',
     'app',
     'add',
@@ -164,9 +163,8 @@ APP_ADD = create_default_feature(
     ),
 )
 
-# ** constant: app_get
-APP_GET = create_default_feature(
-    APP_GET_ID,
+# ** constant: app_get_data
+APP_GET_DATA = create_default_feature_data(
     'Get App Session',
     'app',
     'get',
@@ -175,9 +173,8 @@ APP_GET = create_default_feature(
     params_schema=create_params_schema(interface_id='str'),
 )
 
-# ** constant: app_list
-APP_LIST = create_default_feature(
-    APP_LIST_ID,
+# ** constant: app_list_data
+APP_LIST_DATA = create_default_feature_data(
     'List App Sessions',
     'app',
     'list',
@@ -185,9 +182,8 @@ APP_LIST = create_default_feature(
     description='List all configured app sessions.',
 )
 
-# ** constant: app_update
-APP_UPDATE = create_default_feature(
-    APP_UPDATE_ID,
+# ** constant: app_update_data
+APP_UPDATE_DATA = create_default_feature_data(
     'Update App Session',
     'app',
     'update',
@@ -196,9 +192,8 @@ APP_UPDATE = create_default_feature(
     params_schema=create_params_schema(id='str', attribute='str'),
 )
 
-# ** constant: app_set_constants
-APP_SET_CONSTANTS = create_default_feature(
-    APP_SET_CONSTANTS_ID,
+# ** constant: app_set_constants_data
+APP_SET_CONSTANTS_DATA = create_default_feature_data(
     'Set App Constants',
     'app',
     'set_constants',
@@ -210,9 +205,8 @@ APP_SET_CONSTANTS = create_default_feature(
     ),
 )
 
-# ** constant: app_set_service
-APP_SET_SERVICE = create_default_feature(
-    APP_SET_SERVICE_ID,
+# ** constant: app_set_service_data
+APP_SET_SERVICE_DATA = create_default_feature_data(
     'Set App Service Dependency',
     'app',
     'set_service',
@@ -227,9 +221,8 @@ APP_SET_SERVICE = create_default_feature(
     ),
 )
 
-# ** constant: app_remove_service
-APP_REMOVE_SERVICE = create_default_feature(
-    APP_REMOVE_SERVICE_ID,
+# ** constant: app_remove_service_data
+APP_REMOVE_SERVICE_DATA = create_default_feature_data(
     'Remove App Service Dependency',
     'app',
     'remove_service',
@@ -238,9 +231,8 @@ APP_REMOVE_SERVICE = create_default_feature(
     params_schema=create_params_schema(id='str', service_id='str'),
 )
 
-# ** constant: app_remove
-APP_REMOVE = create_default_feature(
-    APP_REMOVE_ID,
+# ** constant: app_remove_data
+APP_REMOVE_DATA = create_default_feature_data(
     'Remove App Session',
     'app',
     'remove',
@@ -249,9 +241,8 @@ APP_REMOVE = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: cli_add_command
-CLI_ADD_COMMAND = create_default_feature(
-    CLI_ADD_COMMAND_ID,
+# ** constant: cli_add_command_data
+CLI_ADD_COMMAND_DATA = create_default_feature_data(
     'Add CLI Command',
     'cli',
     'add_command',
@@ -267,9 +258,8 @@ CLI_ADD_COMMAND = create_default_feature(
     ),
 )
 
-# ** constant: cli_list_commands
-CLI_LIST_COMMANDS = create_default_feature(
-    CLI_LIST_COMMANDS_ID,
+# ** constant: cli_list_commands_data
+CLI_LIST_COMMANDS_DATA = create_default_feature_data(
     'List CLI Commands',
     'cli',
     'list_commands',
@@ -277,9 +267,8 @@ CLI_LIST_COMMANDS = create_default_feature(
     description='List all CLI command definitions.',
 )
 
-# ** constant: cli_add_argument
-CLI_ADD_ARGUMENT = create_default_feature(
-    CLI_ADD_ARGUMENT_ID,
+# ** constant: cli_add_argument_data
+CLI_ADD_ARGUMENT_DATA = create_default_feature_data(
     'Add CLI Argument',
     'cli',
     'add_argument',
@@ -291,9 +280,8 @@ CLI_ADD_ARGUMENT = create_default_feature(
     ),
 )
 
-# ** constant: error_add
-ERROR_ADD = create_default_feature(
-    ERROR_ADD_ID,
+# ** constant: error_add_data
+ERROR_ADD_DATA = create_default_feature_data(
     'Add Error',
     'error',
     'add',
@@ -308,9 +296,8 @@ ERROR_ADD = create_default_feature(
     ),
 )
 
-# ** constant: error_get
-ERROR_GET = create_default_feature(
-    ERROR_GET_ID,
+# ** constant: error_get_data
+ERROR_GET_DATA = create_default_feature_data(
     'Get Error',
     'error',
     'get',
@@ -319,9 +306,8 @@ ERROR_GET = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: error_list
-ERROR_LIST = create_default_feature(
-    ERROR_LIST_ID,
+# ** constant: error_list_data
+ERROR_LIST_DATA = create_default_feature_data(
     'List Errors',
     'error',
     'list',
@@ -329,9 +315,8 @@ ERROR_LIST = create_default_feature(
     description='List all error definitions.',
 )
 
-# ** constant: error_rename
-ERROR_RENAME = create_default_feature(
-    ERROR_RENAME_ID,
+# ** constant: error_rename_data
+ERROR_RENAME_DATA = create_default_feature_data(
     'Rename Error',
     'error',
     'rename',
@@ -340,9 +325,8 @@ ERROR_RENAME = create_default_feature(
     params_schema=create_params_schema(id='str', new_name='str'),
 )
 
-# ** constant: error_set_message
-ERROR_SET_MESSAGE = create_default_feature(
-    ERROR_SET_MESSAGE_ID,
+# ** constant: error_set_message_data
+ERROR_SET_MESSAGE_DATA = create_default_feature_data(
     'Set Error Message',
     'error',
     'set_message',
@@ -355,9 +339,8 @@ ERROR_SET_MESSAGE = create_default_feature(
     ),
 )
 
-# ** constant: error_remove_message
-ERROR_REMOVE_MESSAGE = create_default_feature(
-    ERROR_REMOVE_MESSAGE_ID,
+# ** constant: error_remove_message_data
+ERROR_REMOVE_MESSAGE_DATA = create_default_feature_data(
     'Remove Error Message',
     'error',
     'remove_message',
@@ -369,9 +352,8 @@ ERROR_REMOVE_MESSAGE = create_default_feature(
     ),
 )
 
-# ** constant: error_remove
-ERROR_REMOVE = create_default_feature(
-    ERROR_REMOVE_ID,
+# ** constant: error_remove_data
+ERROR_REMOVE_DATA = create_default_feature_data(
     'Remove Error',
     'error',
     'remove',
@@ -380,9 +362,8 @@ ERROR_REMOVE = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: feature_add
-FEATURE_ADD = create_default_feature(
-    FEATURE_ADD_ID,
+# ** constant: feature_add_data
+FEATURE_ADD_DATA = create_default_feature_data(
     'Add Feature',
     'feature',
     'add',
@@ -399,9 +380,8 @@ FEATURE_ADD = create_default_feature(
     ),
 )
 
-# ** constant: feature_get
-FEATURE_GET = create_default_feature(
-    FEATURE_GET_ID,
+# ** constant: feature_get_data
+FEATURE_GET_DATA = create_default_feature_data(
     'Get Feature',
     'feature',
     'get',
@@ -410,9 +390,8 @@ FEATURE_GET = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: feature_list
-FEATURE_LIST = create_default_feature(
-    FEATURE_LIST_ID,
+# ** constant: feature_list_data
+FEATURE_LIST_DATA = create_default_feature_data(
     'List Features',
     'feature',
     'list',
@@ -421,9 +400,8 @@ FEATURE_LIST = create_default_feature(
     params_schema=create_params_schema(group_id={'type': 'str', 'required': False}),
 )
 
-# ** constant: feature_remove
-FEATURE_REMOVE = create_default_feature(
-    FEATURE_REMOVE_ID,
+# ** constant: feature_remove_data
+FEATURE_REMOVE_DATA = create_default_feature_data(
     'Remove Feature',
     'feature',
     'remove',
@@ -432,9 +410,8 @@ FEATURE_REMOVE = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: feature_update
-FEATURE_UPDATE = create_default_feature(
-    FEATURE_UPDATE_ID,
+# ** constant: feature_update_data
+FEATURE_UPDATE_DATA = create_default_feature_data(
     'Update Feature',
     'feature',
     'update',
@@ -443,9 +420,8 @@ FEATURE_UPDATE = create_default_feature(
     params_schema=create_params_schema(id='str', attribute='str'),
 )
 
-# ** constant: feature_add_step
-FEATURE_ADD_STEP = create_default_feature(
-    FEATURE_ADD_STEP_ID,
+# ** constant: feature_add_step_data
+FEATURE_ADD_STEP_DATA = create_default_feature_data(
     'Add Feature Step',
     'feature',
     'add_step',
@@ -462,9 +438,8 @@ FEATURE_ADD_STEP = create_default_feature(
     ),
 )
 
-# ** constant: feature_update_step
-FEATURE_UPDATE_STEP = create_default_feature(
-    FEATURE_UPDATE_STEP_ID,
+# ** constant: feature_update_step_data
+FEATURE_UPDATE_STEP_DATA = create_default_feature_data(
     'Update Feature Step',
     'feature',
     'update_step',
@@ -473,9 +448,8 @@ FEATURE_UPDATE_STEP = create_default_feature(
     params_schema=create_params_schema(id='str', position='int', attribute='str'),
 )
 
-# ** constant: feature_remove_step
-FEATURE_REMOVE_STEP = create_default_feature(
-    FEATURE_REMOVE_STEP_ID,
+# ** constant: feature_remove_step_data
+FEATURE_REMOVE_STEP_DATA = create_default_feature_data(
     'Remove Feature Step',
     'feature',
     'remove_step',
@@ -484,9 +458,8 @@ FEATURE_REMOVE_STEP = create_default_feature(
     params_schema=create_params_schema(id='str', position='int'),
 )
 
-# ** constant: feature_reorder_step
-FEATURE_REORDER_STEP = create_default_feature(
-    FEATURE_REORDER_STEP_ID,
+# ** constant: feature_reorder_step_data
+FEATURE_REORDER_STEP_DATA = create_default_feature_data(
     'Reorder Feature Step',
     'feature',
     'reorder_step',
@@ -495,9 +468,8 @@ FEATURE_REORDER_STEP = create_default_feature(
     params_schema=create_params_schema(id='str', start_position='int', end_position='int'),
 )
 
-# ** constant: service_add
-SERVICE_ADD = create_default_feature(
-    SERVICE_ADD_ID,
+# ** constant: service_add_data
+SERVICE_ADD_DATA = create_default_feature_data(
     'Add Service Configuration',
     'service',
     'add',
@@ -512,9 +484,8 @@ SERVICE_ADD = create_default_feature(
     ),
 )
 
-# ** constant: service_list
-SERVICE_LIST = create_default_feature(
-    SERVICE_LIST_ID,
+# ** constant: service_list_data
+SERVICE_LIST_DATA = create_default_feature_data(
     'List All Settings',
     'service',
     'list',
@@ -522,9 +493,8 @@ SERVICE_LIST = create_default_feature(
     description='List all service configurations and constants.',
 )
 
-# ** constant: service_set_default
-SERVICE_SET_DEFAULT = create_default_feature(
-    SERVICE_SET_DEFAULT_ID,
+# ** constant: service_set_default_data
+SERVICE_SET_DEFAULT_DATA = create_default_feature_data(
     'Set Default Service Configuration',
     'service',
     'set_default',
@@ -538,9 +508,8 @@ SERVICE_SET_DEFAULT = create_default_feature(
     ),
 )
 
-# ** constant: service_set_dependency
-SERVICE_SET_DEPENDENCY = create_default_feature(
-    SERVICE_SET_DEPENDENCY_ID,
+# ** constant: service_set_dependency_data
+SERVICE_SET_DEPENDENCY_DATA = create_default_feature_data(
     'Set Service Dependency',
     'service',
     'set_dependency',
@@ -555,9 +524,8 @@ SERVICE_SET_DEPENDENCY = create_default_feature(
     ),
 )
 
-# ** constant: service_remove_dependency
-SERVICE_REMOVE_DEPENDENCY = create_default_feature(
-    SERVICE_REMOVE_DEPENDENCY_ID,
+# ** constant: service_remove_dependency_data
+SERVICE_REMOVE_DEPENDENCY_DATA = create_default_feature_data(
     'Remove Service Dependency',
     'service',
     'remove_dependency',
@@ -566,9 +534,8 @@ SERVICE_REMOVE_DEPENDENCY = create_default_feature(
     params_schema=create_params_schema(id='str', flag='str'),
 )
 
-# ** constant: service_remove
-SERVICE_REMOVE = create_default_feature(
-    SERVICE_REMOVE_ID,
+# ** constant: service_remove_data
+SERVICE_REMOVE_DATA = create_default_feature_data(
     'Remove Service Configuration',
     'service',
     'remove',
@@ -577,9 +544,8 @@ SERVICE_REMOVE = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: service_set_constants
-SERVICE_SET_CONSTANTS = create_default_feature(
-    SERVICE_SET_CONSTANTS_ID,
+# ** constant: service_set_constants_data
+SERVICE_SET_CONSTANTS_DATA = create_default_feature_data(
     'Set Service Constants',
     'service',
     'set_constants',
@@ -588,9 +554,8 @@ SERVICE_SET_CONSTANTS = create_default_feature(
     params_schema=create_params_schema(constants={'type': 'dict', 'required': False, 'default': {}}),
 )
 
-# ** constant: logging_add_formatter
-LOGGING_ADD_FORMATTER = create_default_feature(
-    LOGGING_ADD_FORMATTER_ID,
+# ** constant: logging_add_formatter_data
+LOGGING_ADD_FORMATTER_DATA = create_default_feature_data(
     'Add Formatter',
     'logging',
     'add_formatter',
@@ -605,9 +570,8 @@ LOGGING_ADD_FORMATTER = create_default_feature(
     ),
 )
 
-# ** constant: logging_remove_formatter
-LOGGING_REMOVE_FORMATTER = create_default_feature(
-    LOGGING_REMOVE_FORMATTER_ID,
+# ** constant: logging_remove_formatter_data
+LOGGING_REMOVE_FORMATTER_DATA = create_default_feature_data(
     'Remove Formatter',
     'logging',
     'remove_formatter',
@@ -616,9 +580,8 @@ LOGGING_REMOVE_FORMATTER = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: logging_add_handler
-LOGGING_ADD_HANDLER = create_default_feature(
-    LOGGING_ADD_HANDLER_ID,
+# ** constant: logging_add_handler_data
+LOGGING_ADD_HANDLER_DATA = create_default_feature_data(
     'Add Handler',
     'logging',
     'add_handler',
@@ -637,9 +600,8 @@ LOGGING_ADD_HANDLER = create_default_feature(
     ),
 )
 
-# ** constant: logging_remove_handler
-LOGGING_REMOVE_HANDLER = create_default_feature(
-    LOGGING_REMOVE_HANDLER_ID,
+# ** constant: logging_remove_handler_data
+LOGGING_REMOVE_HANDLER_DATA = create_default_feature_data(
     'Remove Handler',
     'logging',
     'remove_handler',
@@ -648,9 +610,8 @@ LOGGING_REMOVE_HANDLER = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: logging_add_logger
-LOGGING_ADD_LOGGER = create_default_feature(
-    LOGGING_ADD_LOGGER_ID,
+# ** constant: logging_add_logger_data
+LOGGING_ADD_LOGGER_DATA = create_default_feature_data(
     'Add Logger',
     'logging',
     'add_logger',
@@ -665,9 +626,8 @@ LOGGING_ADD_LOGGER = create_default_feature(
     ),
 )
 
-# ** constant: logging_remove_logger
-LOGGING_REMOVE_LOGGER = create_default_feature(
-    LOGGING_REMOVE_LOGGER_ID,
+# ** constant: logging_remove_logger_data
+LOGGING_REMOVE_LOGGER_DATA = create_default_feature_data(
     'Remove Logger',
     'logging',
     'remove_logger',
@@ -676,9 +636,8 @@ LOGGING_REMOVE_LOGGER = create_default_feature(
     params_schema=create_params_schema(id='str'),
 )
 
-# ** constant: logging_list
-LOGGING_LIST = create_default_feature(
-    LOGGING_LIST_ID,
+# ** constant: logging_list_data
+LOGGING_LIST_DATA = create_default_feature_data(
     'List Logging Configs',
     'logging',
     'list',
@@ -690,47 +649,47 @@ LOGGING_LIST = create_default_feature(
 
 # ** constant: default_tiferet_cli_features
 DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
-    APP_ADD_ID: APP_ADD,
-    APP_GET_ID: APP_GET,
-    APP_LIST_ID: APP_LIST,
-    APP_UPDATE_ID: APP_UPDATE,
-    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS,
-    APP_SET_SERVICE_ID: APP_SET_SERVICE,
-    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE,
-    APP_REMOVE_ID: APP_REMOVE,
-    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND,
-    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS,
-    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT,
-    ERROR_ADD_ID: ERROR_ADD,
-    ERROR_GET_ID: ERROR_GET,
-    ERROR_LIST_ID: ERROR_LIST,
-    ERROR_RENAME_ID: ERROR_RENAME,
-    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
-    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
-    ERROR_REMOVE_ID: ERROR_REMOVE,
-    FEATURE_ADD_ID: FEATURE_ADD,
-    FEATURE_GET_ID: FEATURE_GET,
-    FEATURE_LIST_ID: FEATURE_LIST,
-    FEATURE_REMOVE_ID: FEATURE_REMOVE,
-    FEATURE_UPDATE_ID: FEATURE_UPDATE,
-    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
-    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
-    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
-    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
-    SERVICE_ADD_ID: SERVICE_ADD,
-    SERVICE_LIST_ID: SERVICE_LIST,
-    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
-    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
-    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
-    SERVICE_REMOVE_ID: SERVICE_REMOVE,
-    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
-    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER,
-    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER,
-    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER,
-    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER,
-    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER,
-    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER,
-    LOGGING_LIST_ID: LOGGING_LIST,
+    APP_ADD_ID: APP_ADD_DATA,
+    APP_GET_ID: APP_GET_DATA,
+    APP_LIST_ID: APP_LIST_DATA,
+    APP_UPDATE_ID: APP_UPDATE_DATA,
+    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS_DATA,
+    APP_SET_SERVICE_ID: APP_SET_SERVICE_DATA,
+    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE_DATA,
+    APP_REMOVE_ID: APP_REMOVE_DATA,
+    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND_DATA,
+    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS_DATA,
+    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT_DATA,
+    ERROR_ADD_ID: ERROR_ADD_DATA,
+    ERROR_GET_ID: ERROR_GET_DATA,
+    ERROR_LIST_ID: ERROR_LIST_DATA,
+    ERROR_RENAME_ID: ERROR_RENAME_DATA,
+    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE_DATA,
+    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE_DATA,
+    ERROR_REMOVE_ID: ERROR_REMOVE_DATA,
+    FEATURE_ADD_ID: FEATURE_ADD_DATA,
+    FEATURE_GET_ID: FEATURE_GET_DATA,
+    FEATURE_LIST_ID: FEATURE_LIST_DATA,
+    FEATURE_REMOVE_ID: FEATURE_REMOVE_DATA,
+    FEATURE_UPDATE_ID: FEATURE_UPDATE_DATA,
+    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP_DATA,
+    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP_DATA,
+    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP_DATA,
+    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP_DATA,
+    SERVICE_ADD_ID: SERVICE_ADD_DATA,
+    SERVICE_LIST_ID: SERVICE_LIST_DATA,
+    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT_DATA,
+    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY_DATA,
+    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY_DATA,
+    SERVICE_REMOVE_ID: SERVICE_REMOVE_DATA,
+    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS_DATA,
+    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER_DATA,
+    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER_DATA,
+    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER_DATA,
+    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER_DATA,
+    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER_DATA,
+    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER_DATA,
+    LOGGING_LIST_ID: LOGGING_LIST_DATA,
 }
 
 # ** constant: admin_default_features

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -48,10 +48,11 @@ def add_default_app_services(services: Dict[str, Any]) -> Callable:
 
     Wraps a cache-builder callable so that, after the cache is constructed,
     each entry in ``services`` is reconstituted into an ``AppServiceDependency``
-    domain object and stored in the cache under the ``APP_SERVICE_CACHE_PREFIX``
-    namespace keyed by service id.
+    domain object (with its ``service_id`` re-injected) and stored in the
+    cache under the ``APP_SERVICE_CACHE_PREFIX`` namespace keyed by service id.
 
-    :param services: A mapping of service ids to raw service dependency dicts.
+    :param services: A mapping of service ids to raw service dependency dicts
+        (each value is the dependency without its ``service_id``).
     :type services: Dict[str, Any]
     :return: A decorator that wraps a cache-builder callable.
     :rtype: Callable
@@ -67,11 +68,12 @@ def add_default_app_services(services: Dict[str, Any]) -> Callable:
             cache = build_fn(*args, **kwargs)
 
             # Reconstitute each raw service dict into an AppServiceDependency
-            # domain object and cache it under the services namespace.
+            # domain object (re-injecting service_id) and cache it under the
+            # services namespace.
             for service_id, service_data in services.items():
                 cache.set(
                     service_id,
-                    AppServiceDependency.model_validate(service_data),
+                    AppServiceDependency.model_validate({**service_data, 'service_id': service_id}),
                     *APP_SERVICE_CACHE_PREFIX,
                 )
 
@@ -156,7 +158,8 @@ def add_default_admin_services(services: Dict[str, Any]) -> Callable:
     namespace, giving the admin blueprints their own catalog distinct from the
     core app-service catalog.
 
-    :param services: A mapping of service ids to raw service dependency dicts.
+    :param services: A mapping of service ids to raw service dependency dicts
+        (each value is the dependency without its ``service_id``).
     :type services: Dict[str, Any]
     :return: A decorator that wraps a cache-builder callable.
     :rtype: Callable
@@ -172,11 +175,12 @@ def add_default_admin_services(services: Dict[str, Any]) -> Callable:
             cache = build_fn(*args, **kwargs)
 
             # Reconstitute each raw service dict into an AppServiceDependency
-            # domain object and cache it under the admin services namespace.
+            # domain object (re-injecting service_id) and cache it under the
+            # admin services namespace.
             for service_id, service_data in services.items():
                 cache.set(
                     service_id,
-                    AppServiceDependency.model_validate(service_data),
+                    AppServiceDependency.model_validate({**service_data, 'service_id': service_id}),
                     *ADMIN_SERVICE_CACHE_PREFIX,
                 )
 
@@ -258,10 +262,11 @@ def add_default_app_sessions(sessions: Dict[str, Any]) -> Callable:
 
     Wraps a cache-builder callable so that, after the cache is constructed,
     each entry in ``sessions`` is reconstituted into an ``AppSession`` domain
-    object and stored in the cache under the ``APP_SESSION_CACHE_PREFIX``
-    namespace keyed by session id.
+    object (with its id re-injected) and stored in the cache under the
+    ``APP_SESSION_CACHE_PREFIX`` namespace keyed by session id.
 
-    :param sessions: A mapping of session ids to raw session definition dicts.
+    :param sessions: A mapping of session ids to raw session definition dicts
+        (each value is the definition without its id).
     :type sessions: Dict[str, Any]
     :return: A decorator that wraps a cache-builder callable.
     :rtype: Callable
@@ -276,12 +281,13 @@ def add_default_app_sessions(sessions: Dict[str, Any]) -> Callable:
             # Delegate to the wrapped cache-builder.
             cache = build_fn(*args, **kwargs)
 
-            # Reconstitute each raw session dict into an AppSession domain object
-            # and cache it under the sessions namespace keyed by session id.
+            # Reconstitute each raw session dict into an AppSession domain
+            # object (re-injecting the id) and cache it under the sessions
+            # namespace keyed by session id.
             for session_id, session_data in sessions.items():
                 cache.set(
                     session_id,
-                    AppSession.model_validate(session_data),
+                    AppSession.model_validate({**session_data, 'id': session_id}),
                     *APP_SESSION_CACHE_PREFIX,
                 )
 

--- a/tiferet/contexts/error.py
+++ b/tiferet/contexts/error.py
@@ -25,9 +25,11 @@ def add_default_errors(errors: Dict[str, Any]) -> Callable:
 
     Wraps a cache-builder callable so that, after the cache is constructed,
     each entry in ``errors`` is reconstituted into an ``Error`` domain object
-    and stored in the cache under the ``ERROR_CACHE_PREFIX`` namespace.
+    (with its id re-injected) and stored in the cache under the
+    ``ERROR_CACHE_PREFIX`` namespace.
 
-    :param errors: A mapping of error-code IDs to raw error definition dicts.
+    :param errors: A mapping of error-code IDs to raw error definition dicts
+        (each value is the definition without its id).
     :type errors: Dict[str, Any]
     :return: A decorator that wraps a cache-builder callable.
     :rtype: Callable
@@ -42,10 +44,14 @@ def add_default_errors(errors: Dict[str, Any]) -> Callable:
             # Delegate to the wrapped cache-builder.
             cache = build_fn(*args, **kwargs)
 
-            # Reconstitute each raw error dict into an Error domain object and
-            # cache it under the error namespace keyed by error id.
+            # Reconstitute each raw error dict into an Error domain object
+            # (re-injecting the id) and cache it under the error namespace.
             for error_id, error_data in errors.items():
-                cache.set(error_id, Error.model_validate(error_data), *ERROR_CACHE_PREFIX)
+                cache.set(
+                    error_id,
+                    Error.model_validate({**error_data, 'id': error_id}),
+                    *ERROR_CACHE_PREFIX,
+                )
 
             # Return the populated cache context.
             return cache

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -39,11 +39,12 @@ def add_default_features(features: Dict[str, Any]) -> Callable:
     Decorator factory that pre-seeds a cache context with default feature domain objects.
 
     Wraps a cache-builder callable so that, after the cache is constructed,
-    each entry in ``features`` is reconstituted into a ``Feature`` domain object
-    and stored in the cache under the ``FEATURE_CACHE_PREFIX`` namespace keyed
-    by feature id.
+    each entry in ``features`` is reconstituted into a ``Feature`` domain
+    object (with its id re-injected) and stored in the cache under the
+    ``FEATURE_CACHE_PREFIX`` namespace keyed by feature id.
 
-    :param features: A mapping of feature IDs to raw feature definition dicts.
+    :param features: A mapping of feature IDs to raw feature definition dicts
+        (each value is the definition without its id).
     :type features: Dict[str, Any]
     :return: A decorator that wraps a cache-builder callable.
     :rtype: Callable
@@ -58,10 +59,14 @@ def add_default_features(features: Dict[str, Any]) -> Callable:
             # Delegate to the wrapped cache-builder.
             cache = build_fn(*args, **kwargs)
 
-            # Reconstitute each raw feature dict into a Feature domain object and
-            # cache it under the feature namespace keyed by feature id.
+            # Reconstitute each raw feature dict into a Feature domain object
+            # (re-injecting the id) and cache it under the feature namespace.
             for feature_id, feature_data in features.items():
-                cache.set(feature_id, Feature.model_validate(feature_data), *FEATURE_CACHE_PREFIX)
+                cache.set(
+                    feature_id,
+                    Feature.model_validate({**feature_data, 'id': feature_id}),
+                    *FEATURE_CACHE_PREFIX,
+                )
 
             # Return the populated cache context.
             return cache


### PR DESCRIPTION
Closes #973

## Summary
Eliminates the id/data redundancy across the five id-keyed catalog modules (`assets/error.py`, `app.py`, `di.py`, `feature.py`, `cli.py`), per `.trd/973_rfp-catalog-data-id-redundancy-elimination.md`.

- Dropped the `id`/`service_id` positional parameter from the six affected `assets/core.py` factories and renamed them with a `_data` suffix (e.g. `create_default_error` → `create_default_error_data`), since they now build raw data payloads rather than id-bearing definitions.
- Renamed every leaf constant built from those factories to a `_DATA` suffix, signalling raw data rather than an id-keyed model.
- Added defensive id/`service_id` reinjection to the five `add_default_*` decorators that were missing it (`contexts/error.py`, `contexts/feature.py`, `contexts/app.py` x3), mirroring the existing `contexts/cli.py` pattern.
- Updated tests whose fixtures or assertions depended on the old id-embedded factory/catalog shapes.
- Updated docs/skill examples (`docs/core/assets.md`, `docs/core/code_style.md`, `docs/collab/tech_requirements.md`, `tiferet-code-assets`/`tiferet-code-style` skills) to reflect the new factory signatures and naming.

## Scope note
Per user direction, the originally proposed `DEFAULT_TIFERET_CLI_COMMANDS` alias in `assets/cli.py` was intentionally skipped — `ADMIN_DEFAULT_COMMANDS` remains the sole command catalog name.

## Verification
`python -m pytest -q` reports **1089 passed / 11 skipped**, matching the pre-change baseline exactly.

Co-Authored-By: Oz <oz-agent@warp.dev>
