### PR TITLE
Admin CLI input simplification and admin default asset renaming (v2.0.0b16)

### DIFF
--- a/docs/core/testing.md
+++ b/docs/core/testing.md
@@ -195,7 +195,7 @@ class TestAddError(DomainEventTestBase):
         name='New Error',
         message='This is a new error message.',
         lang='en_US',
-        additional_messages=[],
+        additional_messages={},
     )
     required_params = ['id', 'name', 'message']
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -60,15 +60,15 @@ The built-in CLI exposes these command groups:
 Run a group with no command, or an unknown command, to see argparse usage for
 that group.
 
-## JSON-Valued Arguments
+## Dict-Valued Arguments
 
-Some commands accept structured values. These arguments are provided as JSON
-strings on the command line and decoded before the feature executes:
+The admin CLI is JSON-free: flat string-to-string map arguments are provided
+as `key=value` tokens rather than JSON strings, and are parsed by
+`CliArgument.parse_value()` before the feature executes:
 
 - `--parameters`
 - `--constants`
-- `--services`
-- `--flagged-dependencies`
+- `--additional-messages`
 
 Example — add a service registration with parameters:
 
@@ -76,21 +76,25 @@ Example — add a service registration with parameters:
 tiferet --config app/config.yml service add my_svc \
   --module-path tiferet.repos.feature \
   --class-name FeatureConfigRepository \
-  --parameters '{"feature_config": "app/config.yml"}'
+  --parameters feature_config=app/config.yml
 ```
 
-Malformed JSON fails cleanly with a message on stderr and a non-zero exit code
-rather than an unhandled traceback. Optional list/dict arguments that are omitted
-are treated as empty (`[]` / `{}`) by the underlying domain events, except where
-an explicit `null`/absence is meaningful (e.g. `set-constants` clearing all
-constants).
+A `dict` value may contain `=` because `parse_value()` splits on the first
+delimiter only. Optional dict arguments that are omitted are treated as empty
+(`{}`) by the underlying domain events, except where an explicit
+`null`/absence is meaningful (e.g. `set-constants` clearing all constants).
+
+Bulk-record arguments (nested records rather than flat maps, e.g. a service's
+dependency list) are not encoded through the CLI at all. Create the parent
+record first, then use the granular follow-up commands (`app.set-service`,
+`service.set-dependency`) to add records one at a time.
 
 ## Exit Codes
 
 - `0` — success.
 - `1` — a `TiferetAPIError` was raised while executing the feature (the formatted
   error message is printed to stderr).
-- `2` — argument parsing failed, or a JSON-valued argument was malformed.
+- `2` — argument parsing failed.
 
 ## Programmatic Use
 

--- a/docs/guides/events/error.md
+++ b/docs/guides/events/error.md
@@ -40,7 +40,7 @@ Creates a new `Error` with a primary message and optional additional language me
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `lang` | `str` | `'en_US'` | Language code for the primary message |
-| `additional_messages` | `List[Dict[str, Any]]` | `[]` | Additional messages (each with `lang` and `text`) |
+| `additional_messages` | `Dict[str, str]` | `{}` | Additional messages, keyed by language code, mapped to message text |
 
 **Returns:** The created `Error` instance.
 
@@ -54,9 +54,9 @@ result = DomainEvent.handle(
     id='CUSTOM_VALIDATION_ERROR',
     name='Custom Validation Error',
     message='Input validation failed for field {field}.',
-    additional_messages=[
-        {'lang': 'es_ES', 'text': 'La validación falló para el campo {field}.'}
-    ],
+    additional_messages={
+        'es_ES': 'La validación falló para el campo {field}.',
+    },
 )
 ```
 

--- a/tests/events/test_error.py
+++ b/tests/events/test_error.py
@@ -112,7 +112,7 @@ class TestAddError(DomainEventTestBase):
         name='New Error',
         message='This is a new error message.',
         lang='en_US',
-        additional_messages=[],
+        additional_messages={},
     )
 
     # * attribute: required_params
@@ -158,7 +158,7 @@ class TestAddError(DomainEventTestBase):
         # Execute with additional messages.
         result = self.handle(
             mock_dependencies,
-            additional_messages=[{'lang': 'es_ES', 'text': 'Este es un nuevo error.'}],
+            additional_messages={'es_ES': 'Este es un nuevo error.'},
         )
 
         # Assert both messages are present.

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -76,4 +76,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0b15'
+__version__ = '2.0.0b16'

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -156,8 +156,7 @@ APP_ADD_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['class_name'], 'Name of the context class.'),
         create_default_cli_argument(['--description'], 'Optional description.'),
         create_default_cli_argument(['--logger-id'], 'Logger identifier (default: default).', default='default'),
-        create_default_cli_argument(['--services'], 'Service dependencies as JSON string.', type='json'),
-        create_default_cli_argument(['--constants'], 'Constants as JSON string.', type='json'),
+        create_default_cli_argument(['--constants'], 'Constants as key=value pairs.', type='dict'),
     ],
 )
 
@@ -201,7 +200,7 @@ APP_SET_CONSTANTS_CLI_CMD_DATA = create_default_cli_command_data(
     description='Set or clear constants on an app interface.',
     arguments=[
         create_default_cli_argument(['id'], 'The interface identifier.'),
-        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.', type='json'),
+        create_default_cli_argument(['--constants'], 'Constants as key=value pairs. Omit to clear all.', type='dict'),
     ],
 )
 
@@ -216,7 +215,7 @@ APP_SET_SERVICE_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['service_id'], 'The service dependency identifier.'),
         create_default_cli_argument(['module_path'], 'Module path for the service.'),
         create_default_cli_argument(['class_name'], 'Class name for the service.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
+        create_default_cli_argument(['--parameters'], 'Parameters as key=value pairs.', type='dict'),
     ],
 )
 
@@ -293,6 +292,11 @@ ERROR_ADD_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['name'], 'The error name.'),
         create_default_cli_argument(['message'], 'The primary error message text.'),
         create_default_cli_argument(['--lang'], 'Language code for the message (default: en_US).', default='en_US'),
+        create_default_cli_argument(
+            ['--additional-messages'],
+            'Additional messages beyond the primary one, as lang=text pairs.',
+            type='dict',
+        ),
     ],
 )
 
@@ -433,7 +437,7 @@ FEATURE_ADD_STEP_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['id'], 'The feature identifier.'),
         create_default_cli_argument(['name'], 'The step name.'),
         create_default_cli_argument(['service_id'], 'The service configuration ID for the step.'),
-        create_default_cli_argument(['--parameters'], 'Optional step parameters as JSON string.', type='json'),
+        create_default_cli_argument(['--parameters'], 'Optional step parameters as key=value pairs.', type='dict'),
         create_default_cli_argument(['--data-key'], 'Optional result data key.'),
         create_default_cli_argument(['--position'], 'Insertion position (default: append).', type='int'),
     ],
@@ -492,8 +496,7 @@ SERVICE_ADD_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['id'], 'The unique service configuration identifier.'),
         create_default_cli_argument(['--module-path'], 'Default module path.'),
         create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Configuration parameters as JSON string.', type='json'),
-        create_default_cli_argument(['--flagged-dependencies'], 'Flagged dependencies as JSON string.', type='json'),
+        create_default_cli_argument(['--parameters'], 'Configuration parameters as key=value pairs.', type='dict'),
     ],
 )
 
@@ -515,7 +518,7 @@ SERVICE_SET_DEFAULT_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['id'], 'The service configuration identifier.'),
         create_default_cli_argument(['--module-path'], 'Default module path.'),
         create_default_cli_argument(['--class-name'], 'Default class name.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
+        create_default_cli_argument(['--parameters'], 'Parameters as key=value pairs.', type='dict'),
     ],
 )
 
@@ -530,7 +533,7 @@ SERVICE_SET_DEPENDENCY_CLI_CMD_DATA = create_default_cli_command_data(
         create_default_cli_argument(['flag'], 'The flag identifying the dependency.'),
         create_default_cli_argument(['module_path'], 'Module path for the dependency.'),
         create_default_cli_argument(['class_name'], 'Class name for the dependency.'),
-        create_default_cli_argument(['--parameters'], 'Parameters as JSON string.', type='json'),
+        create_default_cli_argument(['--parameters'], 'Parameters as key=value pairs.', type='dict'),
     ],
 )
 
@@ -564,7 +567,7 @@ SERVICE_SET_CONSTANTS_CLI_CMD_DATA = create_default_cli_command_data(
     'Set Service Constants',
     description='Set or clear service-level constants.',
     arguments=[
-        create_default_cli_argument(['--constants'], 'Constants as JSON string. Omit to clear all.', type='json'),
+        create_default_cli_argument(['--constants'], 'Constants as key=value pairs. Omit to clear all.', type='dict'),
     ],
 )
 

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -368,8 +368,8 @@ REMOVE_LOGGER_EVT_DATA = create_service_registration_data(
 
 # *** constants (groups)
 
-# ** constant: default_tiferet_cli_services
-DEFAULT_TIFERET_CLI_SERVICES: Dict[str, Dict[str, Any]] = {
+# ** constant: admin_default_services
+ADMIN_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
     APP_SERVICE_ID: APP_SERVICE_DATA,
     ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT_DATA,
     LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT_DATA,

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -292,7 +292,7 @@ ERROR_ADD_DATA = create_default_feature_data(
         name='str',
         message='str',
         lang={'type': 'str', 'required': False, 'default': 'en_US'},
-        additional_messages={'type': 'list', 'required': False, 'default': []},
+        additional_messages={'type': 'dict', 'required': False, 'default': {}},
     ),
 )
 
@@ -647,8 +647,8 @@ LOGGING_LIST_DATA = create_default_feature_data(
 
 # *** constants (groups)
 
-# ** constant: default_tiferet_cli_features
-DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
+# ** constant: admin_default_features
+ADMIN_DEFAULT_FEATURES: Dict[str, Any] = {
     APP_ADD_ID: APP_ADD_DATA,
     APP_GET_ID: APP_GET_DATA,
     APP_LIST_ID: APP_LIST_DATA,
@@ -691,6 +691,3 @@ DEFAULT_TIFERET_CLI_FEATURES: Dict[str, Any] = {
     LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER_DATA,
     LOGGING_LIST_ID: LOGGING_LIST_DATA,
 }
-
-# ** constant: admin_default_features
-ADMIN_DEFAULT_FEATURES: Dict[str, Any] = DEFAULT_TIFERET_CLI_FEATURES

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -6,7 +6,6 @@
 from typing import (
     List,
     Dict,
-    Any
 )
 
 # ** app
@@ -51,7 +50,7 @@ class AddError(ErrorEvent):
             name: str,
             message: str,
             lang: str = 'en_US',
-            additional_messages: List[Dict[str, Any]] = []
+            additional_messages: Dict[str, str] = {}
         ) -> None:
         '''
         Add a new Error to the app.
@@ -64,8 +63,9 @@ class AddError(ErrorEvent):
         :type message: str
         :param lang: The language of the primary error message (default is 'en_US').
         :type lang: str
-        :param additional_messages: Additional error messages in different languages.
-        :type additional_messages: List[Dict[str, Any]]
+        :param additional_messages: A language-code to message-text mapping of
+            additional messages beyond the primary one.
+        :type additional_messages: Dict[str, str]
         '''
 
         # Check if an error with the same ID already exists.
@@ -77,8 +77,10 @@ class AddError(ErrorEvent):
             id=id
         )
 
-        # Create the Error aggregate.
-        error_messages = [{'lang': lang, 'text': message}] + additional_messages
+        # Create the Error aggregate from the primary message plus any additional ones.
+        error_messages = [{'lang': lang, 'text': message}] + [
+            {'lang': lang_key, 'text': text} for lang_key, text in additional_messages.items()
+        ]
         new_error = ErrorAggregate(
             id=id,
             name=name,


### PR DESCRIPTION
## Summary

Implements RFP #989 (`.trd/989_rfp-admin-cli-input-simplification.md`). Simplifies the built-in admin CLI's structured-value inputs from JSON strings to the `key=value` `dict` shape introduced by #951, and completes the `ADMIN_DEFAULT_*` asset naming group ahead of the Milestone 32 Admin Support Super-TRD port to `main`.

## Changes

- Convert 8 flat map admin CLI arguments in `assets/cli.py` from `type='json'` to `type='dict'`: `app.add --constants`, `app.set-constants --constants`, `app.set-service --parameters`, `feature.add-step --parameters`, `service.add --parameters`, `service.set-default --parameters`, `service.set-dependency --parameters`, `service.set-constants --constants`.
- Remove `app.add`'s `--services` and `service.add`'s `--flagged-dependencies` bulk-record JSON arguments (nested records aren't flat maps); use the granular `app.set-service` / `service.set-dependency` follow-up commands instead.
- Add `error.add`'s `--additional-messages` argument as `type='dict'`.
- Change `AddError.execute`'s `additional_messages` parameter from `List[Dict[str, Any]]` to `Dict[str, str]`, building message entries from `.items()`.
- Rename `assets/di.py::DEFAULT_TIFERET_CLI_SERVICES` → `ADMIN_DEFAULT_SERVICES` and `assets/feature.py::DEFAULT_TIFERET_CLI_FEATURES` → `ADMIN_DEFAULT_FEATURES`, removing the now-redundant alias. No compatibility aliases retained (prototype branch).
- Updated `tests/events/test_error.py` for the new dict-based `AddError` contract, plus `docs/guides/cli.md`, `docs/guides/events/error.md`, and `docs/core/testing.md`.
- Bumped `tiferet.__version__` to `2.0.0b16`.

## Acceptance Criteria

All 10 acceptance criteria from TRD §5 verified, including a repository-wide grep confirming zero active `DEFAULT_TIFERET_CLI_*` references (only historical migration-note prose in `AGENTS.md` remains, describing past releases).

## Testing

`pytest tiferet/ tests/` — 1079 passed, 11 skipped.

Closes #989

Co-Authored-By: Oz <oz-agent@warp.dev>