### PR TITLE
Mappers - Feature Step Parity: add_step Flags/Async Passthrough and Attribute Ordering

### DIFF
--- a/tests/mappers/test_feature.py
+++ b/tests/mappers/test_feature.py
@@ -235,6 +235,25 @@ class TestFeatureAggregate(AggregateTestBase):
         assert step.service_id == 'step_one_event'
         assert step.middleware == ['log']
 
+    # ** test: add_step_async_flags
+    def test_add_step_async_flags(self, aggregate):
+        '''
+        Verifies is_async and flags passthrough.
+        '''
+
+        # Add a step with is_async and flags set to non-default values.
+        step = aggregate.add_step(
+            name='Step One',
+            service_id='step_one_event',
+            is_async=True,
+            flags=['beta'],
+        )
+
+        # Assert the values landed on the appended step.
+        assert aggregate.steps[0] is step
+        assert step.is_async is True
+        assert step.flags == ['beta']
+
     # ** test: add_step_position
     def test_add_step_position(self, aggregate):
         '''

--- a/tiferet/mappers/feature.py
+++ b/tiferet/mappers/feature.py
@@ -108,18 +108,18 @@ class EventFeatureStepConfigObject(EventFeatureStep, TransferObject):
         'to_data': {'by_alias': True, 'exclude': {'type'}},
     }
 
-    # * attribute: middleware
-    middleware: List[str] = Field(
-        default_factory=list,
-        description='Ordered list of middleware service IDs for this step.',
-    )
-
     # * attribute: parameters
     parameters: Dict[str, str] = Field(
         default_factory=dict,
         serialization_alias='params',
         validation_alias=AliasChoices('params', 'parameters'),
         description='The parameters for the event feature step.',
+    )
+
+    # * attribute: middleware
+    middleware: List[str] = Field(
+        default_factory=list,
+        description='Ordered list of middleware service IDs for this step.',
     )
 
     # * method: map
@@ -170,6 +170,8 @@ class FeatureAggregate(Feature, Aggregate):
         pass_on_error: bool = False,
         condition: str | None = None,
         middleware: List[str] | None = None,
+        is_async: bool = False,
+        flags: List[str] | None = None,
         position: int | None = None,
     ) -> EventFeatureStep:
         '''
@@ -189,6 +191,10 @@ class FeatureAggregate(Feature, Aggregate):
         :type condition: str | None
         :param middleware: Optional ordered list of middleware service IDs.
         :type middleware: list[str] | None
+        :param is_async: Whether this step executes asynchronously.
+        :type is_async: bool
+        :param flags: Optional list of feature flags that activate this step.
+        :type flags: list[str] | None
         :param position: Insertion position (None to append).
         :type position: int | None
         :return: Created EventFeatureStep instance.
@@ -204,6 +210,8 @@ class FeatureAggregate(Feature, Aggregate):
             pass_on_error=pass_on_error,
             condition=condition,
             middleware=middleware or [],
+            is_async=is_async,
+            flags=flags or [],
         )
 
         # Copy steps to a local list, insert or append, then reassign.


### PR DESCRIPTION
## Summary

`FeatureAggregate.add_step` gains `is_async`/`flags` passthrough to the constructed `EventFeatureStepAggregate`, and `EventFeatureStepConfigObject` reorders its `parameters`/`middleware` attribute declarations so `parameters` comes first, matching the declaration order already used by `EventFeatureStep` and `EventFeatureStepAggregate`.

## Changes

- `tiferet/mappers/feature.py`:
  - `FeatureAggregate.add_step` — added `is_async: bool = False` and `flags: List[str] | None = None` parameters (positioned after `middleware`, before `position`), passed through to the constructed `EventFeatureStepAggregate`; docstring updated with matching RST `:param:`/`:type:` entries.
  - `EventFeatureStepConfigObject` — reordered the `parameters`/`middleware` attribute declarations so `parameters` precedes `middleware`.
- `tests/mappers/test_feature.py` — added `test_add_step_async_flags` covering non-default `is_async=True` and a non-empty `flags` list on the appended step.

## Acceptance Criteria

- [x] `FeatureAggregate.add_step` declares `is_async: bool = False` and `flags: List[str] | None = None`, positioned after `middleware` and before `position`.
- [x] `add_step`'s `EventFeatureStepAggregate(...)` construction call passes `is_async=is_async` and `flags=flags or []`.
- [x] `add_step`'s docstring documents `is_async` and `flags` with RST `:param:`/`:type:` entries.
- [x] `EventFeatureStepConfigObject` declares `# * attribute: parameters` immediately before `# * attribute: middleware`.
- [x] `tests/mappers/test_feature.py` exercises `add_step` with non-default `is_async=True` and a non-empty `flags` list, asserting both values land on the returned step.
- [x] `pytest tests/mappers/test_feature.py` passes with no regressions.

## Verification

- `pytest tests/mappers/test_feature.py` — 33 passed.
- `pytest tiferet/ tests/` — 1095 passed, 12 skipped, no regressions.

## Related Issues

Closes #993

Co-Authored-By: Oz <oz-agent@warp.dev>