### PR TITLE
Events & Blueprints: Annotation Cleanup (#994)

### DIFF
--- a/tests/events/test_app.py
+++ b/tests/events/test_app.py
@@ -1101,8 +1101,8 @@ class TestUpdateAppSession(ServiceEventTestBase):
         # Assert the correct error code was raised.
         assert exc_info.value.error_code == a.error.APP_SESSION_NOT_FOUND_ID
 
-        # Assert the error carries the interface_id kwarg the message template formats on.
-        assert exc_info.value.kwargs.get('interface_id') == 'missing.session'
+        # Assert the error carries the id kwarg the message template formats on.
+        assert exc_info.value.kwargs.get('id') == 'missing.session'
 
         # Assert no save was attempted for a missing session.
         mock_dependencies['app_service'].save.assert_not_called()

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -130,7 +130,9 @@ def derive_feature_request(parsed: Dict[str, Any]) -> Tuple[str, Dict[str, str]]
     # Return the derived feature id and headers.
     return feature_id, headers
 
-# ** function: parse_cli_args_handler
+# *** blueprints
+
+# ** blueprint: parse_cli_args_handler
 def parse_cli_args_handler(list_commands_evt: Any,
         get_parent_args_evt: Any,
         default_commands_list: List[CliCommand] = None) -> Callable:
@@ -205,7 +207,7 @@ def parse_cli_args_handler(list_commands_evt: Any,
     # Return the closure.
     return handler
 
-# ** function: create_cli_request_context
+# ** blueprint: create_cli_request_context
 def create_cli_request_context(interface_id: str,
         feature_id: str,
         headers: Dict[str, str] = None,
@@ -236,7 +238,7 @@ def create_cli_request_context(interface_id: str,
         feature_id=feature_id,
     )
 
-# ** function: cli_response_handler
+# ** blueprint: cli_response_handler
 def cli_response_handler(request: RequestContext) -> Any:
     '''
     Extract the handled response from a completed CLI request context.
@@ -253,8 +255,6 @@ def cli_response_handler(request: RequestContext) -> Any:
 
     # Delegate to the request context's response handler.
     return request.handle_response()
-
-# *** blueprints
 
 # ** blueprint: build_cli_cache
 @add_default_cli_commands(a.cli.ADMIN_DEFAULT_COMMANDS)

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -173,7 +173,7 @@ class UpdateAppSession(AppEvent):
             expression=app_session is not None,
             error_code=a.error.APP_SESSION_NOT_FOUND_ID,
             message=f'App session with ID {id} not found.',
-            interface_id=id,
+            id=id,
         )
 
         # Update each provided scalar attribute via the aggregate method.

--- a/tiferet/events/app.py
+++ b/tiferet/events/app.py
@@ -463,7 +463,6 @@ class ListAppInterfaces(AppEvent):
         return self.app_service.list()
 
 # ** event: set_service_dependency
-# -- obsolete: Retire in Parity V Story 13.
 class SetServiceDependency(AppEvent):
     '''
     A domain event to set or update a service dependency on an app session.
@@ -525,7 +524,6 @@ class SetServiceDependency(AppEvent):
         return id
 
 # ** event: remove_service_dependency
-# -- obsolete: Retire in Parity V Story 13.
 class RemoveServiceDependency(AppEvent):
     '''
     A domain event to remove a service dependency from an app session (idempotent).

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -74,7 +74,7 @@ class AddError(ErrorEvent):
             expression=exists is False,
             error_code=a.error.ERROR_ALREADY_EXISTS_ID,
             message=f'An error with ID {id} already exists.',
-            id=id
+            id=id,
         )
 
         # Create the Error aggregate.
@@ -82,7 +82,7 @@ class AddError(ErrorEvent):
         new_error = ErrorAggregate(
             id=id,
             name=name,
-            message=error_messages
+            message=error_messages,
         )
 
         # Save the new error.


### PR DESCRIPTION
## Summary
Closes #994.

Three small, unrelated annotation/style corrections, re-verified directly against `main` per `.trd/m32_994_annotation-cleanup__S_2_P1.md`:

- `tiferet/events/app.py`: removed the stale `# -- obsolete: Retire in Parity V Story 13.` markers above `SetServiceDependency` and `RemoveServiceDependency` (both are retained, not deleted).
- `tiferet/events/app.py::UpdateAppSession.execute`: renamed its `verify()` call's `interface_id=id` kwarg to `id=id`; updated the corresponding test assertion in `tests/events/test_app.py`.
- `tiferet/events/error.py::AddError.execute`: added the two missing trailing commas (after `id=id` in `verify()`, and after `message=error_messages` in the `ErrorAggregate(...)` construction).
- `tiferet/blueprints/cli.py`: reclassified `parse_cli_args_handler`, `create_cli_request_context`, `cli_response_handler` from `# ** function:` to `# ** blueprint:`, matching `origin/v2.x-proto`'s section placement.

Explicitly out of scope (per the TRD): the five `# -- obsolete: Superseded by ...` markers on the `*AppInterface` events (deleted outright by Bucket 4), the already-correct `id=id` kwargs on `SetServiceDependency`/`RemoveServiceDependency`, `AddError`'s `additional_messages` logic (Bucket 9), and `GetError`/`ListErrors`'s `include_defaults` (flagged as an unowned gap).

## Testing
- `pytest tests/events/ tests/blueprints/` — 374 passed, 12 skipped
- `pytest tiferet/ tests/` — 1095 passed, 12 skipped

Co-Authored-By: Oz <oz-agent@warp.dev>