### PR TITLE
Docs – AppInterface Layer Retirement Companion

### DIFF
--- a/docs/guides/domain/app.md
+++ b/docs/guides/domain/app.md
@@ -1,4 +1,4 @@
-# Domain – App: AppInterface and AppServiceDependency
+# Domain – App: AppSession and AppServiceDependency
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -7,9 +7,9 @@
 
 ## Overview
 
-The App domain defines the structural foundation for application entry points in Tiferet. Every runnable interface — whether a REST API, CLI, background worker, or custom context — is described by an `AppInterface` domain object. Each interface declares its context implementation, logging configuration, dependency-resolution flags, static constants, and a list of injectable service dependency bindings (`AppServiceDependency`).
+The App domain defines the structural foundation for application entry points in Tiferet. Every runnable session — whether a REST API, CLI, background worker, or custom context — is described by an `AppSession` domain object. Each session declares logging configuration, dependency-resolution flags, static constants, and a list of injectable service dependency bindings (`AppServiceDependency`). The context implementation used to run the session (e.g. the generic `AppSessionContext` or the CLI-oriented `CliSessionContext`) is selected by which blueprint entrypoint the caller invokes, not declared as an attribute on the session itself.
 
-These domain objects are **immutable value objects**: they carry no mutation methods and expose only read-only queries. All state changes (adding/removing services, updating constants, renaming) occur exclusively through Aggregates in the mappers layer.
+`AppSession` is a **read-only value object**: it exposes only the `get_service` query and carries no mutation methods. All state changes (adding/removing services, updating constants, renaming) occur exclusively through `AppSessionAggregate` in the mappers layer. The previous domain-level `apply_defaults` mutator has no replacement on the domain object — default service/constant merging now happens at the blueprint layer via `build_app_service_container`.
 
 **Module:** `tiferet/domain/app.py`
 
@@ -17,15 +17,14 @@ These domain objects are **immutable value objects**: they carry no mutation met
 
 ### AppServiceDependency
 
-Represents a single injectable service dependency binding for an application interface.
+Represents a single injectable service dependency binding for an application session.
 
 | Attribute      | Type                   | Required | Default | Description                                                                      |
-|----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
-| `module_path`  | `str`                  | Yes      | —       | The module path for the app dependency.                                           |
-| `class_name`   | `str`                  | Yes      | —       | The class name for the app dependency.                                            |
-| `service_id`   | `str`                  | No *(todo: required)* | — | The canonical service id for the application dependency.             |
-| `attribute_id` | `str`                  | No *(obsolete)* | — | The attribute id for the application dependency. Superseded by `service_id`. |
-| `parameters`   | `Dict[str, str]`       | No       | `{}`    | The parameters for the application dependency.                                    |
+|----------------|------------------------|----------|---------|------------------------------------------------------------------------------------|
+| `module_path`  | `str`                  | Yes      | —       | The module path for the service dependency.                                       |
+| `class_name`   | `str`                  | Yes      | —       | The class name for the service dependency.                                        |
+| `service_id`   | `str`                  | Yes      | —       | The canonical service id for the application dependency.                          |
+| `parameters`   | `Dict[str, str]`       | No       | `{}`    | The parameters for the service dependency.                                        |
 
 No methods. Pure data structure.
 
@@ -33,58 +32,55 @@ No methods. Pure data structure.
 
 In v1.x, service dependency bindings were called `AppAttribute`. In v2.0, the class is renamed to `AppServiceDependency` to better reflect its role as a service dependency binding rather than a generic attribute. The field set and semantics are unchanged.
 
-### AppInterface
+### AppSession
 
-Represents the complete configuration of an application entry point.
+Represents the complete configuration of an application session — the runtime entry point.
 
 | Attribute      | Type                                | Required | Default       | Description                                           |
-|----------------|-------------------------------------|----------|---------------|-------------------------------------------------------|
-| `id`           | `str`                               | Yes      | —             | The unique identifier for the application interface.   |
-| `name`         | `str`                               | Yes      | —             | The name of the application interface.                 |
-| `description`  | `str \| None`                       | No       | `None`        | The description of the application interface.          |
-| `module_path`  | `str`                               | Yes      | —             | The module path for the application instance context.  |
-| `class_name`   | `str`                               | Yes      | —             | The class name for the application instance context.   |
-| `logger_id`    | `str`                               | No       | `'default'`   | The logger ID for the application instance.            |
-| `flags`        | `List[str]`                         | No       | `['default']` | The flags for the application interface.               |
-| `services`     | `List[AppServiceDependency]`        | Yes      | `[]`          | The application instance service dependencies.         |
-| `constants`    | `Dict[str, str]`                    | No       | `{}`          | The application dependency constants.                  |
+|----------------|-------------------------------------|----------|---------------|--------------------------------------------------------|
+| `id`           | `str`                               | Yes      | —             | The unique identifier for the application session.     |
+| `name`         | `str`                               | Yes      | —             | The name of the application session.                   |
+| `description`  | `str \| None`                       | No       | `None`        | The description of the application session.            |
+| `logger_id`    | `str`                               | No       | `'default'`   | The logger ID for the application session.             |
+| `flags`        | `List[str]`                         | No       | `['default']` | The DI flags for the application session.              |
+| `services`     | `List[AppServiceDependency]`        | No       | `[]`          | The application session service dependencies.          |
+| `constants`    | `Dict[str, str]`                    | No       | `{}`          | The application session dependency constants.          |
 
 #### Methods
 
-**`get_service(service_id: str) -> AppServiceDependency`**
+**`get_service(service_id: str) -> AppServiceDependency | None`**
 
-Returns the `AppServiceDependency` whose `service_id` matches the given value, or `None` if no match is found. For backward compatibility, also falls back to matching on `attribute_id` (this fallback will be removed once `attribute_id` is fully migrated).
+Returns the `AppServiceDependency` whose `service_id` matches the given value, or `None` if no match is found.
 
 ```python
-service = app_interface.get_service('cli_repo')
+service = app_session.get_service('cli_repo')
 if service:
     print(service.module_path, service.class_name)
 ```
 
 ## Runtime Role
 
-The `build_app` blueprint (`tiferet/blueprints/main.py`) is the primary consumer of the App domain at runtime. The flow is:
+The `build_app` blueprint (`tiferet/blueprints/core.py`) is the primary consumer of the App domain at runtime. The flow is:
 
-1. **`App('basic_calc', app_yaml_file='config.yml')`** calls `build_app`, which loads the app service and resolves the interface.
-2. **`resolve_interface(interface_id)`** retrieves the `AppInterface` via the `GetAppInterface` domain event, merging default services.
-3. **`realize_interface(app_interface, ...)`** iterates through `app_interface.services`, imports each class via `ImportDependency.execute()`, and collects them (along with parameters and constants) into a dependencies dict.
-4. The dependencies dict is passed to `create_service_provider`, which builds a DI container that instantiates the context class with all its wired services.
-5. The resulting `AppInterfaceContext` is returned, ready to execute features.
+1. **`App('basic_calc', app_config='config.yml')`** calls `build_app`, which builds the bootstrap cache and resolves the app session.
+2. **`get_app_session(interface_id, cache, ...)`** retrieves the `AppSession` via the `GetAppSession` domain event, preferring a cache-seeded default session when present.
+3. **`build_app_session_context(app_session, cache)`** merges the session's own services/constants with the cache-seeded framework defaults, composes the service resolver, and wires the FE4 template-method handlers.
+4. The resulting **`AppSessionContext`** is returned, bound to the loaded `AppSession` and ready to execute features via `run()`.
 
 ```python
 # Simplified runtime flow
 from tiferet import App
 
-app = App('basic_calc', app_yaml_file='config.yml')  # resolves interface, wires dependencies
+app = App('basic_calc', app_config='config.yml')  # resolves the session, wires dependencies
 result = app.run('calc.add', data={'a': 1, 'b': 2})  # executes features via the wired context
 ```
 
 ## Configuration Mapping
 
-Application interfaces are defined in the `interfaces` section of the configuration file (typically `config.yml`). Each top-level key under `interfaces` maps to an `AppInterface`, and nested `attrs` entries map to `AppServiceDependency` objects. Each key under `attrs` becomes the `service_id` of the corresponding `AppServiceDependency`:
+Application sessions are defined in the `sessions` section of the configuration file (typically `config.yml`). Each top-level key under `sessions` maps to an `AppSession`, and nested `attrs` entries map to `AppServiceDependency` objects. Each key under `attrs` becomes the `service_id` of the corresponding `AppServiceDependency`:
 
 ```yaml
-interfaces:
+sessions:
   basic_calc:
     name: Basic Calculator
     description: Perform basic calculator operations
@@ -94,23 +90,21 @@ interfaces:
     attrs:
       cli_repo:
         module_path: tiferet.repos.cli
-        class_name: CliYamlRepository
+        class_name: CliConfigRepository
         params:
-          cli_yaml_file: config.yml
+          cli_config: config.yml
 ```
-
-CLI interfaces no longer require `module_path`/`class_name` overrides — they use the default `AppInterfaceContext` with argparse wiring handled by the `build_cli` blueprint.
 
 ## Domain Events
 
-The following domain events interact with `AppInterface` and `AppServiceDependency`:
+The following domain events interact with `AppSession` and `AppServiceDependency` (see [docs/guides/events/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/events/app.md) for the complete set):
 
 | Event                | Description                                       |
-|----------------------|---------------------------------------------------|
-| `GetAppInterface`    | Retrieves an `AppInterface` by ID.                |
-| `AddAppInterface`    | Creates and persists a new `AppInterface`.         |
-| `UpdateAppInterface` | Modifies an existing `AppInterface` via aggregate. |
-| `DeleteAppInterface` | Removes an `AppInterface` by ID.                   |
+|----------------------|-----------------------------------------------------|
+| `AddAppSession`      | Creates and persists a new `AppSession`.            |
+| `GetAppSession`      | Retrieves an `AppSession` by ID.                    |
+| `UpdateAppSession`   | Modifies scalar attributes of an existing `AppSession` via aggregate. |
+| `RemoveAppSession`   | Removes an `AppSession` by ID (idempotent).         |
 
 These events depend on the `AppService` interface for persistence operations.
 
@@ -119,34 +113,34 @@ These events depend on the `AppService` interface for persistence operations.
 **`AppService`** (`tiferet/interfaces/app.py`) defines the abstract contract for App domain persistence:
 
 - `exists(id: str) -> bool`
-- `get(id: str) -> AppInterface`
-- `list() -> List[AppInterface]`
-- `save(app_interface) -> None`
+- `get(id: str) -> AppSessionAggregate`
+- `list() -> List[AppSessionAggregate]`
+- `save(session: AppSessionAggregate) -> None`
 - `delete(id: str) -> None`
 
-Concrete implementations (e.g., `AppYamlRepository`) satisfy this interface.
+Concrete implementations (e.g., `AppConfigRepository`) satisfy this interface.
 
 ## Relationships to Other Domains
 
-- **Dependency Injection:** `AppServiceDependency` entries reference service configurations that are resolved at runtime via `DIContext`.
-- **Feature:** Once an interface is loaded and its context instantiated, features defined in the configuration are executed through the `FeatureContext`.
-- **Logging:** `AppInterface.logger_id` references a logger configuration from the Logging domain.
+- **Dependency Injection:** `AppServiceDependency` entries reference service registrations that are resolved at runtime via the `ServiceResolver`.
+- **Feature:** Once a session is loaded and its context instantiated, features defined in the configuration are executed through the `FeatureContext`.
+- **Logging:** `AppSession.logger_id` references a logger configuration from the Logging domain.
 
 ## Instantiation
 
 Both domain objects are instantiated directly via the Pydantic constructor:
 
 ```python
-from tiferet.domain import AppServiceDependency, AppInterface
+from tiferet.domain import AppServiceDependency, AppSession
 
 dep = AppServiceDependency(
     service_id='cli_repo',
     module_path='tiferet.repos.cli',
-    class_name='CliYamlRepository',
-    parameters={'cli_yaml_file': 'config.yml'},
+    class_name='CliConfigRepository',
+    parameters={'cli_config': 'config.yml'},
 )
 
-interface = AppInterface(
+session = AppSession(
     id='basic_calc_cli',
     name='Calculator CLI',
     services=[dep],

--- a/docs/guides/domain/di.md
+++ b/docs/guides/domain/di.md
@@ -63,7 +63,7 @@ dep = config.get_dependency('sqlite', 'yaml')
 
 Flags flow into the DI container from multiple sources:
 
-1. **`AppInterface.flags`** — interface-level flags set in `app/configs/app.yml` (e.g., `['yaml']`, `['sqlite', 'yaml']`).
+1. **`AppSession.flags`** — session-level flags set in `app/configs/app.yml` (e.g., `['yaml']`, `['sqlite', 'yaml']`).
 2. **`Feature.flags`** — feature-level flag overrides defined in `feature.yml`.
 3. **`EventFeatureStep.flags`** — step-level flag overrides within a feature workflow.
 
@@ -134,7 +134,7 @@ Concrete implementations (e.g., `DIYamlRepository`) satisfy this interface.
 
 ## Relationships to Other Domains
 
-- **App:** `AppInterface.flags` provides the primary set of runtime flags used during dependency resolution.
+- **App:** `AppSession.flags` provides the primary set of runtime flags used during dependency resolution.
 - **Feature:** `Feature.flags` and `EventFeatureStep.flags` can override or extend the active flag set for specific workflows.
 - **Error:** Error service implementations are resolved through the DI container, making `ServiceRegistration` entries for `error_service` a common pattern.
 
@@ -165,6 +165,6 @@ config = ServiceRegistration(
 
 - [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comment & formatting rules
 - [docs/core/domain.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/domain.md) — Domain model conventions
-- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (AppInterface, flags)
+- [docs/guides/domain/app.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/app.md) — App domain guide (AppSession, flags)
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing

--- a/docs/guides/events/app.md
+++ b/docs/guides/events/app.md
@@ -1,4 +1,4 @@
-# Events – App Interface Management
+# Events – App Session Management
 
 **Project:** Tiferet Framework  
 **Repository:** https://github.com/greatstrength/tiferet  
@@ -7,36 +7,36 @@
 
 ## Overview
 
-The app event module provides the full CRUD surface for `AppInterface` configurations — the blueprints that define how a Tiferet application is assembled at runtime. Every event in this module depends on an injected `AppService` and operates on `AppInterface` domain objects through the `AppInterfaceAggregate` mapper.
+The app event module provides the full CRUD surface for `AppSession` configurations — the runtime entry-point definitions that describe how a Tiferet application session is assembled. Every event in this module depends on an injected `AppService` and operates on `AppSession` domain objects through the `AppSessionAggregate` mapper.
 
-These events are consumed by `AppManagerContext` during bootstrapping and by management tooling that creates, updates, and removes interface configurations.
+These events are consumed by the `build_app` blueprint chain during bootstrapping and by management tooling that creates, updates, and removes session configurations.
 
 ## Events at a Glance
 
 | Event | Operation | Required Parameters | Returns |
 |---|---|---|---|
-| `AddAppInterface` | Create | `id`, `name`, `module_path`, `class_name` | `AppInterface` |
-| `GetAppInterface` | Read | `interface_id` | `AppInterface` |
-| `ListAppInterfaces` | Read (all) | *(none)* | `List[AppInterface]` |
-| `UpdateAppInterface` | Update (scalar) | `id`, `attribute` | `str` (ID) |
+| `AddAppSession` | Create | `id`, `name` | `AppSession` |
+| `GetAppSession` | Read | `id` | `AppSession` |
+| `UpdateAppSession` | Update (scalar) | `id` | `AppSession` |
+| `ListAppSessions` | Read (all) | *(none)* | `List[AppSession]` |
+| `RemoveAppSession` | Delete | `id` | `None` |
 | `SetAppConstants` | Update (constants) | `id` | `str` (ID) |
 | `SetServiceDependency` | Update (service dep) | `id`, `service_id`, `module_path`, `class_name` | `str` (ID) |
 | `RemoveServiceDependency` | Delete (service dep) | `id`, `service_id` | `str` (ID) |
-| `RemoveAppInterface` | Delete | `id` | `str` (ID) |
 
 ## Dependency
 
 All events inject a single dependency:
 
-- **`app_service: AppService`** — the service interface for persisting and retrieving `AppInterface` configurations.
+- **`app_service: AppService`** — the service interface for persisting and retrieving `AppSession` configurations.
 
 ## Event Details
 
-### AddAppInterface
+### AddAppSession
 
-Creates a new `AppInterface` and persists it via `AppService.save()`.
+Creates a new `AppSession` and persists it via `AppService.save()`.
 
-**Required:** `id`, `name`, `module_path`, `class_name`
+**Required:** `id`, `name`
 
 **Optional parameters:**
 
@@ -48,21 +48,19 @@ Creates a new `AppInterface` and persists it via `AppService.save()`.
 | `services` | `List[Dict]` | `[]` | Service dependency definitions (each dict has `service_id`, `module_path`, `class_name`, optional `parameters`) |
 | `constants` | `Dict[str, str]` | `{}` | Constant values for the DI injector |
 
-**Returns:** The created `AppInterface` instance.
+**Returns:** The created `AppSession` instance.
 
 **Behavior:**
-1. Collects all parameters into a data dict.
-2. Creates an `AppInterfaceAggregate` via the Pydantic constructor for creation and validation.
-3. Saves via `app_service.save(interface)`.
+1. Coerces optional arguments that argparse may pass as `None` to their defaults.
+2. Creates an `AppSessionAggregate` via the Pydantic constructor for creation and validation.
+3. Saves via `app_service.save(app_session)`.
 
 ```python
 result = DomainEvent.handle(
-    AddAppInterface,
+    AddAppSession,
     dependencies={'app_service': app_service},
     id='my_app',
     name='My Application',
-    module_path='myapp.contexts.main',
-    class_name='MainContext',
     services=[{
         'service_id': 'db_service',
         'module_path': 'myapp.repos.db',
@@ -72,76 +70,88 @@ result = DomainEvent.handle(
 )
 ```
 
-### GetAppInterface
+### GetAppSession
 
-Retrieves an `AppInterface` by ID from the app service. It is a repository-only read — it returns the stored interface unchanged and does not merge any defaults.
+Retrieves an `AppSession` by ID via the `AppService` abstraction.
 
-**Required:** `interface_id`
+**Required:** `id`
 
-**Returns:** The loaded `AppInterface` instance.
+**Returns:** The loaded `AppSession` instance.
 
-**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+**Error:** Raises `APP_SESSION_NOT_FOUND` if the session does not exist.
 
 **Behavior:**
-1. Retrieves the interface via `app_service.get(interface_id)`.
+1. Retrieves the session via `app_service.get(id)`.
 2. Raises a structured error if `None`.
-3. Returns the loaded interface.
+3. Returns the loaded session.
 
 ```python
-interface = DomainEvent.handle(
-    GetAppInterface,
+app_session = DomainEvent.handle(
+    GetAppSession,
     dependencies={'app_service': app_service},
-    interface_id='my_app',
+    id='my_app',
 )
 ```
 
-### ListAppInterfaces
+### UpdateAppSession
 
-Lists all configured app interfaces. No required parameters.
+Updates scalar attributes of an existing app session. Each provided attribute is updated via `AppSessionAggregate.set_attribute()`, which enforces a gated allowlist of mutable fields.
 
-**Returns:** `List[AppInterface]` — may be empty.
-
-```python
-interfaces = DomainEvent.handle(
-    ListAppInterfaces,
-    dependencies={'app_service': app_service},
-)
-```
-
-### UpdateAppInterface
-
-Updates a single scalar attribute on an existing app interface. The attribute is updated via `AppInterfaceAggregate.set_attribute()`, which enforces a gated allowlist of mutable fields.
-
-**Required:** `id`, `attribute`
+**Required:** `id`
 
 **Optional parameters:**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `value` | `Any` | — | The new value for the attribute |
+| `name` | `str \| None` | `None` | The new name value, or `None` to leave unchanged |
+| `description` | `str \| None` | `None` | The new description value, or `None` to leave unchanged |
+| `logger_id` | `str \| None` | `None` | The new logger id value, or `None` to leave unchanged |
 
-**Returns:** `str` — the interface ID.
+**Returns:** The updated `AppSession` instance.
 
-**Errors:**
-- `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
-- `INVALID_MODEL_ATTRIBUTE` if the attribute name is not in the supported set.
-- `INVALID_APP_INTERFACE_TYPE` if `module_path` or `class_name` is set to an empty string.
-
-**Supported attributes:** `name`, `description`, `module_path`, `class_name`, `logger_id`, `flags`.
+**Error:** Raises `APP_SESSION_NOT_FOUND` if the session does not exist.
 
 ```python
 DomainEvent.handle(
-    UpdateAppInterface,
+    UpdateAppSession,
     dependencies={'app_service': app_service},
     id='my_app',
-    attribute='description',
-    value='Updated description',
+    description='Updated description',
+)
+```
+
+### ListAppSessions
+
+Lists all configured application sessions. No required parameters.
+
+**Returns:** `List[AppSession]` — may be empty.
+
+```python
+app_sessions = DomainEvent.handle(
+    ListAppSessions,
+    dependencies={'app_service': app_service},
+)
+```
+
+### RemoveAppSession
+
+Removes an app session configuration by ID. The operation is **idempotent** — removing a non-existent session does not raise an error.
+
+**Required:** `id`
+
+**Returns:** `None`
+
+```python
+DomainEvent.handle(
+    RemoveAppSession,
+    dependencies={'app_service': app_service},
+    id='my_app',
 )
 ```
 
 ### SetAppConstants
 
-Sets, merges, or clears constants on an app interface.
+Sets, merges, or clears constants on an app session.
 
 **Required:** `id`
 
@@ -151,11 +161,11 @@ Sets, merges, or clears constants on an app interface.
 |---|---|---|---|
 | `constants` | `dict[str, Any] \| None` | `None` | Constants to apply. `None` clears all constants. Dict keys with `None` values are removed; others are merged. |
 
-**Returns:** `str` — the interface ID.
+**Returns:** `str` — the session ID.
 
-**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+**Error:** Raises `APP_SESSION_NOT_FOUND` if the session does not exist.
 
-**Merge semantics** (delegated to `AppInterfaceAggregate.set_constants`):
+**Merge semantics** (delegated to `AppSessionAggregate.set_constants`):
 - `constants=None` → clears all constants.
 - `constants={'KEY': 'val'}` → merges into existing; existing keys are overwritten.
 - `constants={'KEY': None}` → removes `KEY` from the constants dict.
@@ -180,7 +190,7 @@ DomainEvent.handle(
 
 ### SetServiceDependency
 
-Adds or updates a service dependency on an app interface. Uses PUT semantics — if the `service_id` already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
+Adds or updates a service dependency on an app session. Uses PUT semantics — if the `service_id` already exists, the dependency is updated in place with parameter merge-and-prune; if it does not exist, a new dependency is created.
 
 **Required:** `id`, `service_id`, `module_path`, `class_name`
 
@@ -190,9 +200,9 @@ Adds or updates a service dependency on an app interface. Uses PUT semantics —
 |---|---|---|---|
 | `parameters` | `dict[str, Any] \| None` | `None` | Parameters for the service dependency. `None` clears existing parameters. Dict keys with `None` values are pruned. |
 
-**Returns:** `str` — the interface ID.
+**Returns:** `str` — the session ID.
 
-**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+**Error:** Raises `APP_SESSION_NOT_FOUND` if the session does not exist.
 
 ```python
 DomainEvent.handle(
@@ -208,13 +218,13 @@ DomainEvent.handle(
 
 ### RemoveServiceDependency
 
-Removes a service dependency from an app interface by `service_id`. The operation is **idempotent** — removing a non-existent service does not raise an error.
+Removes a service dependency from an app session by `service_id`. The operation is **idempotent** — removing a non-existent service does not raise an error.
 
 **Required:** `id`, `service_id`
 
-**Returns:** `str` — the interface ID.
+**Returns:** `str` — the session ID.
 
-**Error:** Raises `APP_INTERFACE_NOT_FOUND` if the interface does not exist.
+**Error:** Raises `APP_SESSION_NOT_FOUND` if the session does not exist.
 
 ```python
 DomainEvent.handle(
@@ -225,47 +235,22 @@ DomainEvent.handle(
 )
 ```
 
-### RemoveAppInterface
-
-Deletes an entire app interface configuration by ID. The operation is **idempotent** — removing a non-existent interface does not raise an error.
-
-**Required:** `id`
-
-**Returns:** `str` — the removed interface ID.
-
-```python
-DomainEvent.handle(
-    RemoveAppInterface,
-    dependencies={'app_service': app_service},
-    id='my_app',
-)
-```
-
 ## Common Patterns
 
 ### Retrieve → Verify → Mutate → Save
 
 Most mutation events follow the same four-step pattern:
 
-1. **Retrieve** the `AppInterface` via `app_service.get(id)`.
-2. **Verify** it exists using `self.verify()` or `self.raise_error()`.
+1. **Retrieve** the `AppSession` via `app_service.get(id)`.
+2. **Verify** it exists using `self.verify()`.
 3. **Mutate** the aggregate via its domain methods (`set_attribute`, `set_service`, `set_constants`, etc.).
-4. **Save** the updated aggregate via `app_service.save(interface)`.
+4. **Save** the updated aggregate via `app_service.save(app_session)`.
 
 This pattern ensures that domain rules are enforced by the aggregate, not the event, and that persistence is always explicit.
 
 ### Idempotent Deletes
 
-Both `RemoveServiceDependency` and `RemoveAppInterface` are idempotent — they succeed silently if the target does not exist. This simplifies orchestration workflows where deletions may be retried.
-
-### Default Service Merging
-
-Bootstrap default merging is no longer a concern of `GetAppInterface`; the event is a plain repository read. Framework-level defaults (error repository, feature repository, etc.) are applied outside the event by two dedicated helpers:
-
-- **`AppInterface.apply_defaults(default_services, default_constants)`** (`tiferet/domain/app.py`) — a non-mutating domain helper that returns a new interface with default services added for any missing `service_id` and default constants added for any missing key (existing values win).
-- **`resolve_default_interface(interface_id, default_interfaces)`** (`tiferet/contexts/app.py`) — the context bootstrap helper that resolves an interface and applies its defaults during startup.
-
-Neither helper re-wraps `AppInterfaceAggregate`.
+Both `RemoveServiceDependency` and `RemoveAppSession` are idempotent — they delegate to `AppService.delete()`/aggregate removal, which succeeds silently if the target does not exist. This simplifies orchestration workflows where deletions may be retried.
 
 ## Related Documentation
 

--- a/docs/guides/mappers.md
+++ b/docs/guides/mappers.md
@@ -24,7 +24,7 @@ If a domain object is only ever used as a **nested sub-object** inside a parent 
 
 | Domain Object | Has Aggregate? | Reason |
 |---|---|---|
-| `AppInterface` | Yes (`AppInterfaceAggregate`) | Multi-field mutations (`set_service`, `set_constants`, gated `set_attribute`) |
+| `AppSession` | Yes (`AppSessionAggregate`) | Multi-field mutations (`set_service`, `set_constants`, gated `set_attribute`) |
 | `AppServiceDependency` | No | 1:1 field mapping; parent manages mutations |
 | `Feature` | Yes (`FeatureAggregate`) | Complex `new` factory with ID derivation; step ordering and insertion |
 | `FeatureEvent` | Yes (`FeatureEventAggregate`) | Specialized setters for `pass_on_error` and parameter merging |
@@ -62,7 +62,7 @@ aggregate = FeatureAggregate(id='calc.add', name='Add Number')
 Used when the caller already has a dict (e.g., from YAML loading):
 
 ```python
-aggregate = AppInterfaceAggregate(**app_interface_data)
+aggregate = AppSessionAggregate(**app_session_data)
 ```
 
 Choose the pattern that fits the domain. Derivation via `@model_validator` is useful when an ID is composed from multiple parts; dict-wrapper construction is useful when the aggregate is populated from configuration data.
@@ -74,11 +74,11 @@ When a domain object has no aggregate, the parent aggregate creates instances di
 ### Creation in the parent aggregate
 
 ```python
-# AppInterfaceAggregate.add_service
+# AppSessionAggregate.add_service
 dependency = AppServiceDependency(
     module_path=module_path,
     class_name=class_name,
-    attribute_id=attribute_id,
+    service_id=service_id,
     parameters=parameters,
 )
 self.services.append(dependency)
@@ -89,13 +89,13 @@ self.services.append(dependency)
 The transfer object is responsible for any structural differences between the configuration format and the domain model. The most common pattern is **dict↔list conversion**, where YAML stores sub-objects as a dictionary keyed by an identifier, but the domain model stores them as a list with that identifier as a field.
 
 ```python
-# AppInterfaceYamlObject.map — dict keys become attribute_id fields
-services=[dep.map(attribute_id=dep_id) for dep_id, dep in self.services.items()]
+# AppSessionConfigObject.map — dict keys become service_id fields
+services=[dep.map(service_id=dep_id) for dep_id, dep in self.services.items()]
 
-# AppInterfaceYamlObject.from_model — list items become dict entries
+# AppSessionConfigObject.from_model — list items become dict entries
 services={
-    dep.attribute_id: TransferObject.from_model(AppServiceDependencyYamlObject, dep)
-    for dep in app_interface.services
+    dep.service_id: TransferObject.from_model(AppServiceDependencyConfigObject, dep)
+    for dep in app_session.services
 }
 ```
 

--- a/docs/guides/repos.md
+++ b/docs/guides/repos.md
@@ -64,8 +64,8 @@ error_data = self._load(
 )
 
 # Entire section.
-interfaces_data = self._load(
-    start_node=lambda data: data.get('interfaces', {})
+sessions_data = self._load(
+    start_node=lambda data: data.get('sessions', {})
 )
 ```
 


### PR DESCRIPTION
## Summary
Corrects five guide docs on `main` that still described the retired `AppInterface`/`AppInterfaceAggregate`/`*AppInterface`-event surface as current, now that #995 removed it. Per `.trd/m32_996_appinterface-layer-retirement-docs-companion__M_3_P2.md`.

## Changes ✅
- `docs/guides/domain/app.md` — full rewrite to describe `AppSession` and `AppServiceDependency` only (title, overview, attribute table, runtime-role flow, domain-events table, service-interface signatures, instantiation example).
- `docs/guides/events/app.md` — full rewrite retitled "Events – App Session Management", replacing the retired event set with the real 8 `main` events and removing the retired "Default Service Merging" section.
- `docs/guides/mappers.md` — retargeted three worked examples to `AppSession`/`AppSessionAggregate` using the real `service_id` field (not the stale `attribute_id`).
- `docs/guides/domain/di.md` — retargeted two `AppInterface.flags` prose references and one doc-link description to `AppSession.flags`.
- `docs/guides/repos.md` — fixed the stale `interfaces_data`/`'interfaces'` snippet to `sessions_data`/`'sessions'`, matching `AppConfigRepository`'s actual `_load` calls.

`docs/guides/interfaces.md` and `docs/core/interfaces.md` are unmodified, per the TRD's verification that they contain no retired-surface references.

## Acceptance Criteria
- [x] `grep -rln "AppInterface" docs/guides/domain/app.md docs/guides/events/app.md docs/guides/mappers.md docs/guides/domain/di.md docs/guides/repos.md` returns no results.
- [x] `docs/guides/domain/app.md`'s Service Interface section shows `get`/`list`/`save` typed against `AppSessionAggregate`, matching the parent TRD's `interfaces/app.py` retype.
- [x] `docs/guides/events/app.md`'s Events at a Glance table lists exactly the 8 events in §4 with no `*AppInterface` names remaining.
- [x] `docs/guides/mappers.md`'s three retargeted examples use `service_id`, not `attribute_id`.
- [x] `docs/guides/repos.md`'s "Entire section" snippet reads `data.get('sessions', {})`.
- [x] `docs/guides/interfaces.md` and `docs/core/interfaces.md` are unmodified by this TRD.

## Verification
Docs-only change; no pytest run needed. Code snippets cross-checked against current `tiferet/domain/app.py`, `tiferet/mappers/app.py`, `tiferet/repos/app.py`, `tiferet/events/app.py`, and `tiferet/interfaces/app.py`.

## Related Issues
Closes #996

Co-Authored-By: Oz <oz-agent@warp.dev>