### PR TITLE
Contexts – Correctness & Typing Fixes

### DIFF
--- a/tests/contexts/test_base.py
+++ b/tests/contexts/test_base.py
@@ -107,6 +107,9 @@ def test_for_domain_not_found():
     # Assert the structured CONTEXT_NOT_FOUND error code is raised.
     assert exc_info.value.error_code == 'CONTEXT_NOT_FOUND'
 
+    # Assert a descriptive message naming the unregistered domain type is included.
+    assert 'No context registered for domain type: UnregisteredDomain.' in str(exc_info.value)
+
 # ** test: test_from_domain_on_base
 def test_from_domain_on_base():
     '''

--- a/tests/contexts/test_request.py
+++ b/tests/contexts/test_request.py
@@ -224,3 +224,19 @@ def test_request_context_session_id_auto_generated():
     # Assert a session id was generated on the bound request.
     assert request_context.session_id
     assert request_context.session_id == request_context.domain.session_id
+
+# ** test: request_context_feature_id_none_when_unset
+def test_request_context_feature_id_none_when_unset():
+    '''
+    Test that feature_id is None when a request is constructed without one.
+    '''
+
+    # Create a request context without a feature id.
+    request_context = RequestContext()
+
+    # Assert the feature id proxy reads through as None.
+    assert request_context.feature_id is None
+
+    # Assert None can be written back through the proxy setter.
+    request_context.feature_id = None
+    assert request_context.feature_id is None

--- a/tiferet/contexts/core.py
+++ b/tiferet/contexts/core.py
@@ -104,6 +104,7 @@ class BaseContext(metaclass=ContextMeta):
         if context_cls is None:
             TiferetError.raise_error(
                 a.error.CONTEXT_NOT_FOUND_ID,
+                f'No context registered for domain type: {getattr(domain_cls, "__name__", domain_cls)}.',
                 domain_type=getattr(domain_cls, '__name__', str(domain_cls)),
             )
 

--- a/tiferet/contexts/request.py
+++ b/tiferet/contexts/request.py
@@ -88,24 +88,24 @@ class RequestContext(BaseContext):
 
     # * attribute: feature_id
     @property
-    def feature_id(self) -> str:
+    def feature_id(self) -> str | None:
         '''
         The identifier of the feature being executed.
 
         :return: The feature identifier, or None when unset.
-        :rtype: str
+        :rtype: str | None
         '''
 
         # Return the feature identifier from the bound request.
         return self.domain.feature_id
 
     @feature_id.setter
-    def feature_id(self, value: str):
+    def feature_id(self, value: str | None):
         '''
         Write the feature identifier through to the bound request.
 
         :param value: The feature identifier to set.
-        :type value: str
+        :type value: str | None
         '''
 
         # Write the feature identifier through to the bound request.


### PR DESCRIPTION
## Summary
Two small, unrelated correctness fixes in `tiferet/contexts/`, per the TRD in #1001.

1. `ContextMeta.for_domain` now raises `CONTEXT_NOT_FOUND` with a descriptive message naming the unregistered domain type, instead of no message at all.
2. `RequestContext.feature_id`'s getter/setter are retyped `str | None` to match the property's own docstring (`"or None when unset"`) and proto — no behavioral change, `None` was already an accepted runtime value.

## Changes
- `tiferet/contexts/core.py` — add message argument to the existing `TiferetError.raise_error` call in `BaseContext.for_domain`.
- `tiferet/contexts/request.py` — retype `feature_id` getter (`-> str | None`) and setter (`value: str | None`), updating the `:rtype:`/`:type:` docstring lines.
- `tests/contexts/test_base.py` — assert the descriptive message is present in `test_for_domain_not_found`.
- `tests/contexts/test_request.py` — add `test_request_context_feature_id_none_when_unset` covering the `None` round-trip.

## Testing
`pytest tests/contexts/test_base.py tests/contexts/test_request.py` — 20 passed.

Closes #1001

Co-Authored-By: Oz <oz-agent@warp.dev>