### PR TITLE
Catalog Data/ID Redundancy Elimination (Super-TRD #1004)

### DIFF
--- a/tests/assets/test_app.py
+++ b/tests/assets/test_app.py
@@ -4,39 +4,36 @@
 
 # ** app
 from tiferet.assets import app
-from tiferet.assets.core import create_app_service_dependency
+from tiferet.assets.core import create_app_service_dependency_data
 
 # *** tests
 
-# ** test: create_app_service_dependency_structure
-def test_create_app_service_dependency_structure():
+# ** test: create_app_service_dependency_data_structure
+def test_create_app_service_dependency_data_structure():
     '''
-    Verify create_app_service_dependency returns a dict with the expected keys.
+    Verify create_app_service_dependency_data returns a dict with the expected keys.
     '''
 
     # Create a test service dependency.
-    result = create_app_service_dependency(
-        'test_service',
+    result = create_app_service_dependency_data(
         'tiferet.repos.test',
         'TestRepository',
     )
 
     # Verify the result has all expected keys.
-    assert 'service_id' in result
     assert 'module_path' in result
     assert 'class_name' in result
     assert 'parameters' in result
 
 
-# ** test: create_app_service_dependency_default_parameters
-def test_create_app_service_dependency_default_parameters():
+# ** test: create_app_service_dependency_data_default_parameters
+def test_create_app_service_dependency_data_default_parameters():
     '''
     Verify omitting parameters yields an empty dict.
     '''
 
     # Create a dependency without explicit parameters.
-    result = create_app_service_dependency(
-        'test_service',
+    result = create_app_service_dependency_data(
         'tiferet.repos.test',
         'TestRepository',
     )

--- a/tests/assets/test_core.py
+++ b/tests/assets/test_core.py
@@ -8,15 +8,15 @@ import pytest
 # ** app
 from tiferet.assets.core import (
     create_default_cli_argument,
-    create_default_cli_command,
-    create_default_error,
-    create_default_feature,
+    create_default_cli_command_data,
+    create_default_error_data,
+    create_default_feature_data,
     create_params_schema,
     create_service_module_path,
     create_service_dependency,
-    create_service_registration,
-    create_app_service_dependency,
-    create_default_app_session,
+    create_service_registration_data,
+    create_app_service_dependency_data,
+    create_default_app_session_data,
     create_default_formatter,
     create_default_handler,
     create_default_logger,
@@ -43,34 +43,32 @@ def test_en_us_constant():
     # Verify the constant carries the expected locale.
     assert EN_US == 'en_US'
 
-# ** test: create_default_error_single_message
-def test_create_default_error_single_message():
+# ** test: create_default_error_data_single_message
+def test_create_default_error_data_single_message():
     '''
-    Verify create_default_error returns the expected structure for a single message pair.
+    Verify create_default_error_data returns the expected structure for a single message pair.
 
     :return: None
     :rtype: None
     '''
 
     # Build a default error with one message.
-    result = create_default_error(
-        'TEST_ERROR',
+    result = create_default_error_data(
         'Test Error',
         [(EN_US, 'Something went wrong: {detail}.')],
     )
 
     # Verify the top-level fields.
-    assert result['id'] == 'TEST_ERROR'
     assert result['name'] == 'Test Error'
 
     # Verify the message list shape.
     assert len(result['message']) == 1
     assert result['message'][0] == {'lang': 'en_US', 'text': 'Something went wrong: {detail}.'}
 
-# ** test: create_default_error_preserves_message_order
-def test_create_default_error_preserves_message_order():
+# ** test: create_default_error_data_preserves_message_order
+def test_create_default_error_data_preserves_message_order():
     '''
-    Verify create_default_error preserves the order of multiple message pairs.
+    Verify create_default_error_data preserves the order of multiple message pairs.
 
     :return: None
     :rtype: None
@@ -84,7 +82,7 @@ def test_create_default_error_preserves_message_order():
     ]
 
     # Build the error.
-    result = create_default_error('MULTI_LANG', 'Multi-Language Error', messages)
+    result = create_default_error_data('Multi-Language Error', messages)
 
     # Verify the messages are emitted in the supplied order.
     assert len(result['message']) == 3
@@ -92,20 +90,19 @@ def test_create_default_error_preserves_message_order():
     assert result['message'][1] == {'lang': 'fr_FR', 'text': 'Deuxième message.'}
     assert result['message'][2] == {'lang': 'de_DE', 'text': 'Dritte Nachricht.'}
 
-# ** test: create_default_error_empty_messages
-def test_create_default_error_empty_messages():
+# ** test: create_default_error_data_empty_messages
+def test_create_default_error_data_empty_messages():
     '''
-    Verify create_default_error yields an empty message list when no pairs are supplied.
+    Verify create_default_error_data yields an empty message list when no pairs are supplied.
 
     :return: None
     :rtype: None
     '''
 
     # Build an error with no messages.
-    result = create_default_error('EMPTY_ERROR', 'Empty Error', [])
+    result = create_default_error_data('Empty Error', [])
 
-    # Verify id and name are retained.
-    assert result['id'] == 'EMPTY_ERROR'
+    # Verify name is retained.
     assert result['name'] == 'Empty Error'
 
     # Verify the message list is empty.
@@ -180,10 +177,10 @@ def test_create_service_dependency_with_parameters():
     # Verify the parameters dict is preserved unchanged.
     assert result['parameters'] == {'feature_config': 'config.yml'}
 
-# ** test: create_app_service_dependency_returns_expected_shape
-def test_create_app_service_dependency_returns_expected_shape():
+# ** test: create_app_service_dependency_data_returns_expected_shape
+def test_create_app_service_dependency_data_returns_expected_shape():
     '''
-    Verify create_app_service_dependency returns a dict with the expected keys and values,
+    Verify create_app_service_dependency_data returns a dict with the expected keys and values,
     and that parameters defaults to an empty dict when omitted.
 
     :return: None
@@ -191,31 +188,28 @@ def test_create_app_service_dependency_returns_expected_shape():
     '''
 
     # Create a service dependency without explicit parameters.
-    result = create_app_service_dependency(
-        'test_service',
+    result = create_app_service_dependency_data(
         'tiferet.repos.test',
         'TestRepository',
     )
 
     # Verify the result has all expected keys and correct values.
-    assert set(result.keys()) == {'service_id', 'module_path', 'class_name', 'parameters'}
-    assert result['service_id'] == 'test_service'
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
     assert result['module_path'] == 'tiferet.repos.test'
     assert result['class_name'] == 'TestRepository'
     assert result['parameters'] == {}
 
-# ** test: create_app_service_dependency_omitting_parameters_yields_empty_dict
-def test_create_app_service_dependency_omitting_parameters_yields_empty_dict():
+# ** test: create_app_service_dependency_data_omitting_parameters_yields_empty_dict
+def test_create_app_service_dependency_data_omitting_parameters_yields_empty_dict():
     '''
-    Verify omitting parameters in create_app_service_dependency yields an empty dict, not None.
+    Verify omitting parameters in create_app_service_dependency_data yields an empty dict, not None.
 
     :return: None
     :rtype: None
     '''
 
     # Create a dependency without explicit parameters.
-    result = create_app_service_dependency(
-        'test_service',
+    result = create_app_service_dependency_data(
         'tiferet.repos.test',
         'TestRepository',
     )
@@ -224,10 +218,10 @@ def test_create_app_service_dependency_omitting_parameters_yields_empty_dict():
     assert result['parameters'] == {}
     assert result['parameters'] is not None
 
-# ** test: create_default_app_session_returns_required_fields
-def test_create_default_app_session_returns_required_fields():
+# ** test: create_default_app_session_data_returns_required_fields
+def test_create_default_app_session_data_returns_required_fields():
     '''
-    Verify create_default_app_session returns a dict with id and name; description is
+    Verify create_default_app_session_data returns a dict with name; description is
     absent when not provided.
 
     :return: None
@@ -235,25 +229,23 @@ def test_create_default_app_session_returns_required_fields():
     '''
 
     # Build a session with required fields only.
-    result = create_default_app_session('admin', 'Admin App')
+    result = create_default_app_session_data('Admin App')
 
-    # Verify id and name are present and description is absent.
-    assert result['id'] == 'admin'
+    # Verify name is present and description is absent.
     assert result['name'] == 'Admin App'
     assert 'description' not in result
 
-# ** test: create_default_app_session_includes_description_when_provided
-def test_create_default_app_session_includes_description_when_provided():
+# ** test: create_default_app_session_data_includes_description_when_provided
+def test_create_default_app_session_data_includes_description_when_provided():
     '''
-    Verify create_default_app_session includes description in the returned dict when supplied.
+    Verify create_default_app_session_data includes description in the returned dict when supplied.
 
     :return: None
     :rtype: None
     '''
 
     # Build a session with an explicit description.
-    result = create_default_app_session(
-        'admin',
+    result = create_default_app_session_data(
         'Admin App',
         'Default built-in admin application session',
     )
@@ -378,10 +370,10 @@ def test_create_default_logger_returns_required_fields():
     assert result['is_root'] is False
     assert 'description' not in result
 
-# ** test: create_default_feature_returns_required_fields
-def test_create_default_feature_returns_required_fields():
+# ** test: create_default_feature_data_returns_required_fields
+def test_create_default_feature_data_returns_required_fields():
     '''
-    Verify create_default_feature returns required fields and omits optional
+    Verify create_default_feature_data returns required fields and omits optional
     fields when description and params_schema are not provided.
 
     :return: None
@@ -389,8 +381,7 @@ def test_create_default_feature_returns_required_fields():
     '''
 
     # Call the factory with only required arguments.
-    result = create_default_feature(
-        id='test.feature',
+    result = create_default_feature_data(
         name='Test Feature',
         group_id='test',
         feature_key='feature',
@@ -398,7 +389,6 @@ def test_create_default_feature_returns_required_fields():
     )
 
     # Assert all required fields are present with correct values.
-    assert result['id'] == 'test.feature'
     assert result['name'] == 'Test Feature'
     assert result['group_id'] == 'test'
     assert result['feature_key'] == 'feature'
@@ -408,10 +398,10 @@ def test_create_default_feature_returns_required_fields():
     assert 'description' not in result
     assert 'params_schema' not in result
 
-# ** test: create_default_feature_includes_optional_fields_when_provided
-def test_create_default_feature_includes_optional_fields_when_provided():
+# ** test: create_default_feature_data_includes_optional_fields_when_provided
+def test_create_default_feature_data_includes_optional_fields_when_provided():
     '''
-    Verify create_default_feature includes description and params_schema
+    Verify create_default_feature_data includes description and params_schema
     when they are supplied.
 
     :return: None
@@ -422,8 +412,7 @@ def test_create_default_feature_includes_optional_fields_when_provided():
     schema = create_params_schema(name='str', count='int')
 
     # Call the factory with all optional arguments supplied.
-    result = create_default_feature(
-        id='test.optional',
+    result = create_default_feature_data(
         name='Test Optional',
         group_id='test',
         feature_key='optional',
@@ -458,38 +447,35 @@ def test_create_params_schema_returns_expected_dict():
         'count': {'type': 'int', 'required': True},
     }
 
-# ** test: create_service_registration_returns_expected_shape
-def test_create_service_registration_returns_expected_shape():
+# ** test: create_service_registration_data_returns_expected_shape
+def test_create_service_registration_data_returns_expected_shape():
     '''
-    Verify create_service_registration returns a dict with keys
-    ``{'id', 'module_path', 'class_name', 'parameters'}``; ``id`` matches
-    the first argument; values match inputs; and ``parameters`` defaults
-    to an empty dict when omitted.
+    Verify create_service_registration_data returns a dict with keys
+    ``{'module_path', 'class_name', 'parameters'}``; values match inputs;
+    and ``parameters`` defaults to an empty dict when omitted.
 
     :return: None
     :rtype: None
     '''
 
     # Create a service registration without explicit parameters.
-    result = create_service_registration(
-        'feature_config_repo',
+    result = create_service_registration_data(
         'tiferet.repos.feature',
         'FeatureConfigRepository',
     )
 
     # Verify all expected keys are present.
-    assert set(result.keys()) == {'id', 'module_path', 'class_name', 'parameters'}
+    assert set(result.keys()) == {'module_path', 'class_name', 'parameters'}
 
     # Verify each value matches the input.
-    assert result['id'] == 'feature_config_repo'
     assert result['module_path'] == 'tiferet.repos.feature'
     assert result['class_name'] == 'FeatureConfigRepository'
     assert result['parameters'] == {}
 
-# ** test: create_service_registration_omitting_parameters_yields_empty_dict
-def test_create_service_registration_omitting_parameters_yields_empty_dict():
+# ** test: create_service_registration_data_omitting_parameters_yields_empty_dict
+def test_create_service_registration_data_omitting_parameters_yields_empty_dict():
     '''
-    Verify omitting ``parameters`` in create_service_registration yields
+    Verify omitting ``parameters`` in create_service_registration_data yields
     an empty dict, not ``None``.
 
     :return: None
@@ -497,8 +483,7 @@ def test_create_service_registration_omitting_parameters_yields_empty_dict():
     '''
 
     # Create a registration without explicit parameters.
-    result = create_service_registration(
-        'test_service',
+    result = create_service_registration_data(
         'tiferet.repos.test',
         'TestRepository',
     )
@@ -553,10 +538,10 @@ def test_create_default_cli_argument_includes_optional_fields_when_provided():
     assert result['nargs'] == '?'
     assert result['choices'] == ['DEBUG', 'INFO', 'WARNING']
 
-# ** test: create_default_cli_command_returns_required_fields
-def test_create_default_cli_command_returns_required_fields():
+# ** test: create_default_cli_command_data_returns_required_fields
+def test_create_default_cli_command_data_returns_required_fields():
     '''
-    Verify create_default_cli_command returns a dict with ``id``, ``key``,
+    Verify create_default_cli_command_data returns a dict with ``key``,
     ``group_key``, and ``name``; ``description`` and ``arguments`` are absent
     when not provided.
 
@@ -565,25 +550,23 @@ def test_create_default_cli_command_returns_required_fields():
     '''
 
     # Call the factory with only the required arguments.
-    result = create_default_cli_command(
-        id='app.list',
+    result = create_default_cli_command_data(
         key='list',
         group_key='app',
         name='List App Interfaces',
     )
 
     # Assert required fields are present and optional fields are absent.
-    assert result['id'] == 'app.list'
     assert result['key'] == 'list'
     assert result['group_key'] == 'app'
     assert result['name'] == 'List App Interfaces'
     assert 'description' not in result
     assert 'arguments' not in result
 
-# ** test: create_default_cli_command_includes_optional_fields_when_provided
-def test_create_default_cli_command_includes_optional_fields_when_provided():
+# ** test: create_default_cli_command_data_includes_optional_fields_when_provided
+def test_create_default_cli_command_data_includes_optional_fields_when_provided():
     '''
-    Verify create_default_cli_command includes ``description`` and ``arguments``
+    Verify create_default_cli_command_data includes ``description`` and ``arguments``
     when they are supplied.
 
     :return: None
@@ -597,8 +580,7 @@ def test_create_default_cli_command_includes_optional_fields_when_provided():
     )
 
     # Call the factory with all optional arguments supplied.
-    result = create_default_cli_command(
-        id='app.get',
+    result = create_default_cli_command_data(
         key='get',
         group_key='app',
         name='Get App Interface',

--- a/tests/assets/test_error.py
+++ b/tests/assets/test_error.py
@@ -82,15 +82,18 @@ def test_tier_sizes():
     # TOML_DEFAULT_ERRORS tiers entirely.
     assert len(DEFAULT_ERRORS) == 29
 
-# ** test: every_entry_id_matches_its_key
-def test_every_entry_id_matches_its_key():
+# ** test: every_entry_omits_redundant_id
+def test_every_entry_omits_redundant_id():
     '''
-    Verify each catalog entry carries an id equal to its dict key.
+    Verify no catalog entry embeds a redundant id inside its value dict.
+
+    The id is carried solely by the dict key; ``create_default_error_data``
+    intentionally omits it from the returned definition (issue #1007).
 
     :return: None
     :rtype: None
     '''
 
-    # Verify no entry was filed under a mismatched key during the restructure.
-    for error_id, definition in DEFAULT_ERRORS.items():
-        assert definition['id'] == error_id
+    # Verify no entry restates its own key inside the value dict.
+    for definition in DEFAULT_ERRORS.values():
+        assert 'id' not in definition

--- a/tests/contexts/test_error.py
+++ b/tests/contexts/test_error.py
@@ -82,7 +82,7 @@ def error() -> Error:
     '''
 
     # Build and return the ERROR_NOT_FOUND error.
-    return Error(**DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
+    return Error(id=ERROR_NOT_FOUND_ID, **DEFAULT_ERRORS.get(ERROR_NOT_FOUND_ID))
 
 # *** tests
 

--- a/tests/events/test_error.py
+++ b/tests/events/test_error.py
@@ -60,7 +60,7 @@ def default_errors() -> List[Error]:
 
     # Return a list of default Error aggregates.
     return [
-        ErrorAggregate(**data) for data in a.DEFAULT_ERRORS.values()
+        ErrorAggregate(id=error_id, **data) for error_id, data in a.DEFAULT_ERRORS.items()
     ]
 
 # *** tests
@@ -268,7 +268,7 @@ class TestGetError(ServiceEventTestBase):
         )
 
         # Assert the result matches the expected default error.
-        expected = ErrorAggregate(**a.DEFAULT_ERRORS.get(error_id))
+        expected = ErrorAggregate(id=error_id, **a.DEFAULT_ERRORS.get(error_id))
         assert result == expected
         mock_dependencies['error_service'].get.assert_called_once_with(error_id)
 

--- a/tiferet/assets/app.py
+++ b/tiferet/assets/app.py
@@ -12,8 +12,8 @@ from typing import Any, Dict
 
 # ** app
 from .core import (
-    create_app_service_dependency,
-    create_default_app_session,
+    create_app_service_dependency_data,
+    create_default_app_session_data,
     create_service_module_path,
     TIFERET,
     TIFERET_EVENTS_PATH,
@@ -120,116 +120,100 @@ DEFAULT_APP_SERVICE_PARAMETERS = {
 
 # *** constants (sessions)
 
-# ** constant: default_admin_app_session
-DEFAULT_ADMIN_APP_SESSION = create_default_app_session(
-    TIFERET_ADMIN_ID,
+# ** constant: default_admin_app_session_data
+DEFAULT_ADMIN_APP_SESSION_DATA = create_default_app_session_data(
     'Admin App',
     description='Default built-in admin application session',
 )
 
-# ** constant: default_admin_cli_session
-DEFAULT_ADMIN_CLI_SESSION = create_default_app_session(
-    TIFERET_ADMIN_CLI_ID,
+# ** constant: default_admin_cli_session_data
+DEFAULT_ADMIN_CLI_SESSION_DATA = create_default_app_session_data(
     'Admin CLI',
     description='Built-in CLI for managing Tiferet application configurations',
 )
 
 # *** constants (services)
 
-# ** constant: di_service
-DI_SERVICE = create_app_service_dependency(
-    DI_SERVICE_ID,
+# ** constant: di_service_data
+DI_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, DI_DOMAIN_PATH),
     'DIConfigRepository',
 )
 
-# ** constant: error_service
-ERROR_SERVICE = create_app_service_dependency(
-    ERROR_SERVICE_ID,
+# ** constant: error_service_data
+ERROR_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, ERROR_DOMAIN_PATH),
     'ErrorConfigRepository',
 )
 
-# ** constant: logging_service
-LOGGING_SERVICE = create_app_service_dependency(
-    LOGGING_SERVICE_ID,
+# ** constant: logging_service_data
+LOGGING_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, LOGGING_DOMAIN_PATH),
     'LoggingConfigRepository',
 )
 
-# ** constant: feature_service
-FEATURE_SERVICE = create_app_service_dependency(
-    FEATURE_SERVICE_ID,
+# ** constant: feature_service_data
+FEATURE_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, FEATURE_DOMAIN_PATH),
     'FeatureConfigRepository',
 )
 
-# ** constant: get_error_evt
-GET_ERROR_EVT = create_app_service_dependency(
-    GET_ERROR_EVT_ID,
+# ** constant: get_error_evt_data
+GET_ERROR_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'GetError',
 )
 
-# ** constant: get_feature_evt
-GET_FEATURE_EVT = create_app_service_dependency(
-    GET_FEATURE_EVT_ID,
+# ** constant: get_feature_evt_data
+GET_FEATURE_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'GetFeature',
 )
 
-# ** constant: logging_list_all_evt
-LOGGING_LIST_ALL_EVT = create_app_service_dependency(
-    LOGGING_LIST_ALL_EVT_ID,
+# ** constant: logging_list_all_evt_data
+LOGGING_LIST_ALL_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'ListAllLoggingConfigs',
 )
 
-# ** constant: cli_service
-CLI_SERVICE = create_app_service_dependency(
-    CLI_SERVICE_ID,
+# ** constant: cli_service_data
+CLI_SERVICE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, CLI_DOMAIN_PATH),
     'CliConfigRepository',
 )
 
-# ** constant: list_commands_evt
-LIST_COMMANDS_EVT = create_app_service_dependency(
-    LIST_COMMANDS_EVT_ID,
+# ** constant: list_commands_evt_data
+LIST_COMMANDS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'ListCliCommands',
 )
 
-# ** constant: get_parent_args_evt
-GET_PARENT_ARGS_EVT = create_app_service_dependency(
-    GET_PARENT_ARGS_EVT_ID,
+# ** constant: get_parent_args_evt_data
+GET_PARENT_ARGS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'GetParentArguments',
 )
 
-# ** constant: di_list_all_configs_evt
-DI_LIST_ALL_CONFIGS_EVT = create_app_service_dependency(
-    DI_LIST_ALL_CONFIGS_EVT_ID,
+# ** constant: di_list_all_configs_evt_data
+DI_LIST_ALL_CONFIGS_EVT_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'ListAllSettings',
 )
 
-# ** constant: logging_middleware
-LOGGING_MIDDLEWARE = create_app_service_dependency(
-    LOGGING_MIDDLEWARE_ID,
+# ** constant: logging_middleware_data
+LOGGING_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'LoggingMiddleware',
 )
 
-# ** constant: timing_middleware
-TIMING_MIDDLEWARE = create_app_service_dependency(
-    TIMING_MIDDLEWARE_ID,
+# ** constant: timing_middleware_data
+TIMING_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'TimingMiddleware',
 )
 
-# ** constant: cache_middleware
-CACHE_MIDDLEWARE = create_app_service_dependency(
-    CACHE_MIDDLEWARE_ID,
+# ** constant: cache_middleware_data
+CACHE_MIDDLEWARE_DATA = create_app_service_dependency_data(
     create_service_module_path(TIFERET, TIFERET_UTILS_PATH, CORE_DOMAIN_PATH),
     'CacheMiddleware',
 )
@@ -238,20 +222,20 @@ CACHE_MIDDLEWARE = create_app_service_dependency(
 
 # ** constant: core_default_services
 CORE_DEFAULT_SERVICES: Dict[str, Dict[str, Any]] = {
-    DI_SERVICE_ID: DI_SERVICE,
-    ERROR_SERVICE_ID: ERROR_SERVICE,
-    LOGGING_SERVICE_ID: LOGGING_SERVICE,
-    FEATURE_SERVICE_ID: FEATURE_SERVICE,
-    GET_ERROR_EVT_ID: GET_ERROR_EVT,
-    GET_FEATURE_EVT_ID: GET_FEATURE_EVT,
-    LOGGING_LIST_ALL_EVT_ID: LOGGING_LIST_ALL_EVT,
-    CLI_SERVICE_ID: CLI_SERVICE,
-    LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT,
-    GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT,
-    DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT,
-    LOGGING_MIDDLEWARE_ID: LOGGING_MIDDLEWARE,
-    TIMING_MIDDLEWARE_ID: TIMING_MIDDLEWARE,
-    CACHE_MIDDLEWARE_ID: CACHE_MIDDLEWARE,
+    DI_SERVICE_ID: DI_SERVICE_DATA,
+    ERROR_SERVICE_ID: ERROR_SERVICE_DATA,
+    LOGGING_SERVICE_ID: LOGGING_SERVICE_DATA,
+    FEATURE_SERVICE_ID: FEATURE_SERVICE_DATA,
+    GET_ERROR_EVT_ID: GET_ERROR_EVT_DATA,
+    GET_FEATURE_EVT_ID: GET_FEATURE_EVT_DATA,
+    LOGGING_LIST_ALL_EVT_ID: LOGGING_LIST_ALL_EVT_DATA,
+    CLI_SERVICE_ID: CLI_SERVICE_DATA,
+    LIST_COMMANDS_EVT_ID: LIST_COMMANDS_EVT_DATA,
+    GET_PARENT_ARGS_EVT_ID: GET_PARENT_ARGS_EVT_DATA,
+    DI_LIST_ALL_CONFIGS_EVT_ID: DI_LIST_ALL_CONFIGS_EVT_DATA,
+    LOGGING_MIDDLEWARE_ID: LOGGING_MIDDLEWARE_DATA,
+    TIMING_MIDDLEWARE_ID: TIMING_MIDDLEWARE_DATA,
+    CACHE_MIDDLEWARE_ID: CACHE_MIDDLEWARE_DATA,
 }
 
 # ** constant: core_default_constants
@@ -278,6 +262,6 @@ ADMIN_DEFAULT_CONSTANTS = {
 # ** constant: core_default_app_sessions
 # Built-in session definitions seeded into the cache by build_cache.
 CORE_DEFAULT_APP_SESSIONS = {
-    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION,
-    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION,
+    TIFERET_ADMIN_ID: DEFAULT_ADMIN_APP_SESSION_DATA,
+    TIFERET_ADMIN_CLI_ID: DEFAULT_ADMIN_CLI_SESSION_DATA,
 }

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -10,7 +10,7 @@ IDs, individually named command constants, and the ADMIN_DEFAULT_COMMANDS group 
 from typing import Any, Dict, List
 
 # ** app
-from .core import create_default_cli_argument, create_default_cli_command
+from .core import create_default_cli_argument, create_default_cli_command_data
 
 # *** constants (ids)
 
@@ -136,18 +136,16 @@ LOGGING_LIST_CLI_CMD_ID = 'logging.list'
 
 # *** constants (commands)
 
-# ** constant: app_list_cli_cmd
-APP_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_LIST_CLI_CMD_ID,
+# ** constant: app_list_cli_cmd_data
+APP_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list',
     group_key='app',
     name='List App Interfaces',
     description='List all configured application interfaces.',
 )
 
-# ** constant: app_get_cli_cmd
-APP_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_GET_CLI_CMD_ID,
+# ** constant: app_get_cli_cmd_data
+APP_GET_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='get',
     group_key='app',
     name='Get App Interface',
@@ -160,9 +158,8 @@ APP_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_add_cli_cmd
-APP_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_ADD_CLI_CMD_ID,
+# ** constant: app_add_cli_cmd_data
+APP_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add',
     group_key='app',
     name='Add App Interface',
@@ -205,9 +202,8 @@ APP_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_update_cli_cmd
-APP_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_UPDATE_CLI_CMD_ID,
+# ** constant: app_update_cli_cmd_data
+APP_UPDATE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='update',
     group_key='app',
     name='Update App Interface',
@@ -228,9 +224,8 @@ APP_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_service_cli_cmd
-APP_SET_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_SET_SERVICE_CLI_CMD_ID,
+# ** constant: app_set_service_cli_cmd_data
+APP_SET_SERVICE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-service',
     group_key='app',
     name='Set App Service Dependency',
@@ -260,9 +255,8 @@ APP_SET_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_service_cli_cmd
-APP_REMOVE_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_REMOVE_SERVICE_CLI_CMD_ID,
+# ** constant: app_remove_service_cli_cmd_data
+APP_REMOVE_SERVICE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-service',
     group_key='app',
     name='Remove App Service Dependency',
@@ -279,9 +273,8 @@ APP_REMOVE_SERVICE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_set_constants_cli_cmd
-APP_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_SET_CONSTANTS_CLI_CMD_ID,
+# ** constant: app_set_constants_cli_cmd_data
+APP_SET_CONSTANTS_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-constants',
     group_key='app',
     name='Set App Constants',
@@ -299,9 +292,8 @@ APP_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: app_remove_cli_cmd
-APP_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=APP_REMOVE_CLI_CMD_ID,
+# ** constant: app_remove_cli_cmd_data
+APP_REMOVE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove',
     group_key='app',
     name='Remove App Interface',
@@ -314,18 +306,16 @@ APP_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_list_commands_cli_cmd
-CLI_LIST_COMMANDS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=CLI_LIST_COMMANDS_CLI_CMD_ID,
+# ** constant: cli_list_commands_cli_cmd_data
+CLI_LIST_COMMANDS_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list-commands',
     group_key='cli',
     name='List CLI Commands',
     description='List all configured CLI commands.',
 )
 
-# ** constant: cli_add_command_cli_cmd
-CLI_ADD_COMMAND_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=CLI_ADD_COMMAND_CLI_CMD_ID,
+# ** constant: cli_add_command_cli_cmd_data
+CLI_ADD_COMMAND_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-command',
     group_key='cli',
     name='Add CLI Command',
@@ -354,9 +344,8 @@ CLI_ADD_COMMAND_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: cli_add_argument_cli_cmd
-CLI_ADD_ARGUMENT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=CLI_ADD_ARGUMENT_CLI_CMD_ID,
+# ** constant: cli_add_argument_cli_cmd_data
+CLI_ADD_ARGUMENT_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-argument',
     group_key='cli',
     name='Add CLI Argument',
@@ -379,9 +368,8 @@ CLI_ADD_ARGUMENT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_list_cli_cmd
-ERROR_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_LIST_CLI_CMD_ID,
+# ** constant: error_list_cli_cmd_data
+ERROR_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list',
     group_key='error',
     name='List Errors',
@@ -395,9 +383,8 @@ ERROR_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_get_cli_cmd
-ERROR_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_GET_CLI_CMD_ID,
+# ** constant: error_get_cli_cmd_data
+ERROR_GET_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='get',
     group_key='error',
     name='Get Error',
@@ -410,9 +397,8 @@ ERROR_GET_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_add_cli_cmd
-ERROR_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_ADD_CLI_CMD_ID,
+# ** constant: error_add_cli_cmd_data
+ERROR_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add',
     group_key='error',
     name='Add Error',
@@ -437,9 +423,8 @@ ERROR_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_rename_cli_cmd
-ERROR_RENAME_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_RENAME_CLI_CMD_ID,
+# ** constant: error_rename_cli_cmd_data
+ERROR_RENAME_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='rename',
     group_key='error',
     name='Rename Error',
@@ -456,9 +441,8 @@ ERROR_RENAME_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_set_message_cli_cmd
-ERROR_SET_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_SET_MESSAGE_CLI_CMD_ID,
+# ** constant: error_set_message_cli_cmd_data
+ERROR_SET_MESSAGE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-message',
     group_key='error',
     name='Set Error Message',
@@ -479,9 +463,8 @@ ERROR_SET_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_message_cli_cmd
-ERROR_REMOVE_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_REMOVE_MESSAGE_CLI_CMD_ID,
+# ** constant: error_remove_message_cli_cmd_data
+ERROR_REMOVE_MESSAGE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-message',
     group_key='error',
     name='Remove Error Message',
@@ -498,9 +481,8 @@ ERROR_REMOVE_MESSAGE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: error_remove_cli_cmd
-ERROR_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=ERROR_REMOVE_CLI_CMD_ID,
+# ** constant: error_remove_cli_cmd_data
+ERROR_REMOVE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove',
     group_key='error',
     name='Remove Error',
@@ -513,9 +495,8 @@ ERROR_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_list_cli_cmd
-FEATURE_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_LIST_CLI_CMD_ID,
+# ** constant: feature_list_cli_cmd_data
+FEATURE_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list',
     group_key='feature',
     name='List Features',
@@ -528,9 +509,8 @@ FEATURE_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_add_cli_cmd
-FEATURE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_ADD_CLI_CMD_ID,
+# ** constant: feature_add_cli_cmd_data
+FEATURE_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add',
     group_key='feature',
     name='Add Feature',
@@ -555,9 +535,8 @@ FEATURE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_cli_cmd
-FEATURE_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_UPDATE_CLI_CMD_ID,
+# ** constant: feature_update_cli_cmd_data
+FEATURE_UPDATE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='update',
     group_key='feature',
     name='Update Feature',
@@ -578,9 +557,8 @@ FEATURE_UPDATE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_add_step_cli_cmd
-FEATURE_ADD_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_ADD_STEP_CLI_CMD_ID,
+# ** constant: feature_add_step_cli_cmd_data
+FEATURE_ADD_STEP_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-step',
     group_key='feature',
     name='Add Feature Step',
@@ -620,9 +598,8 @@ FEATURE_ADD_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_update_step_cli_cmd
-FEATURE_UPDATE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_UPDATE_STEP_CLI_CMD_ID,
+# ** constant: feature_update_step_cli_cmd_data
+FEATURE_UPDATE_STEP_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='update-step',
     group_key='feature',
     name='Update Feature Step',
@@ -648,9 +625,8 @@ FEATURE_UPDATE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_step_cli_cmd
-FEATURE_REMOVE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_REMOVE_STEP_CLI_CMD_ID,
+# ** constant: feature_remove_step_cli_cmd_data
+FEATURE_REMOVE_STEP_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-step',
     group_key='feature',
     name='Remove Feature Step',
@@ -668,9 +644,8 @@ FEATURE_REMOVE_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_reorder_step_cli_cmd
-FEATURE_REORDER_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_REORDER_STEP_CLI_CMD_ID,
+# ** constant: feature_reorder_step_cli_cmd_data
+FEATURE_REORDER_STEP_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='reorder-step',
     group_key='feature',
     name='Reorder Feature Step',
@@ -693,9 +668,8 @@ FEATURE_REORDER_STEP_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: feature_remove_cli_cmd
-FEATURE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=FEATURE_REMOVE_CLI_CMD_ID,
+# ** constant: feature_remove_cli_cmd_data
+FEATURE_REMOVE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove',
     group_key='feature',
     name='Remove Feature',
@@ -708,18 +682,16 @@ FEATURE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_list_cli_cmd
-SERVICE_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_LIST_CLI_CMD_ID,
+# ** constant: service_list_cli_cmd_data
+SERVICE_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list',
     group_key='service',
     name='List Services',
     description='List all DI service registrations and constants.',
 )
 
-# ** constant: service_add_cli_cmd
-SERVICE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_ADD_CLI_CMD_ID,
+# ** constant: service_add_cli_cmd_data
+SERVICE_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add',
     group_key='service',
     name='Add Service',
@@ -745,9 +717,8 @@ SERVICE_ADD_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_default_cli_cmd
-SERVICE_SET_DEFAULT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_SET_DEFAULT_CLI_CMD_ID,
+# ** constant: service_set_default_cli_cmd_data
+SERVICE_SET_DEFAULT_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-default',
     group_key='service',
     name='Set Default Service Registration',
@@ -773,9 +744,8 @@ SERVICE_SET_DEFAULT_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_dependency_cli_cmd
-SERVICE_SET_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_SET_DEPENDENCY_CLI_CMD_ID,
+# ** constant: service_set_dependency_cli_cmd_data
+SERVICE_SET_DEPENDENCY_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-dependency',
     group_key='service',
     name='Set Service Dependency',
@@ -805,9 +775,8 @@ SERVICE_SET_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_dependency_cli_cmd
-SERVICE_REMOVE_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID,
+# ** constant: service_remove_dependency_cli_cmd_data
+SERVICE_REMOVE_DEPENDENCY_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-dependency',
     group_key='service',
     name='Remove Service Dependency',
@@ -824,9 +793,8 @@ SERVICE_REMOVE_DEPENDENCY_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_set_constants_cli_cmd
-SERVICE_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_SET_CONSTANTS_CLI_CMD_ID,
+# ** constant: service_set_constants_cli_cmd_data
+SERVICE_SET_CONSTANTS_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='set-constants',
     group_key='service',
     name='Set Service Constants',
@@ -840,9 +808,8 @@ SERVICE_SET_CONSTANTS_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: service_remove_cli_cmd
-SERVICE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=SERVICE_REMOVE_CLI_CMD_ID,
+# ** constant: service_remove_cli_cmd_data
+SERVICE_REMOVE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove',
     group_key='service',
     name='Remove Service',
@@ -855,9 +822,8 @@ SERVICE_REMOVE_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_formatter_cli_cmd
-LOGGING_ADD_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_ADD_FORMATTER_CLI_CMD_ID,
+# ** constant: logging_add_formatter_cli_cmd_data
+LOGGING_ADD_FORMATTER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-formatter',
     group_key='logging',
     name='Add Formatter',
@@ -886,9 +852,8 @@ LOGGING_ADD_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_formatter_cli_cmd
-LOGGING_REMOVE_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_REMOVE_FORMATTER_CLI_CMD_ID,
+# ** constant: logging_remove_formatter_cli_cmd_data
+LOGGING_REMOVE_FORMATTER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-formatter',
     group_key='logging',
     name='Remove Formatter',
@@ -901,9 +866,8 @@ LOGGING_REMOVE_FORMATTER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_handler_cli_cmd
-LOGGING_ADD_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_ADD_HANDLER_CLI_CMD_ID,
+# ** constant: logging_add_handler_cli_cmd_data
+LOGGING_ADD_HANDLER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-handler',
     group_key='logging',
     name='Add Handler',
@@ -949,9 +913,8 @@ LOGGING_ADD_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_handler_cli_cmd
-LOGGING_REMOVE_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_REMOVE_HANDLER_CLI_CMD_ID,
+# ** constant: logging_remove_handler_cli_cmd_data
+LOGGING_REMOVE_HANDLER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-handler',
     group_key='logging',
     name='Remove Handler',
@@ -964,9 +927,8 @@ LOGGING_REMOVE_HANDLER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_add_logger_cli_cmd
-LOGGING_ADD_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_ADD_LOGGER_CLI_CMD_ID,
+# ** constant: logging_add_logger_cli_cmd_data
+LOGGING_ADD_LOGGER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='add-logger',
     group_key='logging',
     name='Add Logger',
@@ -1001,9 +963,8 @@ LOGGING_ADD_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_remove_logger_cli_cmd
-LOGGING_REMOVE_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_REMOVE_LOGGER_CLI_CMD_ID,
+# ** constant: logging_remove_logger_cli_cmd_data
+LOGGING_REMOVE_LOGGER_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='remove-logger',
     group_key='logging',
     name='Remove Logger',
@@ -1016,9 +977,8 @@ LOGGING_REMOVE_LOGGER_CLI_CMD: Dict[str, Any] = create_default_cli_command(
     ],
 )
 
-# ** constant: logging_list_cli_cmd
-LOGGING_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
-    id=LOGGING_LIST_CLI_CMD_ID,
+# ** constant: logging_list_cli_cmd_data
+LOGGING_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
     key='list',
     group_key='logging',
     name='List Logging Configs',
@@ -1029,44 +989,44 @@ LOGGING_LIST_CLI_CMD: Dict[str, Any] = create_default_cli_command(
 
 # ** constant: admin_default_commands
 ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
-    APP_LIST_CLI_CMD_ID: APP_LIST_CLI_CMD,
-    APP_GET_CLI_CMD_ID: APP_GET_CLI_CMD,
-    APP_ADD_CLI_CMD_ID: APP_ADD_CLI_CMD,
-    APP_UPDATE_CLI_CMD_ID: APP_UPDATE_CLI_CMD,
-    APP_SET_SERVICE_CLI_CMD_ID: APP_SET_SERVICE_CLI_CMD,
-    APP_REMOVE_SERVICE_CLI_CMD_ID: APP_REMOVE_SERVICE_CLI_CMD,
-    APP_SET_CONSTANTS_CLI_CMD_ID: APP_SET_CONSTANTS_CLI_CMD,
-    APP_REMOVE_CLI_CMD_ID: APP_REMOVE_CLI_CMD,
-    CLI_LIST_COMMANDS_CLI_CMD_ID: CLI_LIST_COMMANDS_CLI_CMD,
-    CLI_ADD_COMMAND_CLI_CMD_ID: CLI_ADD_COMMAND_CLI_CMD,
-    CLI_ADD_ARGUMENT_CLI_CMD_ID: CLI_ADD_ARGUMENT_CLI_CMD,
-    ERROR_LIST_CLI_CMD_ID: ERROR_LIST_CLI_CMD,
-    ERROR_GET_CLI_CMD_ID: ERROR_GET_CLI_CMD,
-    ERROR_ADD_CLI_CMD_ID: ERROR_ADD_CLI_CMD,
-    ERROR_RENAME_CLI_CMD_ID: ERROR_RENAME_CLI_CMD,
-    ERROR_SET_MESSAGE_CLI_CMD_ID: ERROR_SET_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_MESSAGE_CLI_CMD_ID: ERROR_REMOVE_MESSAGE_CLI_CMD,
-    ERROR_REMOVE_CLI_CMD_ID: ERROR_REMOVE_CLI_CMD,
-    FEATURE_LIST_CLI_CMD_ID: FEATURE_LIST_CLI_CMD,
-    FEATURE_ADD_CLI_CMD_ID: FEATURE_ADD_CLI_CMD,
-    FEATURE_UPDATE_CLI_CMD_ID: FEATURE_UPDATE_CLI_CMD,
-    FEATURE_ADD_STEP_CLI_CMD_ID: FEATURE_ADD_STEP_CLI_CMD,
-    FEATURE_UPDATE_STEP_CLI_CMD_ID: FEATURE_UPDATE_STEP_CLI_CMD,
-    FEATURE_REMOVE_STEP_CLI_CMD_ID: FEATURE_REMOVE_STEP_CLI_CMD,
-    FEATURE_REORDER_STEP_CLI_CMD_ID: FEATURE_REORDER_STEP_CLI_CMD,
-    FEATURE_REMOVE_CLI_CMD_ID: FEATURE_REMOVE_CLI_CMD,
-    SERVICE_LIST_CLI_CMD_ID: SERVICE_LIST_CLI_CMD,
-    SERVICE_ADD_CLI_CMD_ID: SERVICE_ADD_CLI_CMD,
-    SERVICE_SET_DEFAULT_CLI_CMD_ID: SERVICE_SET_DEFAULT_CLI_CMD,
-    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD,
-    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD,
-    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD,
-    SERVICE_REMOVE_CLI_CMD_ID: SERVICE_REMOVE_CLI_CMD,
-    LOGGING_ADD_FORMATTER_CLI_CMD_ID: LOGGING_ADD_FORMATTER_CLI_CMD,
-    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD,
-    LOGGING_ADD_HANDLER_CLI_CMD_ID: LOGGING_ADD_HANDLER_CLI_CMD,
-    LOGGING_REMOVE_HANDLER_CLI_CMD_ID: LOGGING_REMOVE_HANDLER_CLI_CMD,
-    LOGGING_ADD_LOGGER_CLI_CMD_ID: LOGGING_ADD_LOGGER_CLI_CMD,
-    LOGGING_REMOVE_LOGGER_CLI_CMD_ID: LOGGING_REMOVE_LOGGER_CLI_CMD,
-    LOGGING_LIST_CLI_CMD_ID: LOGGING_LIST_CLI_CMD,
+    APP_LIST_CLI_CMD_ID: APP_LIST_CLI_CMD_DATA,
+    APP_GET_CLI_CMD_ID: APP_GET_CLI_CMD_DATA,
+    APP_ADD_CLI_CMD_ID: APP_ADD_CLI_CMD_DATA,
+    APP_UPDATE_CLI_CMD_ID: APP_UPDATE_CLI_CMD_DATA,
+    APP_SET_SERVICE_CLI_CMD_ID: APP_SET_SERVICE_CLI_CMD_DATA,
+    APP_REMOVE_SERVICE_CLI_CMD_ID: APP_REMOVE_SERVICE_CLI_CMD_DATA,
+    APP_SET_CONSTANTS_CLI_CMD_ID: APP_SET_CONSTANTS_CLI_CMD_DATA,
+    APP_REMOVE_CLI_CMD_ID: APP_REMOVE_CLI_CMD_DATA,
+    CLI_LIST_COMMANDS_CLI_CMD_ID: CLI_LIST_COMMANDS_CLI_CMD_DATA,
+    CLI_ADD_COMMAND_CLI_CMD_ID: CLI_ADD_COMMAND_CLI_CMD_DATA,
+    CLI_ADD_ARGUMENT_CLI_CMD_ID: CLI_ADD_ARGUMENT_CLI_CMD_DATA,
+    ERROR_LIST_CLI_CMD_ID: ERROR_LIST_CLI_CMD_DATA,
+    ERROR_GET_CLI_CMD_ID: ERROR_GET_CLI_CMD_DATA,
+    ERROR_ADD_CLI_CMD_ID: ERROR_ADD_CLI_CMD_DATA,
+    ERROR_RENAME_CLI_CMD_ID: ERROR_RENAME_CLI_CMD_DATA,
+    ERROR_SET_MESSAGE_CLI_CMD_ID: ERROR_SET_MESSAGE_CLI_CMD_DATA,
+    ERROR_REMOVE_MESSAGE_CLI_CMD_ID: ERROR_REMOVE_MESSAGE_CLI_CMD_DATA,
+    ERROR_REMOVE_CLI_CMD_ID: ERROR_REMOVE_CLI_CMD_DATA,
+    FEATURE_LIST_CLI_CMD_ID: FEATURE_LIST_CLI_CMD_DATA,
+    FEATURE_ADD_CLI_CMD_ID: FEATURE_ADD_CLI_CMD_DATA,
+    FEATURE_UPDATE_CLI_CMD_ID: FEATURE_UPDATE_CLI_CMD_DATA,
+    FEATURE_ADD_STEP_CLI_CMD_ID: FEATURE_ADD_STEP_CLI_CMD_DATA,
+    FEATURE_UPDATE_STEP_CLI_CMD_ID: FEATURE_UPDATE_STEP_CLI_CMD_DATA,
+    FEATURE_REMOVE_STEP_CLI_CMD_ID: FEATURE_REMOVE_STEP_CLI_CMD_DATA,
+    FEATURE_REORDER_STEP_CLI_CMD_ID: FEATURE_REORDER_STEP_CLI_CMD_DATA,
+    FEATURE_REMOVE_CLI_CMD_ID: FEATURE_REMOVE_CLI_CMD_DATA,
+    SERVICE_LIST_CLI_CMD_ID: SERVICE_LIST_CLI_CMD_DATA,
+    SERVICE_ADD_CLI_CMD_ID: SERVICE_ADD_CLI_CMD_DATA,
+    SERVICE_SET_DEFAULT_CLI_CMD_ID: SERVICE_SET_DEFAULT_CLI_CMD_DATA,
+    SERVICE_SET_DEPENDENCY_CLI_CMD_ID: SERVICE_SET_DEPENDENCY_CLI_CMD_DATA,
+    SERVICE_REMOVE_DEPENDENCY_CLI_CMD_ID: SERVICE_REMOVE_DEPENDENCY_CLI_CMD_DATA,
+    SERVICE_SET_CONSTANTS_CLI_CMD_ID: SERVICE_SET_CONSTANTS_CLI_CMD_DATA,
+    SERVICE_REMOVE_CLI_CMD_ID: SERVICE_REMOVE_CLI_CMD_DATA,
+    LOGGING_ADD_FORMATTER_CLI_CMD_ID: LOGGING_ADD_FORMATTER_CLI_CMD_DATA,
+    LOGGING_REMOVE_FORMATTER_CLI_CMD_ID: LOGGING_REMOVE_FORMATTER_CLI_CMD_DATA,
+    LOGGING_ADD_HANDLER_CLI_CMD_ID: LOGGING_ADD_HANDLER_CLI_CMD_DATA,
+    LOGGING_REMOVE_HANDLER_CLI_CMD_ID: LOGGING_REMOVE_HANDLER_CLI_CMD_DATA,
+    LOGGING_ADD_LOGGER_CLI_CMD_ID: LOGGING_ADD_LOGGER_CLI_CMD_DATA,
+    LOGGING_REMOVE_LOGGER_CLI_CMD_ID: LOGGING_REMOVE_LOGGER_CLI_CMD_DATA,
+    LOGGING_LIST_CLI_CMD_ID: LOGGING_LIST_CLI_CMD_DATA,
 }

--- a/tiferet/assets/core.py
+++ b/tiferet/assets/core.py
@@ -50,69 +50,31 @@ CORE_DOMAIN_PATH = 'core'
 
 # *** functions
 
-# ** function: create_default_feature
-def create_default_feature(id: str,
+# ** function: create_default_error_data
+def create_default_error_data(
         name: str,
-        group_id: str,
-        feature_key: str,
-        steps: List[Dict[str, Any]],
-        description: str = None,
-        params_schema: Dict[str, Any] = None) -> Dict[str, Any]:
+        messages: List[Tuple[str, str]],
+    ) -> Dict[str, Any]:
     '''
-    Build a default feature definition dictionary.
+    Build a default error definition dictionary.
 
-    :param id: The unique feature identifier.
-    :type id: str
-    :param name: The human-readable feature name.
+    The identifier is intentionally not a parameter here: the returned dict
+    is always stored under its owning ``*_ID`` constant as a group-dict key,
+    so embedding the id a second time inside the value would restate it.
+
+    :param name: The human-readable error name.
     :type name: str
-    :param group_id: The feature group identifier.
-    :type group_id: str
-    :param feature_key: The feature key within the group.
-    :type feature_key: str
-    :param steps: Ordered list of feature step dicts.
-    :type steps: List[Dict[str, Any]]
-    :param description: Optional feature description.
-    :type description: str
-    :param params_schema: Optional parameter schema dict.
-    :type params_schema: Dict[str, Any]
-    :return: The feature definition dictionary.
+    :param messages: Ordered (lang, text) message pairs.
+    :type messages: List[Tuple[str, str]]
+    :return: The default error definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
-    # Assemble the base feature definition.
-    feature = {
-        'id': id,
+    # Assemble and return the default error definition dictionary.
+    return {
         'name': name,
-        'group_id': group_id,
-        'feature_key': feature_key,
-        'steps': steps,
+        'message': [{'lang': lang, 'text': text} for lang, text in messages],
     }
-
-    # Add optional fields when provided.
-    if description is not None:
-        feature['description'] = description
-    if params_schema is not None:
-        feature['params_schema'] = params_schema
-
-    # Return the assembled feature definition.
-    return feature
-
-# ** function: create_params_schema
-def create_params_schema(**params: Any) -> Dict[str, Any]:
-    '''
-    Build a parameter schema dictionary from keyword arguments.
-
-    Each keyword argument names one expected request parameter; the value
-    is either a plain type string or a parameter-spec dict.
-
-    :param params: Named parameter specifications.
-    :type params: Any
-    :return: The assembled parameter schema dict.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Return the assembled parameter schema dict.
-    return dict(params)
 
 # ** function: create_service_module_path
 def create_service_module_path(app_base_path: str,
@@ -158,146 +120,8 @@ def create_service_dependency(module_path: str,
         'parameters': parameters or {},
     }
 
-# ** function: create_service_registration
-def create_service_registration(id: str,
-        module_path: str,
-        class_name: str,
-        parameters: Dict[str, Any] = None) -> Dict[str, Any]:
-    '''
-    Build a service registration definition dictionary.
-
-    :param id: The unique service registration identifier.
-    :type id: str
-    :param module_path: The module path of the service implementation.
-    :type module_path: str
-    :param class_name: The class name of the service implementation.
-    :type class_name: str
-    :param parameters: Optional DI parameters for the registration.
-    :type parameters: Dict[str, Any]
-    :return: The service registration definition dictionary.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Assemble and return the service registration definition dictionary.
-    return {'id': id, **create_service_dependency(module_path, class_name, parameters)}
-
-# ** function: create_default_cli_argument
-def create_default_cli_argument(name_or_flags: List[str],
-        description: str = None,
-        type: str = None,
-        default: Any = None,
-        required: bool = None,
-        nargs: str = None,
-        choices: List[str] = None) -> Dict[str, Any]:
-    '''
-    Build a default CLI argument definition dictionary.
-
-    :param name_or_flags: List of argument names or option strings.
-    :type name_or_flags: List[str]
-    :param description: Optional argument description.
-    :type description: str
-    :param type: Optional argument type string ('str', 'int', 'float', 'bool',
-        'json', 'list', or 'dict').
-    :type type: str
-    :param default: Optional default value for the argument.
-    :type default: Any
-    :param required: Optional flag indicating whether the argument is required.
-    :type required: bool
-    :param nargs: Optional number-of-arguments specifier. For 'list' and 'dict'
-        types this defaults to '*' automatically; only set when a different
-        count is required.
-    :type nargs: str
-    :param choices: Optional list of allowed values.
-    :type choices: List[str]
-    :return: The argument definition dictionary.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Assemble the base argument definition.
-    argument = {'name_or_flags': name_or_flags}
-
-    # Add optional fields when provided.
-    if description is not None:
-        argument['description'] = description
-    if type is not None:
-        argument['type'] = type
-    if default is not None:
-        argument['default'] = default
-    if required is not None:
-        argument['required'] = required
-    if nargs is not None:
-        argument['nargs'] = nargs
-    if choices is not None:
-        argument['choices'] = choices
-
-    # Return the assembled argument definition.
-    return argument
-
-# ** function: create_default_cli_command
-def create_default_cli_command(id: str,
-        key: str,
-        group_key: str,
-        name: str,
-        description: str = None,
-        arguments: List[Dict[str, Any]] = None) -> Dict[str, Any]:
-    '''
-    Build a default CLI command definition dictionary.
-
-    :param id: The unique command identifier.
-    :type id: str
-    :param key: The command key used in the CLI.
-    :type key: str
-    :param group_key: The group key this command belongs to.
-    :type group_key: str
-    :param name: The human-readable command name.
-    :type name: str
-    :param description: Optional command description.
-    :type description: str
-    :param arguments: Optional list of argument definition dicts.
-    :type arguments: List[Dict[str, Any]]
-    :return: The command definition dictionary.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Assemble the base command definition.
-    command = {'id': id, 'key': key, 'group_key': group_key, 'name': name}
-
-    # Add optional fields when provided.
-    if description is not None:
-        command['description'] = description
-    if arguments:
-        command['arguments'] = arguments
-
-    # Return the assembled command definition.
-    return command
-
-# ** function: create_default_error
-def create_default_error(id: str,
-        name: str,
-        messages: List[Tuple[str, str]]) -> Dict[str, Any]:
-    '''
-    Build a default error definition dictionary.
-
-    :param id: The unique identifier of the error.
-    :type id: str
-    :param name: The human-readable error name.
-    :type name: str
-    :param messages: Ordered (lang, text) message pairs.
-    :type messages: List[Tuple[str, str]]
-    :return: The default error definition.
-    :rtype: Dict[str, Any]
-    '''
-
-    # Assemble and return the default error definition dictionary.
-    return {
-        'id': id,
-        'name': name,
-        'message': [{'lang': lang, 'text': text} for lang, text in messages],
-    }
-
-# ** function: create_app_service_dependency
-def create_app_service_dependency(
-        service_id: str,
+# ** function: create_app_service_dependency_data
+def create_app_service_dependency_data(
         module_path: str,
         class_name: str,
         parameters: Dict[str, Any] = None,
@@ -305,43 +129,137 @@ def create_app_service_dependency(
     '''
     Build a default app service dependency definition dictionary.
 
-    :param service_id: The unique service identifier for the dependency.
-    :type service_id: str
+    The ``service_id`` is intentionally not a parameter here: the returned
+    dict is always stored under its owning ``*_ID`` constant as a group-dict
+    key, so embedding the id a second time inside the value would restate it.
+
     :param module_path: The module path of the service implementation.
     :type module_path: str
     :param class_name: The class name of the service implementation.
     :type class_name: str
     :param parameters: Optional DI parameters for the dependency.
     :type parameters: Dict[str, Any]
-    :return: The default app service dependency definition.
+    :return: The default app service dependency definition, without its id.
     :rtype: Dict[str, Any]
     '''
 
-    # Assemble and return the default app service dependency definition dictionary.
-    return {
-        'service_id': service_id,
-        **create_service_dependency(module_path, class_name, parameters),
+    # Assemble and return the app service dependency definition dictionary.
+    return create_service_dependency(module_path, class_name, parameters)
+
+# ** function: create_service_registration_data
+def create_service_registration_data(
+        module_path: str,
+        class_name: str,
+        parameters: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default service registration definition dictionary.
+
+    The identifier is intentionally not a parameter here: the returned dict
+    is always stored under its owning ``*_ID`` constant as a group-dict key,
+    so embedding the id a second time inside the value would restate it.
+
+    :param module_path: The module path of the service implementation.
+    :type module_path: str
+    :param class_name: The class name of the service implementation.
+    :type class_name: str
+    :param parameters: Optional DI parameters for the registration.
+    :type parameters: Dict[str, Any]
+    :return: The default service registration definition, without its id.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble and return the service registration definition dictionary.
+    return create_service_dependency(module_path, class_name, parameters)
+
+# ** function: create_default_feature_data
+def create_default_feature_data(
+        name: str,
+        group_id: str,
+        feature_key: str,
+        steps: List[Dict[str, Any]],
+        description: str = None,
+        params_schema: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default feature definition dictionary.
+
+    The identifier is intentionally not a parameter here: the returned dict
+    is always stored under its owning ``*_ID`` constant as a group-dict key,
+    so embedding the id a second time inside the value would restate it.
+
+    :param name: The human-readable feature name.
+    :type name: str
+    :param group_id: The feature group identifier.
+    :type group_id: str
+    :param feature_key: The feature key within the group.
+    :type feature_key: str
+    :param steps: Ordered list of feature step dicts.
+    :type steps: List[Dict[str, Any]]
+    :param description: Optional feature description.
+    :type description: str
+    :param params_schema: Optional parameter schema dict.
+    :type params_schema: Dict[str, Any]
+    :return: The feature definition dictionary, without its id.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base feature definition.
+    feature = {
+        'name': name,
+        'group_id': group_id,
+        'feature_key': feature_key,
+        'steps': steps,
     }
 
-# ** function: create_default_app_session
-def create_default_app_session(id: str,
+    # Add optional fields when provided.
+    if description is not None:
+        feature['description'] = description
+    if params_schema is not None:
+        feature['params_schema'] = params_schema
+
+    # Return the assembled feature definition.
+    return feature
+
+# ** function: create_params_schema
+def create_params_schema(**params: Any) -> Dict[str, Any]:
+    '''
+    Build a parameter schema dictionary from keyword arguments.
+
+    Each keyword argument names one expected request parameter; the value
+    is either a plain type string or a parameter-spec dict.
+
+    :param params: Named parameter specifications.
+    :type params: Any
+    :return: The assembled parameter schema dict.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Return the assembled parameter schema dict.
+    return dict(params)
+
+# ** function: create_default_app_session_data
+def create_default_app_session_data(
         name: str,
-        description: str = None) -> Dict[str, Any]:
+        description: str = None,
+    ) -> Dict[str, Any]:
     '''
     Build a default app session definition dictionary.
 
-    :param id: The unique session identifier.
-    :type id: str
+    The identifier is intentionally not a parameter here: the returned dict
+    is always stored under its owning ``*_ID`` constant as a group-dict key,
+    so embedding the id a second time inside the value would restate it.
+
     :param name: The human-readable session name.
     :type name: str
     :param description: Optional session description.
     :type description: str
-    :return: The app session definition dictionary.
+    :return: The app session definition dictionary, without its id.
     :rtype: Dict[str, Any]
     '''
 
     # Assemble the base session definition.
-    session = {'id': id, 'name': name}
+    session = {'name': name}
 
     # Add the optional description when provided.
     if description is not None:
@@ -486,6 +404,99 @@ def create_default_logger(id: str,
 
     # Return the assembled logger definition.
     return logger
+
+# ** function: create_default_cli_argument
+def create_default_cli_argument(name_or_flags: List[str],
+        description: str = None,
+        type: str = None,
+        default: Any = None,
+        required: bool = None,
+        nargs: str = None,
+        choices: List[str] = None) -> Dict[str, Any]:
+    '''
+    Build a default CLI argument definition dictionary.
+
+    :param name_or_flags: List of argument names or option strings.
+    :type name_or_flags: List[str]
+    :param description: Optional argument description.
+    :type description: str
+    :param type: Optional argument type string ('str', 'int', 'float', 'bool',
+        'json', 'list', or 'dict').
+    :type type: str
+    :param default: Optional default value for the argument.
+    :type default: Any
+    :param required: Optional flag indicating whether the argument is required.
+    :type required: bool
+    :param nargs: Optional number-of-arguments specifier. For 'list' and 'dict'
+        types this defaults to '*' automatically; only set when a different
+        count is required.
+    :type nargs: str
+    :param choices: Optional list of allowed values.
+    :type choices: List[str]
+    :return: The argument definition dictionary.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base argument definition.
+    argument = {'name_or_flags': name_or_flags}
+
+    # Add optional fields when provided.
+    if description is not None:
+        argument['description'] = description
+    if type is not None:
+        argument['type'] = type
+    if default is not None:
+        argument['default'] = default
+    if required is not None:
+        argument['required'] = required
+    if nargs is not None:
+        argument['nargs'] = nargs
+    if choices is not None:
+        argument['choices'] = choices
+
+    # Return the assembled argument definition.
+    return argument
+
+# ** function: create_default_cli_command_data
+def create_default_cli_command_data(
+        key: str,
+        group_key: str,
+        name: str,
+        description: str = None,
+        arguments: List[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+    '''
+    Build a default CLI command definition dictionary.
+
+    The identifier is intentionally not a parameter here: the returned dict
+    is always stored under its owning ``*_ID`` constant as a group-dict key,
+    so embedding the id a second time inside the value would restate it.
+
+    :param key: The command key used in the CLI.
+    :type key: str
+    :param group_key: The group key this command belongs to.
+    :type group_key: str
+    :param name: The human-readable command name.
+    :type name: str
+    :param description: Optional command description.
+    :type description: str
+    :param arguments: Optional list of argument definition dicts.
+    :type arguments: List[Dict[str, Any]]
+    :return: The command definition dictionary, without its id.
+    :rtype: Dict[str, Any]
+    '''
+
+    # Assemble the base command definition.
+    command = {'key': key, 'group_key': group_key, 'name': name}
+
+    # Add optional fields when provided.
+    if description is not None:
+        command['description'] = description
+    if arguments:
+        command['arguments'] = arguments
+
+    # Return the assembled command definition.
+    return command
 
 # *** classes
 

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -4,7 +4,7 @@ Three-section catalog for the built-in Tiferet CLI service registrations.
 Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 37 individually named service ID string constants.
 - ``constants (services)`` — 37 individually named service registration
-  dicts, each built via ``create_service_registration``.
+  dicts, each built via ``create_service_registration_data``.
 - ``constants (groups)`` — the ``DEFAULT_ADMIN_SERVICES`` catalog dict
   keyed by ID constants.
 """
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 # ** app
 from .core import (
-    create_service_registration,
+    create_service_registration_data,
     create_service_module_path,
     TIFERET,
     TIFERET_EVENTS_PATH,
@@ -144,261 +144,224 @@ REMOVE_LOGGER_EVT_ID = 'remove_logger_evt'
 
 # *** constants (services)
 
-# ** constant: app_service
-APP_SERVICE = create_service_registration(
-    APP_SERVICE_ID,
+# ** constant: app_service_data
+APP_SERVICE_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_REPOS_PATH, APP_DOMAIN_PATH),
     'AppConfigRepository',
 )
 
-# ** constant: add_feature_evt
-ADD_FEATURE_EVT = create_service_registration(
-    ADD_FEATURE_EVT_ID,
+# ** constant: add_feature_evt_data
+ADD_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeature',
 )
 
-# ** constant: list_features_evt
-LIST_FEATURES_EVT = create_service_registration(
-    LIST_FEATURES_EVT_ID,
+# ** constant: list_features_evt_data
+LIST_FEATURES_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ListFeatures',
 )
 
-# ** constant: remove_feature_evt
-REMOVE_FEATURE_EVT = create_service_registration(
-    REMOVE_FEATURE_EVT_ID,
+# ** constant: remove_feature_evt_data
+REMOVE_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeature',
 )
 
-# ** constant: update_feature_evt
-UPDATE_FEATURE_EVT = create_service_registration(
-    UPDATE_FEATURE_EVT_ID,
+# ** constant: update_feature_evt_data
+UPDATE_FEATURE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeature',
 )
 
-# ** constant: add_feature_step_evt
-ADD_FEATURE_STEP_EVT = create_service_registration(
-    ADD_FEATURE_STEP_EVT_ID,
+# ** constant: add_feature_step_evt_data
+ADD_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'AddFeatureStep',
 )
 
-# ** constant: update_feature_step_evt
-UPDATE_FEATURE_STEP_EVT = create_service_registration(
-    UPDATE_FEATURE_STEP_EVT_ID,
+# ** constant: update_feature_step_evt_data
+UPDATE_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'UpdateFeatureStep',
 )
 
-# ** constant: remove_feature_step_evt
-REMOVE_FEATURE_STEP_EVT = create_service_registration(
-    REMOVE_FEATURE_STEP_EVT_ID,
+# ** constant: remove_feature_step_evt_data
+REMOVE_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'RemoveFeatureStep',
 )
 
-# ** constant: reorder_feature_step_evt
-REORDER_FEATURE_STEP_EVT = create_service_registration(
-    REORDER_FEATURE_STEP_EVT_ID,
+# ** constant: reorder_feature_step_evt_data
+REORDER_FEATURE_STEP_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, FEATURE_DOMAIN_PATH),
     'ReorderFeatureStep',
 )
 
-# ** constant: add_error_evt
-ADD_ERROR_EVT = create_service_registration(
-    ADD_ERROR_EVT_ID,
+# ** constant: add_error_evt_data
+ADD_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'AddError',
 )
 
-# ** constant: list_errors_evt
-LIST_ERRORS_EVT = create_service_registration(
-    LIST_ERRORS_EVT_ID,
+# ** constant: list_errors_evt_data
+LIST_ERRORS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'ListErrors',
 )
 
-# ** constant: rename_error_evt
-RENAME_ERROR_EVT = create_service_registration(
-    RENAME_ERROR_EVT_ID,
+# ** constant: rename_error_evt_data
+RENAME_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RenameError',
 )
 
-# ** constant: set_error_message_evt
-SET_ERROR_MESSAGE_EVT = create_service_registration(
-    SET_ERROR_MESSAGE_EVT_ID,
+# ** constant: set_error_message_evt_data
+SET_ERROR_MESSAGE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'SetErrorMessage',
 )
 
-# ** constant: remove_error_message_evt
-REMOVE_ERROR_MESSAGE_EVT = create_service_registration(
-    REMOVE_ERROR_MESSAGE_EVT_ID,
+# ** constant: remove_error_message_evt_data
+REMOVE_ERROR_MESSAGE_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveErrorMessage',
 )
 
-# ** constant: remove_error_evt
-REMOVE_ERROR_EVT = create_service_registration(
-    REMOVE_ERROR_EVT_ID,
+# ** constant: remove_error_evt_data
+REMOVE_ERROR_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, ERROR_DOMAIN_PATH),
     'RemoveError',
 )
 
-# ** constant: add_service_registration_evt
-ADD_SERVICE_REGISTRATION_EVT = create_service_registration(
-    ADD_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: add_service_registration_evt_data
+ADD_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'AddServiceRegistration',
 )
 
-# ** constant: set_default_service_registration_evt
-SET_DEFAULT_SERVICE_REGISTRATION_EVT = create_service_registration(
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: set_default_service_registration_evt_data
+SET_DEFAULT_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetDefaultServiceRegistration',
 )
 
-# ** constant: set_di_service_dependency_evt
-SET_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: set_di_service_dependency_evt_data
+SET_DI_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
-# ** constant: remove_di_service_dependency_evt
-REMOVE_DI_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: remove_di_service_dependency_evt_data
+REMOVE_DI_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
-# ** constant: remove_service_registration_evt
-REMOVE_SERVICE_REGISTRATION_EVT = create_service_registration(
-    REMOVE_SERVICE_REGISTRATION_EVT_ID,
+# ** constant: remove_service_registration_evt_data
+REMOVE_SERVICE_REGISTRATION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'RemoveServiceRegistration',
 )
 
-# ** constant: set_service_constants_evt
-SET_SERVICE_CONSTANTS_EVT = create_service_registration(
-    SET_SERVICE_CONSTANTS_EVT_ID,
+# ** constant: set_service_constants_evt_data
+SET_SERVICE_CONSTANTS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, DI_DOMAIN_PATH),
     'SetServiceConstants',
 )
 
-# ** constant: add_app_session_evt
-ADD_APP_SESSION_EVT = create_service_registration(
-    ADD_APP_SESSION_EVT_ID,
+# ** constant: add_app_session_evt_data
+ADD_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'AddAppSession',
 )
 
-# ** constant: get_app_session_evt
-GET_APP_SESSION_EVT = create_service_registration(
-    GET_APP_SESSION_EVT_ID,
+# ** constant: get_app_session_evt_data
+GET_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'GetAppSession',
 )
 
-# ** constant: update_app_session_evt
-UPDATE_APP_SESSION_EVT = create_service_registration(
-    UPDATE_APP_SESSION_EVT_ID,
+# ** constant: update_app_session_evt_data
+UPDATE_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'UpdateAppSession',
 )
 
-# ** constant: set_app_constants_evt
-SET_APP_CONSTANTS_EVT = create_service_registration(
-    SET_APP_CONSTANTS_EVT_ID,
+# ** constant: set_app_constants_evt_data
+SET_APP_CONSTANTS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetAppConstants',
 )
 
-# ** constant: list_app_sessions_evt
-LIST_APP_SESSIONS_EVT = create_service_registration(
-    LIST_APP_SESSIONS_EVT_ID,
+# ** constant: list_app_sessions_evt_data
+LIST_APP_SESSIONS_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'ListAppSessions',
 )
 
-# ** constant: set_app_service_dependency_evt
-SET_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: set_app_service_dependency_evt_data
+SET_APP_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'SetServiceDependency',
 )
 
-# ** constant: remove_app_service_dependency_evt
-REMOVE_APP_SERVICE_DEPENDENCY_EVT = create_service_registration(
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID,
+# ** constant: remove_app_service_dependency_evt_data
+REMOVE_APP_SERVICE_DEPENDENCY_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveServiceDependency',
 )
 
-# ** constant: remove_app_session_evt
-REMOVE_APP_SESSION_EVT = create_service_registration(
-    REMOVE_APP_SESSION_EVT_ID,
+# ** constant: remove_app_session_evt_data
+REMOVE_APP_SESSION_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, APP_DOMAIN_PATH),
     'RemoveAppSession',
 )
 
-# ** constant: add_cli_command_evt
-ADD_CLI_COMMAND_EVT = create_service_registration(
-    ADD_CLI_COMMAND_EVT_ID,
+# ** constant: add_cli_command_evt_data
+ADD_CLI_COMMAND_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliCommand',
 )
 
-# ** constant: add_cli_argument_evt
-ADD_CLI_ARGUMENT_EVT = create_service_registration(
-    ADD_CLI_ARGUMENT_EVT_ID,
+# ** constant: add_cli_argument_evt_data
+ADD_CLI_ARGUMENT_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, CLI_DOMAIN_PATH),
     'AddCliArgument',
 )
 
-# ** constant: add_formatter_evt
-ADD_FORMATTER_EVT = create_service_registration(
-    ADD_FORMATTER_EVT_ID,
+# ** constant: add_formatter_evt_data
+ADD_FORMATTER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddFormatter',
 )
 
-# ** constant: remove_formatter_evt
-REMOVE_FORMATTER_EVT = create_service_registration(
-    REMOVE_FORMATTER_EVT_ID,
+# ** constant: remove_formatter_evt_data
+REMOVE_FORMATTER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveFormatter',
 )
 
-# ** constant: add_handler_evt
-ADD_HANDLER_EVT = create_service_registration(
-    ADD_HANDLER_EVT_ID,
+# ** constant: add_handler_evt_data
+ADD_HANDLER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddHandler',
 )
 
-# ** constant: remove_handler_evt
-REMOVE_HANDLER_EVT = create_service_registration(
-    REMOVE_HANDLER_EVT_ID,
+# ** constant: remove_handler_evt_data
+REMOVE_HANDLER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveHandler',
 )
 
-# ** constant: add_logger_evt
-ADD_LOGGER_EVT = create_service_registration(
-    ADD_LOGGER_EVT_ID,
+# ** constant: add_logger_evt_data
+ADD_LOGGER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'AddLogger',
 )
 
-# ** constant: remove_logger_evt
-REMOVE_LOGGER_EVT = create_service_registration(
-    REMOVE_LOGGER_EVT_ID,
+# ** constant: remove_logger_evt_data
+REMOVE_LOGGER_EVT_DATA = create_service_registration_data(
     create_service_module_path(TIFERET, TIFERET_EVENTS_PATH, LOGGING_DOMAIN_PATH),
     'RemoveLogger',
 )
@@ -407,41 +370,41 @@ REMOVE_LOGGER_EVT = create_service_registration(
 
 # ** constant: default_admin_services
 DEFAULT_ADMIN_SERVICES: Dict[str, Dict] = {
-    APP_SERVICE_ID: APP_SERVICE,
-    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT,
-    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT,
-    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT,
-    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT,
-    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT,
-    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT,
-    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT,
-    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT,
-    ADD_ERROR_EVT_ID: ADD_ERROR_EVT,
-    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT,
-    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT,
-    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT,
-    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT,
-    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT,
-    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT,
-    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT,
-    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT,
-    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT,
-    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT,
-    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT,
-    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT,
-    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT,
-    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT,
-    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT,
-    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT,
-    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT,
-    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT,
-    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT,
-    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT,
-    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT,
-    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT,
-    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT,
-    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT,
+    APP_SERVICE_ID: APP_SERVICE_DATA,
+    ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT_DATA,
+    LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT_DATA,
+    REMOVE_FEATURE_EVT_ID: REMOVE_FEATURE_EVT_DATA,
+    UPDATE_FEATURE_EVT_ID: UPDATE_FEATURE_EVT_DATA,
+    ADD_FEATURE_STEP_EVT_ID: ADD_FEATURE_STEP_EVT_DATA,
+    UPDATE_FEATURE_STEP_EVT_ID: UPDATE_FEATURE_STEP_EVT_DATA,
+    REMOVE_FEATURE_STEP_EVT_ID: REMOVE_FEATURE_STEP_EVT_DATA,
+    REORDER_FEATURE_STEP_EVT_ID: REORDER_FEATURE_STEP_EVT_DATA,
+    ADD_ERROR_EVT_ID: ADD_ERROR_EVT_DATA,
+    LIST_ERRORS_EVT_ID: LIST_ERRORS_EVT_DATA,
+    RENAME_ERROR_EVT_ID: RENAME_ERROR_EVT_DATA,
+    SET_ERROR_MESSAGE_EVT_ID: SET_ERROR_MESSAGE_EVT_DATA,
+    REMOVE_ERROR_MESSAGE_EVT_ID: REMOVE_ERROR_MESSAGE_EVT_DATA,
+    REMOVE_ERROR_EVT_ID: REMOVE_ERROR_EVT_DATA,
+    ADD_SERVICE_REGISTRATION_EVT_ID: ADD_SERVICE_REGISTRATION_EVT_DATA,
+    SET_DEFAULT_SERVICE_REGISTRATION_EVT_ID: SET_DEFAULT_SERVICE_REGISTRATION_EVT_DATA,
+    SET_DI_SERVICE_DEPENDENCY_EVT_ID: SET_DI_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_DI_SERVICE_DEPENDENCY_EVT_ID: REMOVE_DI_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_SERVICE_REGISTRATION_EVT_ID: REMOVE_SERVICE_REGISTRATION_EVT_DATA,
+    SET_SERVICE_CONSTANTS_EVT_ID: SET_SERVICE_CONSTANTS_EVT_DATA,
+    ADD_APP_SESSION_EVT_ID: ADD_APP_SESSION_EVT_DATA,
+    GET_APP_SESSION_EVT_ID: GET_APP_SESSION_EVT_DATA,
+    UPDATE_APP_SESSION_EVT_ID: UPDATE_APP_SESSION_EVT_DATA,
+    SET_APP_CONSTANTS_EVT_ID: SET_APP_CONSTANTS_EVT_DATA,
+    LIST_APP_SESSIONS_EVT_ID: LIST_APP_SESSIONS_EVT_DATA,
+    SET_APP_SERVICE_DEPENDENCY_EVT_ID: SET_APP_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_APP_SERVICE_DEPENDENCY_EVT_ID: REMOVE_APP_SERVICE_DEPENDENCY_EVT_DATA,
+    REMOVE_APP_SESSION_EVT_ID: REMOVE_APP_SESSION_EVT_DATA,
+    ADD_CLI_COMMAND_EVT_ID: ADD_CLI_COMMAND_EVT_DATA,
+    ADD_CLI_ARGUMENT_EVT_ID: ADD_CLI_ARGUMENT_EVT_DATA,
+    ADD_FORMATTER_EVT_ID: ADD_FORMATTER_EVT_DATA,
+    REMOVE_FORMATTER_EVT_ID: REMOVE_FORMATTER_EVT_DATA,
+    ADD_HANDLER_EVT_ID: ADD_HANDLER_EVT_DATA,
+    REMOVE_HANDLER_EVT_ID: REMOVE_HANDLER_EVT_DATA,
+    ADD_LOGGER_EVT_ID: ADD_LOGGER_EVT_DATA,
+    REMOVE_LOGGER_EVT_ID: REMOVE_LOGGER_EVT_DATA,
 }

--- a/tiferet/assets/error.py
+++ b/tiferet/assets/error.py
@@ -8,7 +8,7 @@ domain events when not overridden by consumer configuration.
 # *** imports
 
 # ** app
-from .core import EN_US, create_default_error
+from .core import EN_US, create_default_error_data
 
 # *** constants (ids)
 
@@ -103,211 +103,182 @@ SERVICE_REGISTRATION_NOT_FOUND_ID = 'SERVICE_REGISTRATION_NOT_FOUND'
 
 # *** constants (models)
 
-# ** constant: app_error
-APP_ERROR = create_default_error(
-    APP_ERROR_ID,
+# ** constant: app_error_data
+APP_ERROR_DATA = create_default_error_data(
     'App Error',
     [(EN_US, 'An error occurred in the app: {error_message}.')],
 )
 
-# ** constant: app_session_not_found
-APP_SESSION_NOT_FOUND = create_default_error(
-    APP_SESSION_NOT_FOUND_ID,
+# ** constant: app_session_not_found_data
+APP_SESSION_NOT_FOUND_DATA = create_default_error_data(
     'App Session Not Found',
     [(EN_US, 'App session with ID {interface_id} not found.')],
 )
 
-# ** constant: command_parameter_required
-COMMAND_PARAMETER_REQUIRED = create_default_error(
-    COMMAND_PARAMETER_REQUIRED_ID,
+# ** constant: command_parameter_required_data
+COMMAND_PARAMETER_REQUIRED_DATA = create_default_error_data(
     'Command Parameter Required',
     [(EN_US, 'The required parameter {parameter} for command {command} is missing.')],
 )
 
-# ** constant: context_not_found
-CONTEXT_NOT_FOUND = create_default_error(
-    CONTEXT_NOT_FOUND_ID,
+# ** constant: context_not_found_data
+CONTEXT_NOT_FOUND_DATA = create_default_error_data(
     'Context Not Found',
     [(EN_US, 'No context registered for domain type: {domain_type}.')],
 )
 
-# ** constant: error_not_found
-ERROR_NOT_FOUND = create_default_error(
-    ERROR_NOT_FOUND_ID,
+# ** constant: error_not_found_data
+ERROR_NOT_FOUND_DATA = create_default_error_data(
     'Error Not Found',
     [(EN_US, 'Error not found: {id}.')],
 )
 
-# ** constant: feature_not_found
-FEATURE_NOT_FOUND = create_default_error(
-    FEATURE_NOT_FOUND_ID,
+# ** constant: feature_not_found_data
+FEATURE_NOT_FOUND_DATA = create_default_error_data(
     'Feature Not Found',
     [(EN_US, 'Feature not found: {feature_id}.')],
 )
 
-# ** constant: feature_step_loading_failed
-FEATURE_STEP_LOADING_FAILED = create_default_error(
-    FEATURE_STEP_LOADING_FAILED_ID,
+# ** constant: feature_step_loading_failed_data
+FEATURE_STEP_LOADING_FAILED_DATA = create_default_error_data(
     'Feature Step Loading Failed',
     [(EN_US, 'Failed to load feature step: {service_id}. Error: {exception}.')],
 )
 
-# ** constant: import_dependency_failed
-IMPORT_DEPENDENCY_FAILED = create_default_error(
-    IMPORT_DEPENDENCY_FAILED_ID,
+# ** constant: import_dependency_failed_data
+IMPORT_DEPENDENCY_FAILED_DATA = create_default_error_data(
     'Import Dependency Failed',
     [(EN_US, 'Failed to import {class_name} from {module_path}. Error: {exception}.')],
 )
 
-# ** constant: invalid_app_session_type
-INVALID_APP_SESSION_TYPE = create_default_error(
-    INVALID_APP_SESSION_TYPE_ID,
+# ** constant: invalid_app_session_type_data
+INVALID_APP_SESSION_TYPE_DATA = create_default_error_data(
     'Invalid App Session Type',
     [(EN_US, 'App context for interface is not valid: {interface_id}.')],
 )
 
-# ** constant: logger_creation_failed
-LOGGER_CREATION_FAILED = create_default_error(
-    LOGGER_CREATION_FAILED_ID,
+# ** constant: logger_creation_failed_data
+LOGGER_CREATION_FAILED_DATA = create_default_error_data(
     'Logger Creation Failed',
     [(EN_US, 'Failed to create logger with ID {logger_id}: {exception}.')],
 )
 
-# ** constant: logging_config_failed
-LOGGING_CONFIG_FAILED = create_default_error(
-    LOGGING_CONFIG_FAILED_ID,
+# ** constant: logging_config_failed_data
+LOGGING_CONFIG_FAILED_DATA = create_default_error_data(
     'Logging Configuration Failed',
     [(EN_US, 'Failed to configure logging: {exception}.')],
 )
 
-# ** constant: middleware_loading_failed
-MIDDLEWARE_LOADING_FAILED = create_default_error(
-    MIDDLEWARE_LOADING_FAILED_ID,
+# ** constant: middleware_loading_failed_data
+MIDDLEWARE_LOADING_FAILED_DATA = create_default_error_data(
     'Middleware Loading Failed',
     [(EN_US, 'Failed to load middleware: {service_id}. Error: {exception}.')],
 )
 
-# ** constant: parameter_not_found
-PARAMETER_NOT_FOUND = create_default_error(
-    PARAMETER_NOT_FOUND_ID,
+# ** constant: parameter_not_found_data
+PARAMETER_NOT_FOUND_DATA = create_default_error_data(
     'Parameter Not Found',
     [(EN_US, 'Parameter {parameter} not found in request data.')],
 )
 
-# ** constant: parameter_parsing_failed
-PARAMETER_PARSING_FAILED = create_default_error(
-    PARAMETER_PARSING_FAILED_ID,
+# ** constant: parameter_parsing_failed_data
+PARAMETER_PARSING_FAILED_DATA = create_default_error_data(
     'Parameter Parsing Failed',
     [(EN_US, 'Failed to parse parameter: {parameter}. Error: {exception}.')],
 )
 
-# ** constant: request_not_found
-REQUEST_NOT_FOUND = create_default_error(
-    REQUEST_NOT_FOUND_ID,
+# ** constant: request_not_found_data
+REQUEST_NOT_FOUND_DATA = create_default_error_data(
     'Request Not Found',
     [(EN_US, 'Request data is not available for parameter parsing.')],
 )
 
-# ** constant: request_validation_failed
-REQUEST_VALIDATION_FAILED = create_default_error(
-    REQUEST_VALIDATION_FAILED_ID,
+# ** constant: request_validation_failed_data
+REQUEST_VALIDATION_FAILED_DATA = create_default_error_data(
     'Request Validation Failed',
     [(EN_US, 'Request validation failed for feature {feature_id}: {violations}.')],
 )
 
 # *** constants (models_admin)
 
-# ** constant: cli_command_already_exists
-CLI_COMMAND_ALREADY_EXISTS = create_default_error(
-    CLI_COMMAND_ALREADY_EXISTS_ID,
+# ** constant: cli_command_already_exists_data
+CLI_COMMAND_ALREADY_EXISTS_DATA = create_default_error_data(
     'CLI Command Already Exists',
     [(EN_US, 'CLI command with ID {id} already exists.')],
 )
 
-# ** constant: cli_command_not_found
-CLI_COMMAND_NOT_FOUND = create_default_error(
-    CLI_COMMAND_NOT_FOUND_ID,
+# ** constant: cli_command_not_found_data
+CLI_COMMAND_NOT_FOUND_DATA = create_default_error_data(
     'CLI Command Not Found',
     [(EN_US, 'CLI command {command_id} not found.')],
 )
 
-# ** constant: error_already_exists
-ERROR_ALREADY_EXISTS = create_default_error(
-    ERROR_ALREADY_EXISTS_ID,
+# ** constant: error_already_exists_data
+ERROR_ALREADY_EXISTS_DATA = create_default_error_data(
     'Error Already Exists',
     [(EN_US, 'An error with ID {id} already exists.')],
 )
 
-# ** constant: feature_already_exists
-FEATURE_ALREADY_EXISTS = create_default_error(
-    FEATURE_ALREADY_EXISTS_ID,
+# ** constant: feature_already_exists_data
+FEATURE_ALREADY_EXISTS_DATA = create_default_error_data(
     'Feature Already Exists',
     [(EN_US, 'Feature with ID {id} already exists.')],
 )
 
-# ** constant: feature_command_not_found
-FEATURE_COMMAND_NOT_FOUND = create_default_error(
-    FEATURE_COMMAND_NOT_FOUND_ID,
+# ** constant: feature_command_not_found_data
+FEATURE_COMMAND_NOT_FOUND_DATA = create_default_error_data(
     'Feature Command Not Found',
     [(EN_US, 'Feature command not found for feature {feature_id} at position {position}.')],
 )
 
-# ** constant: feature_name_required
-FEATURE_NAME_REQUIRED = create_default_error(
-    FEATURE_NAME_REQUIRED_ID,
+# ** constant: feature_name_required_data
+FEATURE_NAME_REQUIRED_DATA = create_default_error_data(
     'Feature Name Required',
     [(EN_US, 'A feature name is required when updating the name attribute.')],
 )
 
-# ** constant: invalid_feature_attribute
-INVALID_FEATURE_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_ATTRIBUTE_ID,
+# ** constant: invalid_feature_attribute_data
+INVALID_FEATURE_ATTRIBUTE_DATA = create_default_error_data(
     'Invalid Feature Attribute',
     [(EN_US, 'Invalid feature attribute: {attribute}. Supported attributes are name and description.')],
 )
 
-# ** constant: invalid_feature_command_attribute
-INVALID_FEATURE_COMMAND_ATTRIBUTE = create_default_error(
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID,
+# ** constant: invalid_feature_command_attribute_data
+INVALID_FEATURE_COMMAND_ATTRIBUTE_DATA = create_default_error_data(
     'Invalid Feature Command Attribute',
     [(EN_US,
       'Invalid feature command attribute: {attribute}. Supported attributes are '
       'name, attribute_id, data_key, pass_on_error, and parameters.')],
 )
 
-# ** constant: invalid_flagged_dependency
-INVALID_FLAGGED_DEPENDENCY = create_default_error(
-    INVALID_FLAGGED_DEPENDENCY_ID,
+# ** constant: invalid_flagged_dependency_data
+INVALID_FLAGGED_DEPENDENCY_DATA = create_default_error_data(
     'Invalid Flagged Dependency',
     [(EN_US, 'A flagged dependency must define both module_path and class_name.')],
 )
 
-# ** constant: invalid_service_registration
-INVALID_SERVICE_REGISTRATION = create_default_error(
-    INVALID_SERVICE_REGISTRATION_ID,
+# ** constant: invalid_service_registration_data
+INVALID_SERVICE_REGISTRATION_DATA = create_default_error_data(
     'Invalid Service Registration',
     [(EN_US,
       'A service registration must define either a default type '
       '(module_path/class_name) or at least one flagged dependency.')],
 )
 
-# ** constant: no_error_messages
-NO_ERROR_MESSAGES = create_default_error(
-    NO_ERROR_MESSAGES_ID,
+# ** constant: no_error_messages_data
+NO_ERROR_MESSAGES_DATA = create_default_error_data(
     'No Error Messages',
     [(EN_US, 'No error messages are defined for error ID {id}.')],
 )
 
-# ** constant: service_registration_already_exists
-SERVICE_REGISTRATION_ALREADY_EXISTS = create_default_error(
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID,
+# ** constant: service_registration_already_exists_data
+SERVICE_REGISTRATION_ALREADY_EXISTS_DATA = create_default_error_data(
     'Service Registration Already Exists',
     [(EN_US, 'A service registration with ID {id} already exists.')],
 )
 
-# ** constant: service_registration_not_found
-SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
-    SERVICE_REGISTRATION_NOT_FOUND_ID,
+# ** constant: service_registration_not_found_data
+SERVICE_REGISTRATION_NOT_FOUND_DATA = create_default_error_data(
     'Service Registration Not Found',
     [(EN_US, 'Service registration with ID {id} not found.')],
 )
@@ -316,40 +287,40 @@ SERVICE_REGISTRATION_NOT_FOUND = create_default_error(
 
 # ** constant: core_default_errors
 CORE_DEFAULT_ERRORS = {
-    APP_ERROR_ID: APP_ERROR,
-    APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND,
-    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED,
-    CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND,
-    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND,
-    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND,
-    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED,
-    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED,
-    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE,
-    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED,
-    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED,
-    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED,
-    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND,
-    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED,
-    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND,
-    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED,
+    APP_ERROR_ID: APP_ERROR_DATA,
+    APP_SESSION_NOT_FOUND_ID: APP_SESSION_NOT_FOUND_DATA,
+    COMMAND_PARAMETER_REQUIRED_ID: COMMAND_PARAMETER_REQUIRED_DATA,
+    CONTEXT_NOT_FOUND_ID: CONTEXT_NOT_FOUND_DATA,
+    ERROR_NOT_FOUND_ID: ERROR_NOT_FOUND_DATA,
+    FEATURE_NOT_FOUND_ID: FEATURE_NOT_FOUND_DATA,
+    FEATURE_STEP_LOADING_FAILED_ID: FEATURE_STEP_LOADING_FAILED_DATA,
+    IMPORT_DEPENDENCY_FAILED_ID: IMPORT_DEPENDENCY_FAILED_DATA,
+    INVALID_APP_SESSION_TYPE_ID: INVALID_APP_SESSION_TYPE_DATA,
+    LOGGER_CREATION_FAILED_ID: LOGGER_CREATION_FAILED_DATA,
+    LOGGING_CONFIG_FAILED_ID: LOGGING_CONFIG_FAILED_DATA,
+    MIDDLEWARE_LOADING_FAILED_ID: MIDDLEWARE_LOADING_FAILED_DATA,
+    PARAMETER_NOT_FOUND_ID: PARAMETER_NOT_FOUND_DATA,
+    PARAMETER_PARSING_FAILED_ID: PARAMETER_PARSING_FAILED_DATA,
+    REQUEST_NOT_FOUND_ID: REQUEST_NOT_FOUND_DATA,
+    REQUEST_VALIDATION_FAILED_ID: REQUEST_VALIDATION_FAILED_DATA,
 }
 
 # ** constant: admin_default_errors
 ADMIN_DEFAULT_ERRORS = {
     **CORE_DEFAULT_ERRORS,
-    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS,
-    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND,
-    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS,
-    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS,
-    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND,
-    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED,
-    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE,
-    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE,
-    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY,
-    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION,
-    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES,
-    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS,
-    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND,
+    CLI_COMMAND_ALREADY_EXISTS_ID: CLI_COMMAND_ALREADY_EXISTS_DATA,
+    CLI_COMMAND_NOT_FOUND_ID: CLI_COMMAND_NOT_FOUND_DATA,
+    ERROR_ALREADY_EXISTS_ID: ERROR_ALREADY_EXISTS_DATA,
+    FEATURE_ALREADY_EXISTS_ID: FEATURE_ALREADY_EXISTS_DATA,
+    FEATURE_COMMAND_NOT_FOUND_ID: FEATURE_COMMAND_NOT_FOUND_DATA,
+    FEATURE_NAME_REQUIRED_ID: FEATURE_NAME_REQUIRED_DATA,
+    INVALID_FEATURE_ATTRIBUTE_ID: INVALID_FEATURE_ATTRIBUTE_DATA,
+    INVALID_FEATURE_COMMAND_ATTRIBUTE_ID: INVALID_FEATURE_COMMAND_ATTRIBUTE_DATA,
+    INVALID_FLAGGED_DEPENDENCY_ID: INVALID_FLAGGED_DEPENDENCY_DATA,
+    INVALID_SERVICE_REGISTRATION_ID: INVALID_SERVICE_REGISTRATION_DATA,
+    NO_ERROR_MESSAGES_ID: NO_ERROR_MESSAGES_DATA,
+    SERVICE_REGISTRATION_ALREADY_EXISTS_ID: SERVICE_REGISTRATION_ALREADY_EXISTS_DATA,
+    SERVICE_REGISTRATION_NOT_FOUND_ID: SERVICE_REGISTRATION_NOT_FOUND_DATA,
 }
 
 # ** constant: default_errors

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -4,7 +4,7 @@ Three-section catalog for the built-in Tiferet CLI feature workflows.
 Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 41 individually named feature ID string constants.
 - ``constants (features)`` — 41 individually named feature definition dicts,
-  each built via ``create_default_feature``.
+  each built via ``create_default_feature_data``.
 - ``constants (groups)`` — the ``DEFAULT_ADMIN_FEATURES`` catalog dict
   keyed by ID constants.
 """
@@ -15,7 +15,7 @@ Each section follows the pattern established by ``assets/error.py``:
 from typing import Any, Dict, List
 
 # ** app
-from .core import create_default_feature
+from .core import create_default_feature_data
 
 # *** constants (ids)
 
@@ -144,9 +144,8 @@ LOGGING_LIST_ID = 'logging.list'
 
 # *** constants (features)
 
-# ** constant: app_add
-APP_ADD = create_default_feature(
-    id=APP_ADD_ID,
+# ** constant: app_add_data
+APP_ADD_DATA = create_default_feature_data(
     name='Add App Session',
     group_id='app',
     feature_key='add',
@@ -154,9 +153,8 @@ APP_ADD = create_default_feature(
     description='Add a new application session configuration.',
 )
 
-# ** constant: app_get
-APP_GET = create_default_feature(
-    id=APP_GET_ID,
+# ** constant: app_get_data
+APP_GET_DATA = create_default_feature_data(
     name='Get App Session',
     group_id='app',
     feature_key='get',
@@ -164,9 +162,8 @@ APP_GET = create_default_feature(
     description='Retrieve an app session by ID.',
 )
 
-# ** constant: app_list
-APP_LIST = create_default_feature(
-    id=APP_LIST_ID,
+# ** constant: app_list_data
+APP_LIST_DATA = create_default_feature_data(
     name='List App Sessions',
     group_id='app',
     feature_key='list',
@@ -174,9 +171,8 @@ APP_LIST = create_default_feature(
     description='List all configured app sessions.',
 )
 
-# ** constant: app_update
-APP_UPDATE = create_default_feature(
-    id=APP_UPDATE_ID,
+# ** constant: app_update_data
+APP_UPDATE_DATA = create_default_feature_data(
     name='Update App Session',
     group_id='app',
     feature_key='update',
@@ -184,9 +180,8 @@ APP_UPDATE = create_default_feature(
     description='Update a scalar attribute on an app session.',
 )
 
-# ** constant: app_set_constants
-APP_SET_CONSTANTS = create_default_feature(
-    id=APP_SET_CONSTANTS_ID,
+# ** constant: app_set_constants_data
+APP_SET_CONSTANTS_DATA = create_default_feature_data(
     name='Set App Constants',
     group_id='app',
     feature_key='set_constants',
@@ -194,9 +189,8 @@ APP_SET_CONSTANTS = create_default_feature(
     description='Set or clear constants on an app session.',
 )
 
-# ** constant: app_set_service
-APP_SET_SERVICE = create_default_feature(
-    id=APP_SET_SERVICE_ID,
+# ** constant: app_set_service_data
+APP_SET_SERVICE_DATA = create_default_feature_data(
     name='Set App Service Dependency',
     group_id='app',
     feature_key='set_service',
@@ -204,9 +198,8 @@ APP_SET_SERVICE = create_default_feature(
     description='Set or update a service dependency on an app session.',
 )
 
-# ** constant: app_remove_service
-APP_REMOVE_SERVICE = create_default_feature(
-    id=APP_REMOVE_SERVICE_ID,
+# ** constant: app_remove_service_data
+APP_REMOVE_SERVICE_DATA = create_default_feature_data(
     name='Remove App Service Dependency',
     group_id='app',
     feature_key='remove_service',
@@ -214,9 +207,8 @@ APP_REMOVE_SERVICE = create_default_feature(
     description='Remove a service dependency from an app session.',
 )
 
-# ** constant: app_remove
-APP_REMOVE = create_default_feature(
-    id=APP_REMOVE_ID,
+# ** constant: app_remove_data
+APP_REMOVE_DATA = create_default_feature_data(
     name='Remove App Session',
     group_id='app',
     feature_key='remove',
@@ -224,9 +216,8 @@ APP_REMOVE = create_default_feature(
     description='Remove an app session by ID.',
 )
 
-# ** constant: cli_list_commands
-CLI_LIST_COMMANDS = create_default_feature(
-    id=CLI_LIST_COMMANDS_ID,
+# ** constant: cli_list_commands_data
+CLI_LIST_COMMANDS_DATA = create_default_feature_data(
     name='List CLI Commands',
     group_id='cli',
     feature_key='list_commands',
@@ -234,9 +225,8 @@ CLI_LIST_COMMANDS = create_default_feature(
     description='List all configured CLI commands.',
 )
 
-# ** constant: cli_add_command
-CLI_ADD_COMMAND = create_default_feature(
-    id=CLI_ADD_COMMAND_ID,
+# ** constant: cli_add_command_data
+CLI_ADD_COMMAND_DATA = create_default_feature_data(
     name='Add CLI Command',
     group_id='cli',
     feature_key='add_command',
@@ -244,9 +234,8 @@ CLI_ADD_COMMAND = create_default_feature(
     description='Add a new CLI command definition.',
 )
 
-# ** constant: cli_add_argument
-CLI_ADD_ARGUMENT = create_default_feature(
-    id=CLI_ADD_ARGUMENT_ID,
+# ** constant: cli_add_argument_data
+CLI_ADD_ARGUMENT_DATA = create_default_feature_data(
     name='Add CLI Argument',
     group_id='cli',
     feature_key='add_argument',
@@ -254,9 +243,8 @@ CLI_ADD_ARGUMENT = create_default_feature(
     description='Add an argument to an existing CLI command.',
 )
 
-# ** constant: error_list
-ERROR_LIST = create_default_feature(
-    id=ERROR_LIST_ID,
+# ** constant: error_list_data
+ERROR_LIST_DATA = create_default_feature_data(
     name='List Errors',
     group_id='error',
     feature_key='list',
@@ -264,9 +252,8 @@ ERROR_LIST = create_default_feature(
     description='List all error definitions.',
 )
 
-# ** constant: error_add
-ERROR_ADD = create_default_feature(
-    id=ERROR_ADD_ID,
+# ** constant: error_add_data
+ERROR_ADD_DATA = create_default_feature_data(
     name='Add Error',
     group_id='error',
     feature_key='add',
@@ -274,9 +261,8 @@ ERROR_ADD = create_default_feature(
     description='Add a new error definition.',
 )
 
-# ** constant: error_get
-ERROR_GET = create_default_feature(
-    id=ERROR_GET_ID,
+# ** constant: error_get_data
+ERROR_GET_DATA = create_default_feature_data(
     name='Get Error',
     group_id='error',
     feature_key='get',
@@ -284,9 +270,8 @@ ERROR_GET = create_default_feature(
     description='Retrieve an error by ID.',
 )
 
-# ** constant: error_rename
-ERROR_RENAME = create_default_feature(
-    id=ERROR_RENAME_ID,
+# ** constant: error_rename_data
+ERROR_RENAME_DATA = create_default_feature_data(
     name='Rename Error',
     group_id='error',
     feature_key='rename',
@@ -294,9 +279,8 @@ ERROR_RENAME = create_default_feature(
     description='Rename an existing error definition.',
 )
 
-# ** constant: error_set_message
-ERROR_SET_MESSAGE = create_default_feature(
-    id=ERROR_SET_MESSAGE_ID,
+# ** constant: error_set_message_data
+ERROR_SET_MESSAGE_DATA = create_default_feature_data(
     name='Set Error Message',
     group_id='error',
     feature_key='set_message',
@@ -304,9 +288,8 @@ ERROR_SET_MESSAGE = create_default_feature(
     description='Set the message text on an existing error definition.',
 )
 
-# ** constant: error_remove_message
-ERROR_REMOVE_MESSAGE = create_default_feature(
-    id=ERROR_REMOVE_MESSAGE_ID,
+# ** constant: error_remove_message_data
+ERROR_REMOVE_MESSAGE_DATA = create_default_feature_data(
     name='Remove Error Message',
     group_id='error',
     feature_key='remove_message',
@@ -314,9 +297,8 @@ ERROR_REMOVE_MESSAGE = create_default_feature(
     description='Remove a language message from an existing error definition.',
 )
 
-# ** constant: error_remove
-ERROR_REMOVE = create_default_feature(
-    id=ERROR_REMOVE_ID,
+# ** constant: error_remove_data
+ERROR_REMOVE_DATA = create_default_feature_data(
     name='Remove Error',
     group_id='error',
     feature_key='remove',
@@ -324,9 +306,8 @@ ERROR_REMOVE = create_default_feature(
     description='Remove an error definition.',
 )
 
-# ** constant: feature_list
-FEATURE_LIST = create_default_feature(
-    id=FEATURE_LIST_ID,
+# ** constant: feature_list_data
+FEATURE_LIST_DATA = create_default_feature_data(
     name='List Features',
     group_id='feature',
     feature_key='list',
@@ -334,9 +315,8 @@ FEATURE_LIST = create_default_feature(
     description='List all feature workflow definitions.',
 )
 
-# ** constant: feature_add
-FEATURE_ADD = create_default_feature(
-    id=FEATURE_ADD_ID,
+# ** constant: feature_add_data
+FEATURE_ADD_DATA = create_default_feature_data(
     name='Add Feature',
     group_id='feature',
     feature_key='add',
@@ -344,9 +324,8 @@ FEATURE_ADD = create_default_feature(
     description='Add a new feature workflow definition.',
 )
 
-# ** constant: feature_get
-FEATURE_GET = create_default_feature(
-    id=FEATURE_GET_ID,
+# ** constant: feature_get_data
+FEATURE_GET_DATA = create_default_feature_data(
     name='Get Feature',
     group_id='feature',
     feature_key='get',
@@ -354,9 +333,8 @@ FEATURE_GET = create_default_feature(
     description='Retrieve a feature by ID.',
 )
 
-# ** constant: feature_update
-FEATURE_UPDATE = create_default_feature(
-    id=FEATURE_UPDATE_ID,
+# ** constant: feature_update_data
+FEATURE_UPDATE_DATA = create_default_feature_data(
     name='Update Feature',
     group_id='feature',
     feature_key='update',
@@ -364,9 +342,8 @@ FEATURE_UPDATE = create_default_feature(
     description='Update a metadata attribute on an existing feature.',
 )
 
-# ** constant: feature_add_step
-FEATURE_ADD_STEP = create_default_feature(
-    id=FEATURE_ADD_STEP_ID,
+# ** constant: feature_add_step_data
+FEATURE_ADD_STEP_DATA = create_default_feature_data(
     name='Add Feature Step',
     group_id='feature',
     feature_key='add_step',
@@ -374,9 +351,8 @@ FEATURE_ADD_STEP = create_default_feature(
     description='Add a step to an existing feature workflow.',
 )
 
-# ** constant: feature_update_step
-FEATURE_UPDATE_STEP = create_default_feature(
-    id=FEATURE_UPDATE_STEP_ID,
+# ** constant: feature_update_step_data
+FEATURE_UPDATE_STEP_DATA = create_default_feature_data(
     name='Update Feature Step',
     group_id='feature',
     feature_key='update_step',
@@ -384,9 +360,8 @@ FEATURE_UPDATE_STEP = create_default_feature(
     description='Update an attribute on an existing feature step.',
 )
 
-# ** constant: feature_remove_step
-FEATURE_REMOVE_STEP = create_default_feature(
-    id=FEATURE_REMOVE_STEP_ID,
+# ** constant: feature_remove_step_data
+FEATURE_REMOVE_STEP_DATA = create_default_feature_data(
     name='Remove Feature Step',
     group_id='feature',
     feature_key='remove_step',
@@ -394,9 +369,8 @@ FEATURE_REMOVE_STEP = create_default_feature(
     description='Remove a step from an existing feature workflow.',
 )
 
-# ** constant: feature_reorder_step
-FEATURE_REORDER_STEP = create_default_feature(
-    id=FEATURE_REORDER_STEP_ID,
+# ** constant: feature_reorder_step_data
+FEATURE_REORDER_STEP_DATA = create_default_feature_data(
     name='Reorder Feature Step',
     group_id='feature',
     feature_key='reorder_step',
@@ -404,9 +378,8 @@ FEATURE_REORDER_STEP = create_default_feature(
     description='Reorder a step within an existing feature workflow.',
 )
 
-# ** constant: feature_remove
-FEATURE_REMOVE = create_default_feature(
-    id=FEATURE_REMOVE_ID,
+# ** constant: feature_remove_data
+FEATURE_REMOVE_DATA = create_default_feature_data(
     name='Remove Feature',
     group_id='feature',
     feature_key='remove',
@@ -414,9 +387,8 @@ FEATURE_REMOVE = create_default_feature(
     description='Remove an existing feature workflow definition.',
 )
 
-# ** constant: service_list
-SERVICE_LIST = create_default_feature(
-    id=SERVICE_LIST_ID,
+# ** constant: service_list_data
+SERVICE_LIST_DATA = create_default_feature_data(
     name='List Services',
     group_id='service',
     feature_key='list',
@@ -424,9 +396,8 @@ SERVICE_LIST = create_default_feature(
     description='List all DI service registrations and constants.',
 )
 
-# ** constant: service_add
-SERVICE_ADD = create_default_feature(
-    id=SERVICE_ADD_ID,
+# ** constant: service_add_data
+SERVICE_ADD_DATA = create_default_feature_data(
     name='Add Service',
     group_id='service',
     feature_key='add',
@@ -434,9 +405,8 @@ SERVICE_ADD = create_default_feature(
     description='Add a new DI service registration.',
 )
 
-# ** constant: service_set_default
-SERVICE_SET_DEFAULT = create_default_feature(
-    id=SERVICE_SET_DEFAULT_ID,
+# ** constant: service_set_default_data
+SERVICE_SET_DEFAULT_DATA = create_default_feature_data(
     name='Set Default Service Registration',
     group_id='service',
     feature_key='set_default',
@@ -444,9 +414,8 @@ SERVICE_SET_DEFAULT = create_default_feature(
     description='Set or update the default type for an existing service registration.',
 )
 
-# ** constant: service_set_dependency
-SERVICE_SET_DEPENDENCY = create_default_feature(
-    id=SERVICE_SET_DEPENDENCY_ID,
+# ** constant: service_set_dependency_data
+SERVICE_SET_DEPENDENCY_DATA = create_default_feature_data(
     name='Set Service Dependency',
     group_id='service',
     feature_key='set_dependency',
@@ -454,9 +423,8 @@ SERVICE_SET_DEPENDENCY = create_default_feature(
     description='Set or update a flagged dependency on a service registration.',
 )
 
-# ** constant: service_remove_dependency
-SERVICE_REMOVE_DEPENDENCY = create_default_feature(
-    id=SERVICE_REMOVE_DEPENDENCY_ID,
+# ** constant: service_remove_dependency_data
+SERVICE_REMOVE_DEPENDENCY_DATA = create_default_feature_data(
     name='Remove Service Dependency',
     group_id='service',
     feature_key='remove_dependency',
@@ -464,9 +432,8 @@ SERVICE_REMOVE_DEPENDENCY = create_default_feature(
     description='Remove a flagged dependency from a service registration.',
 )
 
-# ** constant: service_set_constants
-SERVICE_SET_CONSTANTS = create_default_feature(
-    id=SERVICE_SET_CONSTANTS_ID,
+# ** constant: service_set_constants_data
+SERVICE_SET_CONSTANTS_DATA = create_default_feature_data(
     name='Set Service Constants',
     group_id='service',
     feature_key='set_constants',
@@ -474,9 +441,8 @@ SERVICE_SET_CONSTANTS = create_default_feature(
     description='Set or clear DI service constants.',
 )
 
-# ** constant: service_remove
-SERVICE_REMOVE = create_default_feature(
-    id=SERVICE_REMOVE_ID,
+# ** constant: service_remove_data
+SERVICE_REMOVE_DATA = create_default_feature_data(
     name='Remove Service',
     group_id='service',
     feature_key='remove',
@@ -484,9 +450,8 @@ SERVICE_REMOVE = create_default_feature(
     description='Remove a DI service registration.',
 )
 
-# ** constant: logging_add_formatter
-LOGGING_ADD_FORMATTER = create_default_feature(
-    id=LOGGING_ADD_FORMATTER_ID,
+# ** constant: logging_add_formatter_data
+LOGGING_ADD_FORMATTER_DATA = create_default_feature_data(
     name='Add Formatter',
     group_id='logging',
     feature_key='add_formatter',
@@ -494,9 +459,8 @@ LOGGING_ADD_FORMATTER = create_default_feature(
     description='Add a new logging formatter configuration.',
 )
 
-# ** constant: logging_remove_formatter
-LOGGING_REMOVE_FORMATTER = create_default_feature(
-    id=LOGGING_REMOVE_FORMATTER_ID,
+# ** constant: logging_remove_formatter_data
+LOGGING_REMOVE_FORMATTER_DATA = create_default_feature_data(
     name='Remove Formatter',
     group_id='logging',
     feature_key='remove_formatter',
@@ -504,9 +468,8 @@ LOGGING_REMOVE_FORMATTER = create_default_feature(
     description='Remove a logging formatter by ID.',
 )
 
-# ** constant: logging_add_handler
-LOGGING_ADD_HANDLER = create_default_feature(
-    id=LOGGING_ADD_HANDLER_ID,
+# ** constant: logging_add_handler_data
+LOGGING_ADD_HANDLER_DATA = create_default_feature_data(
     name='Add Handler',
     group_id='logging',
     feature_key='add_handler',
@@ -514,9 +477,8 @@ LOGGING_ADD_HANDLER = create_default_feature(
     description='Add a new logging handler configuration.',
 )
 
-# ** constant: logging_remove_handler
-LOGGING_REMOVE_HANDLER = create_default_feature(
-    id=LOGGING_REMOVE_HANDLER_ID,
+# ** constant: logging_remove_handler_data
+LOGGING_REMOVE_HANDLER_DATA = create_default_feature_data(
     name='Remove Handler',
     group_id='logging',
     feature_key='remove_handler',
@@ -524,9 +486,8 @@ LOGGING_REMOVE_HANDLER = create_default_feature(
     description='Remove a logging handler by ID.',
 )
 
-# ** constant: logging_add_logger
-LOGGING_ADD_LOGGER = create_default_feature(
-    id=LOGGING_ADD_LOGGER_ID,
+# ** constant: logging_add_logger_data
+LOGGING_ADD_LOGGER_DATA = create_default_feature_data(
     name='Add Logger',
     group_id='logging',
     feature_key='add_logger',
@@ -534,9 +495,8 @@ LOGGING_ADD_LOGGER = create_default_feature(
     description='Add a new logger configuration.',
 )
 
-# ** constant: logging_remove_logger
-LOGGING_REMOVE_LOGGER = create_default_feature(
-    id=LOGGING_REMOVE_LOGGER_ID,
+# ** constant: logging_remove_logger_data
+LOGGING_REMOVE_LOGGER_DATA = create_default_feature_data(
     name='Remove Logger',
     group_id='logging',
     feature_key='remove_logger',
@@ -544,9 +504,8 @@ LOGGING_REMOVE_LOGGER = create_default_feature(
     description='Remove a logger by ID.',
 )
 
-# ** constant: logging_list
-LOGGING_LIST = create_default_feature(
-    id=LOGGING_LIST_ID,
+# ** constant: logging_list_data
+LOGGING_LIST_DATA = create_default_feature_data(
     name='List Logging Configs',
     group_id='logging',
     feature_key='list',
@@ -558,45 +517,45 @@ LOGGING_LIST = create_default_feature(
 
 # ** constant: default_admin_features
 DEFAULT_ADMIN_FEATURES: Dict[str, Any] = {
-    APP_ADD_ID: APP_ADD,
-    APP_GET_ID: APP_GET,
-    APP_LIST_ID: APP_LIST,
-    APP_UPDATE_ID: APP_UPDATE,
-    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS,
-    APP_SET_SERVICE_ID: APP_SET_SERVICE,
-    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE,
-    APP_REMOVE_ID: APP_REMOVE,
-    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS,
-    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND,
-    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT,
-    ERROR_LIST_ID: ERROR_LIST,
-    ERROR_ADD_ID: ERROR_ADD,
-    ERROR_GET_ID: ERROR_GET,
-    ERROR_RENAME_ID: ERROR_RENAME,
-    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE,
-    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE,
-    ERROR_REMOVE_ID: ERROR_REMOVE,
-    FEATURE_LIST_ID: FEATURE_LIST,
-    FEATURE_ADD_ID: FEATURE_ADD,
-    FEATURE_GET_ID: FEATURE_GET,
-    FEATURE_UPDATE_ID: FEATURE_UPDATE,
-    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP,
-    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP,
-    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP,
-    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP,
-    FEATURE_REMOVE_ID: FEATURE_REMOVE,
-    SERVICE_LIST_ID: SERVICE_LIST,
-    SERVICE_ADD_ID: SERVICE_ADD,
-    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT,
-    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY,
-    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY,
-    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS,
-    SERVICE_REMOVE_ID: SERVICE_REMOVE,
-    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER,
-    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER,
-    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER,
-    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER,
-    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER,
-    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER,
-    LOGGING_LIST_ID: LOGGING_LIST,
+    APP_ADD_ID: APP_ADD_DATA,
+    APP_GET_ID: APP_GET_DATA,
+    APP_LIST_ID: APP_LIST_DATA,
+    APP_UPDATE_ID: APP_UPDATE_DATA,
+    APP_SET_CONSTANTS_ID: APP_SET_CONSTANTS_DATA,
+    APP_SET_SERVICE_ID: APP_SET_SERVICE_DATA,
+    APP_REMOVE_SERVICE_ID: APP_REMOVE_SERVICE_DATA,
+    APP_REMOVE_ID: APP_REMOVE_DATA,
+    CLI_LIST_COMMANDS_ID: CLI_LIST_COMMANDS_DATA,
+    CLI_ADD_COMMAND_ID: CLI_ADD_COMMAND_DATA,
+    CLI_ADD_ARGUMENT_ID: CLI_ADD_ARGUMENT_DATA,
+    ERROR_LIST_ID: ERROR_LIST_DATA,
+    ERROR_ADD_ID: ERROR_ADD_DATA,
+    ERROR_GET_ID: ERROR_GET_DATA,
+    ERROR_RENAME_ID: ERROR_RENAME_DATA,
+    ERROR_SET_MESSAGE_ID: ERROR_SET_MESSAGE_DATA,
+    ERROR_REMOVE_MESSAGE_ID: ERROR_REMOVE_MESSAGE_DATA,
+    ERROR_REMOVE_ID: ERROR_REMOVE_DATA,
+    FEATURE_LIST_ID: FEATURE_LIST_DATA,
+    FEATURE_ADD_ID: FEATURE_ADD_DATA,
+    FEATURE_GET_ID: FEATURE_GET_DATA,
+    FEATURE_UPDATE_ID: FEATURE_UPDATE_DATA,
+    FEATURE_ADD_STEP_ID: FEATURE_ADD_STEP_DATA,
+    FEATURE_UPDATE_STEP_ID: FEATURE_UPDATE_STEP_DATA,
+    FEATURE_REMOVE_STEP_ID: FEATURE_REMOVE_STEP_DATA,
+    FEATURE_REORDER_STEP_ID: FEATURE_REORDER_STEP_DATA,
+    FEATURE_REMOVE_ID: FEATURE_REMOVE_DATA,
+    SERVICE_LIST_ID: SERVICE_LIST_DATA,
+    SERVICE_ADD_ID: SERVICE_ADD_DATA,
+    SERVICE_SET_DEFAULT_ID: SERVICE_SET_DEFAULT_DATA,
+    SERVICE_SET_DEPENDENCY_ID: SERVICE_SET_DEPENDENCY_DATA,
+    SERVICE_REMOVE_DEPENDENCY_ID: SERVICE_REMOVE_DEPENDENCY_DATA,
+    SERVICE_SET_CONSTANTS_ID: SERVICE_SET_CONSTANTS_DATA,
+    SERVICE_REMOVE_ID: SERVICE_REMOVE_DATA,
+    LOGGING_ADD_FORMATTER_ID: LOGGING_ADD_FORMATTER_DATA,
+    LOGGING_REMOVE_FORMATTER_ID: LOGGING_REMOVE_FORMATTER_DATA,
+    LOGGING_ADD_HANDLER_ID: LOGGING_ADD_HANDLER_DATA,
+    LOGGING_REMOVE_HANDLER_ID: LOGGING_REMOVE_HANDLER_DATA,
+    LOGGING_ADD_LOGGER_ID: LOGGING_ADD_LOGGER_DATA,
+    LOGGING_REMOVE_LOGGER_ID: LOGGING_REMOVE_LOGGER_DATA,
+    LOGGING_LIST_ID: LOGGING_LIST_DATA,
 }

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -62,7 +62,7 @@ def add_default_app_services(services: Dict[str, Any]) -> Callable:
             for service_id, service_data in services.items():
                 cache.set(
                     service_id,
-                    AppServiceDependency.model_validate(service_data),
+                    AppServiceDependency.model_validate({**service_data, 'service_id': service_id}),
                     *APP_SERVICE_CACHE_PREFIX,
                 )
 
@@ -161,7 +161,7 @@ def add_default_admin_services(services: Dict[str, Any]) -> Callable:
             for service_id, service_data in services.items():
                 cache.set(
                     service_id,
-                    AppServiceDependency.model_validate(service_data),
+                    AppServiceDependency.model_validate({**service_data, 'service_id': service_id}),
                     *ADMIN_SERVICE_CACHE_PREFIX,
                 )
 
@@ -260,7 +260,7 @@ def add_default_app_sessions(sessions: Dict[str, Any]) -> Callable:
             for session_id, session_data in sessions.items():
                 cache.set(
                     session_id,
-                    AppSession.model_validate(session_data),
+                    AppSession.model_validate({**session_data, 'id': session_id}),
                     *APP_SESSION_CACHE_PREFIX,
                 )
 

--- a/tiferet/contexts/error.py
+++ b/tiferet/contexts/error.py
@@ -47,7 +47,7 @@ def add_default_errors(errors: Dict[str, Any]) -> Callable:
             for error_id, error_data in errors.items():
                 cache.set(
                     error_id,
-                    Error.model_validate(error_data),
+                    Error.model_validate({**error_data, 'id': error_id}),
                     *ERROR_CACHE_PREFIX,
                 )
 

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -60,7 +60,11 @@ def add_default_features(features: Dict[str, Any]) -> Callable:
             # Reconstitute each raw feature dict into a Feature domain object and
             # cache it under the feature namespace keyed by feature id.
             for feature_id, feature_data in features.items():
-                cache.set(feature_id, Feature.model_validate(feature_data), *FEATURE_CACHE_PREFIX)
+                cache.set(
+                    feature_id,
+                    Feature.model_validate({**feature_data, 'id': feature_id}),
+                    *FEATURE_CACHE_PREFIX,
+                )
 
             # Return the populated cache context.
             return cache

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -123,7 +123,7 @@ class GetError(ErrorEvent):
         if include_defaults:
             error_data = a.DEFAULT_ERRORS.get(id)
             if error_data:
-                return ErrorAggregate(**error_data)
+                return ErrorAggregate(id=id, **error_data)
 
         # If still not found and defaults not included, raise structured error.
         self.raise_error(
@@ -156,7 +156,7 @@ class ListErrors(ErrorEvent):
             return self.error_service.list()
 
         # If defaults are included, merge repository and default errors.
-        errors = {id: ErrorAggregate(**data) for id, data in a.DEFAULT_ERRORS.items()}
+        errors = {id: ErrorAggregate(id=id, **data) for id, data in a.DEFAULT_ERRORS.items()}
         repo_errors = self.error_service.list()
         errors.update({error.id: error for error in repo_errors})
 


### PR DESCRIPTION
## Summary
Super-TRD #1004 — Catalog Data/ID Redundancy Elimination. `assets/core.py` defines six factory functions that build catalog entries later stored under an id-keyed group dict, each embedding that same id inside its returned dict — redundant once the group-dict key already carries it. This PR ports proto's delivered rewrite across three children landing sequentially on this branch.

## Child 1a — #1005 — Assets – Catalog Factory `_DATA` Rewrite ✅

**Changes:**
- Renamed and rewrote the six catalog factories in `tiferet/assets/core.py` to their `_DATA`-suffixed, id-free form: `create_default_error_data`, `create_app_service_dependency_data`, `create_service_registration_data`, `create_default_feature_data`, `create_default_app_session_data`, `create_default_cli_command_data`.
- Each drops its `id`/`service_id` parameter and the corresponding dict key.
- Adopted the hanging-indent signature style and reordered the `# *** functions` section to match `origin/v2.x-proto`'s domain-grouped layout.
- Updated `tests/assets/test_core.py` and `tests/assets/test_app.py` call sites to the renamed factories.

**Acceptance Criteria:**
- [x] `assets/core.py` exports the six `_data`-suffixed factories; none accepts an `id`/`service_id` parameter.
- [x] The six old names no longer exist in `tiferet/assets/core.py`, `tests/assets/test_core.py`, or `tests/assets/test_app.py`.
- [x] The `# *** functions` section's order matches `origin/v2.x-proto`'s `assets/core.py` layout.
- [x] The six renamed factories import and behave correctly in isolation (verified via a standalone module load of `core.py`).
- [x] `tests/assets/test_core.py`'s own assertions (renamed to match) pass in isolation.

> Note: The old names still exist in `assets/{error,feature,app,di,cli}.py` (out of scope for this child, owned by 1b/1c below) — this means `python -c "from tiferet.assets.core import ..."` and `pytest tests/assets/test_core.py` currently fail when run through the full `tiferet.assets` package, because `tiferet/assets/__init__.py` eagerly imports those still-unconverted catalog modules. This is expected interim breakage and resolves once 1b and 1c land.

## Child 1b — #1007 — Assets & Contexts – Error/Feature/App Catalog Call Sites and Decorator Reinjection ✅

**Changes:**
- Converted every `create_default_error`/`create_default_feature`/`create_default_app_session`/`create_app_service_dependency` call site in `tiferet/assets/{error,feature,app}.py` to their `_data` counterparts, renaming each leaf constant to its `_DATA` suffix; updated the `# ** constant:` labels and group-dict values to match.
- Added id/service_id reinjection to `contexts/error.py::add_default_errors`, `contexts/feature.py::add_default_features`, `contexts/app.py::add_default_app_services`, `add_default_admin_services`, and `add_default_app_sessions`, each using the exact `{**data, 'id'/'service_id': key}` spread-merge form matching `contexts/cli.py`'s reference pattern — verified byte-for-byte identical to `origin/v2.x-proto`'s implementation.

**Acceptance Criteria:**
- [x] `grep -rn "create_default_error(\|create_default_feature(\|create_default_app_session(\|create_app_service_dependency("  tiferet/assets/` returns no results.
- [x] Every leaf model constant in `assets/error.py`, `assets/feature.py`, `assets/app.py` ends in `_DATA`.
- [x] `add_default_errors`, `add_default_features`, `add_default_app_services`, `add_default_admin_services`, `add_default_app_sessions` each reinject the id/service_id from the group-dict key before calling `model_validate`.
- [x] Building an `AppSessionContext`/`FeatureContext`/`ErrorContext` from the default catalogs succeeds with no `ValidationError` for a missing `id`/`service_id` field.
- [x] `pytest tests/assets/test_error.py tests/assets/test_feature.py tests/assets/test_app.py tests/contexts/test_error.py tests/contexts/test_feature.py tests/contexts/test_app.py` passes — **discrepancy**: `tests/assets/test_feature.py` does not exist in this repo (only `test_app.py`, `test_core.py`, `test_error.py` exist under `tests/assets/`). Ran the five existing files (133 passed) plus the full suite (`pytest tests/`, 1034 passed, 11 skipped) to confirm nothing regressed.

## Child 1c — #1006 — Assets – CLI & DI Catalog Call Sites ✅

**Changes:**
- Converted all 40 `create_default_cli_command` call sites in `tiferet/assets/cli.py` to `create_default_cli_command_data`, dropping the redundant `id=` argument and renaming each leaf constant to its `_DATA` suffix (e.g. `APP_LIST_CLI_CMD` → `APP_LIST_CLI_CMD_DATA`); updated `ADMIN_DEFAULT_COMMANDS` and the `# ** constant:` labels to match.
- Converted all 37 `create_service_registration` call sites in `tiferet/assets/di.py` to `create_service_registration_data`, dropping the positional `id` argument and renaming each leaf constant (e.g. `APP_SERVICE` → `APP_SERVICE_DATA`, `*_EVT` → `*_EVT_DATA`); updated `DEFAULT_ADMIN_SERVICES`, the `# ** constant:` labels, and the module docstring's factory-name reference.
- Audited `contexts/cli.py::add_default_cli_commands`: it does not itself reinject `id`, but `CliCommand`'s own `_derive_id` validator (`group_key.key`) already derives it — verified this matches all 40 `*_ID` constants, so no context change was needed.
- Audited every consumption path of `assets/di.py`'s `DEFAULT_ADMIN_SERVICES`: it currently has zero consumers anywhere in the framework (not wired into any `add_default_*` decorator, `DIConfigRepository`, `blueprints/core.py`, or `di/dependency_injector.py`), so there is nothing to reinject an id into.

**Acceptance Criteria:**
- [x] `grep -n "create_default_cli_command(\|create_service_registration(" tiferet/assets/cli.py tiferet/assets/di.py` returns no results.
- [x] Every leaf model constant in `assets/cli.py`, `assets/di.py` ends in `_DATA`.
- [x] Every consumption path of `assets/di.py`'s catalog is confirmed to supply the registration id externally, not read it from the value dict — confirmed vacuously, since the catalog has no current consumers.
- [x] `pytest tests/assets/test_cli.py tests/assets/test_di.py tests/contexts/test_cli.py tests/repos/test_di.py` passes — **discrepancy**: `tests/assets/test_cli.py` and `tests/assets/test_di.py` do not exist in this repo (only `test_app.py`, `test_core.py`, `test_error.py` exist under `tests/assets/`). Ran the two existing files (`tests/contexts/test_cli.py`, `tests/repos/test_di.py`, 24 passed) plus the full suite (`pytest tests/`, 1034 passed, 11 skipped) to confirm `tiferet.assets` imports cleanly and nothing else regressed.

## Review
Reviewed against each child TRD's Acceptance Criteria (source of truth) plus a restricted-scope diff against `origin/v2.x-proto` for the AC-referenced artifacts. All three children pass their AC in full. See the review comment below for details.

## Related Issues
Closes #1004

Co-Authored-By: Oz <oz-agent@warp.dev>
