### PR TITLE
Super-TRD #1010: Admin Support — Blueprint Port, User Documentation & Config-Management Skill Suite

### DIFF
--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -4,6 +4,7 @@ Canonical, version-controlled copies of the reusable agent **skills** for Tifere
 
 ## Collaboration skills
 - **`tiferet-annotation-artifacts`** — scan, add, and resolve `# ++ todo:` / `# -- obsolete:` annotation artifacts; covers the pre-session scan, resolution procedure, and Collaboration Report integration. **Use at the start of every implementation session.**
+- **`tiferet-admin-config`** — use the Admin App or Admin CLI to add/update errors, service registrations, and features in a consumer's `config.yml`. Directly useful when a TRD introduces a new domain event module and needs an accompanying error, service registration, and feature entry.
 - **`tiferet-create-milestone`** — create or format a GitHub milestone.
 - **`tiferet-author-trd`** — author a Technical Requirements Document.
 - **`tiferet-collab-report`** — generate a Collaboration Report when an issue is confirmed complete.

--- a/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: tiferet-admin-config
+description: Use the Tiferet Admin App or Admin CLI to add or update errors, service registrations, and features in a consumer's config.yml. Use this when a TRD introduces a new domain event module and needs an accompanying error, service registration, and feature entry, or when asked to manage/add/update Tiferet application configuration (errors, services, features, CLI commands, sessions, logging) via the built-in admin surface.
+---
+
+# Tiferet Admin Config Management
+
+## When to use
+
+- **New domain event module integration**: When a TRD or implementation session adds a new domain event module and requires adding or updating an accompanying error definition, service registration, and feature workflow in a consumer's `config.yml`.
+- **Configuration management**: When asked to inspect, add, update, or remove application configuration records (errors, services, features, CLI commands, sessions, logging) in `config.yml` or custom configuration files via the built-in admin surface.
+
+## Primary path: Admin App (Python)
+
+The **Admin App** (`AdminApp` / `build_admin_app`) is the strongly recommended primary path for programmatic configuration management.
+
+### Why Admin App is preferred
+
+- **In-process objects**: Manipulates rich domain objects directly in Python without string serialization or parsing overhead.
+- **No shell-quoting or string-escaping**: Complex parameter dicts and localized messages pass as native Python dicts, lists, and primitives without shell quoting risks.
+- **Direct exception handling**: Returns structured response dicts or raises typed `TiferetError` instances that can be inspected and handled in code.
+
+### Canonical usage pattern
+
+```python
+from tiferet import AdminApp
+
+# Instantiate the admin app (defaults to app_config='config.yml')
+admin = AdminApp()
+
+# Execute a management feature against config.yml
+response = admin.run('feature_id', data={'key': 'value'})
+```
+
+To target a specific configuration file other than `config.yml`:
+
+```python
+admin = AdminApp(app_config='custom_config.yml')
+```
+
+## Secondary path: Admin CLI
+
+The **Admin CLI** (`AdminCLI` / `build_admin_cli` / `tiferet`) is the secondary path for interactive or command-line administration.
+
+### Command-line syntax
+
+```bash
+# Target default config.yml in current working directory
+tiferet <group> <command> [options...]
+
+# Target a specific configuration file
+tiferet --config custom_config.yml <group> <command> [options...]
+```
+
+### Key-value dict syntax
+
+Every flat-map/dict-typed argument on the Admin CLI accepts `key=value` pairs directly on the command line — raw JSON strings are **never** required.
+
+```bash
+# Correct: flat-map key=value pairs
+tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "Token is invalid." --additional-messages es_ES="El token no es válido."
+
+# Correct: flat-map parameters
+tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User" --parameters mode=strict timeout=5.0
+```
+
+## The Six Admin Domains
+
+The admin surface spans six configuration management domains.
+
+### 1. App Domain (`app`)
+
+Manages application interface definitions, session parameters, and app constants.
+
+- **Available features**: `app.add_session`, `app.list_sessions`, `app.get_session`, `app.delete_session`
+- **CLI group**: `tiferet app <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'app.add_session',
+    data={
+        'id': 'web_api',
+        'name': 'Web API Session',
+        'description': 'Main web API application session',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet app add-session --id web_api --name "Web API Session" --description "Main web API application session"
+```
+
+---
+
+### 2. CLI Domain (`cli`)
+
+Manages CLI command definitions, command groups, and argument specifications.
+
+- **Available features**: `cli.add_command`, `cli.list_commands`, `cli.get_command`, `cli.delete_command`
+- **CLI group**: `tiferet cli <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'cli.add_command',
+    data={
+        'group_key': 'reports',
+        'key': 'generate',
+        'name': 'Generate Report',
+        'description': 'Generate summary report',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet cli add-command --group-key reports --key generate --name "Generate Report" --description "Generate summary report"
+```
+
+---
+
+### 3. Error Domain (`error`)
+
+Manages structured error definitions, multilingual error messages, and error codes.
+
+- **Available features**: `error.add`, `error.list_errors`, `error.get_error`, `error.delete_error`
+- **CLI group**: `tiferet error <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'error.add',
+    data={
+        'id': 'INVALID_TOKEN_ID',
+        'name': 'Invalid Token',
+        'message': 'The provided authentication token is invalid.',
+        'additional_messages': {
+            'es_ES': 'El token de autenticación proporcionado no es válido.',
+        },
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+```
+
+---
+
+### 4. Feature Domain (`feature`)
+
+Manages feature workflow definitions, steps, and feature parameters.
+
+- **Available features**: `feature.add`, `feature.add_step`, `feature.list_features`, `feature.get_feature`, `feature.delete_feature`
+- **CLI group**: `tiferet feature <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+
+# Step 1: Define the feature workflow
+admin.run(
+    'feature.add',
+    data={
+        'id': 'user.create',
+        'name': 'Create User Workflow',
+        'description': 'Validates and registers a new user',
+    },
+)
+
+# Step 2: Add a step to the workflow
+admin.run(
+    'feature.add_step',
+    data={
+        'feature_id': 'user.create',
+        'service_id': 'validate_user_evt',
+        'name': 'Validate User Step',
+        'parameters': {'mode': 'strict'},
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet feature add --id user.create --name "Create User Workflow" --description "Validates and registers a new user"
+tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User Step" --parameters mode=strict
+```
+
+---
+
+### 5. Service / DI Domain (`service`)
+
+Manages feature-level service registrations, constructor parameters, and flagged overrides.
+
+- **Available features**: `service.set_dependency`, `service.list_services`, `service.get_service`, `service.delete_service`
+- **CLI group**: `tiferet service <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'service.set_dependency',
+    data={
+        'registration_id': 'validate_user_evt',
+        'module_path': 'app.events.user',
+        'class_name': 'ValidateUserEvent',
+        'parameters': {'timeout': '5.0'},
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet service set-dependency --registration-id validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+```
+
+---
+
+### 6. Logging Domain (`logging`)
+
+Manages logging formatters, handlers, loggers, and logging configuration.
+
+- **Available features**: `logging.add_logger`, `logging.list_loggers`, `logging.get_logger`, `logging.delete_logger`
+- **CLI group**: `tiferet logging <command>`
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'logging.add_logger',
+    data={
+        'logger_id': 'app.audit',
+        'level': 'INFO',
+        'handlers': ['console', 'file'],
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet logging add-logger --logger-id app.audit --level INFO --handlers console file
+```
+
+---
+
+## Worked Example: Pairing a New Domain Event with Config Entries
+
+When a new domain event module is authored (e.g. `VerifyPaymentEvent`), three corresponding entries must be configured in `config.yml` to make it operational:
+
+1. **Error Definition** (`error.add`): Error constant and localized message for failure modes.
+2. **Service Registration** (`service.set_dependency`): DI registration mapping the event ID to its class.
+3. **Feature Step** (`feature.add_step`): Step entry referencing the service ID within a feature workflow.
+
+### Complete Python script
+
+```python
+from tiferet import AdminApp
+
+# Initialize AdminApp against the target configuration file
+admin = AdminApp(app_config='config.yml')
+
+# 1. Add error definition
+admin.run(
+    'error.add',
+    data={
+        'id': 'PAYMENT_VERIFICATION_FAILED_ID',
+        'name': 'Payment Verification Failed',
+        'message': 'Unable to verify payment transaction.',
+        'additional_messages': {
+            'es_ES': 'No se pudo verificar la transacción de pago.',
+        },
+    },
+)
+
+# 2. Register service dependency in DI
+admin.run(
+    'service.set_dependency',
+    data={
+        'registration_id': 'verify_payment_evt',
+        'module_path': 'app.events.payment',
+        'class_name': 'VerifyPaymentEvent',
+        'parameters': {'gateway_timeout': '10.0'},
+    },
+)
+
+# 3. Create or ensure feature workflow exists
+admin.run(
+    'feature.add',
+    data={
+        'id': 'payment.checkout',
+        'name': 'Payment Checkout Feature',
+    },
+)
+
+# 4. Attach domain event as a feature step
+admin.run(
+    'feature.add_step',
+    data={
+        'feature_id': 'payment.checkout',
+        'service_id': 'verify_payment_evt',
+        'name': 'Verify Payment Step',
+        'parameters': {'require_3ds': 'true'},
+    },
+)
+```
+
+---
+
+## Canonical Source
+
+For full architectural details, resolver flag routing, and detailed blueprint specs, see:
+- [docs/guides/admin.md](../../../guides/admin.md) — Admin Support Strategies and Patterns
+- [docs/core/blueprints.md](../../../core/blueprints.md) — Blueprint Architecture and Entry Points

--- a/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
@@ -14,6 +14,12 @@ description: Use the Tiferet Admin App or Admin CLI to add or update errors, ser
 
 The **Admin App** (`AdminApp` / `build_admin_app`) is the strongly recommended primary path for programmatic configuration management.
 
+Import from the blueprints package (not the package root):
+
+```python
+from tiferet.blueprints import AdminApp, AdminCLI
+```
+
 ### Why Admin App is preferred
 
 - **In-process objects**: Manipulates rich domain objects directly in Python without string serialization or parsing overhead.
@@ -23,13 +29,13 @@ The **Admin App** (`AdminApp` / `build_admin_app`) is the strongly recommended p
 ### Canonical usage pattern
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 # Instantiate the admin app (defaults to app_config='config.yml')
 admin = AdminApp()
 
 # Execute a management feature against config.yml
-response = admin.run('feature_id', data={'key': 'value'})
+response = admin.run('feature.list', data={})
 ```
 
 To target a specific configuration file other than `config.yml`:
@@ -46,46 +52,62 @@ The **Admin CLI** (`AdminCLI` / `build_admin_cli` / `tiferet`) is the secondary 
 
 ```bash
 # Target default config.yml in current working directory
-tiferet <group> <command> [options...]
+tiferet <group> <command> [args...]
 
 # Target a specific configuration file
-tiferet --config custom_config.yml <group> <command> [options...]
+tiferet --config custom_config.yml <group> <command> [args...]
 ```
 
 ### Key-value dict syntax
 
-Every flat-map/dict-typed argument on the Admin CLI accepts `key=value` pairs directly on the command line — raw JSON strings are **never** required.
+Every flat-map/dict-typed argument on the Admin CLI accepts `key=value` pairs directly on the command line — raw JSON strings are **never** required for dict args (only for the few `type: json` args such as `cli.add_argument --name-or-flags`).
 
 ```bash
-# Correct: flat-map key=value pairs
-tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "Token is invalid." --additional-messages es_ES="El token no es válido."
+# Correct: positional id/name/message; flat-map additional messages
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "Token is invalid." --additional-messages es_ES="El token no es válido."
 
-# Correct: flat-map parameters
-tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User" --parameters mode=strict timeout=5.0
+# Correct: positional feature id + step name + service_id; flat-map parameters
+tiferet feature add-step user.create "Validate User" validate_user_evt --parameters mode=strict timeout=5.0
 ```
+
+## Catalog source of truth
+
+Landed IDs come from:
+- `ADMIN_DEFAULT_FEATURES` — `tiferet/assets/feature.py` (41 features)
+- `ADMIN_DEFAULT_COMMANDS` — `tiferet/assets/cli.py` (40 commands; `feature.get` is Python-only)
+
+Do **not** invent verbs such as `app.add_session`, `list-sessions`, `list-errors`, `list-features`, or `delete_*`. Use the pairs below.
 
 ## The Six Admin Domains
 
-The admin surface spans six configuration management domains.
-
 ### 1. App Domain (`app`)
 
-Manages application interface definitions, session parameters, and app constants.
+Manages application interface / session definitions, constants, and app-level service dependencies.
 
-- **Available features**: `app.add_session`, `app.list_sessions`, `app.get_session`, `app.delete_session`
-- **CLI group**: `tiferet app <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `app.add` | Add a new application session configuration | `tiferet app add <id> <name> <module_path> <class_name> [--description] [--logger-id] [--flags] [--constants]` |
+| `app.get` | Retrieve an app session by ID | `tiferet app get <interface_id>` |
+| `app.list` | List all configured app sessions | `tiferet app list` |
+| `app.update` | Update a scalar attribute on an app session | `tiferet app update <id> <attribute> <value>` |
+| `app.set_constants` | Set or clear constants on an app session | `tiferet app set-constants <id> [--constants]` |
+| `app.set_service` | Set or update a service dependency on an app session | `tiferet app set-service <id> <service_id> <module_path> <class_name> [--parameters]` |
+| `app.remove_service` | Remove a service dependency from an app session | `tiferet app remove-service <id> <service_id>` |
+| `app.remove` | Remove an app session by ID | `tiferet app remove <id>` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
-    'app.add_session',
+    'app.add',
     data={
         'id': 'web_api',
         'name': 'Web API Session',
+        'module_path': 'app.contexts.api',
+        'class_name': 'ApiSessionContext',
         'description': 'Main web API application session',
     },
 )
@@ -94,30 +116,35 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet app add-session --id web_api --name "Web API Session" --description "Main web API application session"
+tiferet app add web_api "Web API Session" app.contexts.api ApiSessionContext --description "Main web API application session"
+tiferet app list
 ```
 
 ---
 
 ### 2. CLI Domain (`cli`)
 
-Manages CLI command definitions, command groups, and argument specifications.
+Manages CLI command definitions and argument specifications.
 
-- **Available features**: `cli.add_command`, `cli.list_commands`, `cli.get_command`, `cli.delete_command`
-- **CLI group**: `tiferet cli <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `cli.list_commands` | List all configured CLI commands | `tiferet cli list-commands` |
+| `cli.add_command` | Add a new CLI command definition | `tiferet cli add-command <id> <name> <key> <group_key> [--description]` |
+| `cli.add_argument` | Add an argument to an existing CLI command | `tiferet cli add-argument <command_id> --name-or-flags <json> [--description]` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
     'cli.add_command',
     data={
-        'group_key': 'reports',
-        'key': 'generate',
+        'id': 'reports.generate',
         'name': 'Generate Report',
+        'key': 'generate',
+        'group_key': 'reports',
         'description': 'Generate summary report',
     },
 )
@@ -126,22 +153,30 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet cli add-command --group-key reports --key generate --name "Generate Report" --description "Generate summary report"
+tiferet cli add-command reports.generate "Generate Report" generate reports --description "Generate summary report"
+tiferet cli list-commands
 ```
 
 ---
 
 ### 3. Error Domain (`error`)
 
-Manages structured error definitions, multilingual error messages, and error codes.
+Manages structured error definitions and multilingual messages.
 
-- **Available features**: `error.add`, `error.list_errors`, `error.get_error`, `error.delete_error`
-- **CLI group**: `tiferet error <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `error.list` | List all error definitions | `tiferet error list [--include-defaults]` |
+| `error.add` | Add a new error definition | `tiferet error add <id> <name> <message> [--lang] [--additional-messages]` |
+| `error.get` | Retrieve an error by ID | `tiferet error get <id>` |
+| `error.rename` | Rename an existing error definition | `tiferet error rename <id> <new_name>` |
+| `error.set_message` | Set the message text on an existing error | `tiferet error set-message <id> <message> [--lang]` |
+| `error.remove_message` | Remove a language message from an error | `tiferet error remove-message <id> [--lang]` |
+| `error.remove` | Remove an error definition | `tiferet error remove <id>` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
@@ -160,22 +195,32 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error list
 ```
 
 ---
 
 ### 4. Feature Domain (`feature`)
 
-Manages feature workflow definitions, steps, and feature parameters.
+Manages feature workflow definitions and steps.
 
-- **Available features**: `feature.add`, `feature.add_step`, `feature.list_features`, `feature.get_feature`, `feature.delete_feature`
-- **CLI group**: `tiferet feature <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `feature.list` | List all feature workflow definitions | `tiferet feature list [--group-id]` |
+| `feature.add` | Add a new feature workflow definition | `tiferet feature add <name> <group_id> [--feature-key] [--description]` |
+| `feature.get` | Retrieve a feature by ID | *(Python only — no CLI command)* |
+| `feature.update` | Update a metadata attribute on a feature | `tiferet feature update <id> <attribute> <value>` |
+| `feature.add_step` | Add a step to an existing feature workflow | `tiferet feature add-step <id> <name> <service_id> [--parameters] [--data-key] [--pass-on-error] [--position]` |
+| `feature.update_step` | Update an attribute on an existing feature step | `tiferet feature update-step <id> <position> <attribute> [--value]` |
+| `feature.remove_step` | Remove a step from an existing feature workflow | `tiferet feature remove-step <id> <position>` |
+| `feature.reorder_step` | Reorder a step within an existing feature workflow | `tiferet feature reorder-step <id> <start_position> <end_position>` |
+| `feature.remove` | Remove an existing feature workflow definition | `tiferet feature remove <id>` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 
@@ -183,8 +228,9 @@ admin = AdminApp()
 admin.run(
     'feature.add',
     data={
-        'id': 'user.create',
         'name': 'Create User Workflow',
+        'group_id': 'user',
+        'feature_key': 'create',
         'description': 'Validates and registers a new user',
     },
 )
@@ -193,9 +239,9 @@ admin.run(
 admin.run(
     'feature.add_step',
     data={
-        'feature_id': 'user.create',
-        'service_id': 'validate_user_evt',
+        'id': 'user.create',
         'name': 'Validate User Step',
+        'service_id': 'validate_user_evt',
         'parameters': {'mode': 'strict'},
     },
 )
@@ -204,32 +250,49 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet feature add --id user.create --name "Create User Workflow" --description "Validates and registers a new user"
-tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User Step" --parameters mode=strict
+tiferet feature add "Create User Workflow" user --feature-key create --description "Validates and registers a new user"
+tiferet feature add-step user.create "Validate User Step" validate_user_evt --parameters mode=strict
+tiferet feature list
 ```
 
 ---
 
 ### 5. Service / DI Domain (`service`)
 
-Manages feature-level service registrations, constructor parameters, and flagged overrides.
+Manages feature-level service registrations, flagged dependencies, and DI constants.
 
-- **Available features**: `service.set_dependency`, `service.list_services`, `service.get_service`, `service.delete_service`
-- **CLI group**: `tiferet service <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `service.list` | List all DI service registrations and constants | `tiferet service list` |
+| `service.add` | Add a new DI service registration | `tiferet service add <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_default` | Set or update the default type for a registration | `tiferet service set-default <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_dependency` | Set or update a flagged dependency on a registration | `tiferet service set-dependency <id> <flag> <module_path> <class_name> [--parameters]` |
+| `service.remove_dependency` | Remove a flagged dependency from a registration | `tiferet service remove-dependency <id> <flag>` |
+| `service.set_constants` | Set or clear DI service constants | `tiferet service set-constants [--constants]` |
+| `service.remove` | Remove a DI service registration | `tiferet service remove <id>` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
-    'service.set_dependency',
+    'service.add',
     data={
-        'registration_id': 'validate_user_evt',
+        'id': 'validate_user_evt',
         'module_path': 'app.events.user',
         'class_name': 'ValidateUserEvent',
         'parameters': {'timeout': '5.0'},
+    },
+)
+admin.run(
+    'service.set_dependency',
+    data={
+        'id': 'validate_user_evt',
+        'flag': 'test',
+        'module_path': 'app.events.user',
+        'class_name': 'StubValidateUserEvent',
     },
 )
 ```
@@ -237,30 +300,40 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet service set-dependency --registration-id validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+tiferet service add validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+tiferet service set-dependency validate_user_evt test app.events.user StubValidateUserEvent
+tiferet service list
 ```
 
 ---
 
 ### 6. Logging Domain (`logging`)
 
-Manages logging formatters, handlers, loggers, and logging configuration.
+Manages logging formatters, handlers, and loggers.
 
-- **Available features**: `logging.add_logger`, `logging.list_loggers`, `logging.get_logger`, `logging.delete_logger`
-- **CLI group**: `tiferet logging <command>`
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `logging.add_formatter` | Add a new logging formatter configuration | `tiferet logging add-formatter <id> <name> <format> [--description] [--datefmt]` |
+| `logging.remove_formatter` | Remove a logging formatter by ID | `tiferet logging remove-formatter <id>` |
+| `logging.add_handler` | Add a new logging handler configuration | `tiferet logging add-handler <id> <name> <module_path> <class_name> <level> <formatter> [--description] [--stream] [--filename]` |
+| `logging.remove_handler` | Remove a logging handler by ID | `tiferet logging remove-handler <id>` |
+| `logging.add_logger` | Add a new logger configuration | `tiferet logging add-logger <id> <name> <level> <handlers> [--description] [--no-propagate]` |
+| `logging.remove_logger` | Remove a logger by ID | `tiferet logging remove-logger <id>` |
+| `logging.list` | List all logging configurations | `tiferet logging list` |
 
 #### Python (`AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
     'logging.add_logger',
     data={
-        'logger_id': 'app.audit',
+        'id': 'app.audit',
+        'name': 'app.audit',
         'level': 'INFO',
-        'handlers': ['console', 'file'],
+        'handlers': 'console,file',
     },
 )
 ```
@@ -268,7 +341,8 @@ admin.run(
 #### CLI (`tiferet`)
 
 ```bash
-tiferet logging add-logger --logger-id app.audit --level INFO --handlers console file
+tiferet logging add-logger app.audit app.audit INFO console,file
+tiferet logging list
 ```
 
 ---
@@ -278,13 +352,13 @@ tiferet logging add-logger --logger-id app.audit --level INFO --handlers console
 When a new domain event module is authored (e.g. `VerifyPaymentEvent`), three corresponding entries must be configured in `config.yml` to make it operational:
 
 1. **Error Definition** (`error.add`): Error constant and localized message for failure modes.
-2. **Service Registration** (`service.set_dependency`): DI registration mapping the event ID to its class.
-3. **Feature Step** (`feature.add_step`): Step entry referencing the service ID within a feature workflow.
+2. **Service Registration** (`service.add` / optional `service.set_dependency`): DI registration mapping the event ID to its class (and any flagged override).
+3. **Feature Step** (`feature.add` / `feature.add_step`): Feature workflow plus step entry referencing the service ID.
 
 ### Complete Python script
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 # Initialize AdminApp against the target configuration file
 admin = AdminApp(app_config='config.yml')
@@ -302,11 +376,11 @@ admin.run(
     },
 )
 
-# 2. Register service dependency in DI
+# 2. Register the service (default type)
 admin.run(
-    'service.set_dependency',
+    'service.add',
     data={
-        'registration_id': 'verify_payment_evt',
+        'id': 'verify_payment_evt',
         'module_path': 'app.events.payment',
         'class_name': 'VerifyPaymentEvent',
         'parameters': {'gateway_timeout': '10.0'},
@@ -317,8 +391,9 @@ admin.run(
 admin.run(
     'feature.add',
     data={
-        'id': 'payment.checkout',
         'name': 'Payment Checkout Feature',
+        'group_id': 'payment',
+        'feature_key': 'checkout',
     },
 )
 
@@ -326,9 +401,9 @@ admin.run(
 admin.run(
     'feature.add_step',
     data={
-        'feature_id': 'payment.checkout',
-        'service_id': 'verify_payment_evt',
+        'id': 'payment.checkout',
         'name': 'Verify Payment Step',
+        'service_id': 'verify_payment_evt',
         'parameters': {'require_3ds': 'true'},
     },
 )

--- a/docs/core/blueprints.md
+++ b/docs/core/blueprints.md
@@ -1,32 +1,35 @@
 # Blueprints in Tiferet
 
-Blueprints are a core component of the Tiferet framework in v2.0+. They serve as the primary public entry point for applications, providing a clean, high-level API for loading services, preparing defaults, resolving interfaces, and executing features.
+Blueprints are a core component of the Tiferet framework in v2.0+. They serve as the primary public entry point for applications, providing a clean, high-level API for loading services, preparing defaults, resolving sessions, wiring the five-handler context contract, and executing features.
 
-While contexts define the runtime shape and behavior of an individual interface, blueprints orchestrate the overall application lifecycle and wiring.
+While contexts define the runtime shape and behavior of an individual session, blueprints orchestrate the overall application lifecycle and wiring.
 
 ## What is a Blueprint?
 
-A blueprint in Tiferet is a module-level function that encapsulates the initialization and orchestration logic required to prepare and run an application interface. Blueprints are intentionally thin: they focus on service loading, default configuration injection, dependency wiring, and delegation to the appropriate `AppSessionContext`.
+A blueprint in Tiferet is a module-level function that encapsulates the initialization and orchestration logic required to prepare and run an application session. Blueprints are intentionally thin: they focus on service loading, default configuration injection, dependency wiring, handler composition, and delegation to the appropriate `AppSessionContext` or `CliSessionContext`.
 
-The canonical implementation is `build_app` in `tiferet/blueprints/core.py` (exported as `App`), which chains the composition functions `build_cache` → `get_app_session` → `build_app_session_context`. The built-in CLI bootstrapper (`build_tiferet_cli`) uses a separate declarative bootstrap path in `tiferet/blueprints/tiferet_cli.py`.
+The canonical implementation is `build_app` in `tiferet/blueprints/core.py` (exported as `App`), which chains the composition functions `build_cache` → `get_app_session` → `build_app_session_context`. The CLI entrypoint (`build_cli` / `CLI`) and the admin entry points (`build_admin_app` / `AdminApp`, `build_admin_cli` / `AdminCLI`) reuse the same core composition helpers with session-specific cache seeding and resolver wiring.
 
 ### Role in the Architecture
 
 Blueprints sit at the highest level of the application graph:
 
-- They build the shared `CacheContext`, pre-seeded with the framework's default errors, app services, and constants (`build_cache`)
+- They build the shared `CacheContext`, pre-seeded with the framework's default errors, app services, constants, and (where applicable) logging settings, features, and CLI commands (`build_cache`)
 - They compose the application service and resolve the app session via a domain event (`get_app_session` → `GetAppSession`)
 - They build the app service container from the cache defaults merged with the session's own overrides, and compose a feature-level `ServiceResolver` (`build_app_session_context`)
-- They delegate feature execution to the resolved `AppSessionContext`
+- They wire the five required template-method handlers (`build_logger_handler`, `execute_feature_handler`, `create_request_handler`, `raise_error_handler`, `response_handler`) into the session context
+- They delegate feature execution to the resolved `AppSessionContext` / `CliSessionContext`
 
 This design keeps application code simple while maintaining full extensibility and testability.
 
 ## Types of Blueprints
 
-Tiferet currently defines two blueprints:
+Tiferet currently defines four public blueprints:
 
 - **App blueprint**: `build_app` — used for general script and custom interfaces. Exposed globally as `App`.
-- **CLI blueprint**: `build_cli` — a thin entrypoint that resolves and realizes a CLI interface (which must point at `CliContext`) and delegates `sys.argv` translation and feature dispatch to `CliContext.run_cli`. Exposed globally as `CLI`.
+- **CLI blueprint**: `build_cli` — a thin entrypoint that resolves and realizes a CLI session (which must point at `CliSessionContext`) and delegates `sys.argv` translation and feature dispatch to `CliSessionContext.run`. Exposed globally as `CLI`.
+- **Admin App blueprint**: `build_admin_app` — builds the built-in management session (`admin`) with admin-scoped service resolution. Exposed globally as `AdminApp`.
+- **Admin CLI blueprint**: `build_admin_cli` — builds the built-in management CLI (`admin_cli`) and powers the `tiferet` console script. Exposed globally as `AdminCLI`.
 
 Future specialized blueprints may include:
 
@@ -35,12 +38,12 @@ Future specialized blueprints may include:
 
 ### CLI Blueprint Build Procedure
 
-The CLI blueprint (`build_cli`) is a thin entrypoint; argparse parsing and request derivation live in `CliContext` (`tiferet/contexts/cli.py`). Its flow follows these steps:
+The CLI blueprint (`build_cli`) is a thin entrypoint; argparse parsing and request derivation live in `CliSessionContext` (`tiferet/contexts/cli.py`) behind an injected `parse_cli_args` closure. Its flow follows these steps:
 
-1. **Build the context** via `core.build_app(interface_id, ...)`. The interface must point at `tiferet.contexts.cli` / `CliContext`, so the composed context is a `CliContext`.
-2. **Delegate to the context** by calling `cli_context.run_cli(argv)`, which builds the parser from the interface's CLI commands and parent arguments, parses `argv` (argparse exits `2` on failure), derives `feature_id`/`headers`, dispatches through the inherited `run`, prints the response, and converts a `TiferetAPIError` into `sys.exit(1)`.
+1. **Build the context** via the CLI session composer (which wires all five handlers, including `build_logger_handler`, plus `parse_cli_args`). The interface must point at `tiferet.contexts.cli` / `CliSessionContext`.
+2. **Delegate to the context** by calling `cli_context.run(argv)`, which parses `argv` (argparse exits `2` on failure), derives `feature_id`/`headers`/`data`, dispatches through the inherited hub `run`, prints the response when appropriate, and converts a `TiferetAPIError` into `sys.exit(1)`.
 
-Consumer CLI interfaces opt in by declaring `module_path: tiferet.contexts.cli` / `class_name: CliContext` in their interface config.
+Consumer CLI interfaces opt in by declaring `module_path: tiferet.contexts.cli` / `class_name: CliSessionContext` in their session config.
 
 ## Structured Code Design of Blueprints
 
@@ -50,13 +53,139 @@ Blueprints follow Tiferet's standard artifact comment structure.
 
 Blueprints are organized under the `# *** blueprints` top-level comment, with individual blueprints under `# ** blueprint: <snake_case_name>`. Each blueprint function uses standard RST docstrings and code snippet conventions.
 
-Side-effect-free helpers (pure input→output transforms with no I/O, instantiation, or error raising) belong in a `# *** functions` section above `# *** blueprints`, with individual helpers under `# ** function: <snake_case_name>`. In `tiferet/blueprints/tiferet_cli.py` the bootstrap helpers `_resolve_ctor_kwargs`, `_build_wiring_constants`, and `_resolve_collaborators` (module-private, underscore-prefixed) are grouped this way — small pure helpers consumed by the orchestration functions below them (`_wire_services`, `_load_app_instance`, `_resolve_bootstrap_session`). Reserve `# *** blueprints` for the orchestration entry points reused by other blueprints or clients (e.g. `core.build_app`, `core.build_app_session_context`).
+Side-effect-free helpers (pure input→output transforms with no I/O, instantiation, or error raising) belong in a `# *** functions` section above `# *** blueprints`, with individual helpers under `# ** function: <snake_case_name>`. In `tiferet/blueprints/core.py`, `resolve_collaborators` and `merge_logging_settings` are grouped this way — small pure helpers consumed by the orchestration functions below them. Reserve `# *** blueprints` for the orchestration entry points reused by other blueprints or clients (e.g. `core.build_app`, `core.build_app_session_context`, `core.build_logger_handler`).
 
 **Spacing rules:**
 
 - One empty line between `# *** blueprints` and first `# ** blueprint`
 - One empty line between each blueprint function
 - One empty line after docstrings and between code snippets
+
+### Core Blueprint Artifacts (`tiferet/blueprints/core.py`)
+
+Key `# *** functions` and `# *** blueprints` in the core module:
+
+| Artifact | Kind | Role |
+| --- | --- | --- |
+| `RESERVED_CONTEXT_PARAMETERS` | constant | Constructor params supplied by session builders (includes all five handlers + `parse_cli_args`) |
+| `resolve_collaborators` | function | DI-resolves remaining injectable context collaborators, skipping reserved names |
+| `merge_logging_settings` | function | Merges repository logging sections over cache-seeded defaults by `.id` |
+| `parse_parameter` | blueprint | Injectable wrapper over `ParseParameter.execute` |
+| `build_app_service_container` | blueprint | Singleton app container from cache defaults + session overrides |
+| `build_service_resolver` | blueprint | Feature-level resolver; caches the app container under the `app` flag |
+| `build_cache` | blueprint | Shared cache pre-seeded with framework catalogs |
+| `get_error` / `get_feature` | blueprint | Lazy-caching domain-object handlers |
+| `build_logger_handler` | blueprint | Cache-backed logger construction under `LOGGER_CACHE_PREFIX` |
+| `create_request_context` / `create_session_request` | blueprint | Request factory used as `create_request_handler` |
+| `create_feature_context` | blueprint | Returns a domain-bound `FeatureContext` (not a tuple) |
+| `execute_feature_handler` | blueprint | Closure: `create_feature_context(...).execute_feature(request, ...)` |
+| `raise_error_handler` | blueprint | Formats domain errors into `TiferetAPIError` |
+| `response_handler` | blueprint | Delegates to `request.handle_response()` |
+| `build_app_session_context` | blueprint | Wires all five handlers into `AppSessionContext.from_domain` |
+| `build_app` | blueprint | Single-call public entry point (`App`) |
+
+#### `merge_logging_settings`
+
+```python
+# ** function: merge_logging_settings
+def merge_logging_settings(cache, formatters, handlers, loggers) -> LoggingSettings:
+    # Retrieve cache-seeded defaults (tolerate none).
+    # Merge repository entries over defaults keyed by .id (repository wins).
+    # Return LoggingSettings(formatters=..., handlers=..., loggers=...).
+```
+
+#### `build_logger_handler`
+
+```python
+# ** blueprint: build_logger_handler
+def build_logger_handler(cache, get_dependency) -> Callable:
+    def handler(logger_id: str):
+        cached = cache.get(logger_id, *LOGGER_CACHE_PREFIX)
+        if cached is not None:
+            return cached
+        formatters, handlers, loggers = get_dependency('logging_list_all_evt', 'app').execute()
+        settings = merge_logging_settings(cache, formatters, handlers, loggers)
+        logger = LoggingContext.from_domain(settings, logger_id=logger_id).build_logger()
+        cache.set(logger_id, logger, *LOGGER_CACHE_PREFIX)
+        return logger
+    return handler
+```
+
+#### `create_feature_context` / `execute_feature_handler`
+
+```python
+# ** blueprint: create_feature_context
+def create_feature_context(get_dependency, cache, feature_id) -> FeatureContext:
+    feature = get_feature(cache, get_dependency)(feature_id)
+    return FeatureContext.from_domain(feature, get_dependency=get_dependency, cache=cache)
+
+# ** blueprint: execute_feature_handler
+def execute_feature_handler(get_dependency, cache) -> Callable:
+    def handler(feature_id, request, *flags, **kwargs) -> None:
+        feature_context = create_feature_context(get_dependency, cache, feature_id)
+        feature_context.execute_feature(request, *flags, **kwargs)
+    return handler
+```
+
+`create_feature_context` returns only the bound `FeatureContext`. The inner call is `feature_context.execute_feature(request, ...)` — there is no `feature` parameter on the context method.
+
+#### Five-handler wiring in `build_app_session_context`
+
+```python
+handlers = dict(
+    build_logger_handler=build_logger_handler(cache, resolver.get_dependency),
+    execute_feature_handler=execute_feature_handler(resolver.get_dependency, cache),
+    raise_error_handler=raise_error_handler(get_error(cache, resolver.get_dependency)),
+    response_handler=response_handler,
+    create_request_handler=create_session_request,
+)
+return AppSessionContext.from_domain(
+    app_session,
+    get_dependency=resolver.get_dependency,
+    cache=cache,
+    **handlers,
+    **collaborators,
+)
+```
+
+## Admin Blueprints
+
+### `tiferet/blueprints/admin.py`
+
+| Artifact | Role |
+| --- | --- |
+| `build_cache` | Core cache plus admin catalogs: `ADMIN_DEFAULT_SERVICES`, `ADMIN_DEFAULT_CONSTANTS`, `ADMIN_DEFAULT_FEATURES`, `ADMIN_DEFAULT_ERRORS` |
+| `build_admin_service_resolver` | Dual-container resolver: app container under `'app'`; admin container under `'admin'` **and** as the empty-flag default |
+| `build_admin_app_session_context` | Mirrors `build_app_session_context` with the admin resolver and the same five handlers |
+| `build_admin_app` / `AdminApp` | Single-call entry point defaulting to `TIFERET_ADMIN_ID` |
+
+Admin-scoped resolution pattern:
+
+```python
+resolver.add_container(app_container, 'app')
+resolver.add_container(admin_container, 'admin')
+resolver.add_container(admin_container)  # empty-flag default
+```
+
+Feature steps therefore resolve from the admin container unless they explicitly request the `'app'` flag.
+
+### `tiferet/blueprints/admin_cli.py`
+
+| Artifact | Role |
+| --- | --- |
+| `build_cache` | Admin cache plus `ADMIN_DEFAULT_COMMANDS` |
+| `build_admin_cli_session_context` | Wires `CliSessionContext` with the admin resolver, five handlers, and CLI parse/request/response helpers |
+| `build_admin_cli` / `AdminCLI` | Resolves `TIFERET_ADMIN_CLI_ID`, re-seeds all `*_config` constants to the consumer path, runs `cli_context.run(argv)` |
+| `main` | Console entry for the `tiferet` script; pre-parses `--config` without consuming help/remaining argv |
+
+Exports (from `tiferet.blueprints` / top-level `tiferet`):
+
+```python
+from tiferet import App, CLI, AdminApp, AdminCLI
+# also: build_app, build_cli, build_admin_app, build_admin_cli
+```
+
+Full catalog reference: [docs/guides/admin.md](../guides/admin.md).
 
 ## Writing Blueprints
 
@@ -70,7 +199,9 @@ Side-effect-free helpers (pure input→output transforms with no I/O, instantiat
    - `get_app_session` — resolve the app session via the `GetAppSession` event
    - `build_app_service_container` — build the singleton app service container from cache defaults merged with the session's overrides
    - `build_service_resolver` — compose the feature-level `ServiceResolver`, caching the app container under the `app` flag
-   - `build_app_session_context` — import the declared context class, resolve its collaborators, wire the FE4 handlers, and construct the context
+   - `merge_logging_settings` / `build_logger_handler` — logger construction for the fifth handler slot
+   - `create_feature_context` / `execute_feature_handler` — domain-bound feature execution
+   - `build_app_session_context` — import/construct the context class with all five handlers
    - `build_app` — high-level single-call entry point chaining the above
 
 ### Key Patterns
@@ -83,24 +214,14 @@ app = App('basic_calc', app_config='config.yml')
 ```
 
 **Default configuration injection**  
-The core path sources the framework's `CORE_DEFAULT_SERVICES` / `CORE_DEFAULT_CONSTANTS` catalogs (defined in `assets/app.py`, accessed as `a.app`) from the shared cache seeded by `build_cache`. `build_app_service_container` merges those cache defaults with the session's own constants and services (session wins) *before* building the container, so `core.build_app` never calls `apply_defaults`:
+The core path sources the framework's `CORE_DEFAULT_SERVICES` / `CORE_DEFAULT_CONSTANTS` catalogs (defined in `assets/app.py`, accessed as `a.app`) from the shared cache seeded by `build_cache`. `build_app_service_container` merges those cache defaults with the session's own constants and services (session wins) *before* building the container:
 
 ```python
 container = build_app_service_container(cache, app_session)  # cache defaults + session overrides
 ```
 
-The `AppSession.apply_defaults` domain method and the `resolve_default_interface` bootstrap fallback are used by the built-in bootstrappers (`_resolve_bootstrap_session` in `tiferet/blueprints/tiferet_cli.py`), whose sessions (`tiferet_app`, `tiferet_cli`) are not defined in the consumer config.
-
 **Cache pre-seeding**  
-The core `build_cache` blueprint (`tiferet/blueprints/core.py`) pre-seeds a `CacheContext` with three framework catalogs via stacked decorators — `add_default_errors`, `add_default_app_services`, and `add_default_app_constants` (the latter two defined in `contexts/app.py`) — namespacing each catalog under its own cache-key prefix (`error_`, `app_service_`, `app_constant_`). Errors and services are reconstituted into domain objects (`Error`, `AppServiceDependency`); constants are seeded as scalars:
-
-```python
-@add_default_app_constants(a.app.CORE_DEFAULT_CONSTANTS)
-@add_default_app_services(a.app.CORE_DEFAULT_SERVICES)
-@add_default_errors(a.error.CORE_DEFAULT_ERRORS)
-def build_cache(cache=None) -> CacheContext:
-    return CacheContext(cache=cache)
-```
+The core `build_cache` blueprint (`tiferet/blueprints/core.py`) pre-seeds a `CacheContext` with framework catalogs via stacked decorators, namespacing each catalog under its own cache-key prefix.
 
 **Service resolver injection**  
 `build_service_resolver` composes a `ServiceResolver` from the app service container (caching it under the `app` flag), and `build_app_session_context` injects its `get_dependency` handler into the context:
@@ -110,7 +231,8 @@ resolver = build_service_resolver(app_container)
 return context_cls.from_domain(app_session, get_dependency=resolver.get_dependency, ...)
 ```
 
-The declarative registry wiring (`_wire_services` + the `CreateServiceResolver` bootstrap event) is used in `tiferet/blueprints/tiferet_cli.py` for `build_tiferet_cli`'s feature-DI bootstrap.
+**Five-handler context wiring**  
+Always pass `build_logger_handler` (never a long-lived `logging_context` constructor keyword). See [docs/core/contexts.md](contexts.md).
 
 ## Testing Blueprints
 
@@ -118,26 +240,30 @@ Blueprint tests use `pytest` with `unittest.mock`. Focus on:
 
 - Correct composition of the app service and app session (`create_app_service` / `get_app_session`)
 - Cache defaults merged with session overrides in `build_app_service_container`
+- Five-handler wiring in `build_app_session_context` / admin variants
 - Validation of the resolved `AppSessionContext` (raising `INVALID_APP_SESSION_TYPE`)
-- High-level `core.build_app()` behavior
+- High-level `core.build_app()` / `build_admin_app()` behavior
 
 ## Best Practices
 
 - Keep blueprints **thin** — they should orchestrate, not implement domain logic.
-- Always validate the resolved context type (`INVALID_APP_SESSION_TYPE`) in the single-call entry points (`core.build_app`, `build_tiferet_app`, `build_tiferet_cli`).
-- Use `TiferetError.raise_error()` for all domain-outcome error paths with proper constants (e.g. `TiferetError.raise_error(a.error.INVALID_APP_SESSION_TYPE_ID, ...)`).
+- Always validate the resolved context type (`INVALID_APP_SESSION_TYPE`) in the single-call entry points.
+- Use `TiferetError.raise_error()` for all domain-outcome error paths with proper constants.
 - Inject the `ServiceResolver`'s `get_dependency` handler into the context so contexts remain decoupled from the DI engine.
+- Wire all five handlers; never leave a hub slot unset in production paths.
 
 ## Conclusion
 
-Blueprints provide a clean, high-level API for initializing and running Tiferet applications. They encapsulate service loading, default configuration, and interface resolution while delegating execution to `AppSessionContext`. Their functional design ensures consistency, forward-compatibility, and extensibility.
+Blueprints provide a clean, high-level API for initializing and running Tiferet applications. They encapsulate service loading, default configuration, five-handler wiring, and session resolution while delegating execution to `AppSessionContext`. Their functional design ensures consistency, forward-compatibility, and extensibility.
 
 Explore source in `tiferet/blueprints/` and blueprint tests in the top-level `tests/` tree for implementation details.
 
 ## Related Documentation
 
 - [docs/guides/blueprints.md](../guides/blueprints.md) — blueprint strategies and patterns
-- [docs/core/di.md](../core/di.md) — dependency injection and service provider design
-- [docs/core/events.md](../core/events.md) — domain event design and usage
-- [docs/guides/domain/app.md](../guides/domain/app.md) — application interface and service registration guide
-- [docs/core/code_style.md](../core/code_style.md) — artifact comments and formatting
+- [docs/guides/admin.md](../guides/admin.md) — admin application and CLI catalog
+- [docs/core/contexts.md](contexts.md) — five-handler context contract
+- [docs/core/di.md](di.md) — dependency injection and service provider design
+- [docs/core/events.md](events.md) — domain event design and usage
+- [docs/guides/domain/app.md](../guides/domain/app.md) — application session and service registration guide
+- [docs/core/code_style.md](code_style.md) — artifact comments and formatting

--- a/docs/core/blueprints.md
+++ b/docs/core/blueprints.md
@@ -178,11 +178,13 @@ Feature steps therefore resolve from the admin container unless they explicitly 
 | `build_admin_cli` / `AdminCLI` | Resolves `TIFERET_ADMIN_CLI_ID`, re-seeds all `*_config` constants to the consumer path, runs `cli_context.run(argv)` |
 | `main` | Console entry for the `tiferet` script; pre-parses `--config` without consuming help/remaining argv |
 
-Exports (from `tiferet.blueprints` / top-level `tiferet`):
+Exports:
 
 ```python
-from tiferet import App, CLI, AdminApp, AdminCLI
+from tiferet import App, CLI
+from tiferet.blueprints import AdminApp, AdminCLI
 # also: build_app, build_cli, build_admin_app, build_admin_cli
+# AdminApp / AdminCLI are blueprints-package exports only (not package-root).
 ```
 
 Full catalog reference: [docs/guides/admin.md](../guides/admin.md).

--- a/docs/core/contexts.md
+++ b/docs/core/contexts.md
@@ -4,17 +4,17 @@ Contexts are a core component of the Tiferet framework, representing the structu
 
 ## What is a Context?
 
-A Context in Tiferet is a class that encapsulates a specific aspect of an application’s runtime behavior, such as user-facing interactions (e.g., CLI, web), feature execution, dependency injection, error handling, caching, or logging. Contexts form a graph-like structure during execution, defining how the application processes inputs, executes domain logic, and returns outputs. They align with Domain-Driven Design (DDD) principles, isolating concerns to ensure modularity and extensibility.
+A Context in Tiferet is a class that encapsulates a specific aspect of an application's runtime behavior, such as user-facing interactions (e.g., CLI, web), feature execution, dependency injection, error handling, caching, or logging. Contexts form a graph-like structure during execution, defining how the application processes inputs, executes domain logic, and returns outputs. They align with Domain-Driven Design (DDD) principles, isolating concerns to ensure modularity and extensibility.
 
 ### Types of Contexts
 All contexts extend `BaseContext` (`tiferet/contexts/core.py`), which provides a `ContextMeta` registry mapping a domain object type (`domain_type`) to its context class. `BaseContext.for_domain(DomainType)` resolves the registered class, and `BaseContext.from_domain(domain_obj, **kwargs)` constructs a context bound to a loaded domain object (exposed as `ctx.domain`). Caching is not part of the base; contexts that need a `CacheContext` (e.g., `AppSessionContext`, `FeatureContext`) declare and wire it themselves.
 
 Tiferet recognizes two broad categories:
 
-- **High-Level Contexts**: Handle user interactions (e.g., `CliContext` for command-line interfaces, `FlaskApiContext` for web APIs). They extend `AppSessionContext`, the minimal hub built declaratively from the loaded `AppSession`. CLI interfaces point at `CliContext`, which owns argparse parsing; the `build_cli` blueprint is a thin entrypoint that delegates to `CliContext.run_cli`.
-- **Low-Level Contexts**: Support specific functions (e.g., `FeatureContext`, `AsyncFeatureContext`, `ErrorContext`, `CacheContext`, `RequestContext`, `LoggingContext`).
+- **High-Level Contexts**: Handle user interactions (e.g., `CliSessionContext` for command-line interfaces, `FlaskApiContext` for web APIs). They extend `AppSessionContext`, the minimal hub built declaratively from the loaded `AppSession`. CLI interfaces point at `CliSessionContext`, which owns argparse parsing via an injected `parse_cli_args` closure; the `build_cli` blueprint is a thin entrypoint that wires the five-handler contract and delegates to `CliSessionContext.run`.
+- **Low-Level Contexts**: Support specific functions (e.g., `FeatureContext`, `ErrorContext`, `CacheContext`, `RequestContext`, `LoggingContext`).
 
-In the calculator application, `AppSessionContext` handles feature execution, while low-level contexts manage dependency injection, error handling, and logging.
+In the calculator application, `AppSessionContext` handles feature execution through its five required template-method handlers, while low-level contexts manage feature step execution, error formatting, caching, and logger assembly.
 
 **Note on Method Design**: The nature of methods in Contexts is not restrictive regarding inputs and outputs. Methods must be defined according to the domain requirements of the context containing them, allowing flexibility for domain-specific tasks while maintaining clear, documented signatures.
 
@@ -35,16 +35,14 @@ Contexts are organized under the `# *** contexts` top-level comment, with indivi
 - One empty line between each `# *` section.
 - One empty line after docstrings and between code snippets.
 
-**Example** – `tiferet/contexts/app.py` (minimal hub):
+**Example** – `tiferet/contexts/app.py` (minimal hub with the five-handler contract):
 ```python
 # *** imports
 
 # ** app
 from .core import BaseContext
 from .cache import CacheContext
-from .feature import FeatureContext
-from .error import ErrorContext
-from .logging import LoggingContext
+from .request import RequestContext
 from ..domain import AppSession
 
 # *** contexts
@@ -58,46 +56,89 @@ class AppSessionContext(BaseContext):
     # * init
     def __init__(self,
                  get_dependency,
-                 logging_context=None,
                  cache=None,
+                 build_logger_handler=None,
                  execute_feature_handler=None,
                  create_request_handler=None,
                  raise_error_handler=None,
                  response_handler=None):
-        '''
+        """
         Initialize the hub. The loaded AppSession is bound via from_domain as
         self.domain, supplying the session id and logger id on demand.
-        '''
+        """
         super().__init__()
         self.cache = cache if cache is not None else CacheContext()
         self.get_dependency = get_dependency
-        # ... store the injected handler callables and logging context;
-        # sub-contexts are built on demand via BaseContext.for_domain ...
+        # Store the five template-method handlers (validated lazily on first use).
+        self._build_logger = build_logger_handler
+        self._execute_feature = execute_feature_handler
+        self._create_request = create_request_handler
+        self._raise_error = raise_error_handler
+        self._build_response = response_handler
 
     # * method: run
     def run(self, feature_id, headers=None, data=None, **kwargs):
-        '''
+        """
         Execute a feature and return the response.
-        '''
-        # Build the logger from the lazily-created logging context.
-        logger = self.load_logging_context().build_logger()
+        """
+        # Build the logger via the required build_logger template method.
+        logger = self.build_logger()
 
-        # Parse request into a RequestContext (interface id from self.domain.id).
-        request = self.parse_request(headers or {}, data or {}, feature_id)
+        # Build the request context (interface id from self.domain.id).
+        request = self.build_request(feature_id, headers or {}, data or {})
 
         # Execute the feature.
         try:
-            self.execute_feature(feature_id=feature_id, request=request, logger=logger, **kwargs)
+            self.execute_feature(feature_id, request, logger=logger, **kwargs)
         except TiferetError as e:
             return self.handle_error(e)
 
-        # Return the response via the request context.
-        return request.handle_response()
+        # Return the response via the response template method.
+        return self.build_response(request)
 ```
 
-The hub builds the `FeatureContext` and `ErrorContext` on demand (via `BaseContext.for_domain`) inside `execute_feature` / `handle_error`, lazily caches the `LoggingContext` (`load_logging_context`), and loads domain objects via `load_feature_domain` / `get_error`. The hub owns a `CacheContext` — used by `load_feature_domain` and `get_error` (which resolves an error from the cache, pre-seeded with the framework defaults under `error_`-prefixed keys by `build_cache`, before falling back to the get-error event and caching the result) and shared with the `FeatureContext` it builds; the error and logging contexts no longer take a cache. Feature-step services are resolved through the injected `get_dependency` handler (provided by the `ServiceResolver`), which the hub forwards to each `FeatureContext` it builds.
+### The Five Required Handlers
 
-When a loaded `Feature` has `is_async` set to `True`, `execute_feature` selects the `AsyncFeatureContext` subclass — which extends `FeatureContext` with awaiting (`handle_feature_step_async` / `execute_feature_async`) step execution while inheriting the shared step-resolution, parameter-parsing, condition, and middleware helpers — and drives its `execute_feature_async` coroutine to completion via a `_run_coroutine` helper. The helper uses `asyncio.run` when no event loop is running and falls back to a dedicated worker thread when one is, keeping `run()` synchronous. `AsyncFeatureContext` deliberately does not declare its own `domain_type`, so the `Feature → FeatureContext` registry entry is preserved.
+`AppSessionContext` (and subclasses such as `CliSessionContext`) implements a **required five-handler template-method contract**. Each public template method is backed by an injected handler slot:
+
+| Template method | Handler slot | Role |
+| --- | --- | --- |
+| `build_logger` | `build_logger_handler` | Construct (and typically cache) the session logger by `logger_id` |
+| `build_request` | `create_request_handler` | Construct a `RequestContext` for the feature run |
+| `execute_feature` | `execute_feature_handler` | Resolve and drive the bound `FeatureContext` against the request |
+| `handle_error` | `raise_error_handler` | Format a domain error into a structured API error response |
+| `build_response` | `response_handler` | Extract the final response from the completed request |
+
+Handlers are **required**, not optional fallbacks. An unwired slot raises `APP_ERROR` via the module helper `raise_unwired_handler_error(handler_name, interface_id, ...)` on first use. There is no inline fallback implementation on the hub.
+
+`handle_error` also re-raises an incoming `TiferetAPIError` verbatim before consulting `raise_error_handler`, so already-formatted API errors are never double-wrapped.
+
+`build_logger_handler` replaces the former separately-loaded `LoggingContext` on the hub. The hub no longer accepts a `logging_context` constructor keyword constructor keyword, does not cache a `_logging` attribute, and does not call `load_logging_context`. Logger construction is a first-class template method; the blueprint wires a cache-backed closure (`blueprints/core.py::build_logger_handler`) that lists logging configs, merges them over cache-seeded defaults via `merge_logging_settings`, builds a one-shot `LoggingContext.from_domain(settings, logger_id=...)`, and caches the resulting logger under `LOGGER_CACHE_PREFIX`.
+
+Blueprint wiring lives in `build_app_session_context` / `build_cli_session_context` / `build_admin_app_session_context` / `build_admin_cli_session_context`. `RESERVED_CONTEXT_PARAMETERS` in `blueprints/core.py` includes `build_logger_handler` (and the other four handler names) so generic collaborator resolution does not attempt to DI-resolve them.
+
+### Domain-Bound FeatureContext
+
+`FeatureContext` is constructed via `BaseContext.from_domain(feature, get_dependency=..., cache=...)`. The bound `Feature` is available as `self.domain`. Its public execution surface takes **no** `feature` parameter:
+
+```python
+def execute_feature(self, request, *flags, **kwargs):
+    feature = self.domain
+    ...
+
+def resolve_feature_steps(self, request, *execution_flags):
+    feature = self.domain
+    ...
+```
+
+`create_feature_context` in `blueprints/core.py` returns a `FeatureContext` (not a `(Feature, FeatureContext)` tuple). The hub's `execute_feature_handler` therefore calls:
+
+```python
+feature_context = create_feature_context(get_dependency, cache, feature_id)
+feature_context.execute_feature(request, *flags, **kwargs)
+```
+
+Async dispatch is owned by `FeatureContext` itself via `Feature.is_async` and `EventFeatureStep.is_async` (see the Feature domain guide). There is no separate `AsyncFeatureContext` class and no `handle_feature_step` / `get_feature_handler` public surface on the hub.
 
 ### Cache Context and Default Catalogs
 
@@ -109,7 +150,7 @@ The app-context module (`tiferet/contexts/app.py`) provides paired seeders and g
 - `get_default_app_services(cache)` returns the seeded `AppServiceDependency` domain objects (the values behind the `app_service_` prefix).
 - `get_default_app_constants(cache)` returns the seeded bootstrap constants keyed by name, stripping the `app_constant_` prefix.
 
-These getters let the `build_app_service_container` blueprint pull the framework defaults back off the shared cache when composing the app-level service container.
+These getters let the `build_app_service_container` blueprint pull the framework defaults back off the shared cache when composing the app-level service container. Admin blueprints stack additional seeders (`add_default_admin_services`, `add_default_admin_constants`, `add_default_features(ADMIN_DEFAULT_FEATURES)`, `add_default_errors(ADMIN_DEFAULT_ERRORS)`, and for the admin CLI `add_default_cli_commands(ADMIN_DEFAULT_COMMANDS)`).
 
 ## Writing Contexts
 
@@ -129,24 +170,25 @@ class FlaskApiContext(AppSessionContext):
 
     # * init
     def __init__(self, flask_handler, **kwargs):
-        # Forward the resolved hub collaborators/defaults to AppSessionContext.
+        # Forward the resolved hub collaborators/handlers to AppSessionContext.
         # The blueprint imports this class from the interface's module_path/
-        # class_name and constructs it via from_domain.
+        # class_name and constructs it via from_domain with the five handlers.
         super().__init__(**kwargs)
         self.flask_handler = flask_handler
 
     # * method: parse_request
     def parse_request(self, flask_request) -> FlaskRequestContext:
-        '''
+        """
         Parse Flask request into RequestContext.
-        '''
+        """
         # Extract headers, data, feature_id
         ...
 ```
 
 ### Extending Existing Contexts
 - Override methods under `# * method` to customize behavior.
-- Use `super()` for template pattern compliance.
+- Use `super()` for template pattern compliance so unwired-handler guards remain intact.
+- Do not reintroduce truthiness-guarded fallbacks for any of the five required handlers.
 
 ## Testing Contexts
 
@@ -158,36 +200,46 @@ Tests use `pytest` with `unittest.mock`, organized under `# *** fixtures` and `#
 
 # ** fixture: app_session_context
 @pytest.fixture
-def app_session_context(app_session, logging_context):
+def app_session_context(app_session):
     # Build the hub declaratively from a loaded app session via from_domain.
     context = AppSessionContext.from_domain(
         app_session,
         get_dependency=mock.Mock(),
-        logging_context=logging_context,
+        build_logger_handler=mock.Mock(return_value=mock.Mock()),
+        execute_feature_handler=mock.Mock(),
+        create_request_handler=mock.Mock(),
+        raise_error_handler=mock.Mock(),
+        response_handler=mock.Mock(return_value={'ok': True}),
     )
     return context
 
 # *** tests
 
 # ** test: app_session_context_run_success
-def test_app_session_context_run_success(app_session_context, logging_context):
-    # Arrange the logger.
-    logging_context.build_logger.return_value = mock.Mock()
-
+def test_app_session_context_run_success(app_session_context):
     # Act.
     result = app_session_context.run('calc.add', data={'a': 1, 'b': 2})
 
-    # The feature context is built on demand inside execute_feature; assert the
-    # run completed and produced a response.
+    # Assert the five handlers were consulted and a response was produced.
+    app_session_context._build_logger.assert_called()
+    app_session_context._execute_feature.assert_called()
     assert result is not None
 ```
 
 ### Best Practices
 - Use `# ** fixture` and `# ** test` comments.
-- Mock dependencies.
-- Test all `# * method` behaviors.
+- Mock all five handler slots explicitly; leave a slot `None` only when testing the unwired-handler error path.
+- Test all `# * method` behaviors, including `raise_unwired_handler_error` when a handler is missing.
 - Include RST docstrings.
 
 ## Conclusion
 
-Contexts define the runtime shape of Tiferet applications, orchestrating user interaction and internal services. Their structured design ensures consistency and extensibility. Developers can create new Contexts or extend existing ones by following artifact patterns and conventions. Explore `tiferet/contexts/` for source and `tests/contexts/` for test examples.
+Contexts define the runtime shape of Tiferet applications, orchestrating user interaction and internal services through a required five-handler template-method contract. Their structured design ensures consistency and extensibility. Developers can create new Contexts or extend existing ones by following artifact patterns and conventions. Explore `tiferet/contexts/` for source and `tests/contexts/` for test examples.
+
+## Related Documentation
+
+- [docs/guides/contexts.md](../guides/contexts.md) — Context strategies and runtime patterns
+- [docs/core/blueprints.md](blueprints.md) — Blueprint composition and handler wiring
+- [docs/guides/blueprints.md](../guides/blueprints.md) — Blueprint strategies, including admin entry points
+- [docs/guides/admin.md](../guides/admin.md) — Admin application and CLI catalog
+- [docs/core/code_style.md](code_style.md) — Artifact comments and formatting rules

--- a/docs/guides/admin.md
+++ b/docs/guides/admin.md
@@ -1,0 +1,257 @@
+# Admin Support – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Modules:** `tiferet/blueprints/admin.py`, `tiferet/blueprints/admin_cli.py`  
+**Version:** 2.0.0
+
+## Overview
+
+The Tiferet framework provides a built-in admin support layer that allows application developers and operators to inspect, add, update, and remove configuration records directly in consumer `config.yml` files (and YAML/JSON repositories) without building custom management interfaces.
+
+The admin layer is exposed through two single-call entry points:
+- **`AdminApp`** / **`build_admin_app`** — Python entry point returning a fully wired `AppSessionContext` bound to the built-in `admin` session.
+- **`AdminCLI`** / **`build_admin_cli`** — Console entry point (`tiferet`) returning a `CliSessionContext` bound to the built-in `admin_cli` session.
+
+Both entry points pre-seed an admin bootstrap cache containing the framework's full six-domain CRUD catalog and wire an admin service resolver that resolves admin-scoped feature steps from an admin container by default.
+
+## Ubiquitous Language
+
+- **Admin Session**: A built-in application session (`admin` or `admin_cli`) configured with default repositories and management workflows.
+- **Admin CLI**: The `tiferet` command-line entry point that pre-parses `--config` options and dispatches administrative CLI requests.
+- **Six Admin Domains**: The functional CRUD management domains exposed by the admin catalog: App, CLI, Error, Feature, Service/DI, and Logging.
+- **Admin-Scoped Resolution**: Service resolution where default feature steps resolve against the admin service container rather than consumer application overrides.
+
+## Building an Admin Session
+
+The `build_admin_app` blueprint function (exported as `AdminApp`) builds a complete admin session context:
+
+```python
+from tiferet import AdminApp
+
+# Bootstrap the admin application session
+admin = AdminApp()
+
+# Execute a management feature against the consumer's config.yml
+response = admin.run('app.list')
+```
+
+### Resolver Flag Routing
+
+`build_admin_service_resolver` registers the `app` container under the `'app'` flag, while the admin container is registered under both the `'admin'` flag and the empty-flag default:
+
+```python
+# Resolves from the consumer app container
+app_dep = resolver.get_dependency('service_id', 'app')
+
+# Resolves from the admin container
+admin_dep = resolver.get_dependency('service_id', 'admin')
+
+# Resolves from the admin container by default
+default_dep = resolver.get_dependency('service_id')
+```
+
+This guarantees that admin management workflows execute against the framework's administrative services and repositories without interfering with consumer application registrations.
+
+## Building an Admin CLI Session
+
+The `build_admin_cli` blueprint function (exported as `AdminCLI`) and its `main()` console wrapper power the `tiferet` script:
+
+```bash
+# Manage config.yml in the current directory
+tiferet app list-sessions
+
+# Manage a specific configuration file
+tiferet --config custom_config.yml error list-errors
+```
+
+Programmatically, `build_admin_cli` re-seeds the resolved session's constants so every config-file repository points directly at the consumer-supplied configuration file:
+
+```python
+from tiferet import AdminCLI
+
+# Execute an administrative CLI command against a custom config file
+response = AdminCLI(app_config='app_config.yml', argv=['feature', 'list-features'])
+```
+
+## The Six Admin Domains
+
+The admin catalog spans six configuration management domains:
+
+1. **App Domain (`app`)**: Manages application interface definitions, session parameters, and app constants.
+2. **CLI Domain (`cli`)**: Manages CLI command definitions, command groups, and argument specifications.
+3. **Error Domain (`error`)**: Manages structured error definitions, multilingual error messages, and codes.
+4. **Feature Domain (`feature`)**: Manages feature workflow definitions, steps, and feature parameters.
+5. **Service/DI Domain (`service`)**: Manages feature-level service registrations, constructor parameters, and flagged overrides.
+6. **Logging Domain (`logging`)**: Manages logging formatters, handlers, loggers, and logging configuration.
+
+All flat-map arguments across administrative commands accept key-value dict pairs in `key=value` format when invoked via the CLI, eliminating the need for raw JSON strings.
+
+## Worked Examples
+
+Below are side-by-side Python (`AdminApp`) and CLI (`tiferet`) worked examples for all six admin domains.
+
+### 1. App Domain
+
+Adding a new application session definition:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'app.add_session',
+    data={
+        'id': 'web_api',
+        'name': 'Web API Session',
+        'description': 'Main web API application session',
+    },
+)
+```
+
+Equivalent CLI command:
+
+```bash
+tiferet app add-session --id web_api --name "Web API Session" --description "Main web API application session"
+```
+
+### 2. CLI Domain
+
+Adding a new CLI command to a command group:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'cli.add_command',
+    data={
+        'group_key': 'reports',
+        'key': 'generate',
+        'name': 'Generate Report',
+        'description': 'Generate summary report',
+    },
+)
+```
+
+Equivalent CLI command:
+
+```bash
+tiferet cli add-command --group-key reports --key generate --name "Generate Report" --description "Generate summary report"
+```
+
+### 3. Error Domain
+
+Adding a new structured error with additional localized messages using `key=value` pairs:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'error.add',
+    data={
+        'id': 'INVALID_TOKEN_ID',
+        'name': 'Invalid Token',
+        'message': 'The provided authentication token is invalid.',
+        'additional_messages': {
+            'es_ES': 'El token de autenticación proporcionado no es válido.',
+        },
+    },
+)
+```
+
+Equivalent CLI command using flat-map dict syntax (`--additional-messages es_ES="El token..."`):
+
+```bash
+tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+```
+
+### 4. Feature Domain
+
+Adding a feature step to a feature workflow:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'feature.add_step',
+    data={
+        'feature_id': 'user.create',
+        'service_id': 'validate_user_evt',
+        'name': 'Validate User Step',
+        'parameters': {'mode': 'strict'},
+    },
+)
+```
+
+Equivalent CLI command using flat-map dict parameters (`--parameters mode=strict`):
+
+```bash
+tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User Step" --parameters mode=strict
+```
+
+### 5. Service / DI Domain
+
+Registering a feature-level service dependency:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'service.set_dependency',
+    data={
+        'registration_id': 'user_service',
+        'module_path': 'app.services.user',
+        'class_name': 'UserService',
+        'parameters': {'timeout': '5.0'},
+    },
+)
+```
+
+Equivalent CLI command using flat-map dict parameters (`--parameters timeout=5.0`):
+
+```bash
+tiferet service set-dependency --registration-id user_service --module-path app.services.user --class-name UserService --parameters timeout=5.0
+```
+
+### 6. Logging Domain
+
+Adding a logger configuration:
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'logging.add_logger',
+    data={
+        'logger_id': 'app.audit',
+        'level': 'INFO',
+        'handlers': ['console', 'file'],
+    },
+)
+```
+
+Equivalent CLI command:
+
+```bash
+tiferet logging add-logger --logger-id app.audit --level INFO --handlers console file
+```
+
+## Boundaries
+
+- **Inside this domain**: Invoking the built-in `admin` and `admin_cli` application sessions, resolving admin catalog features, executing CRUD management operations against consumer YAML/JSON configuration files, and utilizing flat-map key-value CLI options.
+- **Outside this domain**:
+  - Authoring new domain events, services, or features for a consumer's own domain logic — see [docs/core/blueprints.md](../core/blueprints.md) and component code-style skills (`tiferet-code-domain`, `tiferet-code-events`).
+  - Internal blueprint handler composition and context construction details — see [docs/core/blueprints.md](../core/blueprints.md) and [docs/core/contexts.md](../core/contexts.md).
+
+## Related Documentation
+
+- [docs/core/blueprints.md](../core/blueprints.md) — Blueprint architecture and single-call entry points
+- [docs/core/contexts.md](../core/contexts.md) — Runtime context hub architecture and handler wiring
+- [docs/guides/blueprints.md](blueprints.md) — Blueprint design strategies and patterns
+- [docs/guides/contexts.md](contexts.md) — Context strategies and runtime execution patterns
+- [docs/guides/domain/cli.md](domain/cli.md) — CLI domain models and argument parsing

--- a/docs/guides/admin.md
+++ b/docs/guides/admin.md
@@ -13,7 +13,18 @@ The admin layer is exposed through two single-call entry points:
 - **`AdminApp`** / **`build_admin_app`** — Python entry point returning a fully wired `AppSessionContext` bound to the built-in `admin` session.
 - **`AdminCLI`** / **`build_admin_cli`** — Console entry point (`tiferet`) returning a `CliSessionContext` bound to the built-in `admin_cli` session.
 
+Import both from the blueprints package (they are not re-exported from the package root):
+
+```python
+from tiferet.blueprints import AdminApp, AdminCLI
+# also: build_admin_app, build_admin_cli
+```
+
 Both entry points pre-seed an admin bootstrap cache containing the framework's full six-domain CRUD catalog and wire an admin service resolver that resolves admin-scoped feature steps from an admin container by default.
+
+Source of truth for catalog IDs:
+- Features: `ADMIN_DEFAULT_FEATURES` in `tiferet/assets/feature.py` (41 features)
+- Commands: `ADMIN_DEFAULT_COMMANDS` in `tiferet/assets/cli.py` (40 commands; `feature.get` is Python-only)
 
 ## Ubiquitous Language
 
@@ -27,7 +38,7 @@ Both entry points pre-seed an admin bootstrap cache containing the framework's f
 The `build_admin_app` blueprint function (exported as `AdminApp`) builds a complete admin session context:
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 # Bootstrap the admin application session
 admin = AdminApp()
@@ -59,93 +70,110 @@ The `build_admin_cli` blueprint function (exported as `AdminCLI`) and its `main(
 
 ```bash
 # Manage config.yml in the current directory
-tiferet app list-sessions
+tiferet app list
 
 # Manage a specific configuration file
-tiferet --config custom_config.yml error list-errors
+tiferet --config custom_config.yml error list
 ```
 
 Programmatically, `build_admin_cli` re-seeds the resolved session's constants so every config-file repository points directly at the consumer-supplied configuration file:
 
 ```python
-from tiferet import AdminCLI
+from tiferet.blueprints import AdminCLI
 
 # Execute an administrative CLI command against a custom config file
-response = AdminCLI(app_config='app_config.yml', argv=['feature', 'list-features'])
+response = AdminCLI(app_config='app_config.yml', argv=['feature', 'list'])
 ```
 
 ## The Six Admin Domains
 
-The admin catalog spans six configuration management domains:
+The admin catalog spans six configuration management domains. Each subsection lists every landed feature ID with a one-line purpose and its CLI verb (group + key). CLI shapes use positional arguments unless a flag is shown with `--`.
 
-1. **App Domain (`app`)**: Manages application interface definitions, session parameters, and app constants.
-2. **CLI Domain (`cli`)**: Manages CLI command definitions, command groups, and argument specifications.
-3. **Error Domain (`error`)**: Manages structured error definitions, multilingual error messages, and codes.
-4. **Feature Domain (`feature`)**: Manages feature workflow definitions, steps, and feature parameters.
-5. **Service/DI Domain (`service`)**: Manages feature-level service registrations, constructor parameters, and flagged overrides.
-6. **Logging Domain (`logging`)**: Manages logging formatters, handlers, loggers, and logging configuration.
+All flat-map arguments accept `key=value` pairs on the CLI (`type: dict`); raw JSON is only used where the catalog marks `type: json`.
 
-All flat-map arguments across administrative commands accept key-value dict pairs in `key=value` format when invoked via the CLI, eliminating the need for raw JSON strings.
+### 1. App Domain (`app`)
 
-## Worked Examples
+Manages application interface / session definitions, constants, and app-level service dependencies.
 
-Below are side-by-side Python (`AdminApp`) and CLI (`tiferet`) worked examples for all six admin domains.
-
-### 1. App Domain
-
-Adding a new application session definition:
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `app.add` | Add a new application session configuration | `tiferet app add <id> <name> <module_path> <class_name> [--description] [--logger-id] [--flags] [--constants]` |
+| `app.get` | Retrieve an app session by ID | `tiferet app get <interface_id>` |
+| `app.list` | List all configured app sessions | `tiferet app list` |
+| `app.update` | Update a scalar attribute on an app session | `tiferet app update <id> <attribute> <value>` |
+| `app.set_constants` | Set or clear constants on an app session | `tiferet app set-constants <id> [--constants]` |
+| `app.set_service` | Set or update a service dependency on an app session | `tiferet app set-service <id> <service_id> <module_path> <class_name> [--parameters]` |
+| `app.remove_service` | Remove a service dependency from an app session | `tiferet app remove-service <id> <service_id>` |
+| `app.remove` | Remove an app session by ID | `tiferet app remove <id>` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
-    'app.add_session',
+    'app.add',
     data={
         'id': 'web_api',
         'name': 'Web API Session',
+        'module_path': 'app.contexts.api',
+        'class_name': 'ApiSessionContext',
         'description': 'Main web API application session',
     },
 )
 ```
 
-Equivalent CLI command:
-
 ```bash
-tiferet app add-session --id web_api --name "Web API Session" --description "Main web API application session"
+tiferet app add web_api "Web API Session" app.contexts.api ApiSessionContext --description "Main web API application session"
+tiferet app list
 ```
 
-### 2. CLI Domain
+### 2. CLI Domain (`cli`)
 
-Adding a new CLI command to a command group:
+Manages CLI command definitions and argument specifications.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `cli.list_commands` | List all configured CLI commands | `tiferet cli list-commands` |
+| `cli.add_command` | Add a new CLI command definition | `tiferet cli add-command <id> <name> <key> <group_key> [--description]` |
+| `cli.add_argument` | Add an argument to an existing CLI command | `tiferet cli add-argument <command_id> --name-or-flags <json> [--description]` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
     'cli.add_command',
     data={
-        'group_key': 'reports',
-        'key': 'generate',
+        'id': 'reports.generate',
         'name': 'Generate Report',
+        'key': 'generate',
+        'group_key': 'reports',
         'description': 'Generate summary report',
     },
 )
 ```
 
-Equivalent CLI command:
-
 ```bash
-tiferet cli add-command --group-key reports --key generate --name "Generate Report" --description "Generate summary report"
+tiferet cli add-command reports.generate "Generate Report" generate reports --description "Generate summary report"
+tiferet cli list-commands
 ```
 
-### 3. Error Domain
+### 3. Error Domain (`error`)
 
-Adding a new structured error with additional localized messages using `key=value` pairs:
+Manages structured error definitions and multilingual messages.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `error.list` | List all error definitions | `tiferet error list [--include-defaults]` |
+| `error.add` | Add a new error definition | `tiferet error add <id> <name> <message> [--lang] [--additional-messages]` |
+| `error.get` | Retrieve an error by ID | `tiferet error get <id>` |
+| `error.rename` | Rename an existing error definition | `tiferet error rename <id> <new_name>` |
+| `error.set_message` | Set the message text on an existing error | `tiferet error set-message <id> <message> [--lang]` |
+| `error.remove_message` | Remove a language message from an error | `tiferet error remove-message <id> [--lang]` |
+| `error.remove` | Remove an error definition | `tiferet error remove <id>` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
@@ -161,84 +189,133 @@ admin.run(
 )
 ```
 
-Equivalent CLI command using flat-map dict syntax (`--additional-messages es_ES="El token..."`):
-
 ```bash
-tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" --message "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error list
 ```
 
-### 4. Feature Domain
+### 4. Feature Domain (`feature`)
 
-Adding a feature step to a feature workflow:
+Manages feature workflow definitions and steps.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `feature.list` | List all feature workflow definitions | `tiferet feature list [--group-id]` |
+| `feature.add` | Add a new feature workflow definition | `tiferet feature add <name> <group_id> [--feature-key] [--description]` |
+| `feature.get` | Retrieve a feature by ID | *(Python only — no CLI command)* |
+| `feature.update` | Update a metadata attribute on a feature | `tiferet feature update <id> <attribute> <value>` |
+| `feature.add_step` | Add a step to an existing feature workflow | `tiferet feature add-step <id> <name> <service_id> [--parameters] [--data-key] [--pass-on-error] [--position]` |
+| `feature.update_step` | Update an attribute on an existing feature step | `tiferet feature update-step <id> <position> <attribute> [--value]` |
+| `feature.remove_step` | Remove a step from an existing feature workflow | `tiferet feature remove-step <id> <position>` |
+| `feature.reorder_step` | Reorder a step within an existing feature workflow | `tiferet feature reorder-step <id> <start_position> <end_position>` |
+| `feature.remove` | Remove an existing feature workflow definition | `tiferet feature remove <id>` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
+    'feature.add',
+    data={
+        'name': 'Create User Workflow',
+        'group_id': 'user',
+        'feature_key': 'create',
+        'description': 'Validates and registers a new user',
+    },
+)
+admin.run(
     'feature.add_step',
     data={
-        'feature_id': 'user.create',
-        'service_id': 'validate_user_evt',
+        'id': 'user.create',
         'name': 'Validate User Step',
+        'service_id': 'validate_user_evt',
         'parameters': {'mode': 'strict'},
     },
 )
 ```
 
-Equivalent CLI command using flat-map dict parameters (`--parameters mode=strict`):
-
 ```bash
-tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate User Step" --parameters mode=strict
+tiferet feature add "Create User Workflow" user --feature-key create --description "Validates and registers a new user"
+tiferet feature add-step user.create "Validate User Step" validate_user_evt --parameters mode=strict
+tiferet feature list
 ```
 
-### 5. Service / DI Domain
+### 5. Service / DI Domain (`service`)
 
-Registering a feature-level service dependency:
+Manages feature-level service registrations, flagged dependencies, and DI constants.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `service.list` | List all DI service registrations and constants | `tiferet service list` |
+| `service.add` | Add a new DI service registration | `tiferet service add <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_default` | Set or update the default type for a registration | `tiferet service set-default <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_dependency` | Set or update a flagged dependency on a registration | `tiferet service set-dependency <id> <flag> <module_path> <class_name> [--parameters]` |
+| `service.remove_dependency` | Remove a flagged dependency from a registration | `tiferet service remove-dependency <id> <flag>` |
+| `service.set_constants` | Set or clear DI service constants | `tiferet service set-constants [--constants]` |
+| `service.remove` | Remove a DI service registration | `tiferet service remove <id>` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
+    'service.add',
+    data={
+        'id': 'validate_user_evt',
+        'module_path': 'app.events.user',
+        'class_name': 'ValidateUserEvent',
+        'parameters': {'timeout': '5.0'},
+    },
+)
+admin.run(
     'service.set_dependency',
     data={
-        'registration_id': 'user_service',
-        'module_path': 'app.services.user',
-        'class_name': 'UserService',
-        'parameters': {'timeout': '5.0'},
+        'id': 'validate_user_evt',
+        'flag': 'test',
+        'module_path': 'app.events.user',
+        'class_name': 'StubValidateUserEvent',
     },
 )
 ```
 
-Equivalent CLI command using flat-map dict parameters (`--parameters timeout=5.0`):
-
 ```bash
-tiferet service set-dependency --registration-id user_service --module-path app.services.user --class-name UserService --parameters timeout=5.0
+tiferet service add validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+tiferet service set-dependency validate_user_evt test app.events.user StubValidateUserEvent
+tiferet service list
 ```
 
-### 6. Logging Domain
+### 6. Logging Domain (`logging`)
 
-Adding a logger configuration:
+Manages logging formatters, handlers, and loggers.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `logging.add_formatter` | Add a new logging formatter configuration | `tiferet logging add-formatter <id> <name> <format> [--description] [--datefmt]` |
+| `logging.remove_formatter` | Remove a logging formatter by ID | `tiferet logging remove-formatter <id>` |
+| `logging.add_handler` | Add a new logging handler configuration | `tiferet logging add-handler <id> <name> <module_path> <class_name> <level> <formatter> [--description] [--stream] [--filename]` |
+| `logging.remove_handler` | Remove a logging handler by ID | `tiferet logging remove-handler <id>` |
+| `logging.add_logger` | Add a new logger configuration | `tiferet logging add-logger <id> <name> <level> <handlers> [--description] [--no-propagate]` |
+| `logging.remove_logger` | Remove a logger by ID | `tiferet logging remove-logger <id>` |
+| `logging.list` | List all logging configurations | `tiferet logging list` |
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()
 admin.run(
     'logging.add_logger',
     data={
-        'logger_id': 'app.audit',
+        'id': 'app.audit',
+        'name': 'app.audit',
         'level': 'INFO',
-        'handlers': ['console', 'file'],
+        'handlers': 'console,file',
     },
 )
 ```
 
-Equivalent CLI command:
-
 ```bash
-tiferet logging add-logger --logger-id app.audit --level INFO --handlers console file
+tiferet logging add-logger app.audit app.audit INFO console,file
+tiferet logging list
 ```
 
 ## Boundaries

--- a/docs/guides/blueprints.md
+++ b/docs/guides/blueprints.md
@@ -130,7 +130,7 @@ The admin blueprints expose the framework's built-in configuration-management se
 ### Admin App (`build_admin_app` / `AdminApp`)
 
 ```python
-from tiferet import AdminApp
+from tiferet.blueprints import AdminApp
 
 admin = AdminApp()  # defaults to TIFERET_ADMIN_ID
 response = admin.run('app.list')
@@ -154,17 +154,17 @@ resolver.add_container(admin_container)  # default
 ### Admin CLI (`build_admin_cli` / `AdminCLI`)
 
 ```python
-from tiferet import AdminCLI
+from tiferet.blueprints import AdminCLI
 
-AdminCLI(app_config='config.yml', argv=['feature', 'list-features'])
+AdminCLI(app_config='config.yml', argv=['feature', 'list'])
 ```
 
 Console usage (via `pyproject.toml` → `tiferet.blueprints.admin_cli:main`):
 
 ```bash
-tiferet app list-sessions
-tiferet --config custom_config.yml error list-errors
-tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate" --parameters mode=strict
+tiferet app list
+tiferet --config custom_config.yml error list
+tiferet feature add-step user.create "Validate" validate_user_evt --parameters mode=strict
 ```
 
 What it does:
@@ -205,6 +205,9 @@ Blueprints are **application-level**; contexts are **session-level**.
 ### 1. Single-call Entry Point
 
 ```python
+from tiferet import App
+from tiferet.blueprints import AdminApp
+
 app = App('basic_calc', app_config='config.yml')
 admin = AdminApp()
 ```

--- a/docs/guides/blueprints.md
+++ b/docs/guides/blueprints.md
@@ -13,11 +13,11 @@ A blueprint is responsible for:
 
 - Loading the application service (repository)
 - Preparing default services and constants
-- Resolving interfaces via domain events
-- Wiring dependency injection
-- Executing features through the resolved interface context
+- Resolving sessions via domain events
+- Wiring dependency injection and the five required context handlers
+- Executing features through the resolved session context
 
-The canonical example is `build_app` in `tiferet/blueprints/main.py`.
+The canonical example is `build_app` in `tiferet/blueprints/core.py` (exported as `App`). Sibling entry points cover CLI (`build_cli` / `CLI`), admin app (`build_admin_app` / `AdminApp`), and admin CLI (`build_admin_cli` / `AdminCLI`).
 
 ## Role of Blueprints in the Architecture
 
@@ -26,85 +26,83 @@ Blueprints sit at the highest level of the runtime graph. They are what applicat
 ```python
 from tiferet import App
 
-app = App('basic_calc', app_yaml_file='config.yml')
+app = App('basic_calc', app_config='config.yml')
 result = app.run('calc.add', data={'a': 5, 'b': 3})
 ```
 
 Key responsibilities:
 
 - **Service loading** — dynamic import of the app service (usually a repository)
-- **Default configuration** — injecting `DEFAULT_SERVICES` and `DEFAULT_CONSTANTS` from `assets.blueprints`
-- **Interface resolution** — calling `GetAppInterface` and validating the result
-- **Execution** — delegating to `AppInterfaceContext.run()`
+- **Default configuration** — seeding cache catalogs and merging session overrides
+- **Session resolution** — calling `GetAppSession` / cache-seeded defaults and validating the result
+- **Handler wiring** — injecting `build_logger_handler`, `execute_feature_handler`, `create_request_handler`, `raise_error_handler`, and `response_handler`
+- **Execution** — delegating to `AppSessionContext.run()` or `CliSessionContext.run()`
 
 Blueprints are intentionally **thin** — they coordinate rather than implement business logic.
 
 ## The build_app Blueprint
 
-`build_app` follows a clear, composable pattern built from smaller blueprint functions:
+`build_app` follows a clear, composable pattern built from smaller blueprint functions in `tiferet/blueprints/core.py`:
 
-### 1. Service Provider Factory
-
-A standalone function allows downstream contexts to create providers consistently:
+### 1. Cache and catalogs
 
 ```python
-def create_service_provider(
-    provider_type: type = DynamicServiceProvider,
-    type_map: Dict[str, type] = None,
-    **constants
-) -> ServiceProvider:
-    ...
+cache = build_cache()  # default errors, app services, constants, logging settings, ...
 ```
 
-This is registered in the DI container so contexts can create scoped providers.
-
-### 2. Loading the App Service
+### 2. Session resolution
 
 ```python
-def load_app_service(module_path=..., class_name=..., **parameters) -> Any:
-    service_cls = ImportDependency.execute(module_path, class_name)
-    return service_cls(**parameters)
+app_session = get_app_session(interface_id, cache, app_config='config.yml')
 ```
 
-### 3. Loading Default Services and Constants
+### 3. Container + resolver
 
 ```python
-def load_default_services() -> List[AppServiceDependency]:
-    return [
-        AppServiceDependency.model_construct(...)
-        for ... in a.bps.DEFAULT_SERVICES
-    ]
+app_container = build_app_service_container(cache, app_session)
+resolver = build_service_resolver(app_container)  # app container under 'app' flag
 ```
 
-Constants are passed via `default_constants=a.bps.DEFAULT_CONSTANTS` to `GetAppInterface`.
-
-### 4. Interface Resolution Flow
+### 4. Five-handler session context
 
 ```python
-def resolve_interface(interface_id, ...) -> tuple:
-    app_service = load_app_service(...)
-    default_services = load_default_services()
-    app_interface = DomainEvent.handle(
-        GetAppInterface,
-        dependencies={'app_service': app_service},
-        interface_id=interface_id,
-        default_services=default_services,
-        default_constants=a.bps.DEFAULT_CONSTANTS,
-    )
-    return app_interface, default_services
+handlers = dict(
+    build_logger_handler=build_logger_handler(cache, resolver.get_dependency),
+    execute_feature_handler=execute_feature_handler(resolver.get_dependency, cache),
+    raise_error_handler=raise_error_handler(get_error(cache, resolver.get_dependency)),
+    response_handler=response_handler,
+    create_request_handler=create_session_request,
+)
+context = AppSessionContext.from_domain(
+    app_session,
+    get_dependency=resolver.get_dependency,
+    cache=cache,
+    **handlers,
+)
 ```
 
-### 5. High-level Entry Point
+### 5. High-level entry point
 
 ```python
-def build_app(interface_id, ...) -> AppInterfaceContext:
-    app_interface, _ = resolve_interface(interface_id, ...)
-    return realize_interface(app_interface, interface_id)
+def build_app(interface_id, ...) -> AppSessionContext:
+    cache = build_cache()
+    app_session = get_app_session(interface_id, cache, ...)
+    return build_app_session_context(app_session, cache)
 ```
+
+### Logging helpers
+
+- `merge_logging_settings(cache, formatters, handlers, loggers)` — pure merge of repository logging sections over cache-seeded defaults by `.id`.
+- `build_logger_handler(cache, get_dependency)` — returns a closure that caches loggers under `LOGGER_CACHE_PREFIX`, listing configs on miss, merging via `merge_logging_settings`, and building through `LoggingContext.from_domain(...).build_logger()`.
+
+### Feature execution helpers
+
+- `create_feature_context(get_dependency, cache, feature_id) -> FeatureContext` — resolves the feature and returns a **domain-bound** context (not a `(Feature, FeatureContext)` tuple).
+- `execute_feature_handler(...)` — builds that context and calls `feature_context.execute_feature(request, *flags, **kwargs)` with **no** explicit `feature` argument.
 
 ## The build_cli Blueprint
 
-The CLI blueprint extends the app blueprint with argparse-based CLI parsing. All argparse wiring lives in the blueprint; runtime execution is delegated to `AppInterfaceContext.run`.
+The CLI blueprint is a thin entrypoint over a `CliSessionContext`. Argparse wiring lives behind an injected `parse_cli_args` closure; runtime execution reuses the hub's five handlers (including `build_logger_handler` — there is no standalone `LoggingContext` on the session).
 
 ### Usage
 
@@ -112,19 +110,72 @@ The CLI blueprint extends the app blueprint with argparse-based CLI parsing. All
 from tiferet import CLI
 
 if __name__ == '__main__':
-    CLI('basic_calc_cli', app_yaml_file='config.yml')
+    CLI('basic_calc_cli', app_config='config.yml')
 ```
 
 ### Build Procedure
 
 `build_cli(interface_id, argv=None, ...)` follows these steps:
 
-1. Resolve the interface via `resolve_interface(interface_id, ...)`.
-2. Build the argparse parser by composing `get_commands()`, `get_parent_arguments()`, and `build_parser(cli_commands, parent_arguments)`.
-3. Parse arguments with `parse_argv(parser, argv)`; on failure, print to stderr and `sys.exit(2)`.
-4. Derive `feature_id` and `headers` via `derive_feature_request(parsed)` and dispatch to `interface_context.run(...)`. On `TiferetAPIError`, print to stderr and `sys.exit(1)`; otherwise print and return the response.
+1. Build the CLI session context with all five handlers plus `parse_cli_args`.
+2. Call `cli_context.run(argv)`.
+3. On parse failure, exit `2`; on `TiferetAPIError`, exit `1`.
 
-Because the CLI blueprint uses the default `AppInterfaceContext`, CLI interface definitions in YAML no longer require `module_path`/`class_name` overrides.
+Consumer CLI sessions opt in with `module_path: tiferet.contexts.cli` / `class_name: CliSessionContext`.
+
+## Building the Admin Application
+
+The admin blueprints expose the framework's built-in configuration-management session without requiring a consumer-defined `admin` entry in `config.yml`.
+
+### Admin App (`build_admin_app` / `AdminApp`)
+
+```python
+from tiferet import AdminApp
+
+admin = AdminApp()  # defaults to TIFERET_ADMIN_ID
+response = admin.run('app.list')
+```
+
+What it does:
+
+1. `admin.build_cache()` — core catalogs plus `ADMIN_DEFAULT_SERVICES`, `ADMIN_DEFAULT_CONSTANTS`, `ADMIN_DEFAULT_FEATURES`, and `ADMIN_DEFAULT_ERRORS`.
+2. `get_app_session(TIFERET_ADMIN_ID, cache)` — cache-seeded built-in session.
+3. `build_admin_service_resolver` — dual-container resolver:
+   - app container under the `'app'` flag
+   - admin container under `'admin'` **and** as the empty-flag default
+4. `build_admin_app_session_context` — same five handlers as core, but with the admin resolver so feature steps resolve admin-scoped services by default.
+
+```python
+resolver.add_container(app_container, 'app')
+resolver.add_container(admin_container, 'admin')
+resolver.add_container(admin_container)  # default
+```
+
+### Admin CLI (`build_admin_cli` / `AdminCLI`)
+
+```python
+from tiferet import AdminCLI
+
+AdminCLI(app_config='config.yml', argv=['feature', 'list-features'])
+```
+
+Console usage (via `pyproject.toml` → `tiferet.blueprints.admin_cli:main`):
+
+```bash
+tiferet app list-sessions
+tiferet --config custom_config.yml error list-errors
+tiferet feature add-step --feature-id user.create --service-id validate_user_evt --name "Validate" --parameters mode=strict
+```
+
+What it does:
+
+1. Layers `ADMIN_DEFAULT_COMMANDS` on the admin cache.
+2. Resolves `TIFERET_ADMIN_CLI_ID`.
+3. Re-seeds every `*_config` constant (`app_config`, `cli_config`, `di_config`, `error_config`, `feature_config`, `logging_config`) to the consumer-supplied path.
+4. Wires `CliSessionContext` with the admin resolver and five handlers (including `build_logger_handler`).
+5. Dispatches through `cli_context.run(argv)`.
+
+Flat-map admin arguments use the CLI `'dict'` type (`key=value` pairs) rather than raw JSON. See [docs/guides/domain/cli.md](domain/cli.md) and the full six-domain catalog in [docs/guides/admin.md](admin.md).
 
 ## When to Create a New Blueprint
 
@@ -132,6 +183,7 @@ Create a new blueprint when you need a specialized entry point:
 
 - Web blueprint — for Flask/FastAPI integration
 - Test blueprint — for integration testing with mocked services
+- Domain-specific admin or tooling sessions — mirror `admin.py` / `admin_cli.py` (custom cache seeders + resolver + five-handler wiring)
 
 If you find yourself repeating the same loading and wiring logic in multiple scripts, extract it into a dedicated blueprint.
 
@@ -139,22 +191,22 @@ If you find yourself repeating the same loading and wiring logic in multiple scr
 
 | Concern | Blueprint | Context |
 | --- | --- | --- |
-| Public API | Yes (`App('basic_calc')`) | Internal (used by blueprint) |
+| Public API | Yes (`App('basic_calc')`, `AdminApp()`) | Internal (used by blueprint) |
 | Service loading | Yes | No |
 | Default config injection | Yes | No |
-| Feature execution | Delegates to interface context | Yes (`execute_feature`, `run`) |
-| Lifecycle | Application-level | Per-interface |
+| Five-handler wiring | Yes | Consumes handlers |
+| Feature execution | Delegates to session context | Yes (`execute_feature`, `run`) |
+| Lifecycle | Application-level | Per-session |
 
-Blueprints are **application-level**; contexts are **interface-level**.
+Blueprints are **application-level**; contexts are **session-level**.
 
 ## Best Practices
 
 ### 1. Single-call Entry Point
 
-`build_app` resolves and realizes in one call:
-
 ```python
-app = App('basic_calc', app_yaml_file='config.yml')
+app = App('basic_calc', app_config='config.yml')
+admin = AdminApp()
 ```
 
 ### 2. Consistent Error Handling
@@ -165,18 +217,21 @@ Use framework constants and `TiferetError.raise_error()` for all domain-outcome 
 
 Blueprints should **not** contain domain logic — only orchestration, wiring, and delegation.
 
-### 4. Register `create_service_provider`
+### 4. Always Wire All Five Handlers
 
-Always register the function so contexts can create scoped providers:
+Never construct an `AppSessionContext` / `CliSessionContext` with a missing handler slot or a legacy `logging_context` constructor keyword keyword. Prefer the core helpers (`build_logger_handler`, `execute_feature_handler`, …).
 
-```python
-dependencies['create_service_provider'] = create_service_provider
-```
+### 5. Prefer Domain-Bound Feature Execution
+
+Use `create_feature_context` → `feature_context.execute_feature(request, ...)` rather than passing a `feature` object into the context method.
 
 ## Related Documentation
 
 - [docs/core/blueprints.md](../core/blueprints.md) — detailed blueprint implementation reference
-- [docs/guides/domain/app.md](../guides/domain/app.md) — application-level configuration and runtime orchestration
-- [docs/guides/events/app.md](../guides/events/app.md) — app event usage in interface resolution
-- [docs/core/di.md](../core/di.md) — dependency injection and service provider architecture
+- [docs/guides/admin.md](admin.md) — admin catalog domains and worked examples
+- [docs/core/contexts.md](../core/contexts.md) — five-handler context contract
+- [docs/guides/contexts.md](contexts.md) — context strategies and patterns
+- [docs/guides/domain/app.md](domain/app.md) — application-level configuration and runtime orchestration
+- [docs/guides/events/app.md](events/app.md) — app event usage in session resolution
+- [docs/core/di.md](../core/di.md) — dependency injection and service resolver architecture
 - [docs/core/code_style.md](../core/code_style.md) — artifact comments and formatting

--- a/docs/guides/contexts.md
+++ b/docs/guides/contexts.md
@@ -7,12 +7,12 @@
 
 ## Overview
 
-Contexts form the runtime "body" of a Tiferet application. They encapsulate interaction surfaces, orchestration, and supporting services behind clean, injectable classes. While blueprints (`tiferet/blueprints/`) own the application lifecycle and wiring, contexts own the per-interface runtime shape — how requests are parsed, features are executed, errors are handled, and responses are returned.
+Contexts form the runtime "body" of a Tiferet application. They encapsulate interaction surfaces, orchestration, and supporting services behind clean, injectable classes. While blueprints (`tiferet/blueprints/`) own the application lifecycle and wiring, contexts own the per-session runtime shape — how requests are built, features are executed, errors are handled, loggers are constructed, and responses are returned.
 
 Tiferet distinguishes between two categories of contexts:
 
-- **High-level contexts** — extend `AppInterfaceContext` and expose the interface's runtime entry point (e.g., a CLI interface or a web API). They delegate to lower-level contexts for execution concerns.
-- **Low-level contexts** — single-purpose orchestrators that back the high-level context (e.g., `FeatureContext`, `DIContext`, `RequestContext`, `ErrorContext`, `LoggingContext`, `CacheContext`).
+- **High-level contexts** — extend `AppSessionContext` and expose the session's runtime entry point (e.g., a CLI session or a web API). They implement the five required template-method handlers and delegate low-level work through those slots.
+- **Low-level contexts** — single-purpose orchestrators that back the high-level context (e.g., `FeatureContext`, `RequestContext`, `ErrorContext`, `LoggingContext`, `CacheContext`).
 
 This guide covers cross-cutting strategies for using, extending, and composing contexts. For artifact-level structure and code style, see [docs/core/contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md).
 
@@ -22,98 +22,127 @@ Every context in `tiferet/contexts/` has a single, well-defined responsibility:
 
 | Context | Responsibility |
 | --- | --- |
-| `AppInterfaceContext` | Parse the incoming request, execute the feature, format the response, and handle errors at the interface boundary. |
-| `FeatureContext` | Load a feature, resolve each configured step from the DI container, parse parameters, and execute the steps sequentially against a `RequestContext`. |
-| `DIContext` | Build and cache feature-level service providers from `ServiceConfiguration` objects, resolving per-flag dependency types. |
-| `ErrorContext` | Format exceptions into structured, localized API responses using `ErrorService`. |
-| `LoggingContext` | Build loggers from configured formatters, handlers, and logger specs. |
-| `CacheContext` | Provide an in-memory keyed cache for reusable objects (e.g., loaded features, service providers). |
+| `AppSessionContext` | Session hub: `build_logger` → `build_request` → `execute_feature` → `handle_error` / `build_response` via five required handlers. |
+| `CliSessionContext` | High-level CLI session: injects `parse_cli_args`, overrides `run(argv)` and CLI-aware `build_response`. |
+| `FeatureContext` | Domain-bound feature executor: reads `self.domain`, resolves steps from DI, parses parameters, runs sync/async steps. |
+| `ErrorContext` | Format exceptions into structured, localized API responses from a pre-loaded `Error`. |
+| `LoggingContext` | Build a logger from a pre-assembled `LoggingSettings` domain object (`from_domain` + `build_logger`). |
+| `CacheContext` | Provide an in-memory keyed cache for reusable objects (features, errors, loggers, defaults). |
 | `RequestContext` | Carry request headers, data, and the feature result through the execution pipeline; produce the final response via `handle_response`. |
 
-Contexts are consumed by the `AppInterfaceContext` (and its subclasses) — not by domain events. Domain events only receive injected **services**, never contexts.
+Contexts are consumed by blueprints and by `AppSessionContext` (and its subclasses) — not by domain events. Domain events only receive injected **services**, never contexts.
 
-## The AppInterfaceContext Pattern
+## The AppSessionContext Five-Handler Pattern
 
-`AppInterfaceContext` is the canonical high-level context. Its `run` method defines the standard request lifecycle:
+`AppSessionContext` is the canonical high-level context. Its `run` method defines the standard request lifecycle through five **required** template methods:
 
 ```python
 def run(self, feature_id, headers=None, data=None, **kwargs):
-    # Build logger.
-    logger = self.logging.build_logger()
+    # Build logger via the required build_logger_handler slot.
+    logger = self.build_logger()
 
-    # Parse request into a RequestContext.
-    request = self.parse_request(headers or {}, data or {}, feature_id)
+    # Build the request via create_request_handler.
+    request = self.build_request(feature_id, headers or {}, data or {})
 
-    # Execute the feature, capturing TiferetError.
+    # Execute the feature via execute_feature_handler, capturing TiferetError.
     try:
-        self.execute_feature(feature_id=feature_id, request=request, logger=logger, **kwargs)
+        self.execute_feature(feature_id, request, logger=logger, **kwargs)
     except TiferetError as e:
         return self.handle_error(e)
 
-    # Format and return the response.
-    return self.handle_response(request)
+    # Build and return the response via response_handler.
+    return self.build_response(request)
 ```
 
-The four steps — **parse**, **execute**, **handle errors**, **handle response** — are the extension points subclasses typically override.
+| Template method | Handler constructor kwarg | Unwired behavior |
+| --- | --- | --- |
+| `build_logger` | `build_logger_handler` | `raise_unwired_handler_error('build_logger_handler', ...)` |
+| `build_request` | `create_request_handler` | `raise_unwired_handler_error('create_request_handler', ...)` |
+| `execute_feature` | `execute_feature_handler` | `raise_unwired_handler_error('execute_feature_handler', ...)` |
+| `handle_error` | `raise_error_handler` | Re-raise `TiferetAPIError` verbatim; otherwise unwired → `raise_unwired_handler_error` |
+| `build_response` | `response_handler` | `raise_unwired_handler_error('response_handler', ...)` |
 
-### Extending AppInterfaceContext
+There are **no** truthiness-guarded inline fallbacks. Blueprints must wire every slot. Constructing a hub with a `logging_context` constructor keyword keyword is no longer supported — use `build_logger_handler=`:
+
+```python
+context = AppSessionContext.from_domain(
+    app_session,
+    get_dependency=resolver.get_dependency,
+    cache=cache,
+    build_logger_handler=build_logger_handler(cache, resolver.get_dependency),
+    execute_feature_handler=execute_feature_handler(resolver.get_dependency, cache),
+    create_request_handler=create_session_request,
+    raise_error_handler=raise_error_handler(get_error(cache, resolver.get_dependency)),
+    response_handler=response_handler,
+)
+```
+
+The same five kwargs are forwarded by `CliSessionContext` (plus `parse_cli_args=` for argv parsing).
+
+### Extending AppSessionContext
 
 Create a subclass when the interface needs to translate a transport-specific payload (e.g., CLI `argv`, Flask `Request`) into a `RequestContext`, or when the response needs transport-specific formatting.
 
 ```python
 # ** context: flask_api_context
-class FlaskApiContext(AppInterfaceContext):
-    '''
+class FlaskApiContext(AppSessionContext):
+    """
     Flask API context that translates Flask requests into feature invocations.
-    '''
+    """
 
     # * attribute: flask_handler
     flask_handler: FlaskApiHandler
 
     # * init
-    def __init__(self, interface_id, features, errors, logging, flask_handler):
-        super().__init__(interface_id, features, errors, logging)
+    def __init__(self, flask_handler, **kwargs):
+        # Forward get_dependency, cache, and the five handlers to the hub.
+        super().__init__(**kwargs)
         self.flask_handler = flask_handler
-
-    # * method: parse_request
-    def parse_request(self, flask_request) -> RequestContext:
-        '''
-        Translate a Flask request into a RequestContext.
-        '''
-
-        # Extract headers, data, and feature_id from the Flask request.
-        headers, data, feature_id = self.flask_handler.extract(flask_request)
-
-        # Delegate to the base parse_request for RequestContext construction.
-        return super().parse_request(headers=headers, data=data, feature_id=feature_id)
 ```
 
-Override only the methods you need. Always call `super()` for shared behavior (e.g., adding `interface_id` to headers).
+Override only the methods you need. Always call `super()` for shared behavior so the required-handler guards remain intact.
 
-### CLI Interfaces Without Custom Contexts
+### CLI Sessions with CliSessionContext
 
-In v2.0+, CLI interfaces are handled by `CliBuilder` rather than a `CliContext`. All argparse wiring lives in the builder; the CLI interface runs against the default `AppInterfaceContext`. As a result, CLI interface definitions in `app.yml` no longer require `module_path`/`class_name` overrides.
+CLI interfaces use `CliSessionContext` (`tiferet/contexts/cli.py`), a high-level subclass of `AppSessionContext`. The CLI blueprint wires:
 
-If a CLI interface needs custom request parsing beyond argparse, the preferred pattern is still to extend `CliBuilder` — not to reintroduce a dedicated CLI context.
+- the same five handlers (with CLI-specific `create_request_handler` / `response_handler` where needed)
+- `build_logger_handler` (not a standalone `LoggingContext`)
+- `parse_cli_args`, a closure that discovers commands, builds the argparse parser, and derives `(feature_id, headers, data)`
+
+`CliSessionContext.run(argv=None)` parses argv, then delegates to `AppSessionContext.run`. Consumer CLI interfaces opt in by pointing their session config at `tiferet.contexts.cli` / `CliSessionContext`. The built-in admin CLI uses the same context class via `build_admin_cli`.
 
 ## Low-Level Context Lifecycles
 
 ### FeatureContext
 
-`FeatureContext.execute_feature` drives the core feature pipeline:
+`FeatureContext` is **domain-bound**: the `Feature` is supplied at construction via `from_domain` and read as `self.domain`. Public methods take no `feature` parameter:
 
-1. Load the feature (cached when possible) via `get_feature_handler`.
-2. For each configured step:
-   - Evaluate the step's `condition` expression (if present) via `evaluate_condition`. If the condition resolves to `False`, the step is silently skipped.
-   - Resolve the domain event from `DIContext.get_dependency(service_id, *flags)`.
+```python
+feature_context = FeatureContext.from_domain(
+    feature,
+    get_dependency=get_dependency,
+    cache=cache,
+)
+feature_context.execute_feature(request, *flags, **kwargs)
+```
+
+`execute_feature(request, *flags, **kwargs)` drives the pipeline:
+
+1. Read `feature = self.domain`.
+2. Validate request data against the feature schema (`validate_request`).
+3. If `feature.is_async`, drive the full async loop via `run_coroutine(self._execute_async(...))`.
+4. Otherwise, for each step from `resolve_feature_steps(request, *flags)`:
+   - Evaluate the step's `condition` (if present); skip when `False`.
+   - Resolve the domain event via `get_dependency(service_id, *combined_flags)`.
    - Parse each step parameter with `parse_request_parameter` (supports `$r.<key>` request-backed parameters).
-   - Invoke `handle_command`, which executes the event and stores the result on the `RequestContext` under `data_key`.
+   - If `step.is_async`, drive `run_coroutine(self._execute_step_async(...))`; else call `execute_step`.
 
-Feature-level flags (defined on the `Feature`) are combined with step-level flags and passed to the DI context. Higher priority is given to feature-level flags.
+There is no separate `AsyncFeatureContext` class and no hub-level `get_feature_handler` / `handle_feature_step` API.
 
 ### Conditional Step Execution
 
-`FeatureEvent` supports an optional `condition` field — a boolean expression string evaluated against request data before the step executes. The `$r.` prefix references values from `request.data` (e.g., `$r.b != 0`, `$r.mode == 'advanced'`).
+`EventFeatureStep` supports an optional `condition` field — a boolean expression string evaluated against request data before the step executes. The `$r.` prefix references values from `request.data` (e.g., `$r.b != 0`, `$r.mode == 'advanced'`).
 
 - When `condition` is `None` or empty, the step always executes (backward compatible).
 - When `condition` evaluates to `False`, the step is silently skipped (no error raised).
@@ -133,52 +162,40 @@ features:
           condition: '$r.b != 0'
 ```
 
-### DIContext
-
-`DIContext.build_service_provider(flags)` is the sole entry point for feature-level dependency resolution:
-
-1. Normalize flags and derive a cache key.
-2. Return cached `ServiceProvider` if present.
-3. Load all `ServiceConfiguration` objects and top-level constants from `list_all_configs_handler`.
-4. Merge per-configuration parameters into the constants dict, honoring flag-scoped overrides.
-5. Resolve each configuration to a concrete type via `get_configuration_type`.
-6. Call `create_service_provider(type_map=..., **constants)` to instantiate a provider.
-7. Cache and return the provider.
-
-The `create_service_provider` factory is supplied by the builder via `AppBuilder.create_service_provider` so that app-level and feature-level providers share a consistent construction strategy.
-
 ### RequestContext
 
-`RequestContext` is a plain data carrier populated by `parse_request` and mutated by step handlers via `set_result(result, data_key)`. Its `handle_response` method builds the final response object returned by `AppInterfaceContext.run`.
+`RequestContext` is a plain data carrier populated by `build_request` / `create_request_handler` and mutated by step handlers via `set_result(result, data_key)`. Its `handle_response` method builds the final response object returned by the hub's `response_handler` (default: `request.handle_response()`). CLI runs may use `CliRequestContext`, which maps list/dict results into typed CLI output models.
 
 ### ErrorContext and LoggingContext
 
-Both are configuration-driven:
+Both are configuration-driven, but they are no longer long-lived children of the hub:
 
-- `ErrorContext` receives a `TiferetError`, formats it via `ErrorService`, and returns a localized payload. `AppInterfaceContext.handle_error` wraps the payload in `TiferetAPIError`.
-- `LoggingContext.build_logger` composes formatters, handlers, and loggers defined in configuration into a ready-to-use logger instance.
+- `ErrorContext` receives a pre-loaded `Error` and formats a structured response. The blueprint's `raise_error_handler` resolves the `Error` (via a cache-backed `get_error` closure), constructs the registered `ErrorContext`, and raises `TiferetAPIError`.
+- `LoggingContext` is constructed **on demand** from a `LoggingSettings` value object (`LoggingContext.from_domain(settings, logger_id=...)`) inside the blueprint's `build_logger_handler`. Built loggers are cached under `LOGGER_CACHE_PREFIX` (`('logging', 'loggers')`) so `dictConfig` runs once per logger id per process.
 
-Both contexts are injected into `AppInterfaceContext` and are typically not subclassed — extend the underlying services instead.
+Neither context is stored on `AppSessionContext`. Do not pass `logging_context` constructor keyword into the hub constructor.
 
 ### CacheContext
 
-A simple keyed in-memory cache used by `FeatureContext` (for loaded features) and `DIContext` (for service providers). Treat it as a per-interface cache — it is not shared across interfaces.
+A simple keyed in-memory cache used by blueprints and contexts for loaded features, errors, loggers, and bootstrap catalogs. Treat it as a per-session cache — it is not shared across sessions.
 
 ## Composition in the Application Graph
 
-At runtime, a fully wired interface graph looks roughly like this:
+At runtime, a fully wired session graph looks roughly like this:
 
 ```
-AppBuilder
-  └── AppInterfaceContext
-        ├── FeatureContext
-        │     ├── DIContext  ── CacheContext
-        │     └── CacheContext
-        ├── ErrorContext
-        └── LoggingContext
+build_app / build_cli / build_admin_app / build_admin_cli
+  └── AppSessionContext (or CliSessionContext)
+        ├── handlers:
+        │     build_logger_handler  → LoggingContext (ephemeral) + LOGGER_CACHE_PREFIX
+        │     create_request_handler → RequestContext / CliRequestContext
+        │     execute_feature_handler → FeatureContext.from_domain(feature)
+        │     raise_error_handler → ErrorContext.format_response
+        │     response_handler → request.handle_response (or CLI print path)
+        └── CacheContext (shared bootstrap cache)
 ```
 
-Each `AppInterfaceContext` instance is per-interface; its dependencies are resolved by the app-level service provider. Because all contexts are constructor-injected, tests can replace any node in this graph with a mock.
+Each session context instance is per-session; its handlers and `get_dependency` are resolved by the blueprint. Because handlers are constructor-injected, tests can replace any slot with a mock.
 
 ## Testing Contexts
 
@@ -186,42 +203,44 @@ Context tests use `pytest` with `unittest.mock`. Focus on behavior, not implemen
 
 ### Patterns
 
-- **Mock all injected dependencies** — use `mock.Mock(spec=...)` against the expected type.
-- **Test each method in isolation** — `parse_request`, `execute_feature`, `handle_error`, `handle_response`, and `run`.
-- **Verify service interactions** — assert that service and handler calls occur with expected arguments.
-- **Exercise both success and error paths** — especially for `AppInterfaceContext.run`, which has distinct branches for successful completion and `TiferetError` recovery.
+- **Mock all five handlers** — use `mock.Mock()` for each slot; leave a slot `None` only to assert `raise_unwired_handler_error`.
+- **Test each template method in isolation** — `build_logger`, `build_request`, `execute_feature`, `handle_error`, `build_response`, and `run`.
+- **Verify handler interactions** — assert that handler calls occur with expected arguments.
+- **Exercise both success and error paths** — especially for `AppSessionContext.run`, which has distinct branches for successful completion and `TiferetError` recovery.
+- **FeatureContext tests bind a domain** — construct via `FeatureContext.from_domain(feature, ...)` and call `execute_feature(request)` without a `feature=` argument.
 
 ### Example
 
 ```python
 # *** fixtures
 
-# ** fixture: app_interface_context
+# ** fixture: app_session_context
 @pytest.fixture
-def app_interface_context():
-    return AppInterfaceContext(
-        interface_id='basic_calc',
-        features=mock.Mock(spec=FeatureContext),
-        errors=mock.Mock(spec=ErrorContext),
-        logging=mock.Mock(spec=LoggingContext),
+def app_session_context(app_session):
+    return AppSessionContext.from_domain(
+        app_session,
+        get_dependency=mock.Mock(),
+        build_logger_handler=mock.Mock(return_value=mock.Mock()),
+        execute_feature_handler=mock.Mock(),
+        create_request_handler=mock.Mock(return_value=mock.Mock(spec=RequestContext)),
+        raise_error_handler=mock.Mock(),
+        response_handler=mock.Mock(return_value={'ok': True}),
     )
 
 # *** tests
 
 # ** test: run_success
-def test_run_success(app_interface_context):
-    '''
+def test_run_success(app_session_context):
+    """
     Verify run executes the feature and returns the response payload.
-    '''
-
-    # Arrange the logger and response.
-    app_interface_context.logging.build_logger.return_value = mock.Mock()
+    """
 
     # Act.
-    result = app_interface_context.run('calc.add', data={'a': 1, 'b': 2})
+    result = app_session_context.run('calc.add', data={'a': 1, 'b': 2})
 
     # Assert execution and response handling were invoked.
-    app_interface_context.features.execute_feature.assert_called_once()
+    app_session_context._execute_feature.assert_called_once()
+    app_session_context._build_response.assert_called_once()
     assert result is not None
 ```
 
@@ -231,31 +250,36 @@ def test_run_success(app_interface_context):
 
 A context owns one runtime concern. If a context grows multiple responsibilities, split it into a high-level context plus one or more low-level contexts.
 
-### 2. Delegate to Services, Not Other Contexts (Where Possible)
+### 2. Wire All Five Handlers
 
-Low-level contexts should depend on services — not on each other — except where composition is intrinsic (e.g., `FeatureContext` composing `DIContext` and `CacheContext`). This keeps the dependency graph shallow.
+Never leave a hub handler slot unset in production wiring. Prefer blueprint helpers (`build_logger_handler`, `execute_feature_handler`, `raise_error_handler`, `response_handler`, `create_session_request`) over ad-hoc closures.
 
-### 3. Prefer `super()` Over Reimplementation
+### 3. Delegate to Services, Not Other Contexts (Where Possible)
 
-When extending `AppInterfaceContext`, override only the steps that differ and call `super()` for the rest. This preserves logging, timing, and error handling behavior for free.
+Low-level contexts should depend on services — not on each other — except where composition is intrinsic (e.g., `FeatureContext` sharing a `CacheContext`). This keeps the dependency graph shallow.
 
-### 4. Never Inject Contexts into Domain Events
+### 4. Prefer `super()` Over Reimplementation
+
+When extending `AppSessionContext`, override only the steps that differ and call `super()` for the rest. This preserves the unwired-handler guards, logging, timing, and error handling behavior for free.
+
+### 5. Never Inject Contexts into Domain Events
 
 Domain events depend on **services**, not contexts. Passing a context into an event couples domain logic to the runtime graph and makes the event harder to test.
 
-### 5. Use `TiferetError.raise_error()` for Context-Level Errors
+### 6. Use Structured Errors at the Source
 
-Contexts must raise structured `TiferetError` instances with framework error codes — never raw exceptions. `AppSessionContext.handle_error` wraps unhandled exceptions, but preferring structured errors at the source yields better diagnostics.
+Contexts and blueprints must raise structured `TiferetError` instances with framework error codes — never raw exceptions where a domain outcome is known. Prefer `TiferetError.raise_error(...)` at the source; `handle_error` formats what escapes.
 
-### 6. Treat CacheContext as Per-Interface
+### 7. Treat CacheContext as Per-Session
 
-Do not share a single `CacheContext` instance across interfaces. Each `AppInterfaceContext` (and its nested contexts) gets its own cache instance to avoid cross-interface leakage.
+Do not share a single `CacheContext` instance across sessions. Each `AppSessionContext` (and its handlers) gets its own cache instance to avoid cross-session leakage.
 
 ## Related Documentation
 
-- [docs/core/contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md) — Context base classes, artifact comments, and code style reference
-- [docs/core/blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md) — Blueprint design (build_app, build_cli)
+- [docs/core/contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md) — Context base classes, five-handler contract, artifact comments, and code style reference
+- [docs/core/blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/blueprints.md) — Blueprint design (`build_app`, `build_cli`, `build_admin_app`, `build_admin_cli`)
 - [docs/guides/blueprints.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/blueprints.md) — Blueprint strategies and patterns
-- [docs/core/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md) — Dependency injection and service provider architecture
+- [docs/guides/admin.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/admin.md) — Admin application and CLI catalog
+- [docs/core/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/di.md) — Dependency injection and service resolver architecture
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns and usage
 - [docs/core/code_style.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/code_style.md) — Artifact comments and formatting rules

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -70,11 +70,11 @@ Admin catalog commands that pass structured maps use `'dict'` (not a new type). 
 
 ```bash
 # Flat-map dict syntax (key=value), not JSON strings
-tiferet feature add-step --feature-id user.create --service-id validate_user_evt \
-  --name "Validate User" --parameters mode=strict
-tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" \
-  --message "Token invalid." --additional-messages es_ES="Token inválido."
-tiferet app set-constants --id web_api --constants timeout=30 retries=3
+tiferet feature add-step user.create "Validate User" validate_user_evt \
+  --parameters mode=strict
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "Token invalid." \
+  --additional-messages es_ES="Token inválido."
+tiferet app set-constants web_api --constants timeout=30 retries=3
 ```
 
 `build_admin_cli` / `AdminCLI` (`tiferet/blueprints/admin_cli.py`) is the primary consumer of these admin arguments; see [docs/guides/admin.md](../admin.md).

--- a/docs/guides/domain/cli.md
+++ b/docs/guides/domain/cli.md
@@ -26,7 +26,7 @@ Represents a single command-line argument or flag.
 |-----------------|------------------------|----------|---------|----------------------------------------------------------------------------------|
 | `name_or_flags` | `List[str]`            | Yes      | —       | The name or flags of the argument (e.g., `["-f", "--flag"]`).                     |
 | `description`   | `str \| None`          | No       | `None`  | A brief description of the argument.                                              |
-| `type`          | `str \| None`          | No       | `'str'` | The type: `"str"`, `"int"`, or `"float"`.                                         |
+| `type`          | `str \| None`          | No       | `'str'` | The type: `"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"`, etc.          |
 | `required`      | `bool \| None`         | No       | `None`  | Whether the argument is required.                                                 |
 | `default`       | `str \| None`          | No       | `None`  | The default value if not provided.                                                |
 | `choices`       | `List[str] \| None`    | No       | `None`  | Valid choices for the argument.                                                   |
@@ -35,14 +35,49 @@ Represents a single command-line argument or flag.
 
 #### Methods
 
-**`get_type() -> str | int | float`**
+**`get_type() -> type | callable`**
 
-Maps the stored `type` string to a Python type object. Falls back to `str` if the type is `None` or unrecognized.
+Maps the stored `type` string to a Python type or converter callable. Falls back to `str` if the type is `None` or unrecognized. The `'dict'` type resolves to a flat-map converter that accepts repeated `key=value` tokens from argparse.
 
 ```python
 arg = CliArgument(name_or_flags=['--count'], type='int')
 assert arg.get_type() is int
 ```
+
+#### Argument type reference (including `'dict'`)
+
+| `type` value | Runtime conversion | Typical use |
+| --- | --- | --- |
+| `'str'` (default) | `str` | Free-text flags and positional strings |
+| `'int'` / `'float'` | `int` / `float` | Numeric operands |
+| `'bool'` | boolean converter | Explicit true/false values |
+| `'list'` | list accumulation | Multi-value flags |
+| `'dict'` | flat-map `key=value` pairs → `Dict[str, str]` | Nested parameter/constant maps without raw JSON |
+
+Admin catalog commands that pass structured maps use `'dict'` (not a new type). Worked examples from the built-in admin CLI:
+
+| Command | Flag | Role of the dict payload |
+| --- | --- | --- |
+| `app.add` | `--constants` | Session constant map |
+| `app.set-constants` | `--constants` | Replacement constant map |
+| `app.set-service` | `--parameters` | App service constructor parameters |
+| `feature.add-step` | `--parameters` | Step parameter map |
+| `service.add` | `--parameters` | Registration constructor parameters |
+| `service.set-default` | `--parameters` | Default service parameters |
+| `service.set-dependency` | `--parameters` | Flagged dependency parameters |
+| `service.set-constants` | `--constants` | Service-scoped constants |
+| `error.add` | `--additional-messages` | Extra locale → message pairs |
+
+```bash
+# Flat-map dict syntax (key=value), not JSON strings
+tiferet feature add-step --feature-id user.create --service-id validate_user_evt \
+  --name "Validate User" --parameters mode=strict
+tiferet error add --id INVALID_TOKEN_ID --name "Invalid Token" \
+  --message "Token invalid." --additional-messages es_ES="Token inválido."
+tiferet app set-constants --id web_api --constants timeout=30 retries=3
+```
+
+`build_admin_cli` / `AdminCLI` (`tiferet/blueprints/admin_cli.py`) is the primary consumer of these admin arguments; see [docs/guides/admin.md](../admin.md).
 
 **`to_argparse_kwargs() -> Dict[str, Any]`**
 
@@ -104,13 +139,14 @@ This 1:1 mapping ensures CLI commands are thin entry points that delegate all bu
 
 ## Runtime Role
 
-The `build_cli` blueprint (`tiferet/blueprints/cli.py`) is the primary consumer of the CLI domain at runtime:
+The `build_cli` blueprint (`tiferet/blueprints/cli.py`) and the admin sibling `build_admin_cli` / `AdminCLI` (`tiferet/blueprints/admin_cli.py`) are the primary consumers of the CLI domain at runtime:
 
-1. **`get_commands(service_provider)`** resolves all `CliCommand` entries from the configuration via `CliService`.
-2. **`build_parser()`** iterates each `CliCommand`, registering subparsers and arguments with `argparse` using `CliArgument` attributes (`name_or_flags`, `type`, `required`, `default`, `choices`, `nargs`, `action`).
-3. **`parse_argv()`** parses the user's CLI input and returns the matched command group and key.
-4. **`derive_feature_request()`** maps the parsed arguments to a feature ID (`group_key.key`) and dispatches to `AppInterfaceContext.run()`.
-5. **`FeatureContext`** executes the corresponding feature with the parsed data.
+1. The blueprint wires a `CliSessionContext` with the five required handlers (including `build_logger_handler`) and an injected `parse_cli_args` closure.
+2. **`parse_cli_args`** resolves `CliCommand` entries (repository + cache-seeded defaults), builds the argparse parser from each command's `CliArgument` attributes (`name_or_flags`, `type`, `required`, `default`, `choices`, `nargs`, `action` — including `'dict'` converters), and derives `(feature_id, headers, data)`.
+3. **`CliSessionContext.run(argv)`** dispatches through the hub `run` path.
+4. A domain-bound **`FeatureContext`** executes the corresponding feature with the parsed data (`execute_feature(request)` — no explicit `feature` argument).
+
+Admin CLI additionally re-seeds every `*_config` constant to the consumer `--config` path so management commands edit the target file.
 
 ## Configuration Mapping
 
@@ -171,8 +207,9 @@ Concrete implementations (e.g., `CliYamlRepository`) satisfy this interface.
 ## Relationships to Other Domains
 
 - **Feature:** `CliCommand.id` maps 1:1 to feature IDs in `feature.yml`. CLI commands are thin entry points that delegate to the feature layer.
-- **App:** The CLI interface in the configuration specifies `CliService` as a service dependency. The `build_cli` blueprint handles argparse wiring and dispatches to `AppInterfaceContext`.
-- **Error:** CLI error responses are formatted via `ErrorContext`, providing user-friendly messages for validation failures and domain errors.
+- **App:** The CLI session in the configuration specifies `CliService` as a service dependency. The `build_cli` / `build_admin_cli` blueprints handle argparse wiring and dispatch to `CliSessionContext` / `AppSessionContext`.
+- **Error:** CLI error responses are formatted via the hub's `raise_error_handler` / `ErrorContext`, providing user-friendly messages for validation failures and domain errors.
+- **Admin:** Built-in management commands and `'dict'` flat-map arguments are documented in [docs/guides/admin.md](../admin.md).
 
 ## Instantiation
 

--- a/docs/guides/domain/feature.md
+++ b/docs/guides/domain/feature.md
@@ -43,6 +43,8 @@ Concrete step type that extends `FeatureStep`. Represents the execution of a dom
 | `data_key`       | `str \| None`           | No       | `None`  | Data key to store the result in.                                   |
 | `pass_on_error`  | `bool`                  | No       | `False` | Whether to continue the workflow if the event fails.               |
 | `condition`      | `str \| None`           | No       | `None`  | Boolean expression evaluated against request data before execution. If `False`, the step is silently skipped. |
+| `is_async`       | `bool`                  | No       | `False` | When `True`, the step is driven via `run_coroutine` even inside a sync feature. |
+| `middleware`     | `List[str]`             | No       | `[]`    | Step-level middleware service ids composed inside feature-level middleware. |
 
 Inherits `type` (defaults to `'event'`) and `name` from `FeatureStep`.
 
@@ -71,6 +73,8 @@ Immutable value object representing a complete feature workflow definition.
 | `feature_key`  | `str`                           | Yes      | —       | The key of the feature.                              |
 | `steps`        | `List[EventFeatureStep]`        | No       | `[]`    | The ordered step workflow for the feature.            |
 | `log_params`   | `Dict[str, str]`                | No       | `{}`    | Parameters to log for the feature.                   |
+| `is_async`     | `bool`                          | No       | `False` | When `True`, the entire step loop runs via `run_coroutine(self._execute_async(...))`. |
+| `middleware`   | `List[str]`                     | No       | `[]`    | Feature-level middleware service ids.                |
 
 #### Methods
 
@@ -89,12 +93,17 @@ step = feature.get_step('x')  # None (invalid type)
 
 The Feature domain objects participate in runtime workflow execution through the following flow:
 
-1. `FeatureContext.execute_feature(feature_id, data)` receives a feature ID from the application interface.
-2. The `Feature` is loaded from the `FeatureService` (backed by `feature.yml` configuration).
-3. `FeatureContext` iterates over `feature.steps`, resolving each `EventFeatureStep.service_id` from the DI container.
-4. Each resolved domain event is executed with the merged request data and step parameters.
-5. If `data_key` is set, the result is stored back into the data context under that key for downstream steps.
-6. If `pass_on_error` is `True`, errors from that step are caught and the workflow continues.
+1. The hub's `execute_feature_handler` resolves the `Feature` (cache-backed via `get_feature`) and constructs a domain-bound `FeatureContext` with `FeatureContext.from_domain(feature, get_dependency=..., cache=...)`.
+2. `FeatureContext.execute_feature(request, *flags, **kwargs)` takes **no** `feature` parameter — it reads `self.domain`. The same is true of `resolve_feature_steps(request, *execution_flags)` and the internal `_execute_async(request, ...)` path.
+3. Request data is validated against the feature schema (`validate_request`) before any step runs.
+4. Async dispatch:
+   - `feature.is_async=True` — the entire step loop runs via `run_coroutine(self._execute_async(...))`.
+   - otherwise, each `step.is_async=True` step is driven individually via `run_coroutine(self._execute_step_async(...))`.
+   - both flags `False` — fully synchronous `execute_step`.
+5. For each yielded step from `resolve_feature_steps`, the context resolves `EventFeatureStep.service_id` from DI (execution + feature + step flags combined additively), parses parameters (including `$r.` request-backed values), evaluates `condition`, and executes through composed middleware.
+6. If `data_key` is set, the result is stored on the `RequestContext` for downstream steps. If `pass_on_error` is `True`, step errors are swallowed and the workflow continues.
+
+There is no separate `AsyncFeatureContext` class. Admin bootstrap seeds the management workflow catalog as `assets/feature.py::ADMIN_DEFAULT_FEATURES` (consumed by `admin.build_cache`); see [docs/guides/admin.md](../admin.md).
 
 ## Configuration Mapping
 
@@ -148,7 +157,8 @@ Concrete implementations (e.g., `FeatureYamlRepository`) satisfy this interface.
 
 ## Relationships to Other Domains
 
-- **App:** `FeatureContext` is loaded as part of the application interface bootstrap, receiving `FeatureService` and container resolution via dependency injection.
+- **App:** `FeatureContext` is constructed per feature run by the blueprint's `execute_feature_handler`, receiving `get_dependency` and a shared `CacheContext`.
+- **Admin:** `ADMIN_DEFAULT_FEATURES` seeds the six-domain management catalog used by `AdminApp` / `AdminCLI` — see [docs/guides/admin.md](../admin.md).
 - **DI:** `EventFeatureStep.service_id` references a `ServiceRegistration` entry in the `services` section of the configuration, which is resolved at runtime by the DI container.
 - **Error:** Domain events use `verify()` and `raise_error()` to raise `TiferetError` when features are not found or parameters are invalid. These are resolved to `Error` domain objects for formatted responses.
 - **CLI:** CLI commands map to features via `group_key` and `key`, enabling command-line execution of feature workflows.
@@ -185,3 +195,5 @@ feature = Feature(
 - [docs/guides/domain/di.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/di.md) — DI domain guide
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+- [docs/guides/admin.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/admin.md) — Admin feature catalog (`ADMIN_DEFAULT_FEATURES`)
+- [docs/core/contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md) — Domain-bound `FeatureContext` and five-handler hub

--- a/docs/guides/domain/logging.md
+++ b/docs/guides/domain/logging.md
@@ -146,12 +146,13 @@ Tiferet provides built-in logging defaults in `assets/logging.py`. These define 
 
 The Logging domain objects participate in runtime configuration through the following flow:
 
-1. `LoggingContext.build_logger()` is called during application interface initialization.
-2. `LoggingService` loads all `Formatter`, `Handler`, and `Logger` domain objects from `logging.yml`.
-3. `LoggingContext.build_logger` wraps the loaded formatters, handlers, and loggers in a `LoggingSettings` value object (applying the built-in defaults as the per-section fallback).
-4. `LoggingSettings.format_config()` assembles a complete `dictConfig` dictionary with `formatters`, `handlers`, `loggers`, and `root` sections.
-5. `logging.config.dictConfig(config)` is called to configure the Python logging system.
-6. The configured logger is available for use throughout the application.
+1. The session hub calls `AppSessionContext.build_logger()`, which delegates to the injected `build_logger_handler` (required fifth handler — there is no long-lived `logging_context` constructor keyword on the hub).
+2. `blueprints/core.py::build_logger_handler` checks the shared cache under `LOGGER_CACHE_PREFIX` (`('logging', 'loggers')`) for a previously built logger id.
+3. On a miss, `logging_list_all_evt` loads repository `Formatter` / `Handler` / `Logger` objects; `merge_logging_settings` merges them over cache-seeded defaults by `.id`.
+4. `LoggingContext.from_domain(settings, logger_id=...)` binds the merged `LoggingSettings`; `LoggingContext.build_logger` calls `LoggingSettings.format_config()` and `create_logger`.
+5. The built logger is stored under `LOGGER_CACHE_PREFIX` so `dictConfig` runs once per logger id per process.
+
+Logging CRUD (`logging.add_formatter` / `remove_formatter`, `logging.add_handler` / `remove_handler`, `logging.add_logger` / `remove_logger`, and `logging.list`) is one of the six admin catalog domains managed by `AdminApp` / `AdminCLI`. See [docs/guides/admin.md](../admin.md) for the full management surface and worked examples.
 
 ## Configuration Mapping
 
@@ -194,6 +195,8 @@ The following domain events interact with `Formatter`, `Handler`, and `Logger`:
 | `AddFormatter`            | Creates and persists a new `Formatter`.               |
 | `AddHandler`              | Creates and persists a new `Handler`.                 |
 | `AddLogger`               | Creates and persists a new `Logger`.                  |
+| `RemoveFormatter` / `RemoveHandler` / `RemoveLogger` | Idempotent removals used by admin CRUD. |
+| `ListAllLoggingConfigs`   | Lists formatters, handlers, and loggers (also wired as `logging_list_all_evt`). |
 
 These events depend on the `LoggingService` interface for persistence operations.
 
@@ -212,7 +215,9 @@ Concrete implementations (e.g., `LoggingYamlRepository`) satisfy this interface.
 
 ## Relationships to Other Domains
 
-- **App:** `LoggingContext` is loaded as part of the application interface bootstrap, receiving `LoggingService` via dependency injection. Every application interface can have its own logging configuration.
+- **App:** Logger construction is a first-class hub template method (`build_logger` / `build_logger_handler`). Every application session can select its own `logger_id` and logging configuration.
+- **Blueprints:** `merge_logging_settings` and `build_logger_handler` in `tiferet/blueprints/core.py` own the list → merge → cache path; `LoggingContext` remains the ephemeral assembler.
+- **Admin:** Logging CRUD is one of the six admin catalog domains — see [docs/guides/admin.md](../admin.md).
 - **All Contexts:** Once configured, the Python logging system is available globally to all contexts, domain events, and services throughout the application lifecycle.
 
 ## Instantiation
@@ -259,3 +264,5 @@ lgr = Logger(
 - [docs/guides/domain/feature.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/domain/feature.md) — Feature domain guide
 - [docs/core/interfaces.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/interfaces.md) — Service contract definitions
 - [docs/core/events.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/events.md) — Domain event patterns & testing
+- [docs/guides/admin.md](https://github.com/greatstrength/tiferet/blob/main/docs/guides/admin.md) — Admin Logging CRUD domain
+- [docs/core/contexts.md](https://github.com/greatstrength/tiferet/blob/main/docs/core/contexts.md) — `build_logger_handler` five-handler slot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Repository = "https://github.com/greatstrength/tiferet"
 Download = "https://github.com/greatstrength/tiferet"
 
 [project.scripts]
-tiferet = "tiferet.blueprints.tiferet_cli:main"
+tiferet = "tiferet.blueprints.admin_cli:main"
 
 [project.optional-dependencies]
 test = [

--- a/tests/assets/test_cli.py
+++ b/tests/assets/test_cli.py
@@ -1,0 +1,97 @@
+"""Tests for CLI Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import cli as cli_assets
+
+# *** constants
+
+# ** constant: dict_typed_argument_specs
+# (command_data attribute name, flag name) pairs that must use type='dict'.
+DICT_TYPED_ARGUMENT_SPECS = [
+    ('APP_ADD_CLI_CMD_DATA', '--constants'),
+    ('APP_SET_CONSTANTS_CLI_CMD_DATA', '--constants'),
+    ('APP_SET_SERVICE_CLI_CMD_DATA', '--parameters'),
+    ('FEATURE_ADD_STEP_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_ADD_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_DEFAULT_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_DEPENDENCY_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_CONSTANTS_CLI_CMD_DATA', '--constants'),
+]
+
+# *** functions
+
+# ** function: find_argument
+def find_argument(command_data: dict, flag: str) -> dict | None:
+    '''
+    Return the argument dict whose name_or_flags includes the given flag.
+
+    :param command_data: A CLI command data dict with an arguments list.
+    :type command_data: dict
+    :param flag: The flag string to locate (e.g. '--constants').
+    :type flag: str
+    :return: The matching argument dict, or None when absent.
+    :rtype: dict | None
+    '''
+
+    # Scan the command's arguments for the requested flag.
+    for argument in command_data.get('arguments', []):
+        if flag in argument.get('name_or_flags', []):
+            return argument
+
+    # Return None when the flag is not present.
+    return None
+
+# *** tests
+
+# ** test: eight_flat_map_arguments_use_dict_type
+def test_eight_flat_map_arguments_use_dict_type():
+    '''
+    Verify each of the eight flat-map admin CLI arguments uses type='dict'.
+    '''
+
+    # Assert every listed argument is typed as dict.
+    for attr_name, flag in DICT_TYPED_ARGUMENT_SPECS:
+        command_data = getattr(cli_assets, attr_name)
+        argument = find_argument(command_data, flag)
+        assert argument is not None, f'{attr_name} missing {flag}'
+        assert argument['type'] == 'dict', f'{attr_name} {flag} type is {argument.get("type")!r}'
+
+# ** test: error_add_includes_additional_messages_dict_arg
+def test_error_add_includes_additional_messages_dict_arg():
+    '''
+    Verify error.add exposes --additional-messages with type='dict'.
+    '''
+
+    # Locate the additional-messages argument on error.add.
+    argument = find_argument(
+        cli_assets.ERROR_ADD_CLI_CMD_DATA,
+        '--additional-messages',
+    )
+
+    # Assert the argument exists and is typed as dict.
+    assert argument is not None
+    assert argument['type'] == 'dict'
+    assert argument['description'] == (
+        'Additional messages beyond the primary one, as lang=text pairs.'
+    )
+
+# ** test: list_shaped_json_arguments_remain_json
+def test_list_shaped_json_arguments_remain_json():
+    '''
+    Verify list-shaped arguments out of scope stay type='json'.
+    '''
+
+    # Assert app.add --flags remains json.
+    flags_arg = find_argument(cli_assets.APP_ADD_CLI_CMD_DATA, '--flags')
+    assert flags_arg is not None
+    assert flags_arg['type'] == 'json'
+
+    # Assert cli.add-argument --name-or-flags remains json.
+    name_or_flags_arg = find_argument(
+        cli_assets.CLI_ADD_ARGUMENT_CLI_CMD_DATA,
+        '--name-or-flags',
+    )
+    assert name_or_flags_arg is not None
+    assert name_or_flags_arg['type'] == 'json'

--- a/tests/assets/test_di.py
+++ b/tests/assets/test_di.py
@@ -1,0 +1,38 @@
+"""Tests for DI Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import di as di_assets
+
+# *** tests
+
+# ** test: admin_default_services_exists
+def test_admin_default_services_exists():
+    '''
+    Verify ADMIN_DEFAULT_SERVICES is defined and DEFAULT_ADMIN_SERVICES is gone.
+    '''
+
+    # Assert the renamed catalog is present and non-empty.
+    assert hasattr(di_assets, 'ADMIN_DEFAULT_SERVICES')
+    assert isinstance(di_assets.ADMIN_DEFAULT_SERVICES, dict)
+    assert len(di_assets.ADMIN_DEFAULT_SERVICES) > 0
+
+    # Assert the old name does not exist on the module.
+    assert not hasattr(di_assets, 'DEFAULT_ADMIN_SERVICES')
+
+# ** test: admin_default_services_keys_match_id_constants
+def test_admin_default_services_keys_match_id_constants():
+    '''
+    Verify a representative set of service IDs are catalog keys.
+    '''
+
+    # Assert core admin service registration IDs are present as catalog keys.
+    for service_id in (
+        di_assets.APP_SERVICE_ID,
+        di_assets.ADD_ERROR_EVT_ID,
+        di_assets.ADD_FEATURE_EVT_ID,
+        di_assets.ADD_SERVICE_REGISTRATION_EVT_ID,
+        di_assets.ADD_LOGGER_EVT_ID,
+    ):
+        assert service_id in di_assets.ADMIN_DEFAULT_SERVICES

--- a/tests/assets/test_feature.py
+++ b/tests/assets/test_feature.py
@@ -1,0 +1,38 @@
+"""Tests for Feature Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import feature as feature_assets
+
+# *** tests
+
+# ** test: admin_default_features_exists
+def test_admin_default_features_exists():
+    '''
+    Verify ADMIN_DEFAULT_FEATURES is defined and DEFAULT_ADMIN_FEATURES is gone.
+    '''
+
+    # Assert the renamed catalog is present and non-empty.
+    assert hasattr(feature_assets, 'ADMIN_DEFAULT_FEATURES')
+    assert isinstance(feature_assets.ADMIN_DEFAULT_FEATURES, dict)
+    assert len(feature_assets.ADMIN_DEFAULT_FEATURES) > 0
+
+    # Assert the old name does not exist on the module.
+    assert not hasattr(feature_assets, 'DEFAULT_ADMIN_FEATURES')
+
+# ** test: admin_default_features_keys_match_id_constants
+def test_admin_default_features_keys_match_id_constants():
+    '''
+    Verify a representative set of feature IDs are catalog keys.
+    '''
+
+    # Assert core admin feature IDs are present as catalog keys.
+    for feature_id in (
+        feature_assets.APP_ADD_ID,
+        feature_assets.ERROR_ADD_ID,
+        feature_assets.FEATURE_ADD_STEP_ID,
+        feature_assets.SERVICE_ADD_ID,
+        feature_assets.LOGGING_LIST_ID,
+    ):
+        assert feature_id in feature_assets.ADMIN_DEFAULT_FEATURES

--- a/tests/blueprints/test_admin.py
+++ b/tests/blueprints/test_admin.py
@@ -1,0 +1,167 @@
+"""Tiferet Admin Blueprints Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from tiferet import assets as a
+from tiferet.assets import TiferetError
+from tiferet.blueprints.admin import (
+    AdminApp,
+    build_admin_app,
+    build_admin_app_session_context,
+    build_admin_service_resolver,
+    build_cache,
+)
+from tiferet.blueprints import core
+from tiferet.contexts.app import (
+    ADMIN_SERVICE_CACHE_PREFIX,
+    AppSessionContext,
+)
+from tiferet.contexts.cache import CacheContext
+from tiferet.di import DIAppServiceContainer, DIDynamicServiceResolver
+from tiferet.domain import AppServiceDependency, AppSession
+
+# *** tests
+
+# ** test: build_cache_seeds_admin_services
+def test_build_cache_seeds_admin_services():
+    '''
+    Test that build_cache seeds admin services under ADMIN_SERVICE_CACHE_PREFIX.
+    '''
+
+    # Build the admin cache and resolve a known admin service entry.
+    cache = build_cache()
+    cached = cache.get('di_service', *ADMIN_SERVICE_CACHE_PREFIX)
+
+    # Assert the admin service catalog is seeded under the admin prefix.
+    assert isinstance(cached, AppServiceDependency)
+    assert cached.service_id == 'di_service'
+
+# ** test: build_admin_service_resolver_routes_by_flag
+def test_build_admin_service_resolver_routes_by_flag():
+    '''
+    Test that the app flag resolves from the app container while admin and
+    empty-flag resolution both use the admin container.
+    '''
+
+    # Seed an admin cache and build distinct app and admin containers.
+    cache = build_cache()
+    app_container = DIAppServiceContainer.from_dependencies(
+        services=[
+            AppServiceDependency(
+                service_id='di_service',
+                module_path='tiferet.contexts.cache',
+                class_name='CacheContext',
+            ),
+            AppServiceDependency(
+                service_id='flag_probe',
+                module_path='tiferet.contexts.request',
+                class_name='RequestContext',
+            ),
+        ],
+        constants={},
+    )
+    admin_probe = AppServiceDependency(
+        service_id='flag_probe',
+        module_path='tiferet.contexts.cache',
+        class_name='CacheContext',
+    )
+    with mock.patch(
+        'tiferet.blueprints.admin.get_default_admin_services',
+        return_value=[admin_probe],
+    ), mock.patch(
+        'tiferet.blueprints.admin.get_default_admin_constants',
+        return_value={},
+    ):
+        resolver = build_admin_service_resolver(app_container, cache)
+
+    # Assert flag routing: app vs admin vs empty-flag default.
+    assert isinstance(resolver, DIDynamicServiceResolver)
+    from tiferet.contexts.request import RequestContext
+    assert isinstance(resolver.get_dependency('flag_probe', 'app'), RequestContext)
+    assert isinstance(resolver.get_dependency('flag_probe', 'admin'), CacheContext)
+    assert isinstance(resolver.get_dependency('flag_probe'), CacheContext)
+    assert resolver.get_container('admin') is resolver.get_container()
+
+# ** test: build_admin_app_session_context_wires_handlers
+def test_build_admin_app_session_context_wires_handlers():
+    '''
+    Test that build_admin_app_session_context returns an AppSessionContext with
+    all five handlers wired, including build_logger_handler.
+    '''
+
+    # Seed the admin cache and a minimal session for composition.
+    cache = build_cache()
+    app_session = AppSession(id=a.app.TIFERET_ADMIN_ID, name='Admin App')
+
+    # Bypass the real logging pipeline; this test targets handler wiring only.
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch(
+        'tiferet.blueprints.core.build_logger_handler',
+        return_value=fake_build_logger,
+    ):
+        context = build_admin_app_session_context(app_session, cache)
+
+    # Assert the context is fully wired with all five template-method handlers.
+    assert isinstance(context, AppSessionContext)
+    assert context._build_logger is fake_build_logger
+    assert context._execute_feature is not None
+    assert context._raise_error is not None
+    assert context._build_response is core.response_handler
+    assert context._create_request is core.create_session_request
+
+# ** test: build_admin_app_returns_app_session_context
+def test_build_admin_app_returns_app_session_context():
+    '''
+    Test that build_admin_app returns a fully wired AppSessionContext for the
+    built-in admin session.
+    '''
+
+    # Build the admin app with no consumer config entry required.
+    context = build_admin_app()
+
+    # Assert the composed context is bound to the built-in admin session.
+    assert isinstance(context, AppSessionContext)
+    assert context.domain.id == a.app.TIFERET_ADMIN_ID
+
+    # Assert all five template-method handlers were wired.
+    assert context._build_logger is not None
+    assert context._execute_feature is not None
+    assert context._raise_error is not None
+    assert context._create_request is core.create_session_request
+    assert context._build_response is core.response_handler
+
+# ** test: build_admin_app_alias
+def test_build_admin_app_alias():
+    '''
+    Test that AdminApp is an alias for build_admin_app.
+    '''
+
+    # Assert the exported alias points at the single-call entry point.
+    assert AdminApp is build_admin_app
+
+# ** test: build_admin_app_invalid_type
+def test_build_admin_app_invalid_type():
+    '''
+    Test that build_admin_app raises INVALID_APP_SESSION_TYPE_ID when the
+    resolved context type is invalid.
+    '''
+
+    # Isolate build_admin_app and force an invalid context type.
+    with mock.patch('tiferet.blueprints.admin.build_cache') as mock_cache, \
+         mock.patch('tiferet.blueprints.core.get_app_session') as mock_get_session, \
+         mock.patch('tiferet.blueprints.admin.build_admin_app_session_context') as mock_build_ctx:
+        mock_cache.return_value = CacheContext()
+        mock_get_session.return_value = AppSession(id='admin', name='Admin App')
+        mock_build_ctx.return_value = object()
+
+        # Invoke build_admin_app and expect the structured type error.
+        with pytest.raises(TiferetError) as exc_info:
+            build_admin_app()
+
+    # Assert the structured invalid-type error is raised.
+    assert exc_info.value.error_code == a.error.INVALID_APP_SESSION_TYPE_ID

--- a/tests/blueprints/test_admin_cli.py
+++ b/tests/blueprints/test_admin_cli.py
@@ -1,0 +1,192 @@
+"""Tiferet Admin CLI Blueprints Tests"""
+
+# *** imports
+
+# ** infra
+from unittest import mock
+
+# ** app
+from tiferet import assets as a
+from tiferet.blueprints.admin_cli import (
+    AdminCLI,
+    build_admin_cli,
+    build_admin_cli_session_context,
+    build_cache,
+    main,
+)
+from tiferet.blueprints.cli import (
+    create_cli_request_context,
+    cli_response_handler,
+)
+from tiferet.contexts.cache import CacheContext
+from tiferet.contexts.cli import (
+    CLI_COMMAND_CACHE_PREFIX,
+    CliSessionContext,
+)
+from tiferet.domain import AppSession, CliCommand
+
+# *** tests
+
+# ** test: build_cache_seeds_admin_cli_commands
+def test_build_cache_seeds_admin_cli_commands():
+    '''
+    Test that build_cache seeds admin CLI commands under CLI_COMMAND_CACHE_PREFIX.
+    '''
+
+    # Build the admin CLI cache and collect seeded commands.
+    cache = build_cache()
+    seeded = cache.get_by_prefix(*CLI_COMMAND_CACHE_PREFIX)
+
+    # Assert the admin CLI command catalog is seeded.
+    assert isinstance(cache, CacheContext)
+    assert seeded
+    assert all(isinstance(command, CliCommand) for command in seeded.values())
+    assert 'cli.list_commands' in seeded
+
+# ** test: build_admin_cli_session_context_uses_admin_resolver
+def test_build_admin_cli_session_context_uses_admin_resolver():
+    '''
+    Test that build_admin_cli_session_context wires a CliSessionContext whose
+    resolver carries the admin container under the admin flag and default.
+    '''
+
+    # Seed the admin CLI cache and a minimal session for composition.
+    cache = build_cache()
+    app_session = AppSession(id=a.app.TIFERET_ADMIN_CLI_ID, name='Admin CLI')
+
+    # Capture the resolver produced by the admin composition path.
+    captured = {}
+    real_build = __import__(
+        'tiferet.blueprints.admin',
+        fromlist=['build_admin_service_resolver'],
+    ).build_admin_service_resolver
+
+    def capture_resolver(app_container, cache, parse_parameter=None):
+        kwargs = {}
+        if parse_parameter is not None:
+            kwargs['parse_parameter'] = parse_parameter
+        resolver = real_build(app_container, cache, **kwargs)
+        captured['resolver'] = resolver
+        return resolver
+
+    # Bypass the real logging pipeline; this test targets resolver wiring only.
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch(
+        'tiferet.blueprints.admin.build_admin_service_resolver',
+        side_effect=capture_resolver,
+    ), mock.patch(
+        'tiferet.blueprints.core.build_logger_handler',
+        return_value=fake_build_logger,
+    ):
+        context = build_admin_cli_session_context(app_session, cache)
+
+    # Assert the CLI session context is fully wired with CLI handlers.
+    assert isinstance(context, CliSessionContext)
+    assert context._create_request is create_cli_request_context
+    assert context._build_response is cli_response_handler
+    assert context._parse_cli_args is not None
+    assert context._build_logger is fake_build_logger
+
+    # Assert the built resolver carries the admin container under both keys.
+    resolver = captured['resolver']
+    assert resolver.get_container('admin') is resolver.get_container()
+
+# ** test: build_admin_cli_reseeds_app_config
+def test_build_admin_cli_reseeds_app_config():
+    '''
+    Test that build_admin_cli re-seeds session constants so all config keys
+    equal the consumer-supplied app_config path.
+    '''
+
+    # Isolate build_admin_cli from session resolution and context composition.
+    app_session = AppSession(
+        id=a.app.TIFERET_ADMIN_CLI_ID,
+        name='Admin CLI',
+        constants={'cli_config': 'old.yml'},
+    )
+    mock_context = mock.Mock(spec=CliSessionContext)
+    mock_context.run.return_value = 'admin-cli-response'
+
+    with mock.patch(
+        'tiferet.blueprints.admin_cli.core.get_app_session',
+        return_value=app_session,
+    ) as mock_get_session, mock.patch(
+        'tiferet.blueprints.admin_cli.build_admin_cli_session_context',
+        return_value=mock_context,
+    ) as mock_build_ctx:
+        response = build_admin_cli(
+            app_config='consumer.yml',
+            argv=['cli', 'list-commands'],
+        )
+
+    # Assert the built-in admin CLI session was resolved with the config path.
+    mock_get_session.assert_called_once()
+    assert mock_get_session.call_args.args[0] == a.app.TIFERET_ADMIN_CLI_ID
+    assert mock_get_session.call_args.kwargs['app_config'] == 'consumer.yml'
+
+    # Assert session constants were re-seeded to the consumer config path.
+    assert app_session.constants == {
+        'cli_config': 'consumer.yml',
+        'app_config': 'consumer.yml',
+        'di_config': 'consumer.yml',
+        'error_config': 'consumer.yml',
+        'feature_config': 'consumer.yml',
+        'logging_config': 'consumer.yml',
+    }
+
+    # Assert the context was composed with the mutated session and run invoked.
+    mock_build_ctx.assert_called_once()
+    assert mock_build_ctx.call_args.args[0] is app_session
+    mock_context.run.assert_called_once_with(['cli', 'list-commands'])
+    assert response == 'admin-cli-response'
+
+# ** test: build_admin_cli_alias
+def test_build_admin_cli_alias():
+    '''
+    Test that AdminCLI is an alias for build_admin_cli.
+    '''
+
+    # Assert the exported alias points at the single-call entry point.
+    assert AdminCLI is build_admin_cli
+
+# ** test: package_exports_admin_blueprints
+def test_package_exports_admin_blueprints():
+    '''
+    Test that blueprints package exports admin app and admin CLI entry points.
+    '''
+
+    # Import the package exports and assert the admin symbols resolve.
+    from tiferet.blueprints import (
+        AdminApp,
+        AdminCLI as ExportedAdminCLI,
+        build_admin_app,
+        build_admin_cli as exported_build_admin_cli,
+    )
+
+    # Assert both aliases and builders are exported.
+    assert build_admin_app is not None
+    assert AdminApp is build_admin_app
+    assert exported_build_admin_cli is build_admin_cli
+    assert ExportedAdminCLI is build_admin_cli
+
+# ** test: main_pre_parses_config
+def test_main_pre_parses_config():
+    '''
+    Test that main extracts --config via a help-disabled pre-parser and
+    forwards the remaining argv to build_admin_cli.
+    '''
+
+    # Isolate main from the full admin CLI composition chain.
+    with mock.patch(
+        'tiferet.blueprints.admin_cli.build_admin_cli',
+    ) as mock_build, mock.patch(
+        'sys.argv',
+        ['tiferet', '--config', 'my.yml', 'cli', 'list-commands'],
+    ):
+        main()
+
+    # Assert --config was stripped and the remaining argv was forwarded.
+    mock_build.assert_called_once_with(
+        app_config='my.yml',
+        argv=['cli', 'list-commands'],
+    )

--- a/tests/blueprints/test_cli.py
+++ b/tests/blueprints/test_cli.py
@@ -28,7 +28,6 @@ from tiferet.contexts.cli import (
     CliSessionContext,
     CLI_COMMAND_CACHE_PREFIX,
 )
-from tiferet.contexts.logging import LoggingContext
 from tiferet.domain import AppSession, CliArgument, CliCommand
 from tiferet.events.cli import GetParentArguments, ListCliCommands
 
@@ -315,8 +314,8 @@ def test_build_cli_session_context_wires_cli_handlers() -> None:
     })(lambda: CacheContext())()
 
     # Bypass the real logging pipeline; this test targets handler wiring only.
-    fake_logging_context = mock.Mock(spec=LoggingContext)
-    with mock.patch('tiferet.blueprints.core.build_logging_context', return_value=fake_logging_context):
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch('tiferet.blueprints.core.build_logger_handler', return_value=fake_build_logger):
         context = build_cli_session_context(
             AppSession(id='test_cli', name='Test CLI Session'),
             cache,
@@ -327,7 +326,7 @@ def test_build_cli_session_context_wires_cli_handlers() -> None:
     assert context._create_request is create_cli_request_context
     assert context._build_response is cli_response_handler
     assert context._parse_cli_args is not None
-    assert context._logging is fake_logging_context
+    assert context._build_logger is fake_build_logger
 
 # ** test: build_app_delegates_to_context
 def test_build_app_delegates_to_context() -> None:

--- a/tests/blueprints/test_core.py
+++ b/tests/blueprints/test_core.py
@@ -21,7 +21,8 @@ from tiferet.blueprints.core import (
     load_cache,
     get_error,
     get_feature,
-    build_logging_context,
+    merge_logging_settings,
+    build_logger_handler,
     create_app_service,
     get_app_session,
     create_request_context,
@@ -43,10 +44,14 @@ from tiferet.contexts.app import (
 from tiferet.contexts.cache import CacheContext
 from tiferet.contexts.error import ERROR_CACHE_PREFIX
 from tiferet.contexts.feature import FeatureContext, FEATURE_CACHE_PREFIX
-from tiferet.contexts.logging import LoggingContext, add_default_logging_settings, get_default_logging_settings
+from tiferet.contexts.logging import (
+    LOGGER_CACHE_PREFIX,
+    add_default_logging_settings,
+    get_default_logging_settings,
+)
 from tiferet.contexts.request import RequestContext
 from tiferet.di import DIAppServiceContainer, DIDynamicServiceResolver
-from tiferet.domain import AppSession, AppServiceDependency, Error, Feature, LoggingSettings
+from tiferet.domain import AppSession, AppServiceDependency, Error, Feature, LoggingSettings, Formatter
 from tiferet.events import ParseParameter
 from tiferet.repos.app import AppConfigRepository
 from tiferet.utils.core import CacheMiddleware
@@ -351,17 +356,67 @@ def test_get_feature_returns_cached():
     assert handler('test.feature') is feature
     get_dependency.assert_not_called()
 
-# ** test: build_logging_context_returns_logging_context
-def test_build_logging_context_returns_logging_context():
+# ** test: merge_logging_settings_overrides_by_id
+def test_merge_logging_settings_overrides_by_id():
     '''
-    Test that build_logging_context returns a LoggingContext bound to a merged LoggingSettings.
+    Test that merge_logging_settings keeps unmatched defaults and overrides by id.
     '''
 
-    # Seed the cache with default logging settings.
+    # Seed the cache with a single default formatter.
     cache = add_default_logging_settings({
         'formatters': [{'id': 'default', 'name': 'Default', 'format': '%(message)s'}],
         'handlers': [],
         'loggers': [],
+    })(lambda: CacheContext())()
+
+    # Merge a repository formatter that overrides the default id plus a new one.
+    override = Formatter(id='default', name='Override', format='%(levelname)s %(message)s')
+    extra = Formatter(id='extra', name='Extra', format='%(message)s')
+    settings = merge_logging_settings(cache, [override, extra], [], [])
+
+    # Assert the merge result is a LoggingSettings with override and unmatched defaults preserved.
+    assert isinstance(settings, LoggingSettings)
+    formatters_by_id = {formatter.id: formatter for formatter in settings.formatters}
+    assert formatters_by_id['default'].name == 'Override'
+    assert formatters_by_id['extra'].name == 'Extra'
+
+# ** test: merge_logging_settings_tolerates_empty_defaults
+def test_merge_logging_settings_tolerates_empty_defaults():
+    '''
+    Test that merge_logging_settings accepts a cache with no seeded defaults.
+    '''
+
+    # Merge repository sections against an empty cache.
+    formatter = Formatter(id='repo', name='Repo', format='%(message)s')
+    settings = merge_logging_settings(CacheContext(), [formatter], [], [])
+
+    # Assert the repository entry is the sole formatter.
+    assert [item.id for item in settings.formatters] == ['repo']
+
+# ** test: build_logger_handler_caches_by_logger_id
+def test_build_logger_handler_caches_by_logger_id():
+    '''
+    Test that build_logger_handler builds once per logger id and returns the cache hit.
+    '''
+
+    # Seed the cache with default logging settings sufficient for dictConfig.
+    cache = add_default_logging_settings({
+        'formatters': [{'id': 'default', 'name': 'Default', 'format': '%(message)s'}],
+        'handlers': [{
+            'id': 'default',
+            'name': 'Default',
+            'module_path': 'logging',
+            'class_name': 'StreamHandler',
+            'level': 'CRITICAL',
+            'formatter': 'default',
+            'stream': 'ext://sys.stderr',
+        }],
+        'loggers': [{
+            'id': 'default',
+            'name': 'Default',
+            'level': 'CRITICAL',
+            'handlers': ['default'],
+        }],
     })(lambda: CacheContext())()
 
     # Configure a mock resolver returning empty repository-configured settings.
@@ -369,12 +424,16 @@ def test_build_logging_context_returns_logging_context():
     mock_event.execute.return_value = ([], [], [])
     get_dependency = mock.Mock(return_value=mock_event)
 
-    # Build the logging context and assert it is bound to the merged settings.
-    logging_context = build_logging_context(cache, get_dependency, 'root')
-    assert isinstance(logging_context, LoggingContext)
-    assert isinstance(logging_context.domain, LoggingSettings)
-    assert len(logging_context.domain.formatters) == 1
+    # Build the handler and resolve the same logger id twice.
+    handler = build_logger_handler(cache, get_dependency)
+    first = handler('default')
+    second = handler('default')
+
+    # Assert the logger is cached and the list-all event ran only once.
+    assert first is second
+    assert cache.get('default', *LOGGER_CACHE_PREFIX) is first
     get_dependency.assert_called_once_with('logging_list_all_evt', 'app')
+    mock_event.execute.assert_called_once_with()
 
 # ** test: create_app_service_default
 def test_create_app_service_default():
@@ -452,7 +511,7 @@ def test_create_request_context_sets_interface_id_header():
 # ** test: create_feature_context_resolves_and_binds
 def test_create_feature_context_resolves_and_binds():
     '''
-    Test that create_feature_context resolves the feature and binds a FeatureContext.
+    Test that create_feature_context returns a FeatureContext bound via from_domain.
     '''
 
     # Seed the cache with a Feature domain object.
@@ -461,11 +520,10 @@ def test_create_feature_context_resolves_and_binds():
     cache.set('test.feature', feature, *FEATURE_CACHE_PREFIX)
     get_dependency = mock.Mock()
 
-    # Resolve the feature and its bound context.
-    resolved_feature, feature_context = create_feature_context(get_dependency, cache, 'test.feature')
+    # Resolve the bound feature context.
+    feature_context = create_feature_context(get_dependency, cache, 'test.feature')
 
-    # Assert the resolved feature and bound context.
-    assert resolved_feature is feature
+    # Assert a single FeatureContext is returned with the feature bound as domain.
     assert isinstance(feature_context, FeatureContext)
     assert feature_context.domain is feature
 
@@ -483,7 +541,7 @@ def test_create_session_request_sets_interface_id_header():
 # ** test: execute_feature_handler_drives_feature_context
 def test_execute_feature_handler_drives_feature_context():
     '''
-    Test that the execute_feature_handler closure calls FeatureContext.execute_feature with the resolved feature.
+    Test that the execute_feature_handler closure calls FeatureContext.execute_feature without a feature arg.
     '''
 
     # Seed the cache with a Feature domain object.
@@ -498,8 +556,8 @@ def test_execute_feature_handler_drives_feature_context():
     with mock.patch.object(FeatureContext, 'execute_feature') as mock_execute:
         result = handler('test.feature', request)
 
-    # Assert the feature context was driven with the resolved feature.
-    mock_execute.assert_called_once_with(feature, request)
+    # Assert the feature context was driven with the request only.
+    mock_execute.assert_called_once_with(request)
 
     # Assert the handler is void; the result accrues on the request context.
     assert result is None
@@ -523,7 +581,7 @@ def test_execute_feature_handler_forwards_flags():
         handler('test.feature', request, 'flag_one', 'flag_two', logger=None)
 
     # Assert the execution flags were forwarded positionally to the feature context.
-    mock_execute.assert_called_once_with(feature, request, 'flag_one', 'flag_two', logger=None)
+    mock_execute.assert_called_once_with(request, 'flag_one', 'flag_two', logger=None)
 
 # ** test: raise_error_handler_formats_and_raises
 def test_raise_error_handler_formats_and_raises():
@@ -577,7 +635,7 @@ def test_raise_error_handler_wraps_bare_exception():
 # ** test: build_app_session_context_wires_handlers
 def test_build_app_session_context_wires_handlers():
     '''
-    Test that build_app_session_context returns an AppSessionContext with all FE4 handlers wired.
+    Test that build_app_session_context returns an AppSessionContext with all five handlers wired.
     '''
 
     # Seed the cache with a minimal di_service default.
@@ -591,13 +649,13 @@ def test_build_app_session_context_wires_handlers():
     app_session = AppSession(id='test.session', name='Test Session')
 
     # Bypass the real logging pipeline; this test targets handler wiring only.
-    fake_logging_context = mock.Mock(spec=LoggingContext)
-    with mock.patch('tiferet.blueprints.core.build_logging_context', return_value=fake_logging_context):
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch('tiferet.blueprints.core.build_logger_handler', return_value=fake_build_logger):
         context = build_app_session_context(app_session, cache)
 
-    # Assert the context is fully wired with all four FE4 handlers.
+    # Assert the context is fully wired with all five template-method handlers.
     assert isinstance(context, AppSessionContext)
-    assert context._logging is fake_logging_context
+    assert context._build_logger is fake_build_logger
     assert context._execute_feature is not None
     assert context._raise_error is not None
     assert context._build_response is response_handler
@@ -656,14 +714,14 @@ def test_build_app_end_to_end_wires_session_context(session_config_file):
     assert context.domain.id == 'test_session'
     assert context.domain.name == 'Test Session'
 
-    # Assert all four FE4 handlers were wired by the composition chain.
+    # Assert all five template-method handlers were wired by the composition chain.
+    assert context._build_logger is not None
     assert context._execute_feature is not None
     assert context._raise_error is not None
     assert context._create_request is create_session_request
     assert context._build_response is response_handler
 
-    # Assert the logging context and shared cache were composed for real.
-    assert isinstance(context._logging, LoggingContext)
+    # Assert the shared cache was composed for real.
     assert isinstance(context.cache, CacheContext)
 
 # ** test: build_app_end_to_end_resolves_default_services

--- a/tests/contexts/test_app.py
+++ b/tests/contexts/test_app.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 # ** app
 from tiferet.assets import TiferetError, TiferetAPIError
+from tiferet.assets.error import APP_ERROR_ID
 from tiferet.contexts.app import (
     AppSessionContext,
     add_default_app_services,
@@ -32,10 +33,8 @@ from tiferet.contexts.app import (
 )
 from tiferet.contexts.cache import CacheContext
 from tiferet.contexts.core import BaseContext
-from tiferet.contexts.feature import FeatureContext
-from tiferet.contexts.logging import LoggingContext
 from tiferet.contexts.request import RequestContext
-from tiferet.domain import AppSession, AppServiceDependency, Feature
+from tiferet.domain import AppSession, AppServiceDependency
 from tiferet.interfaces import AppService
 
 # *** fixtures
@@ -102,20 +101,18 @@ def get_dependency() -> Callable:
     # Return a plain mock callable.
     return mock.Mock()
 
-# ** fixture: logging_context
+# ** fixture: build_logger_handler
 @pytest.fixture
-def logging_context() -> LoggingContext:
+def build_logger_handler() -> Callable:
     '''
-    Fixture to create a mock LoggingContext instance.
+    Fixture providing a mock logger-construction handler.
 
-    :return: A mock instance of LoggingContext.
-    :rtype: LoggingContext
+    :return: A mock callable that returns a mock logger.
+    :rtype: Callable
     '''
 
-    # Create a mock LoggingContext whose build_logger returns a mock logger.
-    context = mock.Mock(spec=LoggingContext)
-    context.build_logger.return_value = mock.Mock(spec=logging.Logger)
-    return context
+    # Return a mock logger-construction handler.
+    return mock.Mock(return_value=mock.Mock(spec=logging.Logger))
 
 # ** fixture: execute_feature_handler
 @pytest.fixture
@@ -178,7 +175,7 @@ def response_handler() -> Callable:
 def app_session_context(
         app_session: AppSession,
         get_dependency: Callable,
-        logging_context: LoggingContext,
+        build_logger_handler: Callable,
         execute_feature_handler: Callable,
         create_request_handler: Callable,
         raise_error_handler: Callable,
@@ -195,7 +192,7 @@ def app_session_context(
     return AppSessionContext.from_domain(
         app_session,
         get_dependency=get_dependency,
-        logging_context=logging_context,
+        build_logger_handler=build_logger_handler,
         execute_feature_handler=execute_feature_handler,
         create_request_handler=create_request_handler,
         raise_error_handler=raise_error_handler,
@@ -207,7 +204,7 @@ def app_session_context(
 # ** test: app_session_context_init
 def test_app_session_context_init(app_session_context: AppSessionContext,
         get_dependency: Callable,
-        logging_context: LoggingContext,
+        build_logger_handler: Callable,
         execute_feature_handler: Callable,
         create_request_handler: Callable,
         raise_error_handler: Callable,
@@ -218,11 +215,12 @@ def test_app_session_context_init(app_session_context: AppSessionContext,
 
     # Assert all collaborators are stored.
     assert app_session_context.get_dependency is get_dependency
-    assert app_session_context._logging is logging_context
+    assert app_session_context._build_logger is build_logger_handler
     assert app_session_context._execute_feature is execute_feature_handler
     assert app_session_context._create_request is create_request_handler
     assert app_session_context._raise_error is raise_error_handler
     assert app_session_context._build_response is response_handler
+    assert not hasattr(app_session_context, '_logging')
 
 # ** test: app_session_context_init_default_cache
 def test_app_session_context_init_default_cache(get_dependency: Callable):
@@ -289,14 +287,65 @@ def test_app_session_context_load_not_found():
     # Assert the structured not-found error is raised.
     assert exc_info.value.error_code == 'APP_SESSION_NOT_FOUND'
 
-# ** test: app_session_context_load_logging_context
-def test_app_session_context_load_logging_context(app_session_context: AppSessionContext, logging_context: LoggingContext):
+# ** test: app_session_context_build_logger_wired
+def test_app_session_context_build_logger_wired(
+        app_session_context: AppSessionContext,
+        build_logger_handler: Callable,
+    ):
     '''
-    Test that load_logging_context returns the bound logging context.
+    Test that build_logger delegates to the injected handler when wired.
     '''
 
-    # Assert the bound logging context is returned unchanged.
-    assert app_session_context.load_logging_context() is logging_context
+    # Build the logger through the wired handler.
+    logger = app_session_context.build_logger()
+
+    # Assert the handler was invoked with the session logger id.
+    build_logger_handler.assert_called_once_with(app_session_context.domain.logger_id)
+    assert logger is build_logger_handler.return_value
+
+# ** test: app_session_context_build_logger_unwired
+def test_app_session_context_build_logger_unwired(app_session: AppSession, get_dependency: Callable):
+    '''
+    Test that build_logger raises APP_ERROR when the handler is unwired.
+    '''
+
+    # Construct a context without a logger-construction handler.
+    context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
+
+    # Assert an unwired handler fails loudly with APP_ERROR.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.build_logger()
+
+    # Assert the structured app error names the missing handler.
+    assert exc_info.value.error_code == APP_ERROR_ID
+    assert 'build_logger_handler' in exc_info.value.message
+
+# ** test: app_session_context_build_logger_formats_tiferet_error
+def test_app_session_context_build_logger_formats_tiferet_error(
+        app_session: AppSession,
+        get_dependency: Callable,
+        raise_error_handler: Callable,
+    ):
+    '''
+    Test that build_logger formats a TiferetError from the handler via handle_error.
+    '''
+
+    # Configure the logger handler to raise a domain error.
+    domain_error = TiferetError('LOGGER_CREATION_FAILED', 'Logger failed.')
+    build_logger = mock.Mock(side_effect=domain_error)
+
+    # Construct a context with a failing logger handler and a wired error handler.
+    context = AppSessionContext.from_domain(
+        app_session,
+        get_dependency=get_dependency,
+        build_logger_handler=build_logger,
+        raise_error_handler=raise_error_handler,
+    )
+
+    # Assert the domain error is formatted through handle_error.
+    result = context.build_logger()
+    raise_error_handler.assert_called_once_with(domain_error)
+    assert result == {'error_code': 'TEST_ERROR'}
 
 # ** test: app_session_context_build_request_wired
 def test_app_session_context_build_request_wired(app_session_context: AppSessionContext, create_request_handler: Callable):
@@ -317,21 +366,19 @@ def test_app_session_context_build_request_wired(app_session_context: AppSession
 # ** test: app_session_context_build_request_unwired
 def test_app_session_context_build_request_unwired(app_session: AppSession, get_dependency: Callable):
     '''
-    Test that build_request constructs a RequestContext directly when unwired.
+    Test that build_request raises APP_ERROR when the handler is unwired.
     '''
 
     # Construct a context without a request-construction handler.
     context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
 
-    # Build the request via the default fallback path.
-    request = context.build_request('test.feature', headers={'X-Test': '1'}, data={'key': 'value'})
+    # Assert an unwired handler fails loudly with APP_ERROR.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.build_request('test.feature', headers={'X-Test': '1'}, data={'key': 'value'})
 
-    # Assert a RequestContext was constructed with the interface id stamped in.
-    assert isinstance(request, RequestContext)
-    assert request.headers.get('interface_id') == app_session.id
-    assert request.headers.get('X-Test') == '1'
-    assert request.data == {'key': 'value'}
-    assert request.feature_id == 'test.feature'
+    # Assert the structured app error names the missing handler.
+    assert exc_info.value.error_code == APP_ERROR_ID
+    assert 'create_request_handler' in exc_info.value.message
 
 # ** test: app_session_context_execute_feature_wired
 def test_app_session_context_execute_feature_wired(app_session_context: AppSessionContext, execute_feature_handler: Callable):
@@ -349,24 +396,20 @@ def test_app_session_context_execute_feature_wired(app_session_context: AppSessi
 # ** test: app_session_context_execute_feature_unwired
 def test_app_session_context_execute_feature_unwired(app_session: AppSession, get_dependency: Callable):
     '''
-    Test that execute_feature resolves the registered FeatureContext when unwired.
+    Test that execute_feature raises APP_ERROR when the handler is unwired.
     '''
 
-    # Seed the cache with a Feature domain object under the feature namespace.
-    cache = CacheContext()
-    feature = Feature(id='test.feature', name='Test Feature')
-    cache.set('test.feature', feature, 'app', 'features')
-
     # Construct a context without a feature-execution handler.
-    context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency, cache=cache)
+    context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
     request = RequestContext(feature_id='test.feature')
 
-    # Execute the feature via the default fallback path.
-    with mock.patch.object(FeatureContext, 'execute_feature') as mock_execute:
+    # Assert an unwired handler fails loudly with APP_ERROR.
+    with pytest.raises(TiferetAPIError) as exc_info:
         context.execute_feature('test.feature', request)
 
-    # Assert the registered FeatureContext was driven with the cached feature.
-    mock_execute.assert_called_once_with(feature, request)
+    # Assert the structured app error names the missing handler.
+    assert exc_info.value.error_code == APP_ERROR_ID
+    assert 'execute_feature_handler' in exc_info.value.message
 
 # ** test: app_session_context_handle_error_wired
 def test_app_session_context_handle_error_wired(app_session_context: AppSessionContext, raise_error_handler: Callable):
@@ -382,41 +425,46 @@ def test_app_session_context_handle_error_wired(app_session_context: AppSessionC
     raise_error_handler.assert_called_once_with(error)
     assert result == {'error_code': 'TEST_ERROR'}
 
-# ** test: app_session_context_handle_error_unwired_tiferet_error
-def test_app_session_context_handle_error_unwired_tiferet_error(app_session: AppSession, get_dependency: Callable):
+# ** test: app_session_context_handle_error_api_error_passthrough
+def test_app_session_context_handle_error_api_error_passthrough(
+        app_session_context: AppSessionContext,
+        raise_error_handler: Callable,
+    ):
     '''
-    Test that handle_error wraps a TiferetError into a TiferetAPIError when unwired.
+    Test that handle_error re-raises an incoming TiferetAPIError verbatim.
+    '''
+
+    # Build an already-formatted API error.
+    api_error = TiferetAPIError(
+        error_code=APP_ERROR_ID,
+        name='App Error',
+        message='Already formatted.',
+    )
+
+    # Assert the same instance is re-raised without consulting the handler.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        app_session_context.handle_error(api_error)
+
+    assert exc_info.value is api_error
+    raise_error_handler.assert_not_called()
+
+# ** test: app_session_context_handle_error_unwired
+def test_app_session_context_handle_error_unwired(app_session: AppSession, get_dependency: Callable):
+    '''
+    Test that handle_error raises APP_ERROR when the handler is unwired.
     '''
 
     # Construct a context without an error-handling handler.
     context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
 
-    # Handle a structured error.
-    error = TiferetError('SOME_ERROR', 'Some error message.', extra='value')
+    # Handle a structured error with no wired handler.
+    error = TiferetError('SOME_ERROR', 'Some error message.')
     with pytest.raises(TiferetAPIError) as exc_info:
         context.handle_error(error)
 
-    # Assert the raised API error carries the original error's data.
-    assert exc_info.value.error_code == 'SOME_ERROR'
-    assert exc_info.value.name == 'SOME_ERROR'
-    assert exc_info.value.kwargs.get('extra') == 'value'
-
-# ** test: app_session_context_handle_error_unwired_bare_exception
-def test_app_session_context_handle_error_unwired_bare_exception(app_session: AppSession, get_dependency: Callable):
-    '''
-    Test that handle_error wraps a bare exception into a generic TiferetAPIError when unwired.
-    '''
-
-    # Construct a context without an error-handling handler.
-    context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
-
-    # Handle a plain exception.
-    with pytest.raises(TiferetAPIError) as exc_info:
-        context.handle_error(Exception('boom'))
-
-    # Assert the generic app error code is used.
-    assert exc_info.value.error_code == 'APP_ERROR'
-    assert 'An error occurred in the app' in exc_info.value.message
+    # Assert the structured app error names the missing handler.
+    assert exc_info.value.error_code == APP_ERROR_ID
+    assert 'raise_error_handler' in exc_info.value.message
 
 # ** test: app_session_context_build_response_wired
 def test_app_session_context_build_response_wired(app_session_context: AppSessionContext, response_handler: Callable):
@@ -435,18 +483,20 @@ def test_app_session_context_build_response_wired(app_session_context: AppSessio
 # ** test: app_session_context_build_response_unwired
 def test_app_session_context_build_response_unwired(app_session: AppSession, get_dependency: Callable):
     '''
-    Test that build_response delegates directly to the request context when unwired.
+    Test that build_response raises APP_ERROR when the handler is unwired.
     '''
 
     # Construct a context without a response-building handler.
     context = AppSessionContext.from_domain(app_session, get_dependency=get_dependency)
-
-    # Build a request and set its result.
     request = RequestContext(feature_id='test.feature')
-    request.set_result({'status': 'success'})
 
-    # Assert the response is the request's result.
-    assert context.build_response(request) == {'status': 'success'}
+    # Assert an unwired handler fails loudly with APP_ERROR.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.build_response(request)
+
+    # Assert the structured app error names the missing handler.
+    assert exc_info.value.error_code == APP_ERROR_ID
+    assert 'response_handler' in exc_info.value.message
 
 # ** test: app_session_context_run_success
 def test_app_session_context_run_success(
@@ -454,23 +504,24 @@ def test_app_session_context_run_success(
         create_request_handler: Callable,
         execute_feature_handler: Callable,
         response_handler: Callable,
-        logging_context: LoggingContext,
+        build_logger_handler: Callable,
     ):
     '''
-    Test that run calls build_request, execute_feature, and build_response in sequence.
+    Test that run calls build_logger, build_request, execute_feature, and build_response.
     '''
 
     # Run the app session context.
     result = app_session_context.run('test.feature', headers={'X-Test': '1'}, data={'key': 'value'})
 
-    # Assert all four template methods were driven and the response returned.
+    # Assert all five template methods were driven and the response returned.
+    build_logger_handler.assert_called_once_with(app_session_context.domain.logger_id)
     create_request_handler.assert_called_once()
     execute_feature_handler.assert_called_once()
     response_handler.assert_called_once()
     assert result == {'status': 'success'}
 
     # Assert the logger logged the successful execution with duration.
-    logger = logging_context.build_logger.return_value
+    logger = build_logger_handler.return_value
     info_calls = [call[0][0] for call in logger.info.call_args_list]
     assert len(info_calls) == 1
     assert info_calls[0].startswith('Executed Feature - test.feature (')
@@ -480,7 +531,7 @@ def test_app_session_context_run_error(
         app_session_context: AppSessionContext,
         execute_feature_handler: Callable,
         raise_error_handler: Callable,
-        logging_context: LoggingContext,
+        build_logger_handler: Callable,
     ):
     '''
     Test that a TiferetError during execute_feature triggers handle_error.
@@ -497,7 +548,7 @@ def test_app_session_context_run_error(
     assert result == {'error_code': 'TEST_ERROR'}
 
     # Assert the logger logged the error.
-    logger = logging_context.build_logger.return_value
+    logger = build_logger_handler.return_value
     logger.error.assert_called_once()
 
 # ** test: add_default_app_services_seeds_cache

--- a/tests/contexts/test_feature.py
+++ b/tests/contexts/test_feature.py
@@ -123,33 +123,39 @@ def async_services(async_test_command: AsyncDomainEvent) -> mock.Mock:
 
 # ** fixture: feature_context
 @pytest.fixture
-def feature_context(services: mock.Mock) -> FeatureContext:
+def feature_context(services: mock.Mock, feature: Feature) -> FeatureContext:
     '''
-    Fixture to create a new FeatureContext wired with the sync resolver.
+    Fixture to create a new FeatureContext bound to the default feature and
+    wired with the sync resolver.
 
     :param services: The mock service resolver.
     :type services: mock.Mock
-    :return: A FeatureContext instance.
+    :param feature: The feature domain object to bind.
+    :type feature: Feature
+    :return: A feature-bound FeatureContext instance.
     :rtype: FeatureContext
     '''
 
-    # Create an instance of FeatureContext with the injected resolution handler.
-    return FeatureContext(get_dependency=services.get_dependency)
+    # Construct and bind the context to the default feature in a single step.
+    return FeatureContext.from_domain(feature, get_dependency=services.get_dependency)
 
 # ** fixture: async_feature_context
 @pytest.fixture
-def async_feature_context(async_services: mock.Mock) -> FeatureContext:
+def async_feature_context(async_services: mock.Mock, feature: Feature) -> FeatureContext:
     '''
-    Fixture to create a new FeatureContext wired with the async resolver.
+    Fixture to create a new FeatureContext bound to the default feature and
+    wired with the async resolver.
 
     :param async_services: The mock service resolver returning an async event.
     :type async_services: mock.Mock
-    :return: A FeatureContext instance.
+    :param feature: The feature domain object to bind.
+    :type feature: Feature
+    :return: A feature-bound FeatureContext instance.
     :rtype: FeatureContext
     '''
 
-    # Create an instance of FeatureContext with the injected resolution handler.
-    return FeatureContext(get_dependency=async_services.get_dependency)
+    # Construct and bind the context to the default feature in a single step.
+    return FeatureContext.from_domain(feature, get_dependency=async_services.get_dependency)
 
 # ** fixture: feature
 @pytest.fixture
@@ -974,7 +980,7 @@ def test_feature_context_resolve_feature_steps_yields_steps(
     feature.steps.extend([step_a, step_b])
 
     # Resolve the feature's steps.
-    resolved = list(feature_context.resolve_feature_steps(feature, RequestContext(data={'key': 'value'})))
+    resolved = list(feature_context.resolve_feature_steps(RequestContext(data={'key': 'value'})))
 
     # Assert both steps were yielded with the resolved event and empty params.
     assert resolved == [(test_command, step_a, {}), (test_command, step_b, {})]
@@ -999,7 +1005,7 @@ def test_feature_context_resolve_feature_steps_skips_false_condition(
     feature.steps.extend([skipped, executed])
 
     # Resolve the feature's steps against data that fails the condition.
-    resolved = list(feature_context.resolve_feature_steps(feature, RequestContext(data={'x': 5})))
+    resolved = list(feature_context.resolve_feature_steps(RequestContext(data={'x': 5})))
 
     # Assert only the unconditional step was yielded.
     assert len(resolved) == 1
@@ -1027,21 +1033,16 @@ def test_feature_context_resolve_feature_steps_parses_parameters(
     ))
 
     # Resolve the feature's steps.
-    resolved = list(feature_context.resolve_feature_steps(feature, RequestContext(data={'key': 'resolved_value'})))
+    resolved = list(feature_context.resolve_feature_steps(RequestContext(data={'key': 'resolved_value'})))
 
     # Assert the parameter was resolved from the request data.
     assert resolved[0][2] == {'param': 'resolved_value'}
 
 # ** test: feature_context_resolve_feature_steps_combines_flags_additively
-def test_feature_context_resolve_feature_steps_combines_flags_additively(
-    feature_context: FeatureContext,
-    services: mock.Mock,
-):
+def test_feature_context_resolve_feature_steps_combines_flags_additively(services: mock.Mock):
     '''
     Test that resolve_feature_steps combines execution, feature, and step flags additively.
 
-    :param feature_context: The feature context to test.
-    :type feature_context: FeatureContext
     :param services: The mock service resolver.
     :type services: mock.Mock
     '''
@@ -1060,8 +1061,9 @@ def test_feature_context_resolve_feature_steps_combines_flags_additively(
         ],
     )
 
-    # Resolve the steps with an execution-level flag.
-    list(feature_context.resolve_feature_steps(feature, RequestContext(data={'key': 'value'}), 'exec_flag'))
+    # Bind a fresh context to the local feature and resolve with an execution-level flag.
+    feature_context = FeatureContext.from_domain(feature, get_dependency=services.get_dependency)
+    list(feature_context.resolve_feature_steps(RequestContext(data={'key': 'value'}), 'exec_flag'))
 
     # Assert the resolver received all three flag tiers in additive order.
     services.get_dependency.assert_called_once_with(
@@ -1085,9 +1087,9 @@ def test_feature_context_execute_feature_sync(feature_context: FeatureContext, f
     # Add a standard synchronous step.
     feature.steps.append(EventFeatureStep(name='Test Command', service_id='test_command'))
 
-    # Execute the pre-loaded feature.
+    # Execute the bound feature.
     request = RequestContext(data={'key': 'value'})
-    feature_context.execute_feature(feature, request)
+    feature_context.execute_feature(request)
 
     # Assert the step result was recorded as the response.
     assert request.handle_response() == {'status': 'success', 'data': {'key': 'value'}}
@@ -1111,9 +1113,9 @@ def test_feature_context_execute_feature_with_request_parameter(feature_context:
         data_key='response_data',
     ))
 
-    # Execute the pre-loaded feature.
+    # Execute the bound feature.
     request = RequestContext(data={'key': 'value'})
-    feature_context.execute_feature(feature, request)
+    feature_context.execute_feature(request)
 
     # Assert the parameterized result was stored under the data key.
     assert request.data.get('response_data') == {
@@ -1139,9 +1141,9 @@ def test_feature_context_execute_feature_with_pass_on_error(feature_context: Fea
         pass_on_error=True,
     ))
 
-    # Execute the pre-loaded feature with failing request data.
+    # Execute the bound feature with failing request data.
     request = RequestContext(data={'key': None})
-    feature_context.execute_feature(feature, request)
+    feature_context.execute_feature(request)
 
     # Assert the error was suppressed and no result recorded.
     assert not request.handle_response()
@@ -1162,7 +1164,7 @@ def test_feature_context_execute_feature_accepts_flags(feature_context: FeatureC
 
     # Execute the feature with execution flags.
     request = RequestContext(data={'key': 'value'})
-    feature_context.execute_feature(feature, request, 'flag_a', 'flag_b')
+    feature_context.execute_feature(request, 'flag_a', 'flag_b')
 
     # Assert execution completed normally.
     assert request.handle_response() == {'status': 'success', 'data': {'key': 'value'}}
@@ -1208,24 +1210,19 @@ def test_feature_context_execute_feature_with_feature_middleware(
         middleware if service_id == 'count_middleware' else test_command
     )
 
-    # Execute the pre-loaded feature.
+    # Execute the bound feature.
     request = RequestContext(data={'key': 'value'})
-    feature_context.execute_feature(feature, request)
+    feature_context.execute_feature(request)
 
     # Assert the middleware wrapped the single step execution once.
     assert call_counts == {'pre': 1, 'post': 1}
     assert request.handle_response() == {'status': 'success', 'data': {'key': 'value'}}
 
 # ** test: feature_context_execute_feature_validates_and_coerces
-def test_feature_context_execute_feature_validates_and_coerces(
-    feature_context: FeatureContext,
-    services: mock.Mock,
-):
+def test_feature_context_execute_feature_validates_and_coerces(services: mock.Mock):
     '''
     Test that execute_feature coerces request data before any step runs.
 
-    :param feature_context: The feature context to test.
-    :type feature_context: FeatureContext
     :param services: The mock service resolver.
     :type services: mock.Mock
     '''
@@ -1249,9 +1246,10 @@ def test_feature_context_execute_feature_validates_and_coerces(
         steps=[EventFeatureStep(name='cap', service_id='cap')],
     )
 
-    # Execute the feature with raw string request data.
+    # Bind a fresh context to the local feature and execute with raw string request data.
+    feature_context = FeatureContext.from_domain(feature, get_dependency=services.get_dependency)
     request = RequestContext(data={'a': '5', 'b': '2'})
-    feature_context.execute_feature(feature, request)
+    feature_context.execute_feature(request)
 
     # Assert the data was coerced before the step received it.
     assert request.data['a'] == 5
@@ -1259,15 +1257,10 @@ def test_feature_context_execute_feature_validates_and_coerces(
     assert captured == {'a': 5, 'b': 2.0}
 
 # ** test: feature_context_execute_feature_invalid_request_fails_fast
-def test_feature_context_execute_feature_invalid_request_fails_fast(
-    feature_context: FeatureContext,
-    services: mock.Mock,
-):
+def test_feature_context_execute_feature_invalid_request_fails_fast(services: mock.Mock):
     '''
     Test that invalid request data fails before any step executes.
 
-    :param feature_context: The feature context to test.
-    :type feature_context: FeatureContext
     :param services: The mock service resolver.
     :type services: mock.Mock
     '''
@@ -1290,9 +1283,10 @@ def test_feature_context_execute_feature_invalid_request_fails_fast(
         steps=[EventFeatureStep(name='cap', service_id='cap')],
     )
 
-    # Assert the validation error is raised.
+    # Bind a fresh context to the local feature and assert the validation error is raised.
+    feature_context = FeatureContext.from_domain(feature, get_dependency=services.get_dependency)
     with pytest.raises(TiferetError) as exc_info:
-        feature_context.execute_feature(feature, RequestContext(data={'a': 'notint'}))
+        feature_context.execute_feature(RequestContext(data={'a': 'notint'}))
 
     # Assert no step ran.
     assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
@@ -1316,9 +1310,9 @@ def test_feature_context_execute_feature_async_feature(
     feature.is_async = True
     feature.steps.append(EventFeatureStep(name='Async Command', service_id='async_test_command'))
 
-    # Execute the feature synchronously.
+    # Execute the bound feature.
     request = RequestContext(data={'key': 'value'})
-    async_feature_context.execute_feature(feature, request)
+    async_feature_context.execute_feature(request)
 
     # Assert the async step result was recorded.
     assert request.handle_response() == {'status': 'async_success', 'data': {'key': 'value'}}
@@ -1353,9 +1347,9 @@ def test_feature_context_execute_feature_async_mixed_chain(feature: Feature):
     feature.steps.append(EventFeatureStep(name='Sync Step', service_id='sync_step', data_key='sync_result'))
     feature.steps.append(EventFeatureStep(name='Async Step', service_id='async_step', data_key='async_result'))
 
-    # Execute the feature synchronously.
+    # Bind a fresh context to the feature and execute it synchronously.
     request = RequestContext(data={'key': 'mixed'})
-    FeatureContext(get_dependency=services.get_dependency).execute_feature(feature, request)
+    FeatureContext.from_domain(feature, get_dependency=services.get_dependency).execute_feature(request)
 
     # Assert both steps executed and stored their results.
     assert request.data.get('sync_result') == {'sync': True, 'key': 'mixed'}
@@ -1382,9 +1376,9 @@ def test_feature_context_execute_feature_step_level_async(
         is_async=True,
     ))
 
-    # Execute the feature synchronously.
+    # Execute the bound feature.
     request = RequestContext(data={'key': 'value'})
-    async_feature_context.execute_feature(feature, request)
+    async_feature_context.execute_feature(request)
 
     # Assert the async step produced the expected result.
     assert request.handle_response() == {'status': 'async_success', 'data': {'key': 'value'}}

--- a/tests/events/test_error.py
+++ b/tests/events/test_error.py
@@ -130,7 +130,7 @@ class TestAddError(DomainEventTestBase):
         name='New Error',
         message='This is a new error message.',
         lang='en_US',
-        additional_messages=[],
+        additional_messages={},
     )
 
     # * attribute: required_params
@@ -173,10 +173,10 @@ class TestAddError(DomainEventTestBase):
         Test adding a new error with additional language messages.
         '''
 
-        # Execute with additional messages.
+        # Execute with additional messages as a language-code to text mapping.
         result = self.handle(
             mock_dependencies,
-            additional_messages=[{'lang': 'es_ES', 'text': 'Este es un nuevo error.'}],
+            additional_messages={'es_ES': 'Este es un nuevo error.'},
         )
 
         # Assert both messages are present.

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -196,8 +196,8 @@ APP_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         ),
         create_default_cli_argument(
             name_or_flags=['--constants'],
-            description='Optional JSON-encoded constants dictionary.',
-            type='json',
+            description='Optional constants as key=value pairs.',
+            type='dict',
         ),
     ],
 )
@@ -249,8 +249,8 @@ APP_SET_SERVICE_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         ),
         create_default_cli_argument(
             name_or_flags=['--parameters'],
-            description='Optional JSON-encoded parameters dictionary.',
-            type='json',
+            description='Optional parameters as key=value pairs.',
+            type='dict',
         ),
     ],
 )
@@ -286,8 +286,8 @@ APP_SET_CONSTANTS_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data
         ),
         create_default_cli_argument(
             name_or_flags=['--constants'],
-            description='Optional JSON-encoded constants dictionary. Omit to clear all constants.',
-            type='json',
+            description='Optional constants as key=value pairs. Omit to clear all constants.',
+            type='dict',
         ),
     ],
 )
@@ -419,6 +419,11 @@ ERROR_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         create_default_cli_argument(
             name_or_flags=['--lang'],
             description='Language code for the message. Defaults to "en_US".',
+        ),
+        create_default_cli_argument(
+            name_or_flags=['--additional-messages'],
+            description='Additional messages beyond the primary one, as lang=text pairs.',
+            type='dict',
         ),
     ],
 )
@@ -578,8 +583,8 @@ FEATURE_ADD_STEP_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         ),
         create_default_cli_argument(
             name_or_flags=['--parameters'],
-            description='Optional JSON-encoded step parameters.',
-            type='json',
+            description='Optional step parameters as key=value pairs.',
+            type='dict',
         ),
         create_default_cli_argument(
             name_or_flags=['--data-key'],
@@ -711,8 +716,8 @@ SERVICE_ADD_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         ),
         create_default_cli_argument(
             name_or_flags=['--parameters'],
-            description='Optional JSON-encoded parameters dictionary.',
-            type='json',
+            description='Optional parameters as key=value pairs.',
+            type='dict',
         ),
     ],
 )
@@ -738,8 +743,8 @@ SERVICE_SET_DEFAULT_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_da
         ),
         create_default_cli_argument(
             name_or_flags=['--parameters'],
-            description='Optional JSON-encoded parameters dictionary.',
-            type='json',
+            description='Optional parameters as key=value pairs.',
+            type='dict',
         ),
     ],
 )
@@ -769,8 +774,8 @@ SERVICE_SET_DEPENDENCY_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command
         ),
         create_default_cli_argument(
             name_or_flags=['--parameters'],
-            description='Optional JSON-encoded parameters dictionary.',
-            type='json',
+            description='Optional parameters as key=value pairs.',
+            type='dict',
         ),
     ],
 )
@@ -802,8 +807,8 @@ SERVICE_SET_CONSTANTS_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_
     arguments=[
         create_default_cli_argument(
             name_or_flags=['--constants'],
-            description='Optional JSON-encoded constants dictionary. Omit to clear all.',
-            type='json',
+            description='Optional constants as key=value pairs. Omit to clear all.',
+            type='dict',
         ),
     ],
 )

--- a/tiferet/assets/di.py
+++ b/tiferet/assets/di.py
@@ -5,7 +5,7 @@ Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 37 individually named service ID string constants.
 - ``constants (services)`` — 37 individually named service registration
   dicts, each built via ``create_service_registration_data``.
-- ``constants (groups)`` — the ``DEFAULT_ADMIN_SERVICES`` catalog dict
+- ``constants (groups)`` — the ``ADMIN_DEFAULT_SERVICES`` catalog dict
   keyed by ID constants.
 """
 
@@ -368,8 +368,8 @@ REMOVE_LOGGER_EVT_DATA = create_service_registration_data(
 
 # *** constants (groups)
 
-# ** constant: default_admin_services
-DEFAULT_ADMIN_SERVICES: Dict[str, Dict] = {
+# ** constant: admin_default_services
+ADMIN_DEFAULT_SERVICES: Dict[str, Dict] = {
     APP_SERVICE_ID: APP_SERVICE_DATA,
     ADD_FEATURE_EVT_ID: ADD_FEATURE_EVT_DATA,
     LIST_FEATURES_EVT_ID: LIST_FEATURES_EVT_DATA,

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -149,7 +149,7 @@ APP_ADD_DATA = create_default_feature_data(
     name='Add App Session',
     group_id='app',
     feature_key='add',
-    steps=[{'service_id': 'add_app_session_evt'}],
+    steps=[{'service_id': 'add_app_session_evt', 'name': 'Add app session'}],
     description='Add a new application session configuration.',
 )
 
@@ -158,7 +158,7 @@ APP_GET_DATA = create_default_feature_data(
     name='Get App Session',
     group_id='app',
     feature_key='get',
-    steps=[{'service_id': 'get_app_session_evt'}],
+    steps=[{'service_id': 'get_app_session_evt', 'name': 'Get app session'}],
     description='Retrieve an app session by ID.',
 )
 
@@ -167,7 +167,7 @@ APP_LIST_DATA = create_default_feature_data(
     name='List App Sessions',
     group_id='app',
     feature_key='list',
-    steps=[{'service_id': 'list_app_sessions_evt'}],
+    steps=[{'service_id': 'list_app_sessions_evt', 'name': 'List app sessions'}],
     description='List all configured app sessions.',
 )
 
@@ -176,7 +176,7 @@ APP_UPDATE_DATA = create_default_feature_data(
     name='Update App Session',
     group_id='app',
     feature_key='update',
-    steps=[{'service_id': 'update_app_session_evt'}],
+    steps=[{'service_id': 'update_app_session_evt', 'name': 'Update app session'}],
     description='Update a scalar attribute on an app session.',
 )
 
@@ -185,7 +185,7 @@ APP_SET_CONSTANTS_DATA = create_default_feature_data(
     name='Set App Constants',
     group_id='app',
     feature_key='set_constants',
-    steps=[{'service_id': 'set_app_constants_evt'}],
+    steps=[{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
     description='Set or clear constants on an app session.',
 )
 
@@ -194,7 +194,7 @@ APP_SET_SERVICE_DATA = create_default_feature_data(
     name='Set App Service Dependency',
     group_id='app',
     feature_key='set_service',
-    steps=[{'service_id': 'set_app_service_dependency_evt'}],
+    steps=[{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
     description='Set or update a service dependency on an app session.',
 )
 
@@ -203,7 +203,7 @@ APP_REMOVE_SERVICE_DATA = create_default_feature_data(
     name='Remove App Service Dependency',
     group_id='app',
     feature_key='remove_service',
-    steps=[{'service_id': 'remove_app_service_dependency_evt'}],
+    steps=[{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
     description='Remove a service dependency from an app session.',
 )
 
@@ -212,7 +212,7 @@ APP_REMOVE_DATA = create_default_feature_data(
     name='Remove App Session',
     group_id='app',
     feature_key='remove',
-    steps=[{'service_id': 'remove_app_session_evt'}],
+    steps=[{'service_id': 'remove_app_session_evt', 'name': 'Remove app session'}],
     description='Remove an app session by ID.',
 )
 
@@ -221,7 +221,7 @@ CLI_LIST_COMMANDS_DATA = create_default_feature_data(
     name='List CLI Commands',
     group_id='cli',
     feature_key='list_commands',
-    steps=[{'service_id': 'list_commands_evt'}],
+    steps=[{'service_id': 'list_commands_evt', 'name': 'List CLI commands'}],
     description='List all configured CLI commands.',
 )
 
@@ -230,7 +230,7 @@ CLI_ADD_COMMAND_DATA = create_default_feature_data(
     name='Add CLI Command',
     group_id='cli',
     feature_key='add_command',
-    steps=[{'service_id': 'add_cli_command_evt'}],
+    steps=[{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
     description='Add a new CLI command definition.',
 )
 
@@ -239,7 +239,7 @@ CLI_ADD_ARGUMENT_DATA = create_default_feature_data(
     name='Add CLI Argument',
     group_id='cli',
     feature_key='add_argument',
-    steps=[{'service_id': 'add_cli_argument_evt'}],
+    steps=[{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
     description='Add an argument to an existing CLI command.',
 )
 
@@ -248,7 +248,7 @@ ERROR_LIST_DATA = create_default_feature_data(
     name='List Errors',
     group_id='error',
     feature_key='list',
-    steps=[{'service_id': 'list_errors_evt'}],
+    steps=[{'service_id': 'list_errors_evt', 'name': 'List errors'}],
     description='List all error definitions.',
 )
 
@@ -257,7 +257,7 @@ ERROR_ADD_DATA = create_default_feature_data(
     name='Add Error',
     group_id='error',
     feature_key='add',
-    steps=[{'service_id': 'add_error_evt'}],
+    steps=[{'service_id': 'add_error_evt', 'name': 'Add error'}],
     description='Add a new error definition.',
 )
 
@@ -266,7 +266,7 @@ ERROR_GET_DATA = create_default_feature_data(
     name='Get Error',
     group_id='error',
     feature_key='get',
-    steps=[{'service_id': 'get_error_evt'}],
+    steps=[{'service_id': 'get_error_evt', 'name': 'Get error'}],
     description='Retrieve an error by ID.',
 )
 
@@ -275,7 +275,7 @@ ERROR_RENAME_DATA = create_default_feature_data(
     name='Rename Error',
     group_id='error',
     feature_key='rename',
-    steps=[{'service_id': 'rename_error_evt'}],
+    steps=[{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
     description='Rename an existing error definition.',
 )
 
@@ -284,7 +284,7 @@ ERROR_SET_MESSAGE_DATA = create_default_feature_data(
     name='Set Error Message',
     group_id='error',
     feature_key='set_message',
-    steps=[{'service_id': 'set_error_message_evt'}],
+    steps=[{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
     description='Set the message text on an existing error definition.',
 )
 
@@ -293,7 +293,7 @@ ERROR_REMOVE_MESSAGE_DATA = create_default_feature_data(
     name='Remove Error Message',
     group_id='error',
     feature_key='remove_message',
-    steps=[{'service_id': 'remove_error_message_evt'}],
+    steps=[{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
     description='Remove a language message from an existing error definition.',
 )
 
@@ -302,7 +302,7 @@ ERROR_REMOVE_DATA = create_default_feature_data(
     name='Remove Error',
     group_id='error',
     feature_key='remove',
-    steps=[{'service_id': 'remove_error_evt'}],
+    steps=[{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
     description='Remove an error definition.',
 )
 
@@ -311,7 +311,7 @@ FEATURE_LIST_DATA = create_default_feature_data(
     name='List Features',
     group_id='feature',
     feature_key='list',
-    steps=[{'service_id': 'list_features_evt'}],
+    steps=[{'service_id': 'list_features_evt', 'name': 'List features'}],
     description='List all feature workflow definitions.',
 )
 
@@ -320,7 +320,7 @@ FEATURE_ADD_DATA = create_default_feature_data(
     name='Add Feature',
     group_id='feature',
     feature_key='add',
-    steps=[{'service_id': 'add_feature_evt'}],
+    steps=[{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
     description='Add a new feature workflow definition.',
 )
 
@@ -329,7 +329,7 @@ FEATURE_GET_DATA = create_default_feature_data(
     name='Get Feature',
     group_id='feature',
     feature_key='get',
-    steps=[{'service_id': 'get_feature_evt'}],
+    steps=[{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
     description='Retrieve a feature by ID.',
 )
 
@@ -338,7 +338,7 @@ FEATURE_UPDATE_DATA = create_default_feature_data(
     name='Update Feature',
     group_id='feature',
     feature_key='update',
-    steps=[{'service_id': 'update_feature_evt'}],
+    steps=[{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
     description='Update a metadata attribute on an existing feature.',
 )
 
@@ -347,7 +347,7 @@ FEATURE_ADD_STEP_DATA = create_default_feature_data(
     name='Add Feature Step',
     group_id='feature',
     feature_key='add_step',
-    steps=[{'service_id': 'add_feature_step_evt'}],
+    steps=[{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
     description='Add a step to an existing feature workflow.',
 )
 
@@ -356,7 +356,7 @@ FEATURE_UPDATE_STEP_DATA = create_default_feature_data(
     name='Update Feature Step',
     group_id='feature',
     feature_key='update_step',
-    steps=[{'service_id': 'update_feature_step_evt'}],
+    steps=[{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
     description='Update an attribute on an existing feature step.',
 )
 
@@ -365,7 +365,7 @@ FEATURE_REMOVE_STEP_DATA = create_default_feature_data(
     name='Remove Feature Step',
     group_id='feature',
     feature_key='remove_step',
-    steps=[{'service_id': 'remove_feature_step_evt'}],
+    steps=[{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
     description='Remove a step from an existing feature workflow.',
 )
 
@@ -374,7 +374,7 @@ FEATURE_REORDER_STEP_DATA = create_default_feature_data(
     name='Reorder Feature Step',
     group_id='feature',
     feature_key='reorder_step',
-    steps=[{'service_id': 'reorder_feature_step_evt'}],
+    steps=[{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
     description='Reorder a step within an existing feature workflow.',
 )
 
@@ -383,7 +383,7 @@ FEATURE_REMOVE_DATA = create_default_feature_data(
     name='Remove Feature',
     group_id='feature',
     feature_key='remove',
-    steps=[{'service_id': 'remove_feature_evt'}],
+    steps=[{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
     description='Remove an existing feature workflow definition.',
 )
 
@@ -392,7 +392,7 @@ SERVICE_LIST_DATA = create_default_feature_data(
     name='List Services',
     group_id='service',
     feature_key='list',
-    steps=[{'service_id': 'di_list_all_configs_evt'}],
+    steps=[{'service_id': 'di_list_all_configs_evt', 'name': 'List all settings'}],
     description='List all DI service registrations and constants.',
 )
 
@@ -401,7 +401,7 @@ SERVICE_ADD_DATA = create_default_feature_data(
     name='Add Service',
     group_id='service',
     feature_key='add',
-    steps=[{'service_id': 'add_service_registration_evt'}],
+    steps=[{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
     description='Add a new DI service registration.',
 )
 
@@ -410,7 +410,7 @@ SERVICE_SET_DEFAULT_DATA = create_default_feature_data(
     name='Set Default Service Registration',
     group_id='service',
     feature_key='set_default',
-    steps=[{'service_id': 'set_default_service_registration_evt'}],
+    steps=[{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
     description='Set or update the default type for an existing service registration.',
 )
 
@@ -419,7 +419,7 @@ SERVICE_SET_DEPENDENCY_DATA = create_default_feature_data(
     name='Set Service Dependency',
     group_id='service',
     feature_key='set_dependency',
-    steps=[{'service_id': 'set_di_service_dependency_evt'}],
+    steps=[{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
     description='Set or update a flagged dependency on a service registration.',
 )
 
@@ -428,7 +428,7 @@ SERVICE_REMOVE_DEPENDENCY_DATA = create_default_feature_data(
     name='Remove Service Dependency',
     group_id='service',
     feature_key='remove_dependency',
-    steps=[{'service_id': 'remove_di_service_dependency_evt'}],
+    steps=[{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
     description='Remove a flagged dependency from a service registration.',
 )
 
@@ -437,7 +437,7 @@ SERVICE_SET_CONSTANTS_DATA = create_default_feature_data(
     name='Set Service Constants',
     group_id='service',
     feature_key='set_constants',
-    steps=[{'service_id': 'set_service_constants_evt'}],
+    steps=[{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
     description='Set or clear DI service constants.',
 )
 
@@ -446,7 +446,7 @@ SERVICE_REMOVE_DATA = create_default_feature_data(
     name='Remove Service',
     group_id='service',
     feature_key='remove',
-    steps=[{'service_id': 'remove_service_registration_evt'}],
+    steps=[{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
     description='Remove a DI service registration.',
 )
 
@@ -455,7 +455,7 @@ LOGGING_ADD_FORMATTER_DATA = create_default_feature_data(
     name='Add Formatter',
     group_id='logging',
     feature_key='add_formatter',
-    steps=[{'service_id': 'add_formatter_evt'}],
+    steps=[{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
     description='Add a new logging formatter configuration.',
 )
 
@@ -464,7 +464,7 @@ LOGGING_REMOVE_FORMATTER_DATA = create_default_feature_data(
     name='Remove Formatter',
     group_id='logging',
     feature_key='remove_formatter',
-    steps=[{'service_id': 'remove_formatter_evt'}],
+    steps=[{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
     description='Remove a logging formatter by ID.',
 )
 
@@ -473,7 +473,7 @@ LOGGING_ADD_HANDLER_DATA = create_default_feature_data(
     name='Add Handler',
     group_id='logging',
     feature_key='add_handler',
-    steps=[{'service_id': 'add_handler_evt'}],
+    steps=[{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
     description='Add a new logging handler configuration.',
 )
 
@@ -482,7 +482,7 @@ LOGGING_REMOVE_HANDLER_DATA = create_default_feature_data(
     name='Remove Handler',
     group_id='logging',
     feature_key='remove_handler',
-    steps=[{'service_id': 'remove_handler_evt'}],
+    steps=[{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
     description='Remove a logging handler by ID.',
 )
 
@@ -491,7 +491,7 @@ LOGGING_ADD_LOGGER_DATA = create_default_feature_data(
     name='Add Logger',
     group_id='logging',
     feature_key='add_logger',
-    steps=[{'service_id': 'add_logger_evt'}],
+    steps=[{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
     description='Add a new logger configuration.',
 )
 
@@ -500,7 +500,7 @@ LOGGING_REMOVE_LOGGER_DATA = create_default_feature_data(
     name='Remove Logger',
     group_id='logging',
     feature_key='remove_logger',
-    steps=[{'service_id': 'remove_logger_evt'}],
+    steps=[{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
     description='Remove a logger by ID.',
 )
 
@@ -509,7 +509,7 @@ LOGGING_LIST_DATA = create_default_feature_data(
     name='List Logging Configs',
     group_id='logging',
     feature_key='list',
-    steps=[{'service_id': 'logging_list_all_evt'}],
+    steps=[{'service_id': 'logging_list_all_evt', 'name': 'List all logging configs'}],
     description='List all logging configurations (formatters, handlers, loggers).',
 )
 

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -5,7 +5,7 @@ Each section follows the pattern established by ``assets/error.py``:
 - ``constants (ids)`` — 41 individually named feature ID string constants.
 - ``constants (features)`` — 41 individually named feature definition dicts,
   each built via ``create_default_feature_data``.
-- ``constants (groups)`` — the ``DEFAULT_ADMIN_FEATURES`` catalog dict
+- ``constants (groups)`` — the ``ADMIN_DEFAULT_FEATURES`` catalog dict
   keyed by ID constants.
 """
 
@@ -515,8 +515,8 @@ LOGGING_LIST_DATA = create_default_feature_data(
 
 # *** constants (groups)
 
-# ** constant: default_admin_features
-DEFAULT_ADMIN_FEATURES: Dict[str, Any] = {
+# ** constant: admin_default_features
+ADMIN_DEFAULT_FEATURES: Dict[str, Any] = {
     APP_ADD_ID: APP_ADD_DATA,
     APP_GET_ID: APP_GET_DATA,
     APP_LIST_ID: APP_LIST_DATA,

--- a/tiferet/blueprints/__init__.py
+++ b/tiferet/blueprints/__init__.py
@@ -5,3 +5,5 @@
 # ** app
 from .core import build_app, build_app as App
 from .cli import build_app as build_cli, build_app as CLI
+from .admin import build_admin_app, build_admin_app as AdminApp
+from .admin_cli import build_admin_cli, build_admin_cli as AdminCLI

--- a/tiferet/blueprints/admin.py
+++ b/tiferet/blueprints/admin.py
@@ -1,0 +1,180 @@
+"""Tiferet Admin Blueprints"""
+
+# *** imports
+
+# ** core
+from typing import Any, Callable, Dict
+
+# ** app
+from .. import assets as a
+from ..assets import TiferetError
+from ..contexts.app import (
+    AppSession,
+    AppSessionContext,
+    add_default_admin_constants,
+    add_default_admin_services,
+    get_default_admin_constants,
+    get_default_admin_services,
+)
+from ..contexts.cache import CacheContext
+from ..contexts.error import add_default_errors
+from ..contexts.feature import add_default_features
+from ..di import DIAppServiceContainer, DIDynamicServiceResolver
+from ..di.core import ServiceResolver
+from . import core
+
+# *** blueprints
+
+# ** blueprint: build_cache
+@add_default_admin_services(a.app.ADMIN_DEFAULT_SERVICES)
+@add_default_admin_constants(a.app.ADMIN_DEFAULT_CONSTANTS)
+@add_default_features(a.feat.ADMIN_DEFAULT_FEATURES)
+@add_default_errors(a.error.ADMIN_DEFAULT_ERRORS)
+def build_cache(cache: Dict[str, Any] = None) -> CacheContext:
+    '''
+    Build the admin bootstrap cache, pre-seeded with admin catalogs over the
+    core framework defaults.
+
+    :param cache: An optional initial cache dictionary for the root namespace.
+    :type cache: Dict[str, Any] | None
+    :return: The pre-seeded admin cache context.
+    :rtype: CacheContext
+    '''
+
+    # Delegate to the core cache builder; stacked decorators seed admin catalogs.
+    return core.build_cache(cache=cache)
+
+# ** blueprint: build_admin_service_resolver
+def build_admin_service_resolver(app_container: DIAppServiceContainer,
+        cache: CacheContext,
+        parse_parameter: Callable = core.parse_parameter) -> ServiceResolver:
+    '''
+    Compose the admin feature-level service resolver.
+
+    Registers the app service container under the ``'app'`` flag and the admin
+    container under both the ``'admin'`` flag and as the empty-flag default so
+    admin-scoped feature steps resolve without an explicit flag.
+
+    :param app_container: The built app service container.
+    :type app_container: DIAppServiceContainer
+    :param cache: The admin bootstrap cache holding admin services and constants.
+    :type cache: CacheContext
+    :param parse_parameter: The parameter-parsing callable injected into the resolver.
+    :type parse_parameter: Callable
+    :return: The composed admin service resolver.
+    :rtype: ServiceResolver
+    '''
+
+    # Resolve the DI repository service from the app container.
+    di_service = app_container.get_dependency('di_service')
+
+    # Build the admin container from cache-seeded admin services and constants.
+    admin_container = DIAppServiceContainer.from_dependencies(
+        services=get_default_admin_services(cache),
+        constants={
+            **get_default_admin_constants(cache),
+            'load_cache': core.load_cache(cache),
+        },
+    )
+
+    # Construct the dynamic service resolver with the injected parameter parser.
+    resolver = DIDynamicServiceResolver(
+        di_service=di_service,
+        parse_parameter=parse_parameter,
+    )
+
+    # Register the app service container under the 'app' flag.
+    resolver.add_container(app_container, 'app')
+
+    # Register the admin container under the 'admin' flag and as the default.
+    resolver.add_container(admin_container, 'admin')
+    resolver.add_container(admin_container)
+
+    # Return the composed resolver.
+    return resolver
+
+# ** blueprint: build_admin_app_session_context
+def build_admin_app_session_context(app_session: AppSession,
+        cache: CacheContext,
+        **context_kwargs) -> AppSessionContext:
+    '''
+    Compose a fully wired admin AppSessionContext from a loaded app session.
+
+    Mirrors core.build_app_session_context, substituting the admin service
+    resolver so feature steps resolve from the admin container by default.
+
+    :param app_session: The loaded app session domain object.
+    :type app_session: AppSession
+    :param cache: The admin bootstrap cache.
+    :type cache: CacheContext
+    :param context_kwargs: Additional keyword arguments forwarded to the context constructor.
+    :type context_kwargs: dict
+    :return: The fully wired admin app session context.
+    :rtype: AppSessionContext
+    '''
+
+    # Build the app service container and compose the admin service resolver.
+    app_container = core.build_app_service_container(cache, app_session)
+    resolver = build_admin_service_resolver(app_container, cache)
+
+    # Build the five template-method handlers.
+    handlers = dict(
+        build_logger_handler=core.build_logger_handler(cache, resolver.get_dependency),
+        execute_feature_handler=core.execute_feature_handler(resolver.get_dependency, cache),
+        raise_error_handler=core.raise_error_handler(core.get_error(cache, resolver.get_dependency)),
+        response_handler=core.response_handler,
+        create_request_handler=core.create_session_request,
+    )
+
+    # Resolve any remaining injectable collaborators the context class declares.
+    collaborators = core.resolve_collaborators(AppSessionContext, app_container)
+
+    # Construct and return the wired admin app session context.
+    return AppSessionContext.from_domain(
+        app_session,
+        get_dependency=resolver.get_dependency,
+        cache=cache,
+        **handlers,
+        **collaborators,
+        **context_kwargs,
+    )
+
+# ** blueprint: build_admin_app
+def build_admin_app(interface_id: str = a.app.TIFERET_ADMIN_ID,
+        **parameters: Any) -> AppSessionContext:
+    '''
+    Build a fully resolved admin application session context in a single call.
+
+    The built-in admin session is cache-seeded by CORE_DEFAULT_APP_SESSIONS, so
+    no consumer config entry is required for the default interface id.
+
+    :param interface_id: The interface identifier to load; defaults to the admin session id.
+    :type interface_id: str
+    :param parameters: Additional parameters forwarded to get_app_session.
+    :type parameters: dict
+    :return: The fully wired admin application session context.
+    :rtype: AppSessionContext
+    '''
+
+    # Build the admin bootstrap cache pre-seeded with admin and core defaults.
+    cache = build_cache()
+
+    # Resolve the app session, preferring a cache-seeded default.
+    app_session = core.get_app_session(interface_id, cache, **parameters)
+
+    # Build the fully wired admin app session context.
+    app_session_context = build_admin_app_session_context(app_session, cache)
+
+    # Verify the resolved context is a valid AppSessionContext.
+    if not isinstance(app_session_context, AppSessionContext):
+        TiferetError.raise_error(
+            a.error.INVALID_APP_SESSION_TYPE_ID,
+            f'App context for session is not valid: {interface_id}.',
+            interface_id=interface_id,
+        )
+
+    # Return the validated admin app session context.
+    return app_session_context
+
+# ** blueprint: admin_app (alias)
+AdminApp = build_admin_app

--- a/tiferet/blueprints/admin_cli.py
+++ b/tiferet/blueprints/admin_cli.py
@@ -1,0 +1,162 @@
+"""Tiferet Admin CLI Blueprint — Built-in CLI Management Interface"""
+
+# *** imports
+
+# ** core
+import argparse
+from typing import Any, Dict, List, Optional
+
+# ** app
+from .. import assets as a
+from . import admin, core
+from .cli import (
+    parse_cli_args_handler,
+    create_cli_request_context,
+    cli_response_handler,
+)
+from ..contexts.app import AppSession
+from ..contexts.cache import CacheContext
+from ..contexts.cli import (
+    CliSessionContext,
+    add_default_cli_commands,
+    get_default_cli_commands,
+)
+
+# *** blueprints
+
+# ** blueprint: build_cache
+@add_default_cli_commands(a.cli.ADMIN_DEFAULT_COMMANDS)
+def build_cache(cache: Dict[str, Any] = None) -> CacheContext:
+    '''
+    Build the admin CLI bootstrap cache.
+
+    Layers the admin CLI command catalog on top of the full admin catalog
+    already seeded by ``admin.build_cache`` (errors, admin services, admin
+    constants, and admin features).
+
+    :param cache: An optional initial cache dictionary for the root namespace.
+    :type cache: Dict[str, Any] | None
+    :return: The pre-seeded admin CLI cache context.
+    :rtype: CacheContext
+    '''
+
+    # Delegate to the admin cache builder; the decorator stacks CLI commands.
+    return admin.build_cache(cache=cache)
+
+# ** blueprint: build_admin_cli_session_context
+def build_admin_cli_session_context(app_session: AppSession,
+        cache: CacheContext) -> CliSessionContext:
+    '''
+    Compose a fully wired admin CLI session context from a loaded app session.
+
+    Parallel to ``cli.build_cli_session_context`` but uses
+    ``admin.build_admin_service_resolver`` so feature steps resolve from the
+    admin container by default.
+
+    :param app_session: The loaded app session domain object.
+    :type app_session: AppSession
+    :param cache: The admin CLI bootstrap cache.
+    :type cache: CacheContext
+    :return: The fully wired admin CLI session context.
+    :rtype: CliSessionContext
+    '''
+
+    # Build the app service container and compose the admin service resolver.
+    app_container = core.build_app_service_container(cache, app_session)
+    resolver = admin.build_admin_service_resolver(app_container, cache)
+
+    # Resolve the CLI event collaborators from the app container.
+    list_commands_evt = app_container.get_dependency('list_commands_evt')
+    get_parent_args_evt = app_container.get_dependency('get_parent_args_evt')
+
+    # Build the standard arg-parsing closure from events and cache defaults.
+    parse_cli_args = parse_cli_args_handler(
+        list_commands_evt,
+        get_parent_args_evt,
+        get_default_cli_commands(cache),
+    )
+
+    # Resolve any remaining injectable collaborators the context class declares.
+    collaborators = core.resolve_collaborators(CliSessionContext, app_container)
+
+    # Construct and return the CLI session context with admin resolver wiring
+    # and CLI-specific request/response handlers.
+    return CliSessionContext.from_domain(
+        app_session,
+        get_dependency=resolver.get_dependency,
+        cache=cache,
+        build_logger_handler=core.build_logger_handler(cache, resolver.get_dependency),
+        parse_cli_args=parse_cli_args,
+        execute_feature_handler=core.execute_feature_handler(resolver.get_dependency, cache),
+        create_request_handler=create_cli_request_context,
+        raise_error_handler=core.raise_error_handler(core.get_error(cache, resolver.get_dependency)),
+        response_handler=cli_response_handler,
+        **collaborators,
+    )
+
+# ** blueprint: build_admin_cli
+def build_admin_cli(app_config: str, argv: Optional[List[str]] = None) -> Any:
+    '''
+    Build the admin CLI session context and dispatch argv through it.
+
+    Resolves the built-in ``admin_cli`` session from the cache-seeded defaults,
+    re-seeds session constants so every config-file repository points at the
+    consumer-supplied config path, then dispatches through ``CliSessionContext.run``.
+
+    :param app_config: Path to the consumer configuration file.
+    :type app_config: str
+    :param argv: The argument list; defaults to sys.argv[1:] when None.
+    :type argv: Optional[List[str]]
+    :return: The response from the feature execution.
+    :rtype: Any
+    '''
+
+    # Build the admin CLI bootstrap cache.
+    cache = build_cache()
+
+    # Resolve the built-in admin CLI session; no consumer config entry required.
+    app_session = core.get_app_session(
+        a.app.TIFERET_ADMIN_CLI_ID,
+        cache,
+        app_config=app_config,
+    )
+
+    # Re-seed session constants so every config-file repository uses app_config.
+    session_constants = {
+        **(app_session.constants or {}),
+        'app_config': app_config,
+        'cli_config': app_config,
+        'di_config': app_config,
+        'error_config': app_config,
+        'feature_config': app_config,
+        'logging_config': app_config,
+    }
+    app_session.constants = session_constants
+
+    # Compose the wired admin CLI session context.
+    cli_context = build_admin_cli_session_context(app_session, cache)
+
+    # Dispatch argv through the CLI session context.
+    return cli_context.run(argv)
+
+# ** blueprint: main
+def main() -> None:
+    '''
+    Console entry point for the ``tiferet`` admin CLI script.
+
+    Uses a pre-parser with ``add_help=False`` so ``--config`` is extracted
+    without consuming the remaining argv meant for the full command parser,
+    and so ``--help``/``-h`` is handled by the full parser inside
+    ``build_admin_cli``.
+    '''
+
+    # Pre-parse --config without consuming remaining argv or help flags.
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument('--config', default='config.yml')
+    pre_args, remaining = pre_parser.parse_known_args()
+
+    # Delegate to the admin CLI blueprint with the resolved config path.
+    build_admin_cli(app_config=pre_args.config, argv=remaining)
+
+# ** blueprint: admin_cli (alias)
+AdminCLI = build_admin_cli

--- a/tiferet/blueprints/cli.py
+++ b/tiferet/blueprints/cli.py
@@ -301,9 +301,6 @@ def build_cli_session_context(app_session: AppSession, cache: CacheContext) -> C
     app_container = core.build_app_service_container(cache, app_session)
     resolver = core.build_service_resolver(app_container)
 
-    # Build the logging context once at session startup, as the core path does.
-    logging_ctx = core.build_logging_context(cache, resolver.get_dependency, app_session.logger_id)
-
     # Resolve the CLI event collaborators from the app container.
     list_commands_evt = app_container.get_dependency('list_commands_evt')
     get_parent_args_evt = app_container.get_dependency('get_parent_args_evt')
@@ -318,13 +315,13 @@ def build_cli_session_context(app_session: AppSession, cache: CacheContext) -> C
     # Resolve any remaining injectable collaborators the context class declares.
     collaborators = core.resolve_collaborators(CliSessionContext, app_container)
 
-    # Construct and return the CLI session context, overriding the request and
-    # response handler slots with their CLI-specific implementations.
+    # Construct and return the CLI session context, wiring the five template-method
+    # handlers and overriding the request/response slots with CLI implementations.
     return CliSessionContext.from_domain(
         app_session,
         get_dependency=resolver.get_dependency,
         cache=cache,
-        logging_context=logging_ctx,
+        build_logger_handler=core.build_logger_handler(cache, resolver.get_dependency),
         parse_cli_args=parse_cli_args,
         execute_feature_handler=core.execute_feature_handler(resolver.get_dependency, cache),
         create_request_handler=create_cli_request_context,

--- a/tiferet/blueprints/core.py
+++ b/tiferet/blueprints/core.py
@@ -3,7 +3,7 @@
 # *** imports
 
 # ** core
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict
 
 # ** app
 from .. import assets as a
@@ -22,7 +22,12 @@ from ..contexts.cache import CacheContext
 from ..contexts.core import BaseContext
 from ..contexts.error import add_default_errors, ERROR_CACHE_PREFIX
 from ..contexts.feature import FeatureContext, FEATURE_CACHE_PREFIX
-from ..contexts.logging import LoggingContext, add_default_logging_settings, get_default_logging_settings
+from ..contexts.logging import (
+    LOGGER_CACHE_PREFIX,
+    LoggingContext,
+    add_default_logging_settings,
+    get_default_logging_settings,
+)
 from ..contexts.request import RequestContext
 from ..di import DIAppServiceContainer, DIDynamicServiceContainer, DIDynamicServiceResolver
 from ..di.core import ServiceResolver, injectable_parameter_names
@@ -37,7 +42,7 @@ from ..events import ParseParameter
 RESERVED_CONTEXT_PARAMETERS = (
     'get_dependency',
     'cache',
-    'logging_context',
+    'build_logger_handler',
     'parse_cli_args',
     'execute_feature_handler',
     'create_request_handler',
@@ -74,6 +79,51 @@ def resolve_collaborators(context_cls: type, app_container: DIAppServiceContaine
         and not name.startswith('default_')
         and app_container.has_dependency(name)
     }
+
+# ** function: merge_logging_settings
+def merge_logging_settings(cache: CacheContext,
+        formatters: list,
+        handlers: list,
+        loggers: list) -> LoggingSettings:
+    '''
+    Merge repository-configured logging sections over cache-seeded defaults.
+
+    Each section is keyed by ``.id``; repository entries override the default
+    sharing their id, and unmatched defaults survive. Tolerates a cache with
+    no seeded defaults.
+
+    :param cache: The bootstrap cache holding default logging settings.
+    :type cache: CacheContext
+    :param formatters: Repository-configured formatters.
+    :type formatters: list
+    :param handlers: Repository-configured handlers.
+    :type handlers: list
+    :param loggers: Repository-configured loggers.
+    :type loggers: list
+    :return: The merged logging settings value object.
+    :rtype: LoggingSettings
+    '''
+
+    # Retrieve the cache-seeded default logging settings, tolerating none.
+    defaults = get_default_logging_settings(cache)
+    default_formatters = defaults.formatters if defaults else []
+    default_handlers = defaults.handlers if defaults else []
+    default_loggers = defaults.loggers if defaults else []
+
+    # Merge retrieved configs over the defaults, keyed by id (retrieved wins).
+    merged_formatters = {formatter.id: formatter for formatter in default_formatters}
+    merged_formatters.update({formatter.id: formatter for formatter in formatters})
+    merged_handlers = {handler.id: handler for handler in default_handlers}
+    merged_handlers.update({handler.id: handler for handler in handlers})
+    merged_loggers = {logger.id: logger for logger in default_loggers}
+    merged_loggers.update({logger.id: logger for logger in loggers})
+
+    # Return the merged logging settings value object.
+    return LoggingSettings(
+        formatters=list(merged_formatters.values()),
+        handlers=list(merged_handlers.values()),
+        loggers=list(merged_loggers.values()),
+    )
 
 # *** blueprints
 
@@ -274,47 +324,48 @@ def get_feature(cache: CacheContext, get_dependency: Callable) -> Callable:
     # Return the closure.
     return handler
 
-# ** blueprint: build_logging_context
-def build_logging_context(cache: CacheContext, get_dependency: Callable, logger_id: str) -> LoggingContext:
+# ** blueprint: build_logger_handler
+def build_logger_handler(cache: CacheContext, get_dependency: Callable) -> Callable:
     '''
-    Build the logging context from the merged default and repository-configured
-    logging settings.
+    Build a logger-construction handler that caches loggers by logger id.
 
-    :param cache: The bootstrap cache holding the default logging settings.
+    On a cache hit under ``LOGGER_CACHE_PREFIX``, the previously built logger
+    is returned. On a miss, repository logging configs are listed, merged over
+    cache-seeded defaults, applied via ``LoggingContext``, and cached so
+    ``dictConfig`` runs once per logger id per process.
+
+    :param cache: The bootstrap cache used for lazy logger caching.
     :type cache: CacheContext
     :param get_dependency: The DI resolution handler.
     :type get_dependency: Callable
-    :param logger_id: The identifier of the logger configuration to bind.
-    :type logger_id: str
-    :return: The constructed logging context.
-    :rtype: LoggingContext
+    :return: A handler closure resolving a logger by logger id.
+    :rtype: Callable
     '''
 
-    # Resolve and execute the logging list-all event to retrieve configured settings.
-    list_all_evt = get_dependency('logging_list_all_evt', 'app')
-    formatters, handlers, loggers = list_all_evt.execute()
+    # Return the handler closure bound to the cache and resolver.
+    def handler(logger_id: str):
 
-    # Retrieve the cache-seeded default logging settings.
-    default_settings = get_default_logging_settings(cache)
-    default_formatters = default_settings.formatters if default_settings else []
-    default_handlers = default_settings.handlers if default_settings else []
-    default_loggers = default_settings.loggers if default_settings else []
+        # Return the cached logger when already built for this id.
+        cached = cache.get(logger_id, *LOGGER_CACHE_PREFIX)
+        if cached is not None:
+            return cached
 
-    # Merge retrieved configs over the defaults, keyed by id (retrieved wins).
-    merged_formatters = {formatter.id: formatter for formatter in default_formatters}
-    merged_formatters.update({formatter.id: formatter for formatter in formatters})
-    merged_handlers = {handler.id: handler for handler in default_handlers}
-    merged_handlers.update({handler.id: handler for handler in handlers})
-    merged_loggers = {logger.id: logger for logger in default_loggers}
-    merged_loggers.update({logger.id: logger for logger in loggers})
+        # Resolve and execute the logging list-all event on a cache miss.
+        list_all_evt = get_dependency('logging_list_all_evt', 'app')
+        formatters, handlers, loggers = list_all_evt.execute()
 
-    # Construct the merged logging settings and bind the logging context.
-    settings = LoggingSettings(
-        formatters=list(merged_formatters.values()),
-        handlers=list(merged_handlers.values()),
-        loggers=list(merged_loggers.values()),
-    )
-    return LoggingContext.from_domain(settings, logger_id=logger_id)
+        # Merge repository configs over cache-seeded defaults.
+        settings = merge_logging_settings(cache, formatters, handlers, loggers)
+
+        # Build the logger from the merged settings for the requested id.
+        logger = LoggingContext.from_domain(settings, logger_id=logger_id).build_logger()
+
+        # Cache the built logger and return it.
+        cache.set(logger_id, logger, *LOGGER_CACHE_PREFIX)
+        return logger
+
+    # Return the closure.
+    return handler
 
 # ** blueprint: create_app_service
 def create_app_service(module_path: str,
@@ -416,7 +467,7 @@ def create_request_context(interface_id: str,
 # ** blueprint: create_feature_context
 def create_feature_context(get_dependency: Callable,
         cache: CacheContext,
-        feature_id: str) -> Tuple[Feature, FeatureContext]:
+        feature_id: str) -> FeatureContext:
     '''
     Resolve a Feature domain object and bind it to a fresh FeatureContext.
 
@@ -426,18 +477,15 @@ def create_feature_context(get_dependency: Callable,
     :type cache: CacheContext
     :param feature_id: The identifier of the feature to resolve.
     :type feature_id: str
-    :return: A tuple of the resolved feature and its bound feature context.
-    :rtype: Tuple[Feature, FeatureContext]
+    :return: The feature context bound to the resolved feature domain object.
+    :rtype: FeatureContext
     '''
 
     # Resolve the feature via the lazy-caching get_feature handler.
     feature = get_feature(cache, get_dependency)(feature_id)
 
-    # Construct and bind the feature context in a single step.
-    feature_context = FeatureContext.from_domain(feature, get_dependency=get_dependency, cache=cache)
-
-    # Return the resolved feature and its bound context.
-    return feature, feature_context
+    # Construct and return the feature context bound to the resolved feature.
+    return FeatureContext.from_domain(feature, get_dependency=get_dependency, cache=cache)
 
 # ** blueprint: create_session_request
 def create_session_request(interface_id: str,
@@ -465,7 +513,7 @@ def create_session_request(interface_id: str,
 # ** blueprint: execute_feature_handler
 def execute_feature_handler(get_dependency: Callable, cache: CacheContext) -> Callable:
     '''
-    Build the FE4 feature-execution handler closure.
+    Build the feature-execution handler closure.
 
     :param get_dependency: The DI resolution handler.
     :type get_dependency: Callable
@@ -478,12 +526,12 @@ def execute_feature_handler(get_dependency: Callable, cache: CacheContext) -> Ca
     # Return the handler closure bound to the resolver and cache.
     def handler(feature_id: str, request: RequestContext, *flags, **kwargs) -> None:
 
-        # Resolve the feature and its bound context.
-        feature, feature_context = create_feature_context(get_dependency, cache, feature_id)
+        # Resolve the feature-bound context.
+        feature_context = create_feature_context(get_dependency, cache, feature_id)
 
         # Drive execution; the result is accumulated on the request context and
         # result extraction is the responsibility of the response step.
-        feature_context.execute_feature(feature, request, *flags, **kwargs)
+        feature_context.execute_feature(request, *flags, **kwargs)
 
     # Return the closure.
     return handler
@@ -491,7 +539,7 @@ def execute_feature_handler(get_dependency: Callable, cache: CacheContext) -> Ca
 # ** blueprint: raise_error_handler
 def raise_error_handler(get_error_handler: Callable) -> Callable:
     '''
-    Build the FE4 error-handling handler closure.
+    Build the error-handling handler closure.
 
     :param get_error_handler: The lazy-caching error-resolution handler.
     :type get_error_handler: Callable
@@ -525,7 +573,7 @@ def raise_error_handler(get_error_handler: Callable) -> Callable:
 # ** blueprint: response_handler
 def response_handler(request: RequestContext) -> Any:
     '''
-    Pure FE4 response-building function delegating to the request context.
+    Pure response-building function delegating to the request context.
 
     :param request: The request context object.
     :type request: RequestContext
@@ -555,12 +603,14 @@ def build_app_session_context(app_session: AppSession, cache: CacheContext, **co
     app_container = build_app_service_container(cache, app_session)
     resolver = build_service_resolver(app_container)
 
-    # Build the logging context bound to the session's logger id.
-    logging_ctx = build_logging_context(cache, resolver.get_dependency, app_session.logger_id)
-
-    # Build the four FE4 template-method handlers.
-    execute_feature = execute_feature_handler(resolver.get_dependency, cache)
-    raise_error = raise_error_handler(get_error(cache, resolver.get_dependency))
+    # Build the five template-method handlers.
+    handlers = dict(
+        build_logger_handler=build_logger_handler(cache, resolver.get_dependency),
+        execute_feature_handler=execute_feature_handler(resolver.get_dependency, cache),
+        raise_error_handler=raise_error_handler(get_error(cache, resolver.get_dependency)),
+        response_handler=response_handler,
+        create_request_handler=create_session_request,
+    )
 
     # Resolve any remaining injectable collaborators the context class declares.
     collaborators = resolve_collaborators(AppSessionContext, app_container)
@@ -570,11 +620,7 @@ def build_app_session_context(app_session: AppSession, cache: CacheContext, **co
         app_session,
         get_dependency=resolver.get_dependency,
         cache=cache,
-        logging_context=logging_ctx,
-        execute_feature_handler=execute_feature,
-        raise_error_handler=raise_error,
-        response_handler=response_handler,
-        create_request_handler=create_session_request,
+        **handlers,
         **collaborators,
         **context_kwargs,
     )

--- a/tiferet/contexts/app.py
+++ b/tiferet/contexts/app.py
@@ -3,19 +3,19 @@
 # *** imports
 
 # ** core
+import logging
 import time
 from typing import Any, Callable, Dict, List, Tuple
 
 # ** app
 from ..assets import TiferetError, TiferetAPIError
-from ..domain import AppSession, AppServiceDependency, Feature
+from ..assets.error import APP_ERROR_ID
+from ..domain import AppSession, AppServiceDependency
 from ..events import DomainEvent
 from ..events.app import GetAppSession
 from ..interfaces import AppService
 from .core import BaseContext
 from .cache import CacheContext
-from .feature import FeatureContext, FEATURE_CACHE_PREFIX
-from .logging import LoggingContext
 from .request import RequestContext
 
 # *** constants
@@ -36,6 +36,35 @@ ADMIN_CONSTANT_CACHE_PREFIX: Tuple[str, ...] = ('admin', 'constants')
 APP_SESSION_CACHE_PREFIX: Tuple[str, ...] = ('app', 'sessions')
 
 # *** functions
+
+# ** function: raise_unwired_handler_error
+def raise_unwired_handler_error(handler_name: str, session_id: str, **kwargs) -> None:
+    '''
+    Raise a structured API error when a required hub handler is unwired.
+
+    Always raises; never returns. Callers treat this as a terminal statement.
+
+    :param handler_name: The name of the missing handler slot.
+    :type handler_name: str
+    :param session_id: The app session id that expected the handler.
+    :type session_id: str
+    :param kwargs: Additional context forwarded onto the API error.
+    :type kwargs: dict
+    '''
+
+    # Compose a message naming the missing handler and the session that needed it.
+    message = (
+        f'No {handler_name} is wired on the app session context for session '
+        f'{session_id}; the blueprint must supply {handler_name}.'
+    )
+
+    # Raise a structured API error; this function never returns.
+    raise TiferetAPIError(
+        error_code=APP_ERROR_ID,
+        name='App Error',
+        message=message,
+        **kwargs,
+    )
 
 # ** function: add_default_app_services
 def add_default_app_services(services: Dict[str, Any]) -> Callable:
@@ -296,7 +325,8 @@ class AppSessionContext(BaseContext):
     '''
     The application session hub binds a loaded ``AppSession`` domain object
     and delegates feature execution, error handling, request construction,
-    and response building to four injected FE4 template-method handlers.
+    response building, and logger construction to five injected template-method
+    handlers. An unwired handler is a composition bug and fails loudly.
     '''
 
     # * attribute: domain_type
@@ -308,8 +338,8 @@ class AppSessionContext(BaseContext):
     # * attribute: cache
     cache: CacheContext
 
-    # * attribute: logging (private)
-    _logging: LoggingContext
+    # * attribute: build_logger (private)
+    _build_logger: Callable
 
     # * attribute: execute_feature (private)
     _execute_feature: Callable
@@ -326,8 +356,8 @@ class AppSessionContext(BaseContext):
     # * init
     def __init__(self,
             get_dependency: Callable,
-            logging_context: LoggingContext = None,
             cache: CacheContext = None,
+            build_logger_handler: Callable = None,
             execute_feature_handler: Callable = None,
             create_request_handler: Callable = None,
             raise_error_handler: Callable = None,
@@ -337,17 +367,17 @@ class AppSessionContext(BaseContext):
 
         :param get_dependency: The DI resolution handler injected by the blueprint.
         :type get_dependency: Callable
-        :param logging_context: The logging context bound at bootstrap.
-        :type logging_context: LoggingContext
         :param cache: The shared bootstrap cache.
         :type cache: CacheContext
-        :param execute_feature_handler: The FE4 feature-execution handler.
+        :param build_logger_handler: The logger-construction handler.
+        :type build_logger_handler: Callable
+        :param execute_feature_handler: The feature-execution handler.
         :type execute_feature_handler: Callable
-        :param create_request_handler: The FE4 request-construction handler.
+        :param create_request_handler: The request-construction handler.
         :type create_request_handler: Callable
-        :param raise_error_handler: The FE4 error-handling handler.
+        :param raise_error_handler: The error-handling handler.
         :type raise_error_handler: Callable
-        :param response_handler: The FE4 response-building handler.
+        :param response_handler: The response-building handler.
         :type response_handler: Callable
         '''
 
@@ -358,10 +388,8 @@ class AppSessionContext(BaseContext):
         self.get_dependency = get_dependency
         self.cache = cache or CacheContext()
 
-        # Store the logging context.
-        self._logging = logging_context
-
-        # Store the FE4 template-method handlers.
+        # Store the five template-method handlers (validated lazily on first use).
+        self._build_logger = build_logger_handler
         self._execute_feature = execute_feature_handler
         self._create_request = create_request_handler
         self._raise_error = raise_error_handler
@@ -388,17 +416,31 @@ class AppSessionContext(BaseContext):
             id=interface_id,
         )
 
-    # * method: load_logging_context
-    def load_logging_context(self) -> LoggingContext:
+    # * method: build_logger
+    def build_logger(self) -> logging.Logger:
         '''
-        Return the logging context bound at bootstrap.
+        Build the logger for this session run.
 
-        :return: The bound logging context.
-        :rtype: LoggingContext
+        Delegates to the injected handler; fails loudly via
+        ``raise_unwired_handler_error`` when unwired. Domain errors raised by
+        the handler are formatted through ``handle_error`` so the pre-try
+        region of ``run`` surfaces only ``TiferetAPIError``.
+
+        :return: The configured logger instance.
+        :rtype: logging.Logger
         '''
 
-        # Return the bound logging context.
-        return self._logging
+        # Fail loudly when the logger-construction handler is unwired.
+        if self._build_logger is None:
+            raise_unwired_handler_error('build_logger_handler', self.domain.id)
+
+        # Delegate to the injected handler, formatting domain errors as API errors.
+        try:
+            return self._build_logger(self.domain.logger_id)
+
+        # Format domain errors through handle_error rather than propagating raw.
+        except TiferetError as e:
+            return self.handle_error(e)
 
     # * method: build_request
     def build_request(self,
@@ -407,6 +449,9 @@ class AppSessionContext(BaseContext):
             data: Dict[str, Any] = {}) -> RequestContext:
         '''
         Build the request context for a feature execution.
+
+        Delegates to the injected handler; fails loudly via
+        ``raise_unwired_handler_error`` when unwired.
 
         :param feature_id: The identifier of the feature to execute.
         :type feature_id: str
@@ -418,25 +463,26 @@ class AppSessionContext(BaseContext):
         :rtype: RequestContext
         '''
 
-        # Delegate to the injected request-construction handler when wired.
-        if self._create_request:
-            return self._create_request(self.domain.id, feature_id, headers, data)
+        # Fail loudly when the request-construction handler is unwired.
+        if self._create_request is None:
+            raise_unwired_handler_error(
+                'create_request_handler',
+                self.domain.id,
+                feature_id=feature_id,
+            )
 
-        # Otherwise construct the request context directly, stamping the
-        # interface id onto the request headers.
-        return RequestContext(
-            headers={**(headers or {}), 'interface_id': self.domain.id},
-            data=data,
-            feature_id=feature_id,
-        )
+        # Delegate to the injected request-construction handler.
+        return self._create_request(self.domain.id, feature_id, headers, data)
 
     # * method: execute_feature
     def execute_feature(self, feature_id: str, request: RequestContext, **kwargs):
         '''
         Execute a feature against the given request.
 
-        The execution result is accumulated on the request context; result
-        extraction is the responsibility of the response step.
+        Delegates to the injected handler; fails loudly via
+        ``raise_unwired_handler_error`` when unwired. The execution result is
+        accumulated on the request context; result extraction is the
+        responsibility of the response step.
 
         :param feature_id: The identifier of the feature to execute.
         :type feature_id: str
@@ -446,22 +492,25 @@ class AppSessionContext(BaseContext):
         :type kwargs: dict
         '''
 
-        # Delegate to the injected feature-execution handler when wired.
-        if self._execute_feature:
-            self._execute_feature(feature_id, request, **kwargs)
-            return
+        # Fail loudly when the feature-execution handler is unwired.
+        if self._execute_feature is None:
+            raise_unwired_handler_error(
+                'execute_feature_handler',
+                self.domain.id,
+                feature_id=feature_id,
+            )
 
-        # Otherwise resolve the registered FeatureContext and drive it directly
-        # against a feature pre-seeded on the shared cache.
-        feature_context_cls = BaseContext.for_domain(Feature)
-        feature_context = feature_context_cls(get_dependency=self.get_dependency, cache=self.cache)
-        feature = self.cache.get(feature_id, *FEATURE_CACHE_PREFIX)
-        feature_context.execute_feature(feature, request, **kwargs)
+        # Delegate to the injected feature-execution handler.
+        self._execute_feature(feature_id, request, **kwargs)
 
     # * method: handle_error
     def handle_error(self, error: Exception, **kwargs) -> Any:
         '''
         Handle an error raised during feature execution.
+
+        Re-raises an incoming ``TiferetAPIError`` verbatim. Otherwise delegates
+        to the injected handler; fails loudly via ``raise_unwired_handler_error``
+        when unwired.
 
         :param error: The error to handle.
         :type error: Exception
@@ -471,30 +520,29 @@ class AppSessionContext(BaseContext):
         :rtype: Any
         '''
 
-        # Delegate to the injected error-handling handler when wired.
-        if self._raise_error:
-            return self._raise_error(error, **kwargs)
+        # Pass through an already-formatted API error without modification.
+        if isinstance(error, TiferetAPIError):
+            raise error
 
-        # Wrap bare exceptions in a TiferetError.
-        if not isinstance(error, TiferetError):
-            error = TiferetError(
-                'APP_ERROR',
-                f'An error occurred in the app: {str(error)}',
-                error=str(error),
+        # Fail loudly when the error-handling handler is unwired.
+        if self._raise_error is None:
+            raise_unwired_handler_error(
+                'raise_error_handler',
+                self.domain.id,
+                original_error_code=getattr(error, 'error_code', None),
+                original_error_message=str(error),
             )
 
-        # Raise a structured API error built from the wrapped error.
-        raise TiferetAPIError(
-            error_code=error.error_code,
-            name=error.error_code,
-            message=str(error),
-            **error.kwargs,
-        )
+        # Delegate to the injected error-handling handler.
+        return self._raise_error(error, **kwargs)
 
     # * method: build_response
     def build_response(self, request: RequestContext) -> Any:
         '''
         Build the final response from the executed request.
+
+        Delegates to the injected handler; fails loudly via
+        ``raise_unwired_handler_error`` when unwired.
 
         :param request: The request context object.
         :type request: RequestContext
@@ -502,12 +550,12 @@ class AppSessionContext(BaseContext):
         :rtype: Any
         '''
 
-        # Delegate to the injected response-building handler when wired.
-        if self._build_response:
-            return self._build_response(request)
+        # Fail loudly when the response-building handler is unwired.
+        if self._build_response is None:
+            raise_unwired_handler_error('response_handler', self.domain.id)
 
-        # Otherwise delegate directly to the request context.
-        return request.handle_response()
+        # Delegate to the injected response-building handler.
+        return self._build_response(request)
 
     # * method: run
     def run(self,
@@ -534,7 +582,7 @@ class AppSessionContext(BaseContext):
         start_time = time.perf_counter()
 
         # Build the logger for this session run.
-        logger = self.load_logging_context().build_logger()
+        logger = self.build_logger()
 
         # Build the request context.
         logger.debug(f'Building request for feature: {feature_id}')

--- a/tiferet/contexts/cli.py
+++ b/tiferet/contexts/cli.py
@@ -18,7 +18,6 @@ from ..domain import (
 )
 from .app import AppSessionContext
 from .cache import CacheContext
-from .logging import LoggingContext
 from .request import RequestContext
 
 # *** constants
@@ -191,9 +190,9 @@ class CliSessionContext(AppSessionContext):
     # * init
     def __init__(self,
             get_dependency: Callable,
-            logging_context: LoggingContext = None,
             parse_cli_args: Callable = None,
             cache: CacheContext = None,
+            build_logger_handler: Callable = None,
             execute_feature_handler: Callable = None,
             create_request_handler: Callable = None,
             raise_error_handler: Callable = None,
@@ -203,28 +202,28 @@ class CliSessionContext(AppSessionContext):
 
         :param get_dependency: The DI resolution handler injected by the blueprint.
         :type get_dependency: Callable
-        :param logging_context: The logging context bound at bootstrap.
-        :type logging_context: LoggingContext
         :param parse_cli_args: The injected callable that parses argv and returns
             a (feature_id, headers, data) tuple.
         :type parse_cli_args: Callable
         :param cache: The shared bootstrap cache.
         :type cache: CacheContext
-        :param execute_feature_handler: The FE4 feature-execution handler.
+        :param build_logger_handler: The logger-construction handler.
+        :type build_logger_handler: Callable
+        :param execute_feature_handler: The feature-execution handler.
         :type execute_feature_handler: Callable
-        :param create_request_handler: The FE4 request-construction handler.
+        :param create_request_handler: The request-construction handler.
         :type create_request_handler: Callable
-        :param raise_error_handler: The FE4 error-handling handler.
+        :param raise_error_handler: The error-handling handler.
         :type raise_error_handler: Callable
-        :param response_handler: The FE4 response-building handler.
+        :param response_handler: The response-building handler.
         :type response_handler: Callable
         '''
 
         # Initialize the base application session hub.
         super().__init__(
             get_dependency=get_dependency,
-            logging_context=logging_context,
             cache=cache,
+            build_logger_handler=build_logger_handler,
             execute_feature_handler=execute_feature_handler,
             create_request_handler=create_request_handler,
             raise_error_handler=raise_error_handler,
@@ -239,9 +238,9 @@ class CliSessionContext(AppSessionContext):
         '''
         Build and, when appropriate, print the CLI response.
 
-        Delegates to the injected response handler when one is wired in,
-        otherwise falls back to the request context directly. The formatted or
-        stringified result is printed only when the request is a
+        Extends the hub response step via ``super().build_response`` so an
+        unwired ``response_handler`` raises through the hub guard. The
+        formatted or stringified result is printed only when the request is a
         ``CliRequestContext``; the legacy path leaves printing to the caller.
 
         :param request: The completed request context.
@@ -250,11 +249,8 @@ class CliSessionContext(AppSessionContext):
         :rtype: Any
         '''
 
-        # Use the injected response handler when available, otherwise fall through.
-        if self._build_response is not None:
-            model = self._build_response(request)
-        else:
-            model = request.handle_response()
+        # Delegate response extraction to the hub template method.
+        model = super().build_response(request)
 
         # Only print when using the CLI request context.
         if isinstance(request, CliRequestContext):

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -598,9 +598,9 @@ class FeatureContext(BaseContext):
         request.set_result(result, data_key)
 
     # * method: _execute_async
-    async def _execute_async(self, feature: Feature, request: RequestContext, *flags, **kwargs):
+    async def _execute_async(self, request: RequestContext, *flags, **kwargs):
         '''
-        Execute a pre-loaded async feature, awaiting each step in turn.
+        Execute the bound async feature, awaiting each step in turn.
 
         Supports mixed sync/async step chains: each step is dispatched through
         ``_execute_step_async``, which detects and awaits coroutine-based
@@ -608,10 +608,8 @@ class FeatureContext(BaseContext):
 
         This method is a genuine async coroutine and stays awaitable for any
         future async host. From synchronous code it is driven via
-        ``run_coroutine(self._execute_async(feature, request, ...))``.
+        ``run_coroutine(self._execute_async(request, ...))``.
 
-        :param feature: The pre-loaded feature domain object.
-        :type feature: Feature
         :param request: The request context object.
         :type request: RequestContext
         :param flags: Execution flags combined additively with feature-level
@@ -621,11 +619,14 @@ class FeatureContext(BaseContext):
         :type kwargs: dict
         '''
 
+        # Read the bound feature, populated by BaseContext.from_domain at construction time.
+        feature = self.domain
+
         # Resolve feature-level middleware once for all steps.
         feature_middleware = self.resolve_middleware(feature.middleware)
 
         # Resolve and execute each step, awaiting async commands as needed.
-        for event, step, params in self.resolve_feature_steps(feature, request, *flags):
+        for event, step, params in self.resolve_feature_steps(request, *flags):
 
             # Compose feature-level (outer) + step-level (inner) middleware.
             step_middleware = self.resolve_middleware(step.middleware)
@@ -646,12 +647,11 @@ class FeatureContext(BaseContext):
 
     # * method: resolve_feature_steps
     def resolve_feature_steps(self,
-            feature: Feature,
             request: RequestContext,
             *execution_flags: str,
         ) -> Generator[Tuple[DomainEvent, EventFeatureStep, Dict[str, str]], None, None]:
         '''
-        Resolve and yield executable steps for a pre-loaded feature.
+        Resolve and yield executable steps for the bound feature.
 
         Evaluates step conditions, resolves each step's domain event via the
         injected service-resolution handler, and parses its parameters. Yields
@@ -662,8 +662,6 @@ class FeatureContext(BaseContext):
         the service resolver receives the full combined flag set. No subset
         validation is performed — the resolver is authoritative.
 
-        :param feature: The pre-loaded feature domain object.
-        :type feature: Feature
         :param request: The request context for condition evaluation and parameter parsing.
         :type request: RequestContext
         :param execution_flags: Caller-supplied execution flags combined with
@@ -672,6 +670,9 @@ class FeatureContext(BaseContext):
         :return: A generator yielding (event, step, params) tuples.
         :rtype: Generator[Tuple[DomainEvent, EventFeatureStep, Dict[str, str]], None, None]
         '''
+
+        # Read the bound feature, populated by BaseContext.from_domain at construction time.
+        feature = self.domain
 
         # Build the combined feature-level flag set: execution flags + feature flags.
         combined_feature_flags = list(execution_flags) + (feature.flags or [])
@@ -696,9 +697,9 @@ class FeatureContext(BaseContext):
             yield event, step, params
 
     # * method: execute_feature
-    def execute_feature(self, feature: Feature, request: RequestContext, *flags, **kwargs):
+    def execute_feature(self, request: RequestContext, *flags, **kwargs):
         '''
-        Execute a pre-loaded feature with the provided request.
+        Execute the bound feature with the provided request.
 
         Handles three dispatch cases based on ``is_async`` flags:
 
@@ -709,8 +710,9 @@ class FeatureContext(BaseContext):
            async steps within an otherwise synchronous feature.
         3. Both flags ``False`` — fully synchronous ``execute_step`` execution.
 
-        :param feature: The pre-loaded feature domain object.
-        :type feature: Feature
+        The feature executed is ``self.domain``, populated by
+        ``BaseContext.from_domain`` at construction time.
+
         :param request: The request context object.
         :type request: RequestContext
         :param flags: Execution flags combined additively with feature-level
@@ -720,20 +722,23 @@ class FeatureContext(BaseContext):
         :type kwargs: dict
         '''
 
+        # Read the bound feature, populated by BaseContext.from_domain at construction time.
+        feature = self.domain
+
         # Validate and coerce request data against the feature schema first,
         # failing fast before any step executes.
         validate_request(feature, request)
 
         # Case 1: entire feature is async — drive the full loop via run_coroutine.
         if feature.is_async:
-            run_coroutine(self._execute_async(feature, request, *flags, **kwargs))
+            run_coroutine(self._execute_async(request, *flags, **kwargs))
             return
 
         # Cases 2 & 3: synchronous feature loop with per-step async detection.
         feature_middleware = self.resolve_middleware(feature.middleware)
 
         # Resolve and execute each step in turn.
-        for event, step, params in self.resolve_feature_steps(feature, request, *flags):
+        for event, step, params in self.resolve_feature_steps(request, *flags):
 
             # Compose feature-level (outer) + step-level (inner) middleware.
             step_middleware = self.resolve_middleware(step.middleware)

--- a/tiferet/contexts/logging.py
+++ b/tiferet/contexts/logging.py
@@ -19,6 +19,9 @@ from .. import assets as a
 # ** constant: logging_cache_prefix
 LOGGING_CACHE_PREFIX: Tuple[str, ...] = ('logging',)
 
+# ** constant: logger_cache_prefix
+LOGGER_CACHE_PREFIX: Tuple[str, ...] = ('logging', 'loggers')
+
 # *** functions
 
 # ** function: add_default_logging_settings

--- a/tiferet/events/error.py
+++ b/tiferet/events/error.py
@@ -6,7 +6,6 @@
 from typing import (
     List,
     Dict,
-    Any
 )
 
 # ** app
@@ -51,7 +50,7 @@ class AddError(ErrorEvent):
             name: str,
             message: str,
             lang: str = 'en_US',
-            additional_messages: List[Dict[str, Any]] = []
+            additional_messages: Dict[str, str] = {},
         ) -> None:
         '''
         Add a new Error to the app.
@@ -64,8 +63,8 @@ class AddError(ErrorEvent):
         :type message: str
         :param lang: The language of the primary error message (default is 'en_US').
         :type lang: str
-        :param additional_messages: Additional error messages in different languages.
-        :type additional_messages: List[Dict[str, Any]]
+        :param additional_messages: A language-code to message-text mapping of additional messages beyond the primary one.
+        :type additional_messages: Dict[str, str]
         '''
 
         # Check if an error with the same ID already exists.
@@ -78,7 +77,10 @@ class AddError(ErrorEvent):
         )
 
         # Create the Error aggregate.
-        error_messages = [{'lang': lang, 'text': message}] + additional_messages
+        error_messages = [{'lang': lang, 'text': message}] + [
+            {'lang': lang_key, 'text': text}
+            for lang_key, text in additional_messages.items()
+        ]
         new_error = ErrorAggregate(
             id=id,
             name=name,


### PR DESCRIPTION
## Summary
Implements Super-TRD #1010 (Admin Support — Blueprint Port, User Documentation & Config-Management Skill Suite) across its 9 sequenced children on a single feature branch. This PR is opened after landing the first child (#1011) and will be updated in place as each subsequent child lands.

## Changes

### Child 1 — Contexts: FeatureContext Domain Binding (#1011) ✅
- `FeatureContext.execute_feature`, `resolve_feature_steps`, and `_execute_async` no longer take a `feature` parameter; each reads `feature = self.domain` (populated by `BaseContext.from_domain`) as its first statement.
- `tests/contexts/test_feature.py` updated so every `FeatureContext` under test is constructed via `FeatureContext.from_domain(feature, get_dependency=...)` and the three affected methods are called without a `feature` argument.

### Child 2 — Contexts: AppSessionContext Five-Handler Hub (#1012) ✅
- `AppSessionContext.__init__` accepts `build_logger_handler` and no longer accepts `logging_context`; `_logging` replaced by `_build_logger`.
- Added module-level `raise_unwired_handler_error(handler_name, session_id, **kwargs)` raising `TiferetAPIError` with `APP_ERROR_ID`.
- `build_request`, `execute_feature`, `handle_error`, and `build_response` fail loudly when their handler is unwired; all truthiness-guarded fallbacks removed.
- `handle_error` re-raises an incoming `TiferetAPIError` verbatim before consulting `raise_error_handler`.
- Added `build_logger` template method; `run` calls `self.build_logger()`; `load_logging_context` removed.
- `contexts/logging.py` defines `LOGGER_CACHE_PREFIX = ('logging', 'loggers')`.
- `tests/contexts/test_app.py` covers the required-handler contract, API-error pass-through, and `build_logger` (31 passed).

### Child 3 — Contexts & Blueprints: CLI Hub and Blueprint Wiring for the Five-Handler Contract (#1014) ✅
- `CliSessionContext.__init__` accepts `build_logger_handler` (no `logging_context`) and forwards it to the hub; `build_response` delegates via `super().build_response(request)` then prints for `CliRequestContext` only.
- `blueprints/core.py`: `RESERVED_CONTEXT_PARAMETERS` swaps `logging_context` for `build_logger_handler`; adds `merge_logging_settings` and `build_logger_handler`; removes `build_logging_context`.
- `create_feature_context` returns a single `FeatureContext` from `from_domain`; `execute_feature_handler` calls `execute_feature(request, *flags, **kwargs)` with no feature positional.
- `build_app_session_context` and `build_cli_session_context` wire all five handlers, including lazy `build_logger_handler` (cache under `LOGGER_CACHE_PREFIX`).
- Tests updated in `tests/contexts/test_cli.py` (existing build_response path), `tests/blueprints/test_core.py`, and `tests/blueprints/test_cli.py`; full suite green (`1051 passed, 11 skipped`).

### Child 4 — Assets & Events: Admin Catalog Reconciliation (#1013) ✅
- `assets/feature.py`: `DEFAULT_ADMIN_FEATURES` → `ADMIN_DEFAULT_FEATURES` (label + module docstring).
- `assets/di.py`: `DEFAULT_ADMIN_SERVICES` → `ADMIN_DEFAULT_SERVICES` (label + module docstring). Distinct from existing `assets/app.py::ADMIN_DEFAULT_SERVICES`.
- `assets/cli.py`: eight flat-map args (`app.add/set-constants --constants`, `app.set-service --parameters`, `feature.add-step --parameters`, `service.add/set-default/set-dependency --parameters`, `service.set-constants --constants`) now `type='dict'` with key=value descriptions; list-shaped `--flags` / `--name-or-flags` remain `json`.
- `ERROR_ADD_CLI_CMD_DATA` gains `--additional-messages` (`type='dict'`).
- `AddError.execute`: `additional_messages: Dict[str, str] = {}` with lang→text assembly; dropped unused `Any` import.
- Tests: `tests/events/test_error.py` dict mapping coverage; new `tests/assets/test_{cli,feature,di}.py`. Targeted suite: `75 passed, 3 skipped`.

### Child 5 — Blueprints: Admin App Blueprint (#1015) ✅
- Added `tiferet/blueprints/admin.py` with `build_cache`, `build_admin_service_resolver`, `build_admin_app_session_context`, and `build_admin_app` (`AdminApp` alias).
- Admin `build_cache` stacks admin services/constants/features/errors over `core.build_cache`.
- `build_admin_service_resolver` registers the admin container under both `'admin'` and the empty-flag default.
- `build_admin_app_session_context` wires all five required handlers, including `build_logger_handler`.
- Restored required `EventFeatureStep.name` values on all 41 `ADMIN_DEFAULT_FEATURES` steps (gap left by #1013) so cache seeding validates.
- Added `tests/blueprints/test_admin.py` (admin service seed, resolver flag routing, five-handler wiring, `build_admin_app`); 6 passed.

### Child 6 — Blueprints: Admin CLI Blueprint (#1016) ✅
- Added `tiferet/blueprints/admin_cli.py` with `build_cache`, `build_admin_cli_session_context`, `build_admin_cli`, and `main` (`AdminCLI` alias).
- Admin CLI `build_cache` stacks `ADMIN_DEFAULT_COMMANDS` over `admin.build_cache`.
- `build_admin_cli_session_context` uses `admin.build_admin_service_resolver` and wires CLI-specific request/response handlers.
- `build_admin_cli` re-seeds session constants so all config repos point at the consumer `app_config`, then dispatches via `CliSessionContext.run`.
- `main` pre-parses `--config` with `add_help=False` and forwards remaining argv.
- Exported `build_admin_app`/`AdminApp` and `build_admin_cli`/`AdminCLI` from `tiferet/blueprints/__init__.py`.
- Pointed `pyproject.toml` `[project.scripts] tiferet` at `tiferet.blueprints.admin_cli:main`.
- Added `tests/blueprints/test_admin_cli.py` (command seed, admin resolver flag, config re-seed, exports, main pre-parser); full suite `1070 passed, 11 skipped`.

### Child 7 — Docs: Admin User Guide (#1017) ✅
- Added `docs/guides/admin.md` using the strategy-genre guide structure (`TEMPLATE-strategy.md`).
- Documented `build_admin_app`/`AdminApp` and `build_admin_cli`/`AdminCLI`, explaining admin-scoped service resolution and custom configuration file routing.
- Detailed all six admin catalog domains (App, CLI, Error, Feature, Service/DI, Logging) with side-by-side Python (`AdminApp.run`) and CLI (`tiferet ...`) worked examples using flat-map `key=value` dict args.
- Included mandatory `## Ubiquitous Language`, `## Boundaries`, and `## Related Documentation` sections.

### Child 8 — Docs: Admin Config-Management Skill Suite (#1018) ✅
- Added `docs/collab/agents/skills/tiferet-admin-config/SKILL.md` with valid YAML frontmatter, naming `AdminApp` as the primary path and `AdminCLI` as secondary.
- Documented all six admin CRUD domains with canonical worked patterns and flat-map `key=value` syntax.
- Included complete "pairing a new domain event with its config entries" worked example showing `error.add` → `service.set_dependency` → `feature.add_step`.
- Referenced `docs/guides/admin.md` as canonical source of truth.
- Registered `tiferet-admin-config` under `## Collaboration skills` in `docs/collab/agents/skills/README.md`.

### Child 9 — Docs: Companion Updates for the Five-Handler Contract and Admin Catalog (#1019) ✅
- `docs/core/contexts.md` and `docs/guides/contexts.md`: five required handlers (`build_logger_handler` included), `raise_unwired_handler_error`, domain-bound `FeatureContext.execute_feature(request, ...)` with no `feature` param; removed four-fallback / `logging_context` hub construction / `AsyncFeatureContext` guidance.
- `docs/core/blueprints.md` and `docs/guides/blueprints.md`: documented `merge_logging_settings`, `build_logger_handler`, updated `create_feature_context`/`execute_feature_handler` signatures, admin modules (`admin.py` / `admin_cli.py`), dual-container admin resolver, and a "Building the Admin Application" walkthrough linking `docs/guides/admin.md`.
- `docs/guides/domain/cli.md`: `'dict'` argument-type reference with the nine admin flat-map flags (`--constants` / `--parameters` / `--additional-messages`) and `build_admin_cli` / `AdminCLI`.
- `docs/guides/domain/logging.md`: `LOGGER_CACHE_PREFIX` / `build_logger_handler` runtime path plus admin Logging CRUD cross-reference to `docs/guides/admin.md`.
- `docs/guides/domain/feature.md`: domain-bound execution and `is_async` dispatch; `ADMIN_DEFAULT_FEATURES` note; no examples pass `feature` into `execute_feature` / `resolve_feature_steps` / `_execute_async`.

## Acceptance Criteria
Combined AC from Super-TRD #1010 §5, mapped to owning child:

- [x] 1. `FeatureContext.execute_feature`, `resolve_feature_steps`, and `_execute_async` take no `feature` parameter and read `self.domain` instead. (#1011)
- [x] 2. `AppSessionContext.build_request`, `execute_feature`, `handle_error`, and `build_response` each raise `APP_ERROR` via a `raise_unwired_handler_error` helper when their handler slot is unwired, with no fallback implementation remaining. (#1012)
- [x] 3. `AppSessionContext.handle_error` re-raises an incoming `TiferetAPIError` verbatim before consulting the `raise_error_handler` slot. (#1012)
- [x] 4. `AppSessionContext` gains a `build_logger` template method backed by an injected `build_logger_handler` slot; `_logging`, `load_logging_context`, and the `logging_context` constructor parameter no longer exist on `AppSessionContext` or `CliSessionContext`. (#1012, #1014)
- [x] 5. `blueprints/core.py::RESERVED_CONTEXT_PARAMETERS` includes `build_logger_handler` and no longer includes `logging_context`; `build_app_session_context` wires all five handlers. (#1014)
- [x] 6. `blueprints/cli.py::build_cli_session_context` wires all five handlers, including `build_logger_handler`, and no longer builds a standalone `LoggingContext`. (#1014)
- [x] 7. `assets/feature.py::ADMIN_DEFAULT_FEATURES` and `assets/di.py::ADMIN_DEFAULT_SERVICES` exist; their prior names (`DEFAULT_ADMIN_FEATURES`, `DEFAULT_ADMIN_SERVICES`) no longer exist. (#1013)
- [x] 8. The eight flat-map admin CLI arguments use `type='dict'`; `AddError.execute`'s `additional_messages` parameter is `Dict[str, str]`; `error.add` has a `--additional-messages` argument of type `'dict'`. (#1013)
- [x] 9. `tiferet/blueprints/admin.py` exists with `build_cache`, `build_admin_service_resolver`, `build_admin_app_session_context`, and `build_admin_app`. (#1015)
- [x] 10. `tiferet/blueprints/admin_cli.py` exists with `build_cache`, `build_admin_cli_session_context`, `build_admin_cli`, and `main`. (#1016)
- [x] 11. `from tiferet.blueprints import build_admin_app, AdminApp, build_admin_cli, AdminCLI` succeeds; `pyproject.toml`'s `tiferet` console script points at `tiferet.blueprints.admin_cli:main`. (#1016)
- [x] 12. `docs/guides/admin.md` exists, documents both `build_admin_app` and `build_admin_cli`, and includes one worked example per admin catalog domain. (#1017)
- [x] 13. A `tiferet-admin-config` skill exists under `docs/collab/agents/skills/` and is registered in that directory's `README.md`. (#1018)
- [x] 14. `docs/core/contexts.md`, `docs/guides/contexts.md`, `docs/core/blueprints.md`, `docs/guides/blueprints.md`, `docs/guides/domain/cli.md`, `docs/guides/domain/logging.md`, and `docs/guides/domain/feature.md` describe the five-handler contract and the admin catalog as landed, with no residual references to the four-handler contract, `LoggingContext`-based session construction, or `AsyncFeatureContext`. (#1019)
- [ ] 15. `pytest tiferet/ tests/` passes with no regressions after every child lands.

## Related Issues
Closes #1010

Co-Authored-By: Oz <oz-agent@warp.dev>
