### PR TITLE
Hotfix – Post-v2.0.0 proto packaging, admin wiring, and catalog coverage

### DIFF
--- a/docs/collab/agents/skills/README.md
+++ b/docs/collab/agents/skills/README.md
@@ -4,6 +4,7 @@ Canonical, version-controlled copies of the reusable agent **skills** for Tifere
 
 ## Collaboration skills
 - **`tiferet-annotation-artifacts`** — scan, add, and resolve `# ++ todo:` / `# -- obsolete:` annotation artifacts; covers the pre-session scan, resolution procedure, and Collaboration Report integration. **Use at the start of every implementation session.**
+- **`tiferet-admin-config`** — use the Admin App or Admin CLI to add/update errors, service registrations, and features in a consumer's `config.yml`. Directly useful when a TRD introduces a new domain event module and needs an accompanying error, service registration, and feature entry.
 - **`tiferet-create-milestone`** — create or format a GitHub milestone.
 - **`tiferet-author-trd`** — author a Technical Requirements Document.
 - **`tiferet-collab-report`** — generate a Collaboration Report when an issue is confirmed complete.

--- a/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
+++ b/docs/collab/agents/skills/tiferet-admin-config/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: tiferet-admin-config
+description: Use the Tiferet Admin App or Admin CLI to add or update errors, service registrations, and features in a consumer's config.yml. Use this when a TRD introduces a new domain event module and needs an accompanying error, service registration, and feature entry, or when asked to manage/add/update Tiferet application configuration (errors, services, features, CLI commands, sessions, logging) via the built-in admin surface.
+---
+
+# Tiferet Admin Config Management
+
+## When to use
+
+- **New domain event module integration**: When a TRD or implementation session adds a new domain event module and requires adding or updating an accompanying error definition, service registration, and feature workflow in a consumer's `config.yml`.
+- **Configuration management**: When asked to inspect, add, update, or remove application configuration records (errors, services, features, CLI commands, sessions, logging) in `config.yml` or custom configuration files via the built-in admin surface.
+
+## Primary path: Admin App (Python)
+
+The **Admin App** (`AdminApp` / `build_admin_app`) is the strongly recommended primary path for programmatic configuration management.
+
+Import from the blueprints package (not the package root):
+
+```python
+from tiferet.blueprints import AdminApp, AdminCLI
+```
+
+### Why Admin App is preferred
+
+- **In-process objects**: Manipulates rich domain objects directly in Python without string serialization or parsing overhead.
+- **No shell-quoting or string-escaping**: Complex parameter dicts and localized messages pass as native Python dicts, lists, and primitives without shell quoting risks.
+- **Direct exception handling**: Returns structured response dicts or raises typed `TiferetError` instances that can be inspected and handled in code.
+
+### Canonical usage pattern
+
+```python
+from tiferet.blueprints import AdminApp
+
+# Instantiate the admin app (defaults to app_config='config.yml')
+admin = AdminApp()
+
+# Execute a management feature against config.yml
+response = admin.run('feature.list', data={})
+```
+
+To target a specific configuration file other than `config.yml`:
+
+```python
+admin = AdminApp(app_config='custom_config.yml')
+```
+
+## Secondary path: Admin CLI
+
+The **Admin CLI** (`AdminCLI` / `build_admin_cli` / `tiferet`) is the secondary path for interactive or command-line administration.
+
+### Command-line syntax
+
+```bash
+# Target default config.yml in current working directory
+tiferet <group> <command> [args...]
+
+# Target a specific configuration file
+tiferet --config custom_config.yml <group> <command> [args...]
+```
+
+### Key-value dict syntax
+
+Every flat-map/dict-typed argument on the Admin CLI accepts `key=value` pairs directly on the command line — raw JSON strings are **never** required for dict args (only for the few `type: json` args such as `cli.add_argument --name-or-flags`).
+
+```bash
+# Correct: positional id/name/message; flat-map additional messages
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "Token is invalid." --additional-messages es_ES="El token no es válido."
+
+# Correct: positional feature id + step name + service_id; flat-map parameters
+tiferet feature add-step user.create "Validate User" validate_user_evt --parameters mode=strict timeout=5.0
+```
+
+## Catalog source of truth
+
+Landed IDs come from:
+- `ADMIN_DEFAULT_FEATURES` — `tiferet/assets/feature.py` (41 features)
+- `ADMIN_DEFAULT_COMMANDS` — `tiferet/assets/cli.py` (41 commands, including `feature.get`)
+
+Do **not** invent verbs such as `app.add_session`, `list-sessions`, `list-errors`, `list-features`, or `delete_*`. Use the pairs below.
+
+## The Six Admin Domains
+
+### 1. App Domain (`app`)
+
+Manages application interface / session definitions, constants, and app-level service dependencies.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `app.add` | Add a new application session configuration | `tiferet app add <id> <name> <module_path> <class_name> [--description] [--logger-id] [--flags] [--constants]` |
+| `app.get` | Retrieve an app session by ID | `tiferet app get <interface_id>` |
+| `app.list` | List all configured app sessions | `tiferet app list` |
+| `app.update` | Update a scalar attribute on an app session | `tiferet app update <id> <attribute> <value>` |
+| `app.set_constants` | Set or clear constants on an app session | `tiferet app set-constants <id> [--constants]` |
+| `app.set_service` | Set or update a service dependency on an app session | `tiferet app set-service <id> <service_id> <module_path> <class_name> [--parameters]` |
+| `app.remove_service` | Remove a service dependency from an app session | `tiferet app remove-service <id> <service_id>` |
+| `app.remove` | Remove an app session by ID | `tiferet app remove <id>` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'app.add',
+    data={
+        'id': 'web_api',
+        'name': 'Web API Session',
+        'module_path': 'app.contexts.api',
+        'class_name': 'ApiSessionContext',
+        'description': 'Main web API application session',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet app add web_api "Web API Session" app.contexts.api ApiSessionContext --description "Main web API application session"
+tiferet app list
+```
+
+---
+
+### 2. CLI Domain (`cli`)
+
+Manages CLI command definitions and argument specifications.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `cli.list_commands` | List all configured CLI commands | `tiferet cli list-commands` |
+| `cli.add_command` | Add a new CLI command definition | `tiferet cli add-command <id> <name> <key> <group_key> [--description]` |
+| `cli.add_argument` | Add an argument to an existing CLI command | `tiferet cli add-argument <command_id> --name-or-flags <json> [--description]` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'cli.add_command',
+    data={
+        'id': 'reports.generate',
+        'name': 'Generate Report',
+        'key': 'generate',
+        'group_key': 'reports',
+        'description': 'Generate summary report',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet cli add-command reports.generate "Generate Report" generate reports --description "Generate summary report"
+tiferet cli list-commands
+```
+
+---
+
+### 3. Error Domain (`error`)
+
+Manages structured error definitions and multilingual messages.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `error.list` | List all error definitions | `tiferet error list` |
+| `error.add` | Add a new error definition | `tiferet error add <id> <name> <message> [--lang] [--additional-messages]` |
+| `error.get` | Retrieve an error by ID | `tiferet error get <id>` |
+| `error.rename` | Rename an existing error definition | `tiferet error rename <id> <new_name>` |
+| `error.set_message` | Set the message text on an existing error | `tiferet error set-message <id> <message> [--lang]` |
+| `error.remove_message` | Remove a language message from an error | `tiferet error remove-message <id> [--lang]` |
+| `error.remove` | Remove an error definition | `tiferet error remove <id>` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'error.add',
+    data={
+        'id': 'INVALID_TOKEN_ID',
+        'name': 'Invalid Token',
+        'message': 'The provided authentication token is invalid.',
+        'additional_messages': {
+            'es_ES': 'El token de autenticación proporcionado no es válido.',
+        },
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error list
+```
+
+---
+
+### 4. Feature Domain (`feature`)
+
+Manages feature workflow definitions and steps.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `feature.list` | List all feature workflow definitions | `tiferet feature list [--group-id]` |
+| `feature.add` | Add a new feature workflow definition | `tiferet feature add <name> <group_id> [--feature-key] [--description]` |
+| `feature.get` | Retrieve a feature by ID | `tiferet feature get <id>` |
+| `feature.update` | Update a metadata attribute on a feature | `tiferet feature update <id> <attribute> <value>` |
+| `feature.add_step` | Add a step to an existing feature workflow | `tiferet feature add-step <id> <name> <service_id> [--parameters] [--data-key] [--pass-on-error] [--position]` |
+| `feature.update_step` | Update an attribute on an existing feature step | `tiferet feature update-step <id> <position> <attribute> [--value]` |
+| `feature.remove_step` | Remove a step from an existing feature workflow | `tiferet feature remove-step <id> <position>` |
+| `feature.reorder_step` | Reorder a step within an existing feature workflow | `tiferet feature reorder-step <id> <start_position> <end_position>` |
+| `feature.remove` | Remove an existing feature workflow definition | `tiferet feature remove <id>` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+
+# Step 1: Define the feature workflow
+admin.run(
+    'feature.add',
+    data={
+        'name': 'Create User Workflow',
+        'group_id': 'user',
+        'feature_key': 'create',
+        'description': 'Validates and registers a new user',
+    },
+)
+
+# Step 2: Add a step to the workflow
+admin.run(
+    'feature.add_step',
+    data={
+        'id': 'user.create',
+        'name': 'Validate User Step',
+        'service_id': 'validate_user_evt',
+        'parameters': {'mode': 'strict'},
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet feature add "Create User Workflow" user --feature-key create --description "Validates and registers a new user"
+tiferet feature add-step user.create "Validate User Step" validate_user_evt --parameters mode=strict
+tiferet feature list
+```
+
+---
+
+### 5. Service / DI Domain (`service`)
+
+Manages feature-level service registrations, flagged dependencies, and DI constants.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `service.list` | List all DI service registrations and constants | `tiferet service list` |
+| `service.add` | Add a new DI service registration | `tiferet service add <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_default` | Set or update the default type for a registration | `tiferet service set-default <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_dependency` | Set or update a flagged dependency on a registration | `tiferet service set-dependency <id> <flag> <module_path> <class_name> [--parameters]` |
+| `service.remove_dependency` | Remove a flagged dependency from a registration | `tiferet service remove-dependency <id> <flag>` |
+| `service.set_constants` | Set or clear DI service constants | `tiferet service set-constants [--constants]` |
+| `service.remove` | Remove a DI service registration | `tiferet service remove <id>` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'service.add',
+    data={
+        'id': 'validate_user_evt',
+        'module_path': 'app.events.user',
+        'class_name': 'ValidateUserEvent',
+        'parameters': {'timeout': '5.0'},
+    },
+)
+admin.run(
+    'service.set_dependency',
+    data={
+        'id': 'validate_user_evt',
+        'flag': 'test',
+        'module_path': 'app.events.user',
+        'class_name': 'StubValidateUserEvent',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet service add validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+tiferet service set-dependency validate_user_evt test app.events.user StubValidateUserEvent
+tiferet service list
+```
+
+---
+
+### 6. Logging Domain (`logging`)
+
+Manages logging formatters, handlers, and loggers.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `logging.add_formatter` | Add a new logging formatter configuration | `tiferet logging add-formatter <id> <name> <format> [--description] [--datefmt]` |
+| `logging.remove_formatter` | Remove a logging formatter by ID | `tiferet logging remove-formatter <id>` |
+| `logging.add_handler` | Add a new logging handler configuration | `tiferet logging add-handler <id> <name> <module_path> <class_name> <level> <formatter> [--description] [--stream] [--filename]` |
+| `logging.remove_handler` | Remove a logging handler by ID | `tiferet logging remove-handler <id>` |
+| `logging.add_logger` | Add a new logger configuration | `tiferet logging add-logger <id> <name> <level> <handlers> [--description] [--no-propagate]` |
+| `logging.remove_logger` | Remove a logger by ID | `tiferet logging remove-logger <id>` |
+| `logging.list` | List all logging configurations | `tiferet logging list` |
+
+#### Python (`AdminApp`)
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'logging.add_logger',
+    data={
+        'id': 'app.audit',
+        'name': 'app.audit',
+        'level': 'INFO',
+        'handlers': 'console,file',
+    },
+)
+```
+
+#### CLI (`tiferet`)
+
+```bash
+tiferet logging add-logger app.audit app.audit INFO console,file
+tiferet logging list
+```
+
+---
+
+## Worked Example: Pairing a New Domain Event with Config Entries
+
+When a new domain event module is authored (e.g. `VerifyPaymentEvent`), three corresponding entries must be configured in `config.yml` to make it operational:
+
+1. **Error Definition** (`error.add`): Error constant and localized message for failure modes.
+2. **Service Registration** (`service.add` / optional `service.set_dependency`): DI registration mapping the event ID to its class (and any flagged override).
+3. **Feature Step** (`feature.add` / `feature.add_step`): Feature workflow plus step entry referencing the service ID.
+
+### Complete Python script
+
+```python
+from tiferet.blueprints import AdminApp
+
+# Initialize AdminApp against the target configuration file
+admin = AdminApp(app_config='config.yml')
+
+# 1. Add error definition
+admin.run(
+    'error.add',
+    data={
+        'id': 'PAYMENT_VERIFICATION_FAILED_ID',
+        'name': 'Payment Verification Failed',
+        'message': 'Unable to verify payment transaction.',
+        'additional_messages': {
+            'es_ES': 'No se pudo verificar la transacción de pago.',
+        },
+    },
+)
+
+# 2. Register the service (default type)
+admin.run(
+    'service.add',
+    data={
+        'id': 'verify_payment_evt',
+        'module_path': 'app.events.payment',
+        'class_name': 'VerifyPaymentEvent',
+        'parameters': {'gateway_timeout': '10.0'},
+    },
+)
+
+# 3. Create or ensure feature workflow exists
+admin.run(
+    'feature.add',
+    data={
+        'name': 'Payment Checkout Feature',
+        'group_id': 'payment',
+        'feature_key': 'checkout',
+    },
+)
+
+# 4. Attach domain event as a feature step
+admin.run(
+    'feature.add_step',
+    data={
+        'id': 'payment.checkout',
+        'name': 'Verify Payment Step',
+        'service_id': 'verify_payment_evt',
+        'parameters': {'require_3ds': 'true'},
+    },
+)
+```
+
+---
+
+## Canonical Source
+
+For full architectural details, resolver flag routing, and detailed blueprint specs, see:
+- [docs/guides/admin.md](../../../guides/admin.md) — Admin Support Strategies and Patterns
+- [docs/core/blueprints.md](../../../core/blueprints.md) — Blueprint Architecture and Entry Points

--- a/docs/guides/admin.md
+++ b/docs/guides/admin.md
@@ -1,0 +1,334 @@
+# Admin Support – Strategies and Patterns
+
+**Project:** Tiferet Framework  
+**Repository:** https://github.com/greatstrength/tiferet  
+**Modules:** `tiferet/blueprints/admin.py`, `tiferet/blueprints/admin_cli.py`  
+**Version:** 2.0.0
+
+## Overview
+
+The Tiferet framework provides a built-in admin support layer that allows application developers and operators to inspect, add, update, and remove configuration records directly in consumer `config.yml` files (and YAML/JSON repositories) without building custom management interfaces.
+
+The admin layer is exposed through two single-call entry points:
+- **`AdminApp`** / **`build_admin_app`** — Python entry point returning a fully wired `AppSessionContext` bound to the built-in `admin` session.
+- **`AdminCLI`** / **`build_admin_cli`** — Console entry point (`tiferet`) returning a `CliSessionContext` bound to the built-in `admin_cli` session.
+
+Import both from the blueprints package (they are not re-exported from the package root):
+
+```python
+from tiferet.blueprints import AdminApp, AdminCLI
+# also: build_admin_app, build_admin_cli
+```
+
+Both entry points pre-seed an admin bootstrap cache containing the framework's full six-domain CRUD catalog and wire an admin service resolver that resolves admin-scoped feature steps from an admin container by default.
+
+Source of truth for catalog IDs:
+- Features: `ADMIN_DEFAULT_FEATURES` in `tiferet/assets/feature.py` (41 features)
+- Commands: `ADMIN_DEFAULT_COMMANDS` in `tiferet/assets/cli.py` (41 commands, including `feature.get`)
+
+## Ubiquitous Language
+
+- **Admin Session**: A built-in application session (`admin` or `admin_cli`) configured with default repositories and management workflows.
+- **Admin CLI**: The `tiferet` command-line entry point that pre-parses `--config` options and dispatches administrative CLI requests.
+- **Six Admin Domains**: The functional CRUD management domains exposed by the admin catalog: App, CLI, Error, Feature, Service/DI, and Logging.
+- **Admin-Scoped Resolution**: Service resolution where default feature steps resolve against the admin service container rather than consumer application overrides.
+
+## Building an Admin Session
+
+The `build_admin_app` blueprint function (exported as `AdminApp`) builds a complete admin session context:
+
+```python
+from tiferet.blueprints import AdminApp
+
+# Bootstrap the admin application session
+admin = AdminApp()
+
+# Execute a management feature against the consumer's config.yml
+response = admin.run('app.list')
+```
+
+### Resolver Flag Routing
+
+`build_admin_service_resolver` registers the `app` container under the `'app'` flag, while the admin container is registered under both the `'admin'` flag and the empty-flag default:
+
+```python
+# Resolves from the consumer app container
+app_dep = resolver.get_dependency('service_id', 'app')
+
+# Resolves from the admin container
+admin_dep = resolver.get_dependency('service_id', 'admin')
+
+# Resolves from the admin container by default
+default_dep = resolver.get_dependency('service_id')
+```
+
+This guarantees that admin management workflows execute against the framework's administrative services and repositories without interfering with consumer application registrations.
+
+## Building an Admin CLI Session
+
+The `build_admin_cli` blueprint function (exported as `AdminCLI`) and its `main()` console wrapper power the `tiferet` script:
+
+```bash
+# Manage config.yml in the current directory
+tiferet app list
+
+# Manage a specific configuration file
+tiferet --config custom_config.yml error list
+```
+
+Programmatically, `build_admin_cli` re-seeds the resolved session's constants so every config-file repository points directly at the consumer-supplied configuration file:
+
+```python
+from tiferet.blueprints import AdminCLI
+
+# Execute an administrative CLI command against a custom config file
+response = AdminCLI(app_config='app_config.yml', argv=['feature', 'list'])
+```
+
+## The Six Admin Domains
+
+The admin catalog spans six configuration management domains. Each subsection lists every landed feature ID with a one-line purpose and its CLI verb (group + key). CLI shapes use positional arguments unless a flag is shown with `--`.
+
+All flat-map arguments accept `key=value` pairs on the CLI (`type: dict`); raw JSON is only used where the catalog marks `type: json`.
+
+### 1. App Domain (`app`)
+
+Manages application interface / session definitions, constants, and app-level service dependencies.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `app.add` | Add a new application session configuration | `tiferet app add <id> <name> <module_path> <class_name> [--description] [--logger-id] [--flags] [--constants]` |
+| `app.get` | Retrieve an app session by ID | `tiferet app get <interface_id>` |
+| `app.list` | List all configured app sessions | `tiferet app list` |
+| `app.update` | Update a scalar attribute on an app session | `tiferet app update <id> <attribute> <value>` |
+| `app.set_constants` | Set or clear constants on an app session | `tiferet app set-constants <id> [--constants]` |
+| `app.set_service` | Set or update a service dependency on an app session | `tiferet app set-service <id> <service_id> <module_path> <class_name> [--parameters]` |
+| `app.remove_service` | Remove a service dependency from an app session | `tiferet app remove-service <id> <service_id>` |
+| `app.remove` | Remove an app session by ID | `tiferet app remove <id>` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'app.add',
+    data={
+        'id': 'web_api',
+        'name': 'Web API Session',
+        'module_path': 'app.contexts.api',
+        'class_name': 'ApiSessionContext',
+        'description': 'Main web API application session',
+    },
+)
+```
+
+```bash
+tiferet app add web_api "Web API Session" app.contexts.api ApiSessionContext --description "Main web API application session"
+tiferet app list
+```
+
+### 2. CLI Domain (`cli`)
+
+Manages CLI command definitions and argument specifications.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `cli.list_commands` | List all configured CLI commands | `tiferet cli list-commands` |
+| `cli.add_command` | Add a new CLI command definition | `tiferet cli add-command <id> <name> <key> <group_key> [--description]` |
+| `cli.add_argument` | Add an argument to an existing CLI command | `tiferet cli add-argument <command_id> --name-or-flags <json> [--description]` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'cli.add_command',
+    data={
+        'id': 'reports.generate',
+        'name': 'Generate Report',
+        'key': 'generate',
+        'group_key': 'reports',
+        'description': 'Generate summary report',
+    },
+)
+```
+
+```bash
+tiferet cli add-command reports.generate "Generate Report" generate reports --description "Generate summary report"
+tiferet cli list-commands
+```
+
+### 3. Error Domain (`error`)
+
+Manages structured error definitions and multilingual messages.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `error.list` | List all error definitions | `tiferet error list` |
+| `error.add` | Add a new error definition | `tiferet error add <id> <name> <message> [--lang] [--additional-messages]` |
+| `error.get` | Retrieve an error by ID | `tiferet error get <id>` |
+| `error.rename` | Rename an existing error definition | `tiferet error rename <id> <new_name>` |
+| `error.set_message` | Set the message text on an existing error | `tiferet error set-message <id> <message> [--lang]` |
+| `error.remove_message` | Remove a language message from an error | `tiferet error remove-message <id> [--lang]` |
+| `error.remove` | Remove an error definition | `tiferet error remove <id>` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'error.add',
+    data={
+        'id': 'INVALID_TOKEN_ID',
+        'name': 'Invalid Token',
+        'message': 'The provided authentication token is invalid.',
+        'additional_messages': {
+            'es_ES': 'El token de autenticación proporcionado no es válido.',
+        },
+    },
+)
+```
+
+```bash
+tiferet error add INVALID_TOKEN_ID "Invalid Token" "The provided authentication token is invalid." --additional-messages es_ES="El token de autenticación proporcionado no es válido."
+tiferet error list
+```
+
+### 4. Feature Domain (`feature`)
+
+Manages feature workflow definitions and steps.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `feature.list` | List all feature workflow definitions | `tiferet feature list [--group-id]` |
+| `feature.add` | Add a new feature workflow definition | `tiferet feature add <name> <group_id> [--feature-key] [--description]` |
+| `feature.get` | Retrieve a feature by ID | `tiferet feature get <id>` |
+| `feature.update` | Update a metadata attribute on a feature | `tiferet feature update <id> <attribute> <value>` |
+| `feature.add_step` | Add a step to an existing feature workflow | `tiferet feature add-step <id> <name> <service_id> [--parameters] [--data-key] [--pass-on-error] [--position]` |
+| `feature.update_step` | Update an attribute on an existing feature step | `tiferet feature update-step <id> <position> <attribute> [--value]` |
+| `feature.remove_step` | Remove a step from an existing feature workflow | `tiferet feature remove-step <id> <position>` |
+| `feature.reorder_step` | Reorder a step within an existing feature workflow | `tiferet feature reorder-step <id> <start_position> <end_position>` |
+| `feature.remove` | Remove an existing feature workflow definition | `tiferet feature remove <id>` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'feature.add',
+    data={
+        'name': 'Create User Workflow',
+        'group_id': 'user',
+        'feature_key': 'create',
+        'description': 'Validates and registers a new user',
+    },
+)
+admin.run(
+    'feature.add_step',
+    data={
+        'id': 'user.create',
+        'name': 'Validate User Step',
+        'service_id': 'validate_user_evt',
+        'parameters': {'mode': 'strict'},
+    },
+)
+```
+
+```bash
+tiferet feature add "Create User Workflow" user --feature-key create --description "Validates and registers a new user"
+tiferet feature add-step user.create "Validate User Step" validate_user_evt --parameters mode=strict
+tiferet feature list
+```
+
+### 5. Service / DI Domain (`service`)
+
+Manages feature-level service registrations, flagged dependencies, and DI constants.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `service.list` | List all DI service registrations and constants | `tiferet service list` |
+| `service.add` | Add a new DI service registration | `tiferet service add <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_default` | Set or update the default type for a registration | `tiferet service set-default <id> [--module-path] [--class-name] [--parameters]` |
+| `service.set_dependency` | Set or update a flagged dependency on a registration | `tiferet service set-dependency <id> <flag> <module_path> <class_name> [--parameters]` |
+| `service.remove_dependency` | Remove a flagged dependency from a registration | `tiferet service remove-dependency <id> <flag>` |
+| `service.set_constants` | Set or clear DI service constants | `tiferet service set-constants [--constants]` |
+| `service.remove` | Remove a DI service registration | `tiferet service remove <id>` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'service.add',
+    data={
+        'id': 'validate_user_evt',
+        'module_path': 'app.events.user',
+        'class_name': 'ValidateUserEvent',
+        'parameters': {'timeout': '5.0'},
+    },
+)
+admin.run(
+    'service.set_dependency',
+    data={
+        'id': 'validate_user_evt',
+        'flag': 'test',
+        'module_path': 'app.events.user',
+        'class_name': 'StubValidateUserEvent',
+    },
+)
+```
+
+```bash
+tiferet service add validate_user_evt --module-path app.events.user --class-name ValidateUserEvent --parameters timeout=5.0
+tiferet service set-dependency validate_user_evt test app.events.user StubValidateUserEvent
+tiferet service list
+```
+
+### 6. Logging Domain (`logging`)
+
+Manages logging formatters, handlers, and loggers.
+
+| Feature | Purpose | CLI |
+| --- | --- | --- |
+| `logging.add_formatter` | Add a new logging formatter configuration | `tiferet logging add-formatter <id> <name> <format> [--description] [--datefmt]` |
+| `logging.remove_formatter` | Remove a logging formatter by ID | `tiferet logging remove-formatter <id>` |
+| `logging.add_handler` | Add a new logging handler configuration | `tiferet logging add-handler <id> <name> <module_path> <class_name> <level> <formatter> [--description] [--stream] [--filename]` |
+| `logging.remove_handler` | Remove a logging handler by ID | `tiferet logging remove-handler <id>` |
+| `logging.add_logger` | Add a new logger configuration | `tiferet logging add-logger <id> <name> <level> <handlers> [--description] [--no-propagate]` |
+| `logging.remove_logger` | Remove a logger by ID | `tiferet logging remove-logger <id>` |
+| `logging.list` | List all logging configurations | `tiferet logging list` |
+
+```python
+from tiferet.blueprints import AdminApp
+
+admin = AdminApp()
+admin.run(
+    'logging.add_logger',
+    data={
+        'id': 'app.audit',
+        'name': 'app.audit',
+        'level': 'INFO',
+        'handlers': 'console,file',
+    },
+)
+```
+
+```bash
+tiferet logging add-logger app.audit app.audit INFO console,file
+tiferet logging list
+```
+
+## Boundaries
+
+- **Inside this domain**: Invoking the built-in `admin` and `admin_cli` application sessions, resolving admin catalog features, executing CRUD management operations against consumer YAML/JSON configuration files, and utilizing flat-map key-value CLI options.
+- **Outside this domain**:
+  - Authoring new domain events, services, or features for a consumer's own domain logic — see [docs/core/blueprints.md](../core/blueprints.md) and component code-style skills (`tiferet-code-domain`, `tiferet-code-events`).
+  - Internal blueprint handler composition and context construction details — see [docs/core/blueprints.md](../core/blueprints.md) and [docs/core/contexts.md](../core/contexts.md).
+
+## Related Documentation
+
+- [docs/core/blueprints.md](../core/blueprints.md) — Blueprint architecture and single-call entry points
+- [docs/core/contexts.md](../core/contexts.md) — Runtime context hub architecture and handler wiring
+- [docs/guides/blueprints.md](blueprints.md) — Blueprint design strategies and patterns
+- [docs/guides/contexts.md](contexts.md) — Context strategies and runtime execution patterns
+- [docs/guides/domain/cli.md](domain/cli.md) — CLI domain models and argument parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Repository = "https://github.com/greatstrength/tiferet"
 Download = "https://github.com/greatstrength/tiferet"
 
 [project.scripts]
-tiferet = "tiferet.blueprints.tiferet_cli:main"
+tiferet = "tiferet.blueprints.admin_cli:main"
 
 [project.optional-dependencies]
 test = [

--- a/tests/assets/test_cli.py
+++ b/tests/assets/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for CLI Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import cli as cli_assets
+
+# *** constants
+
+# ** constant: dict_typed_argument_specs
+# (command_data attribute name, flag name) pairs that must use type='dict'.
+DICT_TYPED_ARGUMENT_SPECS = [
+    ('APP_ADD_CLI_CMD_DATA', '--constants'),
+    ('APP_SET_CONSTANTS_CLI_CMD_DATA', '--constants'),
+    ('APP_SET_SERVICE_CLI_CMD_DATA', '--parameters'),
+    ('FEATURE_ADD_STEP_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_ADD_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_DEFAULT_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_DEPENDENCY_CLI_CMD_DATA', '--parameters'),
+    ('SERVICE_SET_CONSTANTS_CLI_CMD_DATA', '--constants'),
+]
+
+# *** functions
+
+# ** function: find_argument
+def find_argument(command_data: dict, flag: str) -> dict | None:
+    '''
+    Return the argument dict whose name_or_flags includes the given flag.
+
+    :param command_data: A CLI command data dict with an arguments list.
+    :type command_data: dict
+    :param flag: The flag string to locate (e.g. '--constants').
+    :type flag: str
+    :return: The matching argument dict, or None when absent.
+    :rtype: dict | None
+    '''
+
+    # Scan the command's arguments for the requested flag.
+    for argument in command_data.get('arguments', []):
+        if flag in argument.get('name_or_flags', []):
+            return argument
+
+    # Return None when the flag is not present.
+    return None
+
+# *** tests
+
+# ** test: eight_flat_map_arguments_use_dict_type
+def test_eight_flat_map_arguments_use_dict_type():
+    '''
+    Verify each of the eight flat-map admin CLI arguments uses type='dict'.
+    '''
+
+    # Assert every listed argument is typed as dict.
+    for attr_name, flag in DICT_TYPED_ARGUMENT_SPECS:
+        command_data = getattr(cli_assets, attr_name)
+        argument = find_argument(command_data, flag)
+        assert argument is not None, f'{attr_name} missing {flag}'
+        assert argument['type'] == 'dict', f'{attr_name} {flag} type is {argument.get("type")!r}'
+
+# ** test: error_add_includes_additional_messages_dict_arg
+def test_error_add_includes_additional_messages_dict_arg():
+    '''
+    Verify error.add exposes --additional-messages with type='dict'.
+    '''
+
+    # Locate the additional-messages argument on error.add.
+    argument = find_argument(
+        cli_assets.ERROR_ADD_CLI_CMD_DATA,
+        '--additional-messages',
+    )
+
+    # Assert the argument exists and is typed as dict.
+    assert argument is not None
+    assert argument['type'] == 'dict'
+    assert argument['description'] == (
+        'Additional messages beyond the primary one, as lang=text pairs.'
+    )
+
+# ** test: list_shaped_json_arguments_remain_json
+def test_list_shaped_json_arguments_remain_json():
+    '''
+    Verify list-shaped arguments out of scope stay type='json'.
+    '''
+
+    # Assert app.add --flags remains json when the catalog still exposes it.
+    flags_arg = find_argument(cli_assets.APP_ADD_CLI_CMD_DATA, '--flags')
+    if flags_arg is not None:
+        assert flags_arg['type'] == 'json'
+
+    # Assert cli.add-argument still declares a name_or_flags argument.
+    name_or_flags_arg = find_argument(
+        cli_assets.CLI_ADD_ARGUMENT_CLI_CMD_DATA,
+        'name_or_flags',
+    )
+    assert name_or_flags_arg is not None
+
+# ** test: feature_get_cli_command_is_registered
+def test_feature_get_cli_command_is_registered():
+    '''
+    Verify feature.get is a registered admin CLI command.
+    '''
+
+    # Assert the proto catalog exposes feature.get on the CLI.
+    assert hasattr(cli_assets, 'FEATURE_GET_CLI_CMD_ID')
+    assert cli_assets.FEATURE_GET_CLI_CMD_ID == 'feature.get'
+    assert cli_assets.FEATURE_GET_CLI_CMD_ID in cli_assets.ADMIN_DEFAULT_COMMANDS

--- a/tests/assets/test_di.py
+++ b/tests/assets/test_di.py
@@ -1,0 +1,38 @@
+"""Tests for DI Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import di as di_assets
+
+# *** tests
+
+# ** test: admin_default_services_exists
+def test_admin_default_services_exists():
+    '''
+    Verify ADMIN_DEFAULT_SERVICES is defined and DEFAULT_ADMIN_SERVICES is gone.
+    '''
+
+    # Assert the renamed catalog is present and non-empty.
+    assert hasattr(di_assets, 'ADMIN_DEFAULT_SERVICES')
+    assert isinstance(di_assets.ADMIN_DEFAULT_SERVICES, dict)
+    assert len(di_assets.ADMIN_DEFAULT_SERVICES) > 0
+
+    # Assert the old name does not exist on the module.
+    assert not hasattr(di_assets, 'DEFAULT_ADMIN_SERVICES')
+
+# ** test: admin_default_services_keys_match_id_constants
+def test_admin_default_services_keys_match_id_constants():
+    '''
+    Verify a representative set of service IDs are catalog keys.
+    '''
+
+    # Assert core admin service registration IDs are present as catalog keys.
+    for service_id in (
+        di_assets.APP_SERVICE_ID,
+        di_assets.ADD_ERROR_EVT_ID,
+        di_assets.ADD_FEATURE_EVT_ID,
+        di_assets.ADD_SERVICE_REGISTRATION_EVT_ID,
+        di_assets.ADD_LOGGER_EVT_ID,
+    ):
+        assert service_id in di_assets.ADMIN_DEFAULT_SERVICES

--- a/tests/assets/test_error.py
+++ b/tests/assets/test_error.py
@@ -1,0 +1,47 @@
+"""Tests for Error Assets"""
+
+# *** imports
+
+# ** app
+from tiferet.assets.error import (
+    ADMIN_DEFAULT_ERRORS,
+    CORE_DEFAULT_ERRORS,
+)
+
+
+# *** tests
+
+# ** test: test_admin_default_errors_extends_core
+def test_admin_default_errors_extends_core():
+    '''
+    Verify ADMIN_DEFAULT_ERRORS layers the admin tier on top of the core tier.
+    '''
+
+    # Admin is a strict superset of core.
+    assert set(ADMIN_DEFAULT_ERRORS) > set(CORE_DEFAULT_ERRORS)
+
+    # Core entries are shared by identity (not merely equal).
+    for error_id, definition in CORE_DEFAULT_ERRORS.items():
+        assert ADMIN_DEFAULT_ERRORS[error_id] is definition
+
+
+# ** test: test_tier_sizes
+def test_tier_sizes():
+    '''
+    Lock the core and admin-only tier sizes after orphaned-constant removal.
+    '''
+
+    # Core tier size and admin-only delta.
+    assert len(CORE_DEFAULT_ERRORS) == 15
+    assert len(set(ADMIN_DEFAULT_ERRORS) - set(CORE_DEFAULT_ERRORS)) == 13
+
+
+# ** test: test_every_entry_omits_redundant_id
+def test_every_entry_omits_redundant_id():
+    '''
+    Verify every catalog entry is id-free (id lives only as the mapping key).
+    '''
+
+    # No leaf definition re-embeds its own id.
+    for definition in ADMIN_DEFAULT_ERRORS.values():
+        assert 'id' not in definition

--- a/tests/assets/test_feature.py
+++ b/tests/assets/test_feature.py
@@ -1,0 +1,48 @@
+"""Tests for Feature Assets — admin catalog reconciliation."""
+
+# *** imports
+
+# ** app
+from tiferet.assets import feature as feature_assets
+
+# *** tests
+
+# ** test: admin_default_features_exists
+def test_admin_default_features_exists():
+    '''
+    Verify ADMIN_DEFAULT_FEATURES is defined and DEFAULT_ADMIN_FEATURES is gone.
+    '''
+
+    # Assert the renamed catalog is present and non-empty.
+    assert hasattr(feature_assets, 'ADMIN_DEFAULT_FEATURES')
+    assert isinstance(feature_assets.ADMIN_DEFAULT_FEATURES, dict)
+    assert len(feature_assets.ADMIN_DEFAULT_FEATURES) > 0
+
+    # Assert the old name does not exist on the module.
+    assert not hasattr(feature_assets, 'DEFAULT_ADMIN_FEATURES')
+
+# ** test: admin_default_features_keys_match_id_constants
+def test_admin_default_features_keys_match_id_constants():
+    '''
+    Verify a representative set of feature IDs are catalog keys.
+    '''
+
+    # Assert core admin feature IDs are present as catalog keys.
+    for feature_id in (
+        feature_assets.APP_ADD_ID,
+        feature_assets.ERROR_ADD_ID,
+        feature_assets.FEATURE_GET_ID,
+        feature_assets.FEATURE_ADD_STEP_ID,
+        feature_assets.SERVICE_ADD_ID,
+        feature_assets.LOGGING_LIST_ID,
+    ):
+        assert feature_id in feature_assets.ADMIN_DEFAULT_FEATURES
+
+    # Assert request-taking features carry a params_schema (list-only features may omit it).
+    for feature_id in (
+        feature_assets.FEATURE_GET_ID,
+        feature_assets.ERROR_ADD_ID,
+        feature_assets.FEATURE_ADD_STEP_ID,
+        feature_assets.SERVICE_ADD_ID,
+    ):
+        assert feature_assets.ADMIN_DEFAULT_FEATURES[feature_id].get('params_schema') is not None, feature_id

--- a/tests/blueprints/test_admin.py
+++ b/tests/blueprints/test_admin.py
@@ -1,0 +1,167 @@
+"""Tiferet Admin Blueprints Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+from unittest import mock
+
+# ** app
+from tiferet import assets as a
+from tiferet.assets import TiferetError
+from tiferet.blueprints.admin import (
+    AdminApp,
+    build_admin_app,
+    build_admin_app_session_context,
+    build_admin_service_resolver,
+    build_cache,
+)
+from tiferet.blueprints import core
+from tiferet.contexts.app import (
+    ADMIN_SERVICE_CACHE_PREFIX,
+    AppSessionContext,
+)
+from tiferet.contexts.cache import CacheContext
+from tiferet.di import DIAppServiceContainer, DIDynamicServiceResolver
+from tiferet.domain import AppServiceDependency, AppSession
+
+# *** tests
+
+# ** test: build_cache_seeds_admin_services
+def test_build_cache_seeds_admin_services():
+    '''
+    Test that build_cache seeds admin services under ADMIN_SERVICE_CACHE_PREFIX.
+    '''
+
+    # Build the admin cache and resolve a known admin service entry.
+    cache = build_cache()
+    cached = cache.get('di_service', *ADMIN_SERVICE_CACHE_PREFIX)
+
+    # Assert the admin service catalog is seeded under the admin prefix.
+    assert isinstance(cached, AppServiceDependency)
+    assert cached.service_id == 'di_service'
+
+# ** test: build_admin_service_resolver_routes_by_flag
+def test_build_admin_service_resolver_routes_by_flag():
+    '''
+    Test that the app flag resolves from the app container while admin and
+    empty-flag resolution both use the admin container.
+    '''
+
+    # Seed an admin cache and build distinct app and admin containers.
+    cache = build_cache()
+    app_container = DIAppServiceContainer.from_dependencies(
+        services=[
+            AppServiceDependency(
+                service_id='di_service',
+                module_path='tiferet.contexts.cache',
+                class_name='CacheContext',
+            ),
+            AppServiceDependency(
+                service_id='flag_probe',
+                module_path='tiferet.contexts.request',
+                class_name='RequestContext',
+            ),
+        ],
+        constants={},
+    )
+    admin_probe = AppServiceDependency(
+        service_id='flag_probe',
+        module_path='tiferet.contexts.cache',
+        class_name='CacheContext',
+    )
+    with mock.patch(
+        'tiferet.blueprints.admin.get_default_admin_services',
+        return_value=[admin_probe],
+    ), mock.patch(
+        'tiferet.blueprints.admin.get_default_admin_constants',
+        return_value={},
+    ):
+        resolver = build_admin_service_resolver(app_container, cache)
+
+    # Assert flag routing: app vs admin vs empty-flag default.
+    assert isinstance(resolver, DIDynamicServiceResolver)
+    from tiferet.contexts.request import RequestContext
+    assert isinstance(resolver.get_dependency('flag_probe', 'app'), RequestContext)
+    assert isinstance(resolver.get_dependency('flag_probe', 'admin'), CacheContext)
+    assert isinstance(resolver.get_dependency('flag_probe'), CacheContext)
+    assert resolver.get_container('admin') is resolver.get_container()
+
+# ** test: build_admin_app_session_context_wires_handlers
+def test_build_admin_app_session_context_wires_handlers():
+    '''
+    Test that build_admin_app_session_context returns an AppSessionContext with
+    all five handlers wired, including build_logger_handler.
+    '''
+
+    # Seed the admin cache and a minimal session for composition.
+    cache = build_cache()
+    app_session = AppSession(id=a.app.TIFERET_ADMIN_ID, name='Admin App')
+
+    # Bypass the real logging pipeline; this test targets handler wiring only.
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch(
+        'tiferet.blueprints.core.build_logger_handler',
+        return_value=fake_build_logger,
+    ):
+        context = build_admin_app_session_context(app_session, cache)
+
+    # Assert the context is fully wired with all five template-method handlers.
+    assert isinstance(context, AppSessionContext)
+    assert context._build_logger is fake_build_logger
+    assert context._execute_feature is not None
+    assert context._raise_error is not None
+    assert context._build_response is core.response_handler
+    assert context._create_request is core.create_session_request
+
+# ** test: build_admin_app_returns_app_session_context
+def test_build_admin_app_returns_app_session_context():
+    '''
+    Test that build_admin_app returns a fully wired AppSessionContext for the
+    built-in admin session.
+    '''
+
+    # Build the admin app with no consumer config entry required.
+    context = build_admin_app()
+
+    # Assert the composed context is bound to the built-in admin session.
+    assert isinstance(context, AppSessionContext)
+    assert context.domain.id == a.app.TIFERET_ADMIN_ID
+
+    # Assert all five template-method handlers were wired.
+    assert context._build_logger is not None
+    assert context._execute_feature is not None
+    assert context._raise_error is not None
+    assert context._create_request is core.create_session_request
+    assert context._build_response is core.response_handler
+
+# ** test: build_admin_app_alias
+def test_build_admin_app_alias():
+    '''
+    Test that AdminApp is an alias for build_admin_app.
+    '''
+
+    # Assert the exported alias points at the single-call entry point.
+    assert AdminApp is build_admin_app
+
+# ** test: build_admin_app_invalid_type
+def test_build_admin_app_invalid_type():
+    '''
+    Test that build_admin_app raises INVALID_APP_SESSION_TYPE_ID when the
+    resolved context type is invalid.
+    '''
+
+    # Isolate build_admin_app and force an invalid context type.
+    with mock.patch('tiferet.blueprints.admin.build_cache') as mock_cache, \
+         mock.patch('tiferet.blueprints.core.get_app_session') as mock_get_session, \
+         mock.patch('tiferet.blueprints.admin.build_admin_app_session_context') as mock_build_ctx:
+        mock_cache.return_value = CacheContext()
+        mock_get_session.return_value = AppSession(id='admin', name='Admin App')
+        mock_build_ctx.return_value = object()
+
+        # Invoke build_admin_app and expect the structured type error.
+        with pytest.raises(TiferetError) as exc_info:
+            build_admin_app()
+
+    # Assert the structured invalid-type error is raised.
+    assert exc_info.value.error_code == a.error.INVALID_APP_SESSION_TYPE_ID

--- a/tests/blueprints/test_admin_cli.py
+++ b/tests/blueprints/test_admin_cli.py
@@ -1,0 +1,192 @@
+"""Tiferet Admin CLI Blueprints Tests"""
+
+# *** imports
+
+# ** infra
+from unittest import mock
+
+# ** app
+from tiferet import assets as a
+from tiferet.blueprints.admin_cli import (
+    AdminCLI,
+    build_admin_cli,
+    build_admin_cli_session_context,
+    build_cache,
+    main,
+)
+from tiferet.blueprints.cli import (
+    create_cli_request_context,
+    cli_response_handler,
+)
+from tiferet.contexts.cache import CacheContext
+from tiferet.contexts.cli import (
+    CLI_COMMAND_CACHE_PREFIX,
+    CliSessionContext,
+)
+from tiferet.domain import AppSession, CliCommand
+
+# *** tests
+
+# ** test: build_cache_seeds_admin_cli_commands
+def test_build_cache_seeds_admin_cli_commands():
+    '''
+    Test that build_cache seeds admin CLI commands under CLI_COMMAND_CACHE_PREFIX.
+    '''
+
+    # Build the admin CLI cache and collect seeded commands.
+    cache = build_cache()
+    seeded = cache.get_by_prefix(*CLI_COMMAND_CACHE_PREFIX)
+
+    # Assert the admin CLI command catalog is seeded.
+    assert isinstance(cache, CacheContext)
+    assert seeded
+    assert all(isinstance(command, CliCommand) for command in seeded.values())
+    assert 'cli.list_commands' in seeded
+
+# ** test: build_admin_cli_session_context_uses_admin_resolver
+def test_build_admin_cli_session_context_uses_admin_resolver():
+    '''
+    Test that build_admin_cli_session_context wires a CliSessionContext whose
+    resolver carries the admin container under the admin flag and default.
+    '''
+
+    # Seed the admin CLI cache and a minimal session for composition.
+    cache = build_cache()
+    app_session = AppSession(id=a.app.TIFERET_ADMIN_CLI_ID, name='Admin CLI')
+
+    # Capture the resolver produced by the admin composition path.
+    captured = {}
+    real_build = __import__(
+        'tiferet.blueprints.admin',
+        fromlist=['build_admin_service_resolver'],
+    ).build_admin_service_resolver
+
+    def capture_resolver(app_container, cache, parse_parameter=None):
+        kwargs = {}
+        if parse_parameter is not None:
+            kwargs['parse_parameter'] = parse_parameter
+        resolver = real_build(app_container, cache, **kwargs)
+        captured['resolver'] = resolver
+        return resolver
+
+    # Bypass the real logging pipeline; this test targets resolver wiring only.
+    fake_build_logger = mock.Mock(name='build_logger_handler')
+    with mock.patch(
+        'tiferet.blueprints.admin.build_admin_service_resolver',
+        side_effect=capture_resolver,
+    ), mock.patch(
+        'tiferet.blueprints.core.build_logger_handler',
+        return_value=fake_build_logger,
+    ):
+        context = build_admin_cli_session_context(app_session, cache)
+
+    # Assert the CLI session context is fully wired with CLI handlers.
+    assert isinstance(context, CliSessionContext)
+    assert context._create_request is create_cli_request_context
+    assert context._build_response is cli_response_handler
+    assert context._parse_cli_args is not None
+    assert context._build_logger is fake_build_logger
+
+    # Assert the built resolver carries the admin container under both keys.
+    resolver = captured['resolver']
+    assert resolver.get_container('admin') is resolver.get_container()
+
+# ** test: build_admin_cli_reseeds_app_config
+def test_build_admin_cli_reseeds_app_config():
+    '''
+    Test that build_admin_cli re-seeds session constants so all config keys
+    equal the consumer-supplied app_config path.
+    '''
+
+    # Isolate build_admin_cli from session resolution and context composition.
+    app_session = AppSession(
+        id=a.app.TIFERET_ADMIN_CLI_ID,
+        name='Admin CLI',
+        constants={'cli_config': 'old.yml'},
+    )
+    mock_context = mock.Mock(spec=CliSessionContext)
+    mock_context.run.return_value = 'admin-cli-response'
+
+    with mock.patch(
+        'tiferet.blueprints.admin_cli.core.get_app_session',
+        return_value=app_session,
+    ) as mock_get_session, mock.patch(
+        'tiferet.blueprints.admin_cli.build_admin_cli_session_context',
+        return_value=mock_context,
+    ) as mock_build_ctx:
+        response = build_admin_cli(
+            app_config='consumer.yml',
+            argv=['cli', 'list-commands'],
+        )
+
+    # Assert the built-in admin CLI session was resolved with the config path.
+    mock_get_session.assert_called_once()
+    assert mock_get_session.call_args.args[0] == a.app.TIFERET_ADMIN_CLI_ID
+    assert mock_get_session.call_args.kwargs['app_config'] == 'consumer.yml'
+
+    # Assert session constants were re-seeded to the consumer config path.
+    assert app_session.constants == {
+        'cli_config': 'consumer.yml',
+        'app_config': 'consumer.yml',
+        'di_config': 'consumer.yml',
+        'error_config': 'consumer.yml',
+        'feature_config': 'consumer.yml',
+        'logging_config': 'consumer.yml',
+    }
+
+    # Assert the context was composed with the mutated session and run invoked.
+    mock_build_ctx.assert_called_once()
+    assert mock_build_ctx.call_args.args[0] is app_session
+    mock_context.run.assert_called_once_with(['cli', 'list-commands'])
+    assert response == 'admin-cli-response'
+
+# ** test: build_admin_cli_alias
+def test_build_admin_cli_alias():
+    '''
+    Test that AdminCLI is an alias for build_admin_cli.
+    '''
+
+    # Assert the exported alias points at the single-call entry point.
+    assert AdminCLI is build_admin_cli
+
+# ** test: package_exports_admin_blueprints
+def test_package_exports_admin_blueprints():
+    '''
+    Test that blueprints package exports admin app and admin CLI entry points.
+    '''
+
+    # Import the package exports and assert the admin symbols resolve.
+    from tiferet.blueprints import (
+        AdminApp,
+        AdminCLI as ExportedAdminCLI,
+        build_admin_app,
+        build_admin_cli as exported_build_admin_cli,
+    )
+
+    # Assert both aliases and builders are exported.
+    assert build_admin_app is not None
+    assert AdminApp is build_admin_app
+    assert exported_build_admin_cli is build_admin_cli
+    assert ExportedAdminCLI is build_admin_cli
+
+# ** test: main_pre_parses_config
+def test_main_pre_parses_config():
+    '''
+    Test that main extracts --config via a help-disabled pre-parser and
+    forwards the remaining argv to build_admin_cli.
+    '''
+
+    # Isolate main from the full admin CLI composition chain.
+    with mock.patch(
+        'tiferet.blueprints.admin_cli.build_admin_cli',
+    ) as mock_build, mock.patch(
+        'sys.argv',
+        ['tiferet', '--config', 'my.yml', 'cli', 'list-commands'],
+    ):
+        main()
+
+    # Assert --config was stripped and the remaining argv was forwarded.
+    mock_build.assert_called_once_with(
+        app_config='my.yml',
+        argv=['cli', 'list-commands'],
+    )

--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -76,4 +76,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0b16'
+__version__ = '2.0.0b17'

--- a/tiferet/blueprints/admin.py
+++ b/tiferet/blueprints/admin.py
@@ -150,8 +150,9 @@ def build_admin_app_session_context(
     # Resolve the context's collaborators from the app container by id.
     collaborators = core.resolve_collaborators(context_cls, app_container)
 
-    # Build the four FE4 template-method handlers.
+    # Build the five template-method handlers.
     handlers = dict(
+        build_logger_handler=core.build_logger_handler(cache, resolver.get_dependency),
         execute_feature_handler=core.execute_feature_handler(resolver.get_dependency, cache),
         create_request_handler=core.create_session_request,
         raise_error_handler=core.raise_error_handler(core.get_error(cache, resolver.get_dependency)),
@@ -159,7 +160,7 @@ def build_admin_app_session_context(
     )
 
     # Construct the context via from_domain, injecting the resolver handler,
-    # cache, all collaborators, and the four FE4 handlers.
+    # cache, all collaborators, and the five handlers.
     return context_cls.from_domain(
         app_session,
         get_dependency=resolver.get_dependency,
@@ -217,4 +218,7 @@ def build_admin_app(
 
     # Return the validated admin app session context.
     return app_session_context
+
+# ** blueprint: admin_app (alias)
+AdminApp = build_admin_app
 

--- a/tiferet/blueprints/admin_cli.py
+++ b/tiferet/blueprints/admin_cli.py
@@ -99,9 +99,10 @@ def build_admin_cli_session_context(
     # reserved and supplied explicitly.
     collaborators = core.resolve_collaborators(CliSessionContext, app_container)
 
-    # Build the four FE4 handlers, overriding the request and response slots
+    # Build the five handlers, overriding the request and response slots
     # with CLI-specific implementations.
     handlers = dict(
+        build_logger_handler=core.build_logger_handler(cache, resolver.get_dependency),
         execute_feature_handler=core.execute_feature_handler(resolver.get_dependency, cache),
         create_request_handler=create_cli_request_context,
         raise_error_handler=core.raise_error_handler(core.get_error(cache, resolver.get_dependency)),
@@ -208,3 +209,6 @@ def main() -> None:
 
     # Delegate to build_admin_cli with the resolved config path.
     build_admin_cli(app_config=pre_args.config, argv=remaining)
+
+# ** blueprint: admin_cli (alias)
+AdminCLI = build_admin_cli

--- a/tiferet/mappers/core.py
+++ b/tiferet/mappers/core.py
@@ -11,14 +11,6 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 # ** app
 from ..domain import DomainObject, ModelError
 
-# *** constants
-
-# ** constant: default_module_path
-DEFAULT_MODULE_PATH = 'tiferet.contexts.app'
-
-# ** constant: default_class_name
-DEFAULT_CLASS_NAME = 'AppSessionContext'
-
 # *** classes
 
 # ** class: aggregate


### PR DESCRIPTION
## Summary

Internal RFP hotfix batch from `.handoff/main-proto-full-artifact-diff-post-v2.0.0.handoff.md` (H-1 through H-5).

- **H-1:** Point `[project.scripts] tiferet` at `tiferet.blueprints.admin_cli:main`. The old `tiferet_cli` module is gone on both lines.
- **H-2:** Bump `__version__` to `2.0.0b17` (no tag in this PR).
- **H-3:** Delete unused `DEFAULT_MODULE_PATH` / `DEFAULT_CLASS_NAME` from `tiferet/mappers/core.py`.
- **H-4:** Port admin/catalog tests from `main` and adapt them to proto (`feature.get` CLI, core error catalog size 15). Also wire `build_logger_handler` and restore `AdminApp` / `AdminCLI` aliases so the admin paths match the five-handler hub.
- **H-5:** Port `docs/guides/admin.md` and `tiferet-admin-config`, keeping proto's Super-TRD skills in the index. Docs record proto's `feature.get` CLI command.

## Test plan

- [x] `python -c "from tiferet.blueprints.admin_cli import main; from tiferet.blueprints import AdminApp, AdminCLI"`
- [x] `pytest tests/assets/test_{cli,di,error,feature}.py tests/blueprints/test_admin.py tests/blueprints/test_admin_cli.py tests/mappers/test_core.py` — 36 passed
- [x] Full suite: **1115 passed, 11 skipped**

Conversation: https://app.warp.dev/conversation/0a8f514c-a897-47d6-b62d-d9f96b12dda3

Co-Authored-By: Oz <oz-agent@warp.dev>