### PR TITLE
Domain & Contexts – RequestSpecification.coerce and layer error conversion (#1035)

### DIFF
--- a/tests/contexts/test_feature.py
+++ b/tests/contexts/test_feature.py
@@ -574,8 +574,10 @@ def test_validate_request_invalid_data_raises():
     with pytest.raises(TiferetError) as exc_info:
         validate_request(feature, request)
 
-    # Assert the error code identifies the validation failure.
+    # Assert the error code and unpacked violations identify the validation failure.
     assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
+    assert exc_info.value.kwargs.get('feature_id') == 'calc.add'
+    assert len(exc_info.value.kwargs.get('violations')) == 1
 
 # ** test: feature_context_init
 def test_feature_context_init(services: mock.Mock):

--- a/tests/domain/test_feature.py
+++ b/tests/domain/test_feature.py
@@ -4,6 +4,7 @@
 
 # ** infra
 import pytest
+from pydantic import ValidationError
 
 # ** app
 from tiferet.domain.feature import (
@@ -13,7 +14,6 @@ from tiferet.domain.feature import (
     ParameterSpecification,
     RequestSpecification,
 )
-from tiferet.assets import TiferetError
 
 # *** fixtures
 
@@ -281,17 +281,17 @@ def test_request_specification_normalizes_expanded() -> None:
     assert param.default == 1.0
     assert param.minimum == 0.0
 
-# ** test: request_specification_validate_coerces_and_preserves_extra
-def test_request_specification_validate_coerces_and_preserves_extra() -> None:
+# ** test: request_specification_coerce_coerces_and_preserves_extra
+def test_request_specification_coerce_coerces_and_preserves_extra() -> None:
     '''
-    Test that validate coerces typed fields, applies defaults, and preserves extra keys.
+    Test that coerce coerces typed fields, applies defaults, and preserves extra keys.
     '''
 
-    # Validate a payload against a schema with a defaulted optional field.
+    # Coerce a payload against a schema with a defaulted optional field.
     spec = RequestSpecification.model_validate(
         {'a': 'int', 'b': {'type': 'float', 'required': False, 'default': 1.0}}
     )
-    result = spec.validate({'a': '5', 'extra': 'keep'})
+    result = spec.coerce({'a': '5', 'extra': 'keep'})
 
     # Assert coercion, default application, and extra-key preservation.
     assert result['a'] == 5
@@ -299,52 +299,49 @@ def test_request_specification_validate_coerces_and_preserves_extra() -> None:
     assert result['b'] == 1.0
     assert result['extra'] == 'keep'
 
-# ** test: request_specification_validate_missing_required_raises
-def test_request_specification_validate_missing_required_raises() -> None:
+# ** test: request_specification_coerce_missing_required_raises
+def test_request_specification_coerce_missing_required_raises() -> None:
     '''
-    Test that missing required parameters raise a single REQUEST_VALIDATION_FAILED error.
+    Test that missing required parameters raise a Pydantic ValidationError.
     '''
 
-    # Validate an empty payload against a required schema.
+    # Coerce an empty payload against a required schema.
     spec = RequestSpecification.model_validate({'a': 'int'})
-    with pytest.raises(TiferetError) as exc_info:
-        spec.validate({}, feature_id='calc.add')
+    with pytest.raises(ValidationError) as exc_info:
+        spec.coerce({})
 
-    # Assert the structured validation error with one violation.
-    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
-    assert exc_info.value.kwargs.get('feature_id') == 'calc.add'
-    assert len(exc_info.value.kwargs.get('violations')) == 1
+    # Assert one field error is reported by Pydantic.
+    assert len(exc_info.value.errors()) == 1
 
-# ** test: request_specification_validate_aggregates_multiple_errors
-def test_request_specification_validate_aggregates_multiple_errors() -> None:
+# ** test: request_specification_coerce_aggregates_multiple_errors
+def test_request_specification_coerce_aggregates_multiple_errors() -> None:
     '''
-    Test that multiple validation failures are aggregated into one error.
+    Test that multiple validation failures are aggregated into one ValidationError.
     '''
 
-    # Validate a payload that fails two fields.
+    # Coerce a payload that fails two fields.
     spec = RequestSpecification.model_validate({'a': 'int', 'b': 'int'})
-    with pytest.raises(TiferetError) as exc_info:
-        spec.validate({'a': 'x', 'b': 'y'}, feature_id='calc.add')
+    with pytest.raises(ValidationError) as exc_info:
+        spec.coerce({'a': 'x', 'b': 'y'})
 
-    # Assert both violations are aggregated.
-    assert exc_info.value.error_code == 'REQUEST_VALIDATION_FAILED'
-    assert len(exc_info.value.kwargs.get('violations')) == 2
+    # Assert both field errors are aggregated.
+    assert len(exc_info.value.errors()) == 2
 
-# ** test: request_specification_validate_choices
-def test_request_specification_validate_choices() -> None:
+# ** test: request_specification_coerce_choices
+def test_request_specification_coerce_choices() -> None:
     '''
     Test that choices restrict values via a Literal annotation.
     '''
 
-    # Validate a payload constrained by choices.
+    # Coerce a payload constrained by choices.
     spec = RequestSpecification.model_validate(
         {'mode': {'type': 'str', 'choices': ['add', 'sub']}}
     )
 
     # Assert a valid choice passes and an invalid choice fails.
-    assert spec.validate({'mode': 'add'})['mode'] == 'add'
-    with pytest.raises(TiferetError):
-        spec.validate({'mode': 'bad'})
+    assert spec.coerce({'mode': 'add'})['mode'] == 'add'
+    with pytest.raises(ValidationError):
+        spec.coerce({'mode': 'bad'})
 
 # ** test: request_specification_is_satisfied_by
 def test_request_specification_is_satisfied_by() -> None:

--- a/tiferet/contexts/feature.py
+++ b/tiferet/contexts/feature.py
@@ -8,6 +8,9 @@ import re
 import threading
 from typing import Any, Callable, Dict, Generator, List, Tuple
 
+# ** infra
+from pydantic import ValidationError
+
 # ** app
 from .core import BaseContext
 from .cache import CacheContext
@@ -17,13 +20,14 @@ from ..assets.error import (
     MIDDLEWARE_LOADING_FAILED_ID,
     REQUEST_NOT_FOUND_ID,
     PARAMETER_NOT_FOUND_ID,
+    REQUEST_VALIDATION_FAILED_ID,
 )
 from ..assets.core import REQUEST_REF_PREFIX
 from ..events import (
     DomainEvent,
     TiferetError,
 )
-from ..domain import Feature, EventFeatureStep
+from ..domain import Feature, EventFeatureStep, unpack_validation_error
 
 # *** constants
 
@@ -362,11 +366,19 @@ def validate_request(feature: Feature, request: RequestContext) -> None:
     if feature.params_schema is None:
         return
 
-    # Validate and coerce the request data, assigning the merged result back.
-    request.data = feature.params_schema.validate(
-        request.data,
-        feature_id=feature.id,
-    )
+    # Coerce the request data, assigning the merged result back.
+    try:
+        request.data = feature.params_schema.coerce(request.data)
+
+    # Name the schema failure in the framework's request vocabulary.
+    except ValidationError as error:
+        violations = unpack_validation_error(error)
+        TiferetError.raise_error(
+            REQUEST_VALIDATION_FAILED_ID,
+            f'Request validation failed for feature {feature.id}: {violations}.',
+            feature_id=feature.id,
+            violations=violations,
+        )
 
 # *** contexts
 

--- a/tiferet/domain/feature.py
+++ b/tiferet/domain/feature.py
@@ -10,8 +10,6 @@ from pydantic import ConfigDict, Field, ValidationError, create_model, model_val
 
 # ** app
 from .core import DomainObject
-from .. import assets as a
-from ..assets import TiferetError
 
 # *** models
 
@@ -255,17 +253,19 @@ class RequestSpecification(DomainObject):
             **field_definitions,
         )
 
-    # * method: validate
-    def validate(self, data: Dict[str, Any], feature_id: str = None) -> Dict[str, Any]:
+    # * method: coerce
+    def coerce(self, data: Dict[str, Any]) -> Dict[str, Any]:
         '''
         Validate and coerce ``data`` against the schema, returning the original
         request data merged with coerced schema-covered fields and defaults.
         Unspecified extra request keys are preserved.
 
-        :param data: The request data to validate.
+        Pydantic's ``ValidationError`` propagates untouched: naming the failure
+        is the orchestration layer's concern, so the domain carries no framework
+        error vocabulary.
+
+        :param data: The request data to coerce.
         :type data: Dict[str, Any]
-        :param feature_id: The feature id used for error context.
-        :type feature_id: str
         :return: The merged, coerced request data.
         :rtype: Dict[str, Any]
         '''
@@ -274,25 +274,7 @@ class RequestSpecification(DomainObject):
         model_cls = self.build_model()
 
         # Validate and coerce the request data, aggregating all field errors.
-        try:
-            validated = model_cls(**(data or {}))
-
-        # Convert Pydantic validation errors into a single structured error.
-        except ValidationError as error:
-            violations = [
-                {
-                    'field': '.'.join(str(loc) for loc in err.get('loc', ())),
-                    'type': err.get('type'),
-                    'message': err.get('msg'),
-                }
-                for err in error.errors()
-            ]
-            raise TiferetError(
-                a.error.REQUEST_VALIDATION_FAILED_ID,
-                f'Request validation failed for feature {feature_id}: {violations}.',
-                feature_id=feature_id,
-                violations=violations,
-            )
+        validated = model_cls(**(data or {}))
 
         # Merge coerced schema fields and defaults over the original data.
         return {**(data or {}), **validated.model_dump()}
@@ -308,11 +290,11 @@ class RequestSpecification(DomainObject):
         :rtype: bool
         '''
 
-        # Attempt validation, treating a validation error as not satisfied.
+        # Attempt coercion, treating a validation error as not satisfied.
         try:
-            self.validate(data)
+            self.coerce(data)
             return True
-        except TiferetError:
+        except ValidationError:
             return False
 
 # ** model: feature


### PR DESCRIPTION
## Summary
Implements #1035 (v2.0.1 P0): move request-schema error naming out of the domain layer.

- Rename `RequestSpecification.validate` → `coerce`; drop `feature_id`; let `pydantic.ValidationError` propagate
- Remove `assets` / `TiferetError` imports from `domain/feature.py`
- `is_satisfied_by` catches `ValidationError`
- `contexts/feature.py:validate_request` converts failures via `unpack_validation_error` + `TiferetError.raise_error(REQUEST_VALIDATION_FAILED_ID, …)`
- Domain tests expect `ValidationError`; context tests keep `TiferetError` / `REQUEST_VALIDATION_FAILED` (+ `violations` kwarg)

Closes #1035

## Validation
```
pytest tests/domain/test_feature.py tests/contexts/test_feature.py
# 81 passed
```

## Acceptance Criteria
1. `RequestSpecification` has `# * method: coerce` and no `# * method: validate`
2. `domain/feature.py` does not import `TiferetError` or assets
3. `spec.coerce(bad_data)` raises `ValidationError`, not `TiferetError`
4. Successful coerce merges coerced fields + preserves extras
5. `is_satisfied_by` returns False on invalid data without raising
6. `validate_request` raises `TiferetError` with `REQUEST_VALIDATION_FAILED` and `violations`
7. Targeted pytest passes

Co-Authored-By: Oz <oz-agent@warp.dev>