### PR TITLE
Assets – admin feature params_schema and feature.get CLI (#1036)

### DIFF
--- a/tests/assets/test_cli.py
+++ b/tests/assets/test_cli.py
@@ -95,3 +95,28 @@ def test_list_shaped_json_arguments_remain_json():
     )
     assert name_or_flags_arg is not None
     assert name_or_flags_arg['type'] == 'json'
+
+# ** test: feature_get_cli_command_registered
+def test_feature_get_cli_command_registered():
+    '''
+    Verify feature.get CLI artifacts exist and sit after feature.list in the catalog.
+    '''
+
+    # Assert the feature.get command id and catalog entry.
+    assert cli_assets.FEATURE_GET_CLI_CMD_ID == 'feature.get'
+    assert cli_assets.FEATURE_GET_CLI_CMD_ID in cli_assets.ADMIN_DEFAULT_COMMANDS
+    assert (
+        cli_assets.ADMIN_DEFAULT_COMMANDS[cli_assets.FEATURE_GET_CLI_CMD_ID]
+        is cli_assets.FEATURE_GET_CLI_CMD_DATA
+    )
+
+    # Assert command identity fields.
+    assert cli_assets.FEATURE_GET_CLI_CMD_DATA['key'] == 'get'
+    assert cli_assets.FEATURE_GET_CLI_CMD_DATA['group_key'] == 'feature'
+
+    # Assert insertion order: list, get, add.
+    command_ids = list(cli_assets.ADMIN_DEFAULT_COMMANDS)
+    list_index = command_ids.index(cli_assets.FEATURE_LIST_CLI_CMD_ID)
+    get_index = command_ids.index(cli_assets.FEATURE_GET_CLI_CMD_ID)
+    add_index = command_ids.index(cli_assets.FEATURE_ADD_CLI_CMD_ID)
+    assert list_index < get_index < add_index

--- a/tests/assets/test_feature.py
+++ b/tests/assets/test_feature.py
@@ -36,3 +36,17 @@ def test_admin_default_features_keys_match_id_constants():
         feature_assets.LOGGING_LIST_ID,
     ):
         assert feature_id in feature_assets.ADMIN_DEFAULT_FEATURES
+
+# ** test: admin_feature_params_schema_presence
+def test_admin_feature_params_schema_presence():
+    '''
+    Verify params_schema is attached to input features and omitted from list-style ones.
+    '''
+
+    # Assert representative updated constants expose a params_schema key.
+    assert 'params_schema' in feature_assets.FEATURE_GET_DATA
+    assert 'params_schema' in feature_assets.APP_ADD_DATA
+    assert 'params_schema' in feature_assets.FEATURE_LIST_DATA
+
+    # Assert list-style features stay schema-less.
+    assert 'params_schema' not in feature_assets.APP_LIST_DATA

--- a/tiferet/assets/cli.py
+++ b/tiferet/assets/cli.py
@@ -71,6 +71,9 @@ ERROR_REMOVE_CLI_CMD_ID = 'error.remove'
 # ** constant: feature_list_cli_cmd_id
 FEATURE_LIST_CLI_CMD_ID = 'feature.list'
 
+# ** constant: feature_get_cli_cmd_id
+FEATURE_GET_CLI_CMD_ID = 'feature.get'
+
 # ** constant: feature_add_cli_cmd_id
 FEATURE_ADD_CLI_CMD_ID = 'feature.add'
 
@@ -503,6 +506,20 @@ FEATURE_LIST_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
         create_default_cli_argument(
             name_or_flags=['--group-id'],
             description='Optional group identifier to filter results.',
+        ),
+    ],
+)
+
+# ** constant: feature_get_cli_cmd_data
+FEATURE_GET_CLI_CMD_DATA: Dict[str, Any] = create_default_cli_command_data(
+    key='get',
+    group_key='feature',
+    name='Get Feature',
+    description='Retrieve a feature by ID.',
+    arguments=[
+        create_default_cli_argument(
+            name_or_flags=['id'],
+            description='The feature identifier (e.g. calc.add).',
         ),
     ],
 )
@@ -1006,6 +1023,7 @@ ADMIN_DEFAULT_COMMANDS: Dict[str, Dict[str, Any]] = {
     ERROR_REMOVE_MESSAGE_CLI_CMD_ID: ERROR_REMOVE_MESSAGE_CLI_CMD_DATA,
     ERROR_REMOVE_CLI_CMD_ID: ERROR_REMOVE_CLI_CMD_DATA,
     FEATURE_LIST_CLI_CMD_ID: FEATURE_LIST_CLI_CMD_DATA,
+    FEATURE_GET_CLI_CMD_ID: FEATURE_GET_CLI_CMD_DATA,
     FEATURE_ADD_CLI_CMD_ID: FEATURE_ADD_CLI_CMD_DATA,
     FEATURE_UPDATE_CLI_CMD_ID: FEATURE_UPDATE_CLI_CMD_DATA,
     FEATURE_ADD_STEP_CLI_CMD_ID: FEATURE_ADD_STEP_CLI_CMD_DATA,

--- a/tiferet/assets/feature.py
+++ b/tiferet/assets/feature.py
@@ -15,7 +15,7 @@ Each section follows the pattern established by ``assets/error.py``:
 from typing import Any, Dict, List
 
 # ** app
-from .core import create_default_feature_data
+from .core import create_default_feature_data, create_params_schema
 
 # *** constants (ids)
 
@@ -151,6 +151,17 @@ APP_ADD_DATA = create_default_feature_data(
     feature_key='add',
     steps=[{'service_id': 'add_app_session_evt', 'name': 'Add app session'}],
     description='Add a new application session configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        module_path='str',
+        class_name='str',
+        description={'type': 'str', 'required': False},
+        logger_id={'type': 'str', 'required': False, 'default': 'default'},
+        flags={'type': 'list', 'required': False, 'default': ['default']},
+        services={'type': 'list', 'required': False, 'default': []},
+        constants={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: app_get_data
@@ -160,6 +171,9 @@ APP_GET_DATA = create_default_feature_data(
     feature_key='get',
     steps=[{'service_id': 'get_app_session_evt', 'name': 'Get app session'}],
     description='Retrieve an app session by ID.',
+    params_schema=create_params_schema(
+        interface_id='str',
+    ),
 )
 
 # ** constant: app_list_data
@@ -178,6 +192,10 @@ APP_UPDATE_DATA = create_default_feature_data(
     feature_key='update',
     steps=[{'service_id': 'update_app_session_evt', 'name': 'Update app session'}],
     description='Update a scalar attribute on an app session.',
+    params_schema=create_params_schema(
+        id='str',
+        attribute='str',
+    ),
 )
 
 # ** constant: app_set_constants_data
@@ -187,6 +205,10 @@ APP_SET_CONSTANTS_DATA = create_default_feature_data(
     feature_key='set_constants',
     steps=[{'service_id': 'set_app_constants_evt', 'name': 'Set app constants'}],
     description='Set or clear constants on an app session.',
+    params_schema=create_params_schema(
+        id='str',
+        constants={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: app_set_service_data
@@ -196,6 +218,13 @@ APP_SET_SERVICE_DATA = create_default_feature_data(
     feature_key='set_service',
     steps=[{'service_id': 'set_app_service_dependency_evt', 'name': 'Set app service dependency'}],
     description='Set or update a service dependency on an app session.',
+    params_schema=create_params_schema(
+        id='str',
+        service_id='str',
+        module_path='str',
+        class_name='str',
+        parameters={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: app_remove_service_data
@@ -205,6 +234,10 @@ APP_REMOVE_SERVICE_DATA = create_default_feature_data(
     feature_key='remove_service',
     steps=[{'service_id': 'remove_app_service_dependency_evt', 'name': 'Remove app service dependency'}],
     description='Remove a service dependency from an app session.',
+    params_schema=create_params_schema(
+        id='str',
+        service_id='str',
+    ),
 )
 
 # ** constant: app_remove_data
@@ -214,6 +247,9 @@ APP_REMOVE_DATA = create_default_feature_data(
     feature_key='remove',
     steps=[{'service_id': 'remove_app_session_evt', 'name': 'Remove app session'}],
     description='Remove an app session by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: cli_list_commands_data
@@ -232,6 +268,14 @@ CLI_ADD_COMMAND_DATA = create_default_feature_data(
     feature_key='add_command',
     steps=[{'service_id': 'add_cli_command_evt', 'name': 'Add CLI command'}],
     description='Add a new CLI command definition.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        key='str',
+        group_key='str',
+        description={'type': 'str', 'required': False},
+        arguments={'type': 'list', 'required': False, 'default': []},
+    ),
 )
 
 # ** constant: cli_add_argument_data
@@ -241,6 +285,10 @@ CLI_ADD_ARGUMENT_DATA = create_default_feature_data(
     feature_key='add_argument',
     steps=[{'service_id': 'add_cli_argument_evt', 'name': 'Add CLI argument'}],
     description='Add an argument to an existing CLI command.',
+    params_schema=create_params_schema(
+        command_id='str',
+        description={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: error_list_data
@@ -259,6 +307,13 @@ ERROR_ADD_DATA = create_default_feature_data(
     feature_key='add',
     steps=[{'service_id': 'add_error_evt', 'name': 'Add error'}],
     description='Add a new error definition.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+        additional_messages={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: error_get_data
@@ -268,6 +323,9 @@ ERROR_GET_DATA = create_default_feature_data(
     feature_key='get',
     steps=[{'service_id': 'get_error_evt', 'name': 'Get error'}],
     description='Retrieve an error by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: error_rename_data
@@ -277,6 +335,10 @@ ERROR_RENAME_DATA = create_default_feature_data(
     feature_key='rename',
     steps=[{'service_id': 'rename_error_evt', 'name': 'Rename error'}],
     description='Rename an existing error definition.',
+    params_schema=create_params_schema(
+        id='str',
+        new_name='str',
+    ),
 )
 
 # ** constant: error_set_message_data
@@ -286,6 +348,11 @@ ERROR_SET_MESSAGE_DATA = create_default_feature_data(
     feature_key='set_message',
     steps=[{'service_id': 'set_error_message_evt', 'name': 'Set error message'}],
     description='Set the message text on an existing error definition.',
+    params_schema=create_params_schema(
+        id='str',
+        message='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
 )
 
 # ** constant: error_remove_message_data
@@ -295,6 +362,10 @@ ERROR_REMOVE_MESSAGE_DATA = create_default_feature_data(
     feature_key='remove_message',
     steps=[{'service_id': 'remove_error_message_evt', 'name': 'Remove error message'}],
     description='Remove a language message from an existing error definition.',
+    params_schema=create_params_schema(
+        id='str',
+        lang={'type': 'str', 'required': False, 'default': 'en_US'},
+    ),
 )
 
 # ** constant: error_remove_data
@@ -304,6 +375,9 @@ ERROR_REMOVE_DATA = create_default_feature_data(
     feature_key='remove',
     steps=[{'service_id': 'remove_error_evt', 'name': 'Remove error'}],
     description='Remove an error definition.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: feature_list_data
@@ -313,6 +387,9 @@ FEATURE_LIST_DATA = create_default_feature_data(
     feature_key='list',
     steps=[{'service_id': 'list_features_evt', 'name': 'List features'}],
     description='List all feature workflow definitions.',
+    params_schema=create_params_schema(
+        group_id={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: feature_add_data
@@ -322,6 +399,15 @@ FEATURE_ADD_DATA = create_default_feature_data(
     feature_key='add',
     steps=[{'service_id': 'add_feature_evt', 'name': 'Add feature'}],
     description='Add a new feature workflow definition.',
+    params_schema=create_params_schema(
+        name='str',
+        group_id='str',
+        feature_key={'type': 'str', 'required': False},
+        id={'type': 'str', 'required': False},
+        description={'type': 'str', 'required': False},
+        steps={'type': 'list', 'required': False},
+        log_params={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: feature_get_data
@@ -331,6 +417,9 @@ FEATURE_GET_DATA = create_default_feature_data(
     feature_key='get',
     steps=[{'service_id': 'get_feature_evt', 'name': 'Get feature'}],
     description='Retrieve a feature by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: feature_update_data
@@ -340,6 +429,10 @@ FEATURE_UPDATE_DATA = create_default_feature_data(
     feature_key='update',
     steps=[{'service_id': 'update_feature_evt', 'name': 'Update feature'}],
     description='Update a metadata attribute on an existing feature.',
+    params_schema=create_params_schema(
+        id='str',
+        attribute='str',
+    ),
 )
 
 # ** constant: feature_add_step_data
@@ -349,6 +442,15 @@ FEATURE_ADD_STEP_DATA = create_default_feature_data(
     feature_key='add_step',
     steps=[{'service_id': 'add_feature_step_evt', 'name': 'Add feature step'}],
     description='Add a step to an existing feature workflow.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        service_id='str',
+        parameters={'type': 'dict', 'required': False},
+        data_key={'type': 'str', 'required': False},
+        pass_on_error={'type': 'bool', 'required': False, 'default': False},
+        position={'type': 'int', 'required': False},
+    ),
 )
 
 # ** constant: feature_update_step_data
@@ -358,6 +460,11 @@ FEATURE_UPDATE_STEP_DATA = create_default_feature_data(
     feature_key='update_step',
     steps=[{'service_id': 'update_feature_step_evt', 'name': 'Update feature step'}],
     description='Update an attribute on an existing feature step.',
+    params_schema=create_params_schema(
+        id='str',
+        position='int',
+        attribute='str',
+    ),
 )
 
 # ** constant: feature_remove_step_data
@@ -367,6 +474,10 @@ FEATURE_REMOVE_STEP_DATA = create_default_feature_data(
     feature_key='remove_step',
     steps=[{'service_id': 'remove_feature_step_evt', 'name': 'Remove feature step'}],
     description='Remove a step from an existing feature workflow.',
+    params_schema=create_params_schema(
+        id='str',
+        position='int',
+    ),
 )
 
 # ** constant: feature_reorder_step_data
@@ -376,6 +487,11 @@ FEATURE_REORDER_STEP_DATA = create_default_feature_data(
     feature_key='reorder_step',
     steps=[{'service_id': 'reorder_feature_step_evt', 'name': 'Reorder feature step'}],
     description='Reorder a step within an existing feature workflow.',
+    params_schema=create_params_schema(
+        id='str',
+        start_position='int',
+        end_position='int',
+    ),
 )
 
 # ** constant: feature_remove_data
@@ -385,6 +501,9 @@ FEATURE_REMOVE_DATA = create_default_feature_data(
     feature_key='remove',
     steps=[{'service_id': 'remove_feature_evt', 'name': 'Remove feature'}],
     description='Remove an existing feature workflow definition.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: service_list_data
@@ -403,6 +522,13 @@ SERVICE_ADD_DATA = create_default_feature_data(
     feature_key='add',
     steps=[{'service_id': 'add_service_registration_evt', 'name': 'Add service configuration'}],
     description='Add a new DI service registration.',
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+        flagged_dependencies={'type': 'list', 'required': False, 'default': []},
+    ),
 )
 
 # ** constant: service_set_default_data
@@ -412,6 +538,12 @@ SERVICE_SET_DEFAULT_DATA = create_default_feature_data(
     feature_key='set_default',
     steps=[{'service_id': 'set_default_service_registration_evt', 'name': 'Set default service configuration'}],
     description='Set or update the default type for an existing service registration.',
+    params_schema=create_params_schema(
+        id='str',
+        module_path={'type': 'str', 'required': False},
+        class_name={'type': 'str', 'required': False},
+        parameters={'type': 'dict', 'required': False},
+    ),
 )
 
 # ** constant: service_set_dependency_data
@@ -421,6 +553,13 @@ SERVICE_SET_DEPENDENCY_DATA = create_default_feature_data(
     feature_key='set_dependency',
     steps=[{'service_id': 'set_di_service_dependency_evt', 'name': 'Set service dependency'}],
     description='Set or update a flagged dependency on a service registration.',
+    params_schema=create_params_schema(
+        id='str',
+        flag='str',
+        module_path='str',
+        class_name='str',
+        parameters={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: service_remove_dependency_data
@@ -430,6 +569,10 @@ SERVICE_REMOVE_DEPENDENCY_DATA = create_default_feature_data(
     feature_key='remove_dependency',
     steps=[{'service_id': 'remove_di_service_dependency_evt', 'name': 'Remove service dependency'}],
     description='Remove a flagged dependency from a service registration.',
+    params_schema=create_params_schema(
+        id='str',
+        flag='str',
+    ),
 )
 
 # ** constant: service_set_constants_data
@@ -439,6 +582,9 @@ SERVICE_SET_CONSTANTS_DATA = create_default_feature_data(
     feature_key='set_constants',
     steps=[{'service_id': 'set_service_constants_evt', 'name': 'Set service constants'}],
     description='Set or clear DI service constants.',
+    params_schema=create_params_schema(
+        constants={'type': 'dict', 'required': False, 'default': {}},
+    ),
 )
 
 # ** constant: service_remove_data
@@ -448,6 +594,9 @@ SERVICE_REMOVE_DATA = create_default_feature_data(
     feature_key='remove',
     steps=[{'service_id': 'remove_service_registration_evt', 'name': 'Remove service configuration'}],
     description='Remove a DI service registration.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: logging_add_formatter_data
@@ -457,6 +606,13 @@ LOGGING_ADD_FORMATTER_DATA = create_default_feature_data(
     feature_key='add_formatter',
     steps=[{'service_id': 'add_formatter_evt', 'name': 'Add formatter'}],
     description='Add a new logging formatter configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        format='str',
+        description={'type': 'str', 'required': False},
+        datefmt={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: logging_remove_formatter_data
@@ -466,6 +622,9 @@ LOGGING_REMOVE_FORMATTER_DATA = create_default_feature_data(
     feature_key='remove_formatter',
     steps=[{'service_id': 'remove_formatter_evt', 'name': 'Remove formatter'}],
     description='Remove a logging formatter by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: logging_add_handler_data
@@ -475,6 +634,17 @@ LOGGING_ADD_HANDLER_DATA = create_default_feature_data(
     feature_key='add_handler',
     steps=[{'service_id': 'add_handler_evt', 'name': 'Add handler'}],
     description='Add a new logging handler configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        module_path='str',
+        class_name='str',
+        level='str',
+        formatter='str',
+        description={'type': 'str', 'required': False},
+        stream={'type': 'str', 'required': False},
+        filename={'type': 'str', 'required': False},
+    ),
 )
 
 # ** constant: logging_remove_handler_data
@@ -484,6 +654,9 @@ LOGGING_REMOVE_HANDLER_DATA = create_default_feature_data(
     feature_key='remove_handler',
     steps=[{'service_id': 'remove_handler_evt', 'name': 'Remove handler'}],
     description='Remove a logging handler by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: logging_add_logger_data
@@ -493,6 +666,13 @@ LOGGING_ADD_LOGGER_DATA = create_default_feature_data(
     feature_key='add_logger',
     steps=[{'service_id': 'add_logger_evt', 'name': 'Add logger'}],
     description='Add a new logger configuration.',
+    params_schema=create_params_schema(
+        id='str',
+        name='str',
+        level='str',
+        description={'type': 'str', 'required': False},
+        propagate={'type': 'bool', 'required': False, 'default': True},
+    ),
 )
 
 # ** constant: logging_remove_logger_data
@@ -502,6 +682,9 @@ LOGGING_REMOVE_LOGGER_DATA = create_default_feature_data(
     feature_key='remove_logger',
     steps=[{'service_id': 'remove_logger_evt', 'name': 'Remove logger'}],
     description='Remove a logger by ID.',
+    params_schema=create_params_schema(
+        id='str',
+    ),
 )
 
 # ** constant: logging_list_data


### PR DESCRIPTION
## Summary
- Add `params_schema=` via `create_params_schema(...)` to the 36 admin feature `_DATA` constants listed in TRD §4.1
- Leave schema-less: `APP_LIST`, `CLI_LIST_COMMANDS`, `ERROR_LIST`, `SERVICE_LIST`, `LOGGING_LIST`
- Add `FEATURE_GET_CLI_CMD_ID` / `FEATURE_GET_CLI_CMD_DATA` and insert into `ADMIN_DEFAULT_COMMANDS` immediately after `feature.list`

Closes #1036

## Validation
```bash
pytest tests/assets/test_feature.py tests/assets/test_cli.py -q
# 7 passed
```
Exact TRD schema equality verified for all 36 entries; five list-style features remain schema-less; CLI order list → get → add.

## Test plan
- [x] `pytest tests/assets/test_feature.py tests/assets/test_cli.py`
- [x] Manual AC check for exact `params_schema` values and CLI insertion order

Co-Authored-By: Oz <oz-agent@warp.dev>