### PR TITLE
Tests – relocate integration suite to repo-root tests_int/ (#1039)

### DIFF
--- a/tests_int/__init__.py
+++ b/tests_int/__init__.py
@@ -1,7 +1,7 @@
 # *** imports
 
 # ** app
-from ..events import DomainEvent
+from tiferet.events import DomainEvent
 
 # *** classes
 

--- a/tests_int/test_cli.py
+++ b/tests_int/test_cli.py
@@ -18,19 +18,19 @@ TEST_CALC_CONFIG = {
     'services': {
         'add_number_cmd': {
             'class_name': 'TestAddNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'subtract_number_cmd': {
             'class_name': 'TestSubtractNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'multiply_number_cmd': {
             'class_name': 'TestMultiplyNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'divide_number_cmd': {
             'class_name': 'TestDivideNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
     },
     'errors': {
@@ -360,7 +360,7 @@ def cli_subprocess_env():
     '''
     Build the environment for CLI subprocesses with PYTHONPATH set to the
     repository root so the spawned interpreter can resolve the
-    ``tiferet`` package and its ``tests_int`` subpackage even when the
+    ``tiferet`` package and the top-level ``tests_int`` package even when the
     package is not installed in the active interpreter.
 
     :return: A copy of the current environment with PYTHONPATH prefixed by
@@ -369,14 +369,14 @@ def cli_subprocess_env():
     '''
 
     # Resolve the repository root from this test module's location
-    # (tiferet/tests_int/test_cli.py -> repository root is two parents up).
-    repo_root = str(Path(__file__).resolve().parents[2])
+    # (tests_int/test_cli.py -> repository root is one parent up).
+    repo_root = str(Path(__file__).resolve().parents[1])
 
     # Copy the current environment to avoid mutating the test process env.
     env = os.environ.copy()
 
     # Prefix the existing PYTHONPATH with the repository root so the
-    # subprocess can import tiferet and tiferet.tests_int regardless of
+    # subprocess can import tiferet and tests_int regardless of
     # whether the package is installed in the active interpreter.
     existing_pythonpath = env.get('PYTHONPATH', '')
     env['PYTHONPATH'] = (

--- a/tests_int/test_main.py
+++ b/tests_int/test_main.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 # ** app
-from .. import App, TiferetAPIError
+from tiferet import App, TiferetAPIError
 
 # *** constants
 
@@ -17,19 +17,19 @@ TEST_CALC_CONFIG = {
     'services': {
         'add_number_cmd': {
             'class_name': 'TestAddNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'subtract_number_cmd': {
             'class_name': 'TestSubtractNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'multiply_number_cmd': {
             'class_name': 'TestMultiplyNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
         'divide_number_cmd': {
             'class_name': 'TestDivideNumber',
-            'module_path': 'tiferet.tests_int',
+            'module_path': 'tests_int',
         },
     },
     'errors': {


### PR DESCRIPTION
## Summary
Relocates the integration suite from `tiferet/tests_int/` to repo-root `tests_int/`, matching unit tests under `tests/`.

- `git mv` `__init__.py`, `test_main.py`, `test_cli.py` to `tests_int/`
- Absolute imports: `from tiferet.events import DomainEvent`, `from tiferet import App, TiferetAPIError`
- Service `module_path`: `tiferet.tests_int` → `tests_int`
- CLI subprocess `repo_root` via `Path(__file__).resolve().parents[1]`
- Removed empty `tiferet/contexts/tests/__init__.py`
- `pyproject.toml` `testpaths` already includes `tests_int` (unchanged)

Closes #1039

## Verification
- `pytest tests_int/` → **13 passed**
- Default collection includes `tests_int/` (13 tests)
- No remaining `tiferet.tests_int` under `tests_int/`
- `tiferet/tests_int/` absent

## Notes
- No product behavior change; tests-only.
- No `__version__` bump (single 2.0.1 bump after milestone).

Co-Authored-By: Oz <oz-agent@warp.dev>