### PR TITLE
Version – 2.0.1

### DIFF
--- a/tiferet/__init__.py
+++ b/tiferet/__init__.py
@@ -39,4 +39,4 @@ except Exception as e:
 
 # *** version
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
## Summary
Single packaging bump for the v2.0.1 patch release after all six milestone issues merged.

- Bump `tiferet.__version__` from `2.0.0` → `2.0.1`
- `pyproject.toml` reads version dynamically from `tiferet.__version__` (no other location)

## Milestone
https://github.com/greatstrength/tiferet/milestone/33

### Included issues
- #1034 Parse-Parameter Promotion and ImportDependency Retirement
- #1035 RequestSpecification.coerce and Layer Error Conversion
- #1036 Admin Feature params_schema and feature.get CLI
- #1037 Route Domain Types Through Contexts
- #1038 Publish Admin Exports in `__all__`
- #1039 Relocate Integration Suite to Repo-Root `tests_int/`

## Test plan
- [x] Diff is one line in `tiferet/__init__.py`
- [ ] Merge to `main`, annotated tag `v2.0.1`, GitHub Release, close milestone 33

Co-Authored-By: Oz <oz-agent@warp.dev>